### PR TITLE
1_3_audit_fix_orm_drift: Migrate remaining ORM drift to UnitStaffAssignment

### DIFF
--- a/backend/bunk_logs/bunklogs/admin.py
+++ b/backend/bunk_logs/bunklogs/admin.py
@@ -298,7 +298,7 @@ class StaffLogAdmin(TestDataAdminMixin, admin.ModelAdmin):
 
             counselor_ids = User.objects.filter(
                 role="Counselor",
-                assigned_bunks__unit_id__in=set(unit_assignments),
+                bunk_assignments__bunk__unit_id__in=set(unit_assignments),
             ).values_list("id", flat=True)
 
             return qs.filter(staff_member_id__in=counselor_ids)

--- a/backend/bunk_logs/users/serializers.py
+++ b/backend/bunk_logs/users/serializers.py
@@ -1,11 +1,17 @@
 from typing import Any
 
 from django.contrib.auth import get_user_model
+from django.db.models import Q
+from django.utils import timezone
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
+from bunk_logs.bunks.models import CounselorBunkAssignment
+from bunk_logs.bunks.models import UnitStaffAssignment
+
 User = get_user_model()
+
 
 class UserSerializer(serializers.ModelSerializer):
     bunks = serializers.SerializerMethodField()
@@ -30,21 +36,34 @@ class UserSerializer(serializers.ModelSerializer):
     @extend_schema_field(OpenApiTypes.OBJECT)
     def get_bunks(self, obj) -> list[dict[str, Any]]:
         if obj.role == "Counselor":
-            bunks = obj.assigned_bunks.filter(is_active=True)
+            today = timezone.now().date()
+            assignments = CounselorBunkAssignment.objects.filter(
+                counselor=obj,
+                start_date__lte=today,
+            ).filter(
+                Q(end_date__isnull=True) | Q(end_date__gte=today),
+            ).select_related("bunk__cabin", "bunk__session")
             return [{
-                "id": str(bunk.id),
-                "name": bunk.name,
-                "cabin": bunk.cabin.name if bunk.cabin else None,
-                "session": bunk.session.name if bunk.session else None,
-            } for bunk in bunks]
+                "id": str(a.bunk.id),
+                "name": a.bunk.name,
+                "cabin": a.bunk.cabin.name if a.bunk.cabin else None,
+                "session": a.bunk.session.name if a.bunk.session else None,
+            } for a in assignments]
         return []
 
     @extend_schema_field(OpenApiTypes.OBJECT)
     def get_units(self, obj) -> list[dict[str, Any]]:
         if obj.role == "Unit Head":
-            units = obj.managed_units.all()
+            today = timezone.now().date()
+            assignments = UnitStaffAssignment.objects.filter(
+                staff_member=obj,
+                role="unit_head",
+                start_date__lte=today,
+            ).filter(
+                Q(end_date__isnull=True) | Q(end_date__gte=today),
+            ).select_related("unit")
             return [{
-                "id": str(unit.id),
-                "name": unit.name,
-            } for unit in units]
+                "id": str(a.unit.id),
+                "name": a.unit.name,
+            } for a in assignments]
         return []

--- a/backend/bunk_logs/users/tests/test_serializers.py
+++ b/backend/bunk_logs/users/tests/test_serializers.py
@@ -1,0 +1,124 @@
+"""Tests for UserSerializer ORM drift fix (step 1_3)."""
+
+from datetime import date
+from datetime import timedelta
+
+import pytest
+
+from bunk_logs.bunks.models import Bunk
+from bunk_logs.bunks.models import Cabin
+from bunk_logs.bunks.models import CounselorBunkAssignment
+from bunk_logs.bunks.models import Session
+from bunk_logs.bunks.models import Unit
+from bunk_logs.bunks.models import UnitStaffAssignment
+from bunk_logs.users.models import User
+from bunk_logs.users.serializers import UserSerializer
+
+TODAY = date.today()
+
+
+@pytest.fixture
+def session(db):
+    return Session.objects.create(
+        name="Summer 2026",
+        start_date=TODAY - timedelta(days=30),
+        end_date=TODAY + timedelta(days=60),
+    )
+
+
+@pytest.fixture
+def cabin(db):
+    return Cabin.objects.create(name="Cabin A", capacity=10)
+
+
+@pytest.fixture
+def unit(db):
+    return Unit.objects.create(name="Unit 1")
+
+
+@pytest.fixture
+def bunk(db, session, cabin, unit):
+    return Bunk.objects.create(cabin=cabin, session=session, unit=unit, is_active=True)
+
+
+@pytest.fixture
+def counselor(db):
+    return User.objects.create_user(email="c@test.com", password="pass", role=User.COUNSELOR)
+
+
+@pytest.fixture
+def unit_head(db):
+    return User.objects.create_user(email="uh@test.com", password="pass", role=User.UNIT_HEAD)
+
+
+@pytest.fixture
+def admin_user(db):
+    return User.objects.create_user(email="a@test.com", password="pass", role=User.ADMIN)
+
+
+# --- get_bunks ---
+
+@pytest.mark.django_db
+def test_get_bunks_returns_active_assignment_for_counselor(counselor, bunk):
+    CounselorBunkAssignment.objects.create(
+        counselor=counselor,
+        bunk=bunk,
+        start_date=TODAY - timedelta(days=7),
+    )
+    data = UserSerializer(counselor).data
+    assert len(data["bunks"]) == 1
+    assert data["bunks"][0]["id"] == str(bunk.id)
+    assert "name" in data["bunks"][0]
+
+
+@pytest.mark.django_db
+def test_get_bunks_excludes_expired_assignment(counselor, bunk):
+    CounselorBunkAssignment.objects.create(
+        counselor=counselor,
+        bunk=bunk,
+        start_date=TODAY - timedelta(days=30),
+        end_date=TODAY - timedelta(days=1),
+    )
+    data = UserSerializer(counselor).data
+    assert data["bunks"] == []
+
+
+@pytest.mark.django_db
+def test_get_bunks_returns_empty_for_non_counselor(admin_user):
+    data = UserSerializer(admin_user).data
+    assert data["bunks"] == []
+
+
+# --- get_units ---
+
+@pytest.mark.django_db
+def test_get_units_returns_active_assignment_for_unit_head(unit_head, unit):
+    UnitStaffAssignment.objects.create(
+        unit=unit,
+        staff_member=unit_head,
+        role="unit_head",
+        start_date=TODAY - timedelta(days=7),
+    )
+    data = UserSerializer(unit_head).data
+    assert len(data["units"]) == 1
+    assert data["units"][0]["id"] == str(unit.id)
+    assert data["units"][0]["name"] == unit.name
+
+
+@pytest.mark.django_db
+def test_get_units_excludes_expired_assignment(unit_head, unit):
+    UnitStaffAssignment.objects.create(
+        unit=unit,
+        staff_member=unit_head,
+        role="unit_head",
+        start_date=TODAY - timedelta(days=30),
+        end_date=TODAY - timedelta(days=1),
+    )
+    data = UserSerializer(unit_head).data
+    assert data["units"] == []
+
+
+@pytest.mark.django_db
+def test_get_units_returns_empty_for_non_unit_head(counselor):
+    data = UserSerializer(counselor).data
+    assert data["units"] == []

--- a/backend/config/auth_api.py
+++ b/backend/config/auth_api.py
@@ -1,9 +1,14 @@
 from django.contrib.auth import get_user_model
+from django.db.models import Q
 from django.http import JsonResponse
 from django.middleware.csrf import get_token
+from django.utils import timezone
 from django.views.decorators.csrf import ensure_csrf_cookie
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from rest_framework_simplejwt.views import TokenObtainPairView
+
+from bunk_logs.bunks.models import CounselorBunkAssignment
+from bunk_logs.bunks.models import UnitStaffAssignment
 
 User = get_user_model()
 
@@ -71,25 +76,32 @@ def get_auth_status(request):
 
         # Add bunk information for counselors
         if request.user.role == "Counselor":
-            # Get assigned bunks for the counselor
-            bunks = list(request.user.assigned_bunks.filter(is_active=True).values(
-                "id", "cabin__name", "session__name",
-            ))
-
-            # Format the bunks for the response
-            formatted_bunks = []
-            for bunk in bunks:
-                formatted_bunks.append({
-                    "id": bunk["id"],
-                    "name": f"{bunk['cabin__name']} - {bunk['session__name']}",
-                })
-
-            response_data["user"]["bunks"] = formatted_bunks
+            today = timezone.now().date()
+            assignments = CounselorBunkAssignment.objects.filter(
+                counselor=request.user,
+                start_date__lte=today,
+            ).filter(
+                Q(end_date__isnull=True) | Q(end_date__gte=today),
+            ).select_related("bunk__cabin", "bunk__session")
+            response_data["user"]["bunks"] = [{
+                "id": str(a.bunk.id),
+                "name": a.bunk.name,
+            } for a in assignments]
 
         # For Unit Heads, include their managed units
         elif request.user.role == "Unit Head":
-            units = list(request.user.managed_units.all().values("id", "name"))
-            response_data["user"]["units"] = units
+            today = timezone.now().date()
+            unit_assignments = UnitStaffAssignment.objects.filter(
+                staff_member=request.user,
+                role="unit_head",
+                start_date__lte=today,
+            ).filter(
+                Q(end_date__isnull=True) | Q(end_date__gte=today),
+            ).select_related("unit")
+            response_data["user"]["units"] = [{
+                "id": str(a.unit.id),
+                "name": a.unit.name,
+            } for a in unit_assignments]
 
         return JsonResponse(response_data)
     return JsonResponse({

--- a/backend/config/tests/test_auth_api.py
+++ b/backend/config/tests/test_auth_api.py
@@ -1,0 +1,143 @@
+"""Tests for config.auth_api ORM drift fix (step 1_3)."""
+
+from datetime import date
+from datetime import timedelta
+
+import pytest
+from django.test import RequestFactory
+
+from bunk_logs.bunks.models import Bunk
+from bunk_logs.bunks.models import Cabin
+from bunk_logs.bunks.models import CounselorBunkAssignment
+from bunk_logs.bunks.models import Session
+from bunk_logs.bunks.models import Unit
+from bunk_logs.bunks.models import UnitStaffAssignment
+from bunk_logs.users.models import User
+from config.auth_api import get_auth_status
+
+TODAY = date.today()
+
+
+@pytest.fixture
+def rf():
+    return RequestFactory()
+
+
+@pytest.fixture
+def session(db):
+    return Session.objects.create(
+        name="Summer 2026",
+        start_date=TODAY - timedelta(days=30),
+        end_date=TODAY + timedelta(days=60),
+    )
+
+
+@pytest.fixture
+def cabin(db):
+    return Cabin.objects.create(name="Cabin A", capacity=10)
+
+
+@pytest.fixture
+def unit(db):
+    return Unit.objects.create(name="Unit 1")
+
+
+@pytest.fixture
+def bunk(db, session, cabin, unit):
+    return Bunk.objects.create(cabin=cabin, session=session, unit=unit, is_active=True)
+
+
+@pytest.fixture
+def counselor(db):
+    return User.objects.create_user(
+        email="c@test.com", password="pass", role=User.COUNSELOR,
+        first_name="Cara", last_name="C",
+    )
+
+
+@pytest.fixture
+def unit_head(db):
+    return User.objects.create_user(
+        email="uh@test.com", password="pass", role=User.UNIT_HEAD,
+        first_name="Uma", last_name="H",
+    )
+
+
+@pytest.mark.django_db
+def test_unauthenticated_returns_not_authenticated(rf):
+    from django.contrib.auth.models import AnonymousUser
+    request = rf.get("/fake/")
+    request.user = AnonymousUser()
+    response = get_auth_status(request)
+    import json
+    data = json.loads(response.content)
+    assert data["isAuthenticated"] is False
+
+
+@pytest.mark.django_db
+def test_counselor_bunks_use_counselor_bunk_assignment(rf, counselor, bunk):
+    CounselorBunkAssignment.objects.create(
+        counselor=counselor,
+        bunk=bunk,
+        start_date=TODAY - timedelta(days=7),
+    )
+    request = rf.get("/fake/")
+    request.user = counselor
+    response = get_auth_status(request)
+    import json
+    data = json.loads(response.content)
+    assert data["isAuthenticated"] is True
+    assert len(data["user"]["bunks"]) == 1
+    assert data["user"]["bunks"][0]["id"] == str(bunk.id)
+
+
+@pytest.mark.django_db
+def test_counselor_expired_assignment_not_included(rf, counselor, bunk):
+    CounselorBunkAssignment.objects.create(
+        counselor=counselor,
+        bunk=bunk,
+        start_date=TODAY - timedelta(days=30),
+        end_date=TODAY - timedelta(days=1),
+    )
+    request = rf.get("/fake/")
+    request.user = counselor
+    response = get_auth_status(request)
+    import json
+    data = json.loads(response.content)
+    assert data["user"]["bunks"] == []
+
+
+@pytest.mark.django_db
+def test_unit_head_units_use_unit_staff_assignment(rf, unit_head, unit):
+    UnitStaffAssignment.objects.create(
+        unit=unit,
+        staff_member=unit_head,
+        role="unit_head",
+        start_date=TODAY - timedelta(days=7),
+    )
+    request = rf.get("/fake/")
+    request.user = unit_head
+    response = get_auth_status(request)
+    import json
+    data = json.loads(response.content)
+    assert data["isAuthenticated"] is True
+    assert len(data["user"]["units"]) == 1
+    assert data["user"]["units"][0]["id"] == str(unit.id)
+    assert data["user"]["units"][0]["name"] == unit.name
+
+
+@pytest.mark.django_db
+def test_unit_head_expired_assignment_not_included(rf, unit_head, unit):
+    UnitStaffAssignment.objects.create(
+        unit=unit,
+        staff_member=unit_head,
+        role="unit_head",
+        start_date=TODAY - timedelta(days=30),
+        end_date=TODAY - timedelta(days=1),
+    )
+    request = rf.get("/fake/")
+    request.user = unit_head
+    response = get_auth_status(request)
+    import json
+    data = json.loads(response.content)
+    assert data["user"]["units"] == []


### PR DESCRIPTION
## Summary

- `UserSerializer.get_bunks`: replaced `obj.assigned_bunks.filter(is_active=True)` with a date-bounded `CounselorBunkAssignment` query
- `UserSerializer.get_units`: replaced `obj.managed_units.all()` with a date-bounded `UnitStaffAssignment` query
- `config/auth_api.py` `get_auth_status`: same replacements for both the Counselor and Unit Head branches
- `bunk_logs/bunklogs/admin.py`: replaced `assigned_bunks__unit_id__in` with `bunk_assignments__bunk__unit_id__in` (the correct reverse relation on `CounselorBunkAssignment`)

Also adds top-level imports for `CounselorBunkAssignment`, `UnitStaffAssignment`, `Q`, and `timezone` in both fixed files so the logic is explicit at the module level rather than buried in method bodies.

## Files changed

| File | Change |
|---|---|
| `bunk_logs/users/serializers.py` | Fix both `get_bunks` and `get_units` methods |
| `config/auth_api.py` | Fix Counselor and Unit Head branches of `get_auth_status` |
| `bunk_logs/bunklogs/admin.py` | Fix counselor filter in StaffLog admin queryset |
| `bunk_logs/users/tests/test_serializers.py` | New — 6 tests covering serializer bunks/units with active and expired assignments |
| `config/tests/test_auth_api.py` | New — 5 tests covering `get_auth_status` for all roles |

## Test plan

- [x] `make test-backend` — 126 passed, 0 failed
- [x] `ruff check` on all changed files — All checks passed

Made with [Cursor](https://cursor.com)