### PR TITLE
1_2_resolve_duplicate_viewset: Resolve duplicate BunkLogsAllByDateViewSet and migrate to UnitStaffAssignment queries

### DIFF
--- a/backend/bunk_logs/api/tests/test_bunk_logs_all_by_date.py
+++ b/backend/bunk_logs/api/tests/test_bunk_logs_all_by_date.py
@@ -1,0 +1,282 @@
+"""Tests for BunkLogsAllByDateViewSet role-based filtering."""
+
+from datetime import date
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from bunk_logs.bunklogs.models import BunkLog
+from bunk_logs.bunks.models import Bunk
+from bunk_logs.bunks.models import Cabin
+from bunk_logs.bunks.models import CounselorBunkAssignment
+from bunk_logs.bunks.models import Session
+from bunk_logs.bunks.models import Unit
+from bunk_logs.bunks.models import UnitStaffAssignment
+from bunk_logs.campers.models import Camper
+from bunk_logs.campers.models import CamperBunkAssignment
+from bunk_logs.users.models import User
+
+TODAY = date.today()
+DATE_STR = TODAY.strftime("%Y-%m-%d")
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def session(db):
+    return Session.objects.create(
+        name="Summer 2026",
+        start_date=TODAY - timedelta(days=30),
+        end_date=TODAY + timedelta(days=60),
+    )
+
+
+@pytest.fixture
+def cabin_a(db):
+    return Cabin.objects.create(name="Cabin A", capacity=10)
+
+
+@pytest.fixture
+def cabin_b(db):
+    return Cabin.objects.create(name="Cabin B", capacity=10)
+
+
+@pytest.fixture
+def unit_1(db):
+    return Unit.objects.create(name="Unit 1")
+
+
+@pytest.fixture
+def unit_2(db):
+    return Unit.objects.create(name="Unit 2")
+
+
+@pytest.fixture
+def bunk_a(db, session, cabin_a, unit_1):
+    return Bunk.objects.create(cabin=cabin_a, session=session, unit=unit_1, is_active=True)
+
+
+@pytest.fixture
+def bunk_b(db, session, cabin_b, unit_2):
+    return Bunk.objects.create(cabin=cabin_b, session=session, unit=unit_2, is_active=True)
+
+
+@pytest.fixture
+def admin_user(db):
+    return User.objects.create_user(
+        email="admin@test.com", password="pass", role=User.ADMIN, is_staff=True,
+    )
+
+
+@pytest.fixture
+def unit_head_1(db):
+    return User.objects.create_user(email="unithead1@test.com", password="pass", role=User.UNIT_HEAD)
+
+
+@pytest.fixture
+def camper_care_1(db):
+    return User.objects.create_user(email="cc1@test.com", password="pass", role=User.CAMPER_CARE)
+
+
+@pytest.fixture
+def counselor_a(db):
+    return User.objects.create_user(email="counselora@test.com", password="pass", role=User.COUNSELOR)
+
+
+@pytest.fixture
+def counselor_b(db):
+    return User.objects.create_user(email="counselorb@test.com", password="pass", role=User.COUNSELOR)
+
+
+@pytest.fixture
+def camper_in_bunk_a(db, bunk_a):
+    camper = Camper.objects.create(first_name="Alice", last_name="Smith")
+    CamperBunkAssignment.objects.create(
+        camper=camper, bunk=bunk_a, start_date=TODAY - timedelta(days=7), is_active=True,
+    )
+    return camper
+
+
+@pytest.fixture
+def camper_in_bunk_b(db, bunk_b):
+    camper = Camper.objects.create(first_name="Bob", last_name="Jones")
+    CamperBunkAssignment.objects.create(
+        camper=camper, bunk=bunk_b, start_date=TODAY - timedelta(days=7), is_active=True,
+    )
+    return camper
+
+
+@pytest.fixture
+def log_in_bunk_a(db, camper_in_bunk_a, bunk_a, counselor_a):
+    assignment = CamperBunkAssignment.objects.get(camper=camper_in_bunk_a, bunk=bunk_a)
+    return BunkLog.objects.create(
+        bunk_assignment=assignment,
+        date=TODAY,
+        counselor=counselor_a,
+        social_score=4,
+        behavior_score=4,
+        participation_score=4,
+    )
+
+
+@pytest.fixture
+def log_in_bunk_b(db, camper_in_bunk_b, bunk_b, counselor_b):
+    assignment = CamperBunkAssignment.objects.get(camper=camper_in_bunk_b, bunk=bunk_b)
+    return BunkLog.objects.create(
+        bunk_assignment=assignment,
+        date=TODAY,
+        counselor=counselor_b,
+        social_score=3,
+        behavior_score=3,
+        participation_score=3,
+    )
+
+
+def _url(date_str=DATE_STR):
+    return reverse("api:all-bunk-logs-by-date", kwargs={"date": date_str})
+
+
+# --- Admin ---
+
+@pytest.mark.django_db
+def test_admin_sees_all_logs(api_client, admin_user, log_in_bunk_a, log_in_bunk_b):
+    api_client.force_authenticate(user=admin_user)
+    response = api_client.get(_url())
+    assert response.status_code == status.HTTP_200_OK
+    ids = {log["id"] for log in response.data["logs"]}
+    assert str(log_in_bunk_a.id) in ids
+    assert str(log_in_bunk_b.id) in ids
+
+
+# --- Unit Head ---
+
+@pytest.mark.django_db
+def test_unit_head_sees_only_own_unit_logs(
+    api_client, unit_head_1, unit_1, unit_2, log_in_bunk_a, log_in_bunk_b,
+):
+    UnitStaffAssignment.objects.create(
+        unit=unit_1,
+        staff_member=unit_head_1,
+        role="unit_head",
+        start_date=TODAY - timedelta(days=10),
+    )
+    api_client.force_authenticate(user=unit_head_1)
+    response = api_client.get(_url())
+    assert response.status_code == status.HTTP_200_OK
+    ids = {log["id"] for log in response.data["logs"]}
+    assert str(log_in_bunk_a.id) in ids
+    assert str(log_in_bunk_b.id) not in ids
+
+
+@pytest.mark.django_db
+def test_unit_head_with_no_assignment_sees_nothing(api_client, unit_head_1, log_in_bunk_a):
+    api_client.force_authenticate(user=unit_head_1)
+    response = api_client.get(_url())
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["total_logs"] == 0
+
+
+# --- Camper Care ---
+
+@pytest.mark.django_db
+def test_camper_care_sees_only_own_unit_logs(
+    api_client, camper_care_1, unit_1, log_in_bunk_a, log_in_bunk_b,
+):
+    UnitStaffAssignment.objects.create(
+        unit=unit_1,
+        staff_member=camper_care_1,
+        role="camper_care",
+        start_date=TODAY - timedelta(days=10),
+    )
+    api_client.force_authenticate(user=camper_care_1)
+    response = api_client.get(_url())
+    assert response.status_code == status.HTTP_200_OK
+    ids = {log["id"] for log in response.data["logs"]}
+    assert str(log_in_bunk_a.id) in ids
+    assert str(log_in_bunk_b.id) not in ids
+
+
+# --- Counselor ---
+
+@pytest.mark.django_db
+def test_counselor_sees_only_own_bunk_logs(
+    api_client, counselor_a, bunk_a, log_in_bunk_a, log_in_bunk_b,
+):
+    CounselorBunkAssignment.objects.create(
+        counselor=counselor_a,
+        bunk=bunk_a,
+        start_date=TODAY - timedelta(days=10),
+    )
+    api_client.force_authenticate(user=counselor_a)
+    response = api_client.get(_url())
+    assert response.status_code == status.HTTP_200_OK
+    ids = {log["id"] for log in response.data["logs"]}
+    assert str(log_in_bunk_a.id) in ids
+    assert str(log_in_bunk_b.id) not in ids
+
+
+@pytest.mark.django_db
+def test_counselor_with_no_assignment_sees_nothing(api_client, counselor_a, log_in_bunk_a):
+    api_client.force_authenticate(user=counselor_a)
+    response = api_client.get(_url())
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["total_logs"] == 0
+
+
+@pytest.mark.django_db
+def test_counselor_expired_assignment_sees_nothing(
+    api_client, counselor_a, bunk_a, log_in_bunk_a,
+):
+    CounselorBunkAssignment.objects.create(
+        counselor=counselor_a,
+        bunk=bunk_a,
+        start_date=TODAY - timedelta(days=30),
+        end_date=TODAY - timedelta(days=1),
+    )
+    api_client.force_authenticate(user=counselor_a)
+    response = api_client.get(_url())
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["total_logs"] == 0
+
+
+# --- Error cases ---
+
+@pytest.mark.django_db
+def test_unauthenticated_request_is_rejected(api_client):
+    response = api_client.get(_url())
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_unknown_role_gets_403(api_client):
+    user = User.objects.create_user(email="other@test.com", password="pass", role="Kitchen Staff")
+    api_client.force_authenticate(user=user)
+    response = api_client.get(_url())
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_invalid_date_format_returns_400(api_client, admin_user):
+    api_client.force_authenticate(user=admin_user)
+    response = api_client.get(_url("not-a-date"))
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# --- Response shape ---
+
+@pytest.mark.django_db
+def test_response_includes_bunk_id(api_client, admin_user, log_in_bunk_a):
+    api_client.force_authenticate(user=admin_user)
+    response = api_client.get(_url())
+    assert response.status_code == status.HTTP_200_OK
+    log = response.data["logs"][0]
+    assert "bunk_id" in log
+    assert "bunk_name" in log
+    assert "camper_first_name" in log
+    assert "camper_last_name" in log

--- a/backend/bunk_logs/api/views.py
+++ b/backend/bunk_logs/api/views.py
@@ -2206,122 +2206,6 @@ def get_camper_care_bunks(request, camper_care_id, date):
 
 @extend_schema(
     summary="Get all bunk logs by date",
-    description="API view to get all bunk logs for a specific date with comprehensive camper information.",
-    parameters=[
-        OpenApiParameter(
-            name="date",
-            description="Date in YYYY-MM-DD format",
-            required=True,
-            type=OpenApiTypes.DATE,
-            location=OpenApiParameter.PATH,
-        ),
-    ],
-    responses={
-        200: OpenApiResponse(description="Bunk logs data retrieved successfully"),
-        403: OpenApiResponse(description="Permission denied"),
-        400: OpenApiResponse(description="Invalid date format"),
-    },
-)
-class BunkLogsAllByDateViewSet(APIView):
-    """
-    API view to get all bunk logs for a specific date.
-    Returns comprehensive information including camper details, bunk assignment,
-    scores, reporting counselor, and support requests.
-    """
-    renderer_classes = [JSONRenderer]
-    permission_classes = [IsAuthenticated]
-
-    def get(self, request, date):
-        user = request.user
-
-        # Parse and validate date
-        try:
-            query_date = datetime.strptime(date, "%Y-%m-%d").date()
-        except ValueError:
-            return Response({"error": "Invalid date format. Use YYYY-MM-DD format."}, status=400)
-
-        # Get queryset based on user permissions
-        if user.is_staff or user.role == "Admin":
-            queryset = BunkLog.objects.filter(date=query_date)
-        elif user.role == "Unit Head":
-            unit_assignments = UnitStaffAssignment.objects.filter(
-                staff_member=user,
-                role="unit_head",
-                start_date__lte=query_date,
-            ).filter(Q(end_date__isnull=True) | Q(end_date__gte=query_date))
-
-            queryset = BunkLog.objects.filter(
-                date=query_date,
-                bunk_assignment__bunk__unit_id__in=unit_assignments,
-            )
-        elif user.role == "Camper Care":
-            unit_assignments = UnitStaffAssignment.objects.filter(
-                staff_member=user,
-                role="camper_care",
-                start_date__lte=query_date,
-            ).filter(Q(end_date__isnull=True) | Q(end_date__gte=query_date))
-
-            queryset = BunkLog.objects.filter(
-                date=query_date,
-                bunk_assignment__bunk__unit_id__in=unit_assignments,
-            )
-        elif user.role == "Counselor":
-            queryset = BunkLog.objects.filter(
-                date=query_date,
-                bunk_assignment__bunk__in=user.assigned_bunks.all(),
-            )
-        else:
-            return Response({"error": "You are not authorized to access bunk logs data"}, status=403)
-
-        # Optimize queries
-        queryset = queryset.select_related(
-            "bunk_assignment__camper",
-            "bunk_assignment__bunk",
-            "bunk_assignment__bunk__unit",
-            "counselor",
-        ).order_by(
-            "bunk_assignment__bunk__unit__name",
-            "bunk_assignment__bunk__cabin__name",
-            "bunk_assignment__camper__last_name",
-        )
-
-        # Build response data
-        logs_data = []
-        for log in queryset:
-            log_data = {
-                "id": str(log.id),
-                "date": log.date.strftime("%Y-%m-%d"),
-                "camper_first_name": log.bunk_assignment.camper.first_name,
-                "camper_last_name": log.bunk_assignment.camper.last_name,
-                "camper_id": str(log.bunk_assignment.camper.id),
-                "bunk_assignment_id": str(log.bunk_assignment.id),
-                "bunk_name": log.bunk_assignment.bunk.name,
-                "bunk_cabin_name": log.bunk_assignment.bunk.cabin.name if log.bunk_assignment.bunk.cabin else None,
-                "bunk_session": log.bunk_assignment.bunk.session.name if log.bunk_assignment.bunk.session else None,
-                "unit_name": log.bunk_assignment.bunk.unit.name if log.bunk_assignment.bunk.unit else None,
-                "social_score": log.social_score,
-                "participation_score": log.participation_score,
-                "behavioral_score": log.behavior_score,
-                "description": log.description,
-                "not_on_camp": log.not_on_camp,
-                "reporting_counselor_first_name": log.counselor.first_name if log.counselor else None,
-                "reporting_counselor_last_name": log.counselor.last_name if log.counselor else None,
-                "reporting_counselor_email": log.counselor.email if log.counselor else None,
-                "unit_head_help_requested": log.request_unit_head_help,
-                "camper_care_help_requested": log.request_camper_care_help,
-                "created_at": log.created_at.isoformat() if log.created_at else None,
-                "updated_at": log.updated_at.isoformat() if log.updated_at else None,
-            }
-            logs_data.append(log_data)
-
-        return Response({
-            "date": date,
-            "total_logs": len(logs_data),
-            "logs": logs_data,
-        })
-
-@extend_schema(
-    summary="Get all bunk logs by date",
     description="API view to get all bunk logs for a specific date. Returns comprehensive information including camper details, bunk assignment, scores, reporting counselor, and support requests.",  # noqa: E501
     parameters=[
         OpenApiParameter(
@@ -2344,7 +2228,7 @@ class BunkLogsAllByDateViewSet(APIView):
         ),
     },
 )
-class BunkLogsAllByDateViewSet(APIView):  # noqa: F811
+class BunkLogsAllByDateViewSet(APIView):
     """
     API view to get all bunk logs for a specific date.
     The endpoint will be '/api/v1/bunklogs/all/<str:date>/''
@@ -2381,33 +2265,42 @@ class BunkLogsAllByDateViewSet(APIView):  # noqa: F811
             queryset = BunkLog.objects.filter(date=query_date)
         elif user.role == "Unit Head":
             # Unit heads can see logs for bunks in their units
-            unit_assignments = UnitStaffAssignment.objects.filter(
+            unit_ids = UnitStaffAssignment.objects.filter(
                 staff_member=user,
                 role="unit_head",
                 start_date__lte=query_date,
-            ).filter(Q(end_date__isnull=True) | Q(end_date__gte=query_date))
+            ).filter(
+                Q(end_date__isnull=True) | Q(end_date__gte=query_date),
+            ).values_list("unit_id", flat=True)
 
             queryset = BunkLog.objects.filter(
                 date=query_date,
-                bunk_assignment__bunk__unit_id__in=unit_assignments,
+                bunk_assignment__bunk__unit_id__in=unit_ids,
             )
         elif user.role == "Camper Care":
             # Camper care can see logs for bunks in their assigned units
-            unit_assignments = UnitStaffAssignment.objects.filter(
+            unit_ids = UnitStaffAssignment.objects.filter(
                 staff_member=user,
                 role="camper_care",
                 start_date__lte=query_date,
-            ).filter(Q(end_date__isnull=True) | Q(end_date__gte=query_date))
+            ).filter(
+                Q(end_date__isnull=True) | Q(end_date__gte=query_date),
+            ).values_list("unit_id", flat=True)
 
             queryset = BunkLog.objects.filter(
                 date=query_date,
-                bunk_assignment__bunk__unit_id__in=unit_assignments,
+                bunk_assignment__bunk__unit_id__in=unit_ids,
             )
         elif user.role == "Counselor":
             # Counselors can see logs for their bunks only
+            active_assignments = CounselorBunkAssignment.objects.filter(
+                counselor=user,
+                start_date__lte=query_date,
+            ).filter(Q(end_date__isnull=True) | Q(end_date__gte=query_date))
+            assigned_bunks = [assignment.bunk for assignment in active_assignments]
             queryset = BunkLog.objects.filter(
                 date=query_date,
-                bunk_assignment__bunk__in=user.assigned_bunks.all(),
+                bunk_assignment__bunk__in=assigned_bunks,
             )
         else:
             # Default: no access


### PR DESCRIPTION
## Summary

- Removed the duplicate `BunkLogsAllByDateViewSet` class that was silently overriding itself with a `# noqa: F811` suppressor
- Fixed the Counselor branch to use `CounselorBunkAssignment` queries instead of the removed `user.assigned_bunks` M2M field
- Fixed the Unit Head and Camper Care branches to use `.values_list("unit_id", flat=True)` so the ORM lookup receives correct scalar IDs

## Changes

**`backend/bunk_logs/api/views.py`**
- Deleted the first (older/simpler) duplicate definition of `BunkLogsAllByDateViewSet` and its `@extend_schema` decorator
- Removed `# noqa: F811` from the surviving class declaration
- Replaced `user.assigned_bunks.all()` with date-bounded `CounselorBunkAssignment` filter for the Counselor role
- Replaced `unit_id__in=unit_assignments` (wrong queryset type) with `unit_id__in=unit_ids` (flat values) for Unit Head and Camper Care roles

**`backend/bunk_logs/api/tests/test_bunk_logs_all_by_date.py`** (new)
- 11 tests covering Admin sees all, Unit Head sees own unit only, Camper Care sees own unit only, Counselor sees own bunks only, expired assignment, no assignment, unauthenticated (401), unknown role (403), bad date (400), response shape

## Test plan

- [x] `make test-backend` — 120 passed, 0 failed
- [x] `ruff check` — no errors in changed files (pre-existing issues in unrelated files unchanged)

Made with [Cursor](https://cursor.com)