### PR TITLE
fix(migration): non-atomic batched stafflog data migration to survive Render DB recovery

### DIFF
--- a/backend/bunk_logs/bunklogs/migrations/0005_stafflog_data.py
+++ b/backend/bunk_logs/bunklogs/migrations/0005_stafflog_data.py
@@ -1,39 +1,55 @@
 from django.db import migrations
 
+BATCH_SIZE = 500
+
 
 def copy_counselor_logs_to_staff_logs(apps, schema_editor):
     """Copy all existing CounselorLog rows into the new StaffLog table.
 
     Preserves PKs so that any external references survive. Skips rows already
     present in bunklogs_stafflog (makes the migration idempotent).
+
+    Rows are inserted in batches of BATCH_SIZE. Because the Migration sets
+    atomic = False, each batch is committed immediately rather than being
+    held in a single long-lived transaction. This prevents the Postgres
+    connection from being dropped on managed-DB environments (e.g. Render)
+    when the total copy takes longer than the server's idle-in-transaction
+    timeout. A mid-run failure can be retried safely: the existing-ID check
+    and bulk_create(ignore_conflicts=True) together ensure idempotency.
     """
     CounselorLog = apps.get_model("bunklogs", "CounselorLog")
     StaffLog = apps.get_model("bunklogs", "StaffLog")
 
     existing_ids = set(StaffLog.objects.values_list("id", flat=True))
 
-    staff_logs = []
+    batch = []
     for cl in CounselorLog.objects.select_related("counselor").iterator():
         if cl.pk in existing_ids:
             continue
-        staff_logs.append(StaffLog(
-            id=cl.pk,
-            staff_member_id=cl.counselor_id,
-            date=cl.date,
-            day_quality_score=cl.day_quality_score,
-            support_level_score=cl.support_level_score,
-            elaboration=cl.elaboration,
-            day_off=cl.day_off,
-            staff_care_support_needed=cl.staff_care_support_needed,
-            values_reflection=cl.values_reflection,
-            is_test_data=cl.is_test_data,
-            # Note: created_at / updated_at are auto fields; we accept that they
-            # will be set to now() rather than the original timestamps because
-            # Django does not allow overriding auto_now_add in bulk_create without
-            # raw SQL. Historical accuracy of these fields is not required.
-        ))
+        # Note: created_at / updated_at are auto fields; we accept that they
+        # will be set to now() rather than the original timestamps because
+        # Django does not allow overriding auto_now_add in bulk_create without
+        # raw SQL. Historical accuracy of these fields is not required.
+        batch.append(
+            StaffLog(
+                id=cl.pk,
+                staff_member_id=cl.counselor_id,
+                date=cl.date,
+                day_quality_score=cl.day_quality_score,
+                support_level_score=cl.support_level_score,
+                elaboration=cl.elaboration,
+                day_off=cl.day_off,
+                staff_care_support_needed=cl.staff_care_support_needed,
+                values_reflection=cl.values_reflection,
+                is_test_data=cl.is_test_data,
+            )
+        )
+        if len(batch) >= BATCH_SIZE:
+            StaffLog.objects.bulk_create(batch, ignore_conflicts=True)
+            batch = []
 
-    StaffLog.objects.bulk_create(staff_logs, ignore_conflicts=True)
+    if batch:
+        StaffLog.objects.bulk_create(batch, ignore_conflicts=True)
 
     # After inserting rows with explicit PKs the Postgres sequence is behind.
     # Advance it so subsequent auto-increment inserts start after the current max.
@@ -47,7 +63,17 @@ def copy_counselor_logs_to_staff_logs(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-    """Copy CounselorLog rows into StaffLog before the old table is dropped."""
+    """Copy CounselorLog rows into StaffLog before the old table is dropped.
+
+    atomic = False so Django does not wrap the entire data copy in one
+    long-lived transaction. Each batch of BATCH_SIZE rows commits immediately,
+    which avoids losing the connection on Render's managed Postgres when the
+    operation holds a transaction open longer than the server's
+    idle-in-transaction timeout. The migration function is idempotent, so a
+    mid-run failure can be retried without data loss or duplication.
+    """
+
+    atomic = False
 
     dependencies = [
         ("bunklogs", "0004_stafflog_schema"),


### PR DESCRIPTION
## Summary

- The `0005_stafflog_data` migration copies all `CounselorLog` rows into the new `StaffLog` table in a single `bulk_create` call inside one large transaction. On Render's managed Postgres, this long-lived transaction causes the DB to enter recovery mode mid-migration and drop the connection — the build then fails at `set_autocommit(True)` cleanup, even after the `wait_for_db` guard was added.
- Set `atomic = False` on the `Migration` class so Django does not hold one transaction open for the entire copy. Each batch of 500 rows commits immediately.
- Process rows in batches of 500 rather than accumulating them all before the single `bulk_create`.
- The migration was already idempotent (`ignore_conflicts=True` + existing-ID check at start), so partial runs can be retried safely.

## Test plan

- [ ] Confirm Render preview deploy succeeds: watch for `bunklogs.0005_stafflog_data` completing without a connection error
- [ ] Verify `bunklogs.0006_stafflog_proxy` applies cleanly after
- [ ] Check `/health/` responds on the preview URL
- [ ] Merge and confirm production deploy succeeds end-to-end

Made with [Cursor](https://cursor.com)