### PR TITLE
fix(migration): use raw INSERT...SELECT to avoid bulk_create autocommit toggling

### DIFF
--- a/backend/bunk_logs/bunklogs/migrations/0005_stafflog_data.py
+++ b/backend/bunk_logs/bunklogs/migrations/0005_stafflog_data.py
@@ -1,55 +1,53 @@
 from django.db import migrations
 
-BATCH_SIZE = 500
-
 
 def copy_counselor_logs_to_staff_logs(apps, schema_editor):
     """Copy all existing CounselorLog rows into the new StaffLog table.
 
-    Preserves PKs so that any external references survive. Skips rows already
-    present in bunklogs_stafflog (makes the migration idempotent).
+    Uses a single INSERT INTO ... SELECT ... ON CONFLICT DO NOTHING statement
+    executed via schema_editor so it runs in autocommit mode (the Migration
+    class sets atomic = False). This avoids Django's bulk_create(), which
+    internally calls transaction.atomic() and toggles set_autocommit(True/False)
+    on the connection — the call that was failing on Render's managed Postgres
+    when the server entered recovery mode mid-migration.
 
-    Rows are inserted in batches of BATCH_SIZE. Because the Migration sets
-    atomic = False, each batch is committed immediately rather than being
-    held in a single long-lived transaction. This prevents the Postgres
-    connection from being dropped on managed-DB environments (e.g. Render)
-    when the total copy takes longer than the server's idle-in-transaction
-    timeout. A mid-run failure can be retried safely: the existing-ID check
-    and bulk_create(ignore_conflicts=True) together ensure idempotency.
+    In autocommit mode each schema_editor.execute() call is committed by the
+    database engine immediately without any client-side transaction toggling.
+    If the connection drops the statement rolls back cleanly, and the retry
+    can re-run the whole INSERT safely because ON CONFLICT DO NOTHING is
+    idempotent.
     """
-    CounselorLog = apps.get_model("bunklogs", "CounselorLog")
-    StaffLog = apps.get_model("bunklogs", "StaffLog")
-
-    existing_ids = set(StaffLog.objects.values_list("id", flat=True))
-
-    batch = []
-    for cl in CounselorLog.objects.select_related("counselor").iterator():
-        if cl.pk in existing_ids:
-            continue
-        # Note: created_at / updated_at are auto fields; we accept that they
-        # will be set to now() rather than the original timestamps because
-        # Django does not allow overriding auto_now_add in bulk_create without
-        # raw SQL. Historical accuracy of these fields is not required.
-        batch.append(
-            StaffLog(
-                id=cl.pk,
-                staff_member_id=cl.counselor_id,
-                date=cl.date,
-                day_quality_score=cl.day_quality_score,
-                support_level_score=cl.support_level_score,
-                elaboration=cl.elaboration,
-                day_off=cl.day_off,
-                staff_care_support_needed=cl.staff_care_support_needed,
-                values_reflection=cl.values_reflection,
-                is_test_data=cl.is_test_data,
-            )
+    schema_editor.execute("""
+        INSERT INTO bunklogs_stafflog (
+            id,
+            staff_member_id,
+            date,
+            day_quality_score,
+            support_level_score,
+            elaboration,
+            day_off,
+            staff_care_support_needed,
+            values_reflection,
+            is_test_data,
+            created_at,
+            updated_at
         )
-        if len(batch) >= BATCH_SIZE:
-            StaffLog.objects.bulk_create(batch, ignore_conflicts=True)
-            batch = []
-
-    if batch:
-        StaffLog.objects.bulk_create(batch, ignore_conflicts=True)
+        SELECT
+            id,
+            counselor_id,
+            date,
+            day_quality_score,
+            support_level_score,
+            elaboration,
+            day_off,
+            staff_care_support_needed,
+            values_reflection,
+            is_test_data,
+            NOW(),
+            NOW()
+        FROM bunklogs_counselorlog
+        ON CONFLICT DO NOTHING
+    """)
 
     # After inserting rows with explicit PKs the Postgres sequence is behind.
     # Advance it so subsequent auto-increment inserts start after the current max.
@@ -65,12 +63,11 @@ def copy_counselor_logs_to_staff_logs(apps, schema_editor):
 class Migration(migrations.Migration):
     """Copy CounselorLog rows into StaffLog before the old table is dropped.
 
-    atomic = False so Django does not wrap the entire data copy in one
-    long-lived transaction. Each batch of BATCH_SIZE rows commits immediately,
-    which avoids losing the connection on Render's managed Postgres when the
-    operation holds a transaction open longer than the server's
-    idle-in-transaction timeout. The migration function is idempotent, so a
-    mid-run failure can be retried without data loss or duplication.
+    atomic = False so Django does not wrap anything in a transaction.
+    The data copy runs as a single server-side INSERT...SELECT statement via
+    schema_editor.execute(), which commits immediately in autocommit mode
+    without any client-side set_autocommit() toggling. This is robust to
+    the Render managed-Postgres entering recovery mode mid-build.
     """
 
     atomic = False


### PR DESCRIPTION
## Root cause (finally found)

Even with `atomic = False` on the `Migration` class, Django's `bulk_create()` internally calls `transaction.atomic()`, which toggles `set_autocommit(False)` → runs INSERT → `set_autocommit(True)`. It is the `set_autocommit(True)` call at the END that was failing when Render's Postgres entered recovery mode — not the insert itself.

## Fix

Replace the Python-level `bulk_create()` loop with a single `schema_editor.execute(INSERT INTO ... SELECT ... ON CONFLICT DO NOTHING)`. Because the migration has `atomic = False`, `schema_editor.execute()` runs in autocommit mode — the database engine commits the statement immediately with no client-side `set_autocommit()` toggling at all. A recovery-mode event cannot cause a `set_autocommit` failure.

Also fixes the Render dashboard build command: it was set to the old manual command (`pip install ... && manage.py migrate ...`) instead of `./build.sh`, which meant all the `wait_for_db` and retry logic we added was being bypassed entirely. The build command has been updated via the Render API to `./build.sh`.

## Test plan

- [ ] Confirm Render deploy shows `./build.sh` running (not the old inline command)
- [ ] Confirm `bunklogs.0005_stafflog_data` applies without a connection error
- [ ] Confirm `bunklogs.0006_stafflog_proxy` applies cleanly after
- [ ] Verify `/health/` responds

Made with [Cursor](https://cursor.com)