### PR TITLE
fix: wait for Postgres primary before migrating (recovery mode guard)

### DIFF
--- a/backend/build.sh
+++ b/backend/build.sh
@@ -9,11 +9,17 @@ echo "📦 Collecting static files..."
 python manage.py collectstatic --no-input
 
 echo "🗄️ Running database migrations..."
-# Retry migrate up to 5 times with exponential back-off so that transient
-# Postgres states (recovery mode, brief failover) don't fail the build.
+# Before each migrate attempt, wait until Postgres is accepting connections AND
+# is not in recovery mode (pg_is_in_recovery() = false). A database in recovery
+# mode accepts reads but rejects writes, which causes migration cleanup to fail
+# mid-transaction even though the migration SQL already ran. Retrying migrate up
+# to 5 times with exponential back-off handles any transient re-entry into
+# recovery mode that occurs during the migration itself.
 MAX_RETRIES=5
 WAIT=5
 for attempt in $(seq 1 $MAX_RETRIES); do
+    echo "  ↳ Waiting for database to be ready (attempt $attempt)..."
+    python manage.py wait_for_db
     if python manage.py migrate; then
         echo "✅ Migration succeeded on attempt $attempt."
         break

--- a/backend/bunk_logs/users/management/commands/wait_for_db.py
+++ b/backend/bunk_logs/users/management/commands/wait_for_db.py
@@ -6,19 +6,48 @@ from django.db.utils import OperationalError
 
 
 class Command(BaseCommand):
-    """Django command to pause execution until database is available"""
+    """Pause execution until the database is accepting connections and is not in recovery mode.
+
+    A PostgreSQL standby or a primary mid-crash-recovery will accept connections
+    and respond to SELECT 1, but reject writes. Checking pg_is_in_recovery()
+    ensures we only proceed once the primary is fully writable before running
+    migrations.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--timeout",
+            type=int,
+            default=120,
+            help="Maximum seconds to wait before aborting (default: 120)",
+        )
 
     def handle(self, *args, **options):
-        self.stdout.write("Waiting for database...")
-        db_conn = None
-        while not db_conn:
+        timeout = options["timeout"]
+        deadline = time.monotonic() + timeout
+        self.stdout.write(f"Waiting up to {timeout}s for database to be ready...")
+
+        while True:
+            if time.monotonic() > deadline:
+                raise SystemExit(
+                    f"Database was not ready after {timeout} seconds — aborting."
+                )
             try:
-                db_conn = connections["default"]
-                # Test the connection
-                with db_conn.cursor() as cursor:
-                    cursor.execute("SELECT 1;")
+                conn = connections["default"]
+                with conn.cursor() as cursor:
+                    cursor.execute("SELECT pg_is_in_recovery();")
+                    in_recovery = cursor.fetchone()[0]
+                # Explicitly close so migrate gets a fresh connection.
+                conn.close()
+                if in_recovery:
+                    self.stdout.write(
+                        "Database is in recovery mode, retrying in 3s..."
+                    )
+                    time.sleep(3)
+                    continue
+                break
             except OperationalError:
-                self.stdout.write("Database unavailable, waiting 1 second...")
+                self.stdout.write("Database unavailable, retrying in 1s...")
                 time.sleep(1)
 
-        self.stdout.write(self.style.SUCCESS("Database available!"))
+        self.stdout.write(self.style.SUCCESS("Database is ready (primary, not in recovery)."))

--- a/backend/bunk_logs/users/management/commands/wait_for_db.py
+++ b/backend/bunk_logs/users/management/commands/wait_for_db.py
@@ -1,6 +1,7 @@
 import time
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
 from django.db import connections
 from django.db.utils import OperationalError
 

--- a/backend/bunk_logs/users/management/commands/wait_for_db.py
+++ b/backend/bunk_logs/users/management/commands/wait_for_db.py
@@ -1,6 +1,6 @@
 import time
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.db import connections
 from django.db.utils import OperationalError
 
@@ -29,9 +29,8 @@ class Command(BaseCommand):
 
         while True:
             if time.monotonic() > deadline:
-                raise SystemExit(
-                    f"Database was not ready after {timeout} seconds — aborting."
-                )
+                msg = f"Database was not ready after {timeout} seconds — aborting."
+                raise CommandError(msg)
             try:
                 conn = connections["default"]
                 with conn.cursor() as cursor:
@@ -41,7 +40,7 @@ class Command(BaseCommand):
                 conn.close()
                 if in_recovery:
                     self.stdout.write(
-                        "Database is in recovery mode, retrying in 3s..."
+                        "Database is in recovery mode, retrying in 3s...",
                     )
                     time.sleep(3)
                     continue


### PR DESCRIPTION
## Summary

- Deploys are failing because Postgres enters recovery mode mid-migration. Django's migration cleanup (`set_autocommit(True)`) then loses its connection and the build aborts with `FATAL: the database system is in recovery mode`.
- The existing `wait_for_db` command only runs `SELECT 1`, which succeeds even when the DB is in recovery mode. The existing retry loop re-runs `migrate` without re-checking readiness, so all retries hit the same state.
- This PR fixes both: `wait_for_db` now checks `pg_is_in_recovery()` and loops until the primary is writable; `build.sh` calls it before every migration attempt.

## Test plan

- [ ] Confirm the Render preview deploy for this PR completes (watch for "Database is ready (primary, not in recovery)" in the build log before migration runs)
- [ ] Verify `/health/` responds on the preview URL
- [ ] Merge and confirm production deploy succeeds

Made with [Cursor](https://cursor.com)