### PR TITLE
1_6_migrate_api_endpoints: Consolidate API endpoints under /api/v1/

### DIFF
--- a/backend/bunk_logs/api/tests/test_permissions.py
+++ b/backend/bunk_logs/api/tests/test_permissions.py
@@ -71,28 +71,28 @@ class CounselorPermissionsTest(TestCase):
     def test_counselor_can_access_own_bunk(self):
         """Test that a counselor can access their own bunk's data"""
         self.client.force_authenticate(user=self.counselor1)
-        url = reverse("bunklog-by-date", kwargs={"bunk_id": self.bunk.id, "date": "2025-06-15"})
+        url = reverse("api:bunklog-by-date", kwargs={"bunk_id": self.bunk.id, "date": "2025-06-15"})
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
 
     def test_counselor_cannot_access_other_bunk(self):
         """Test that a counselor cannot access another bunk's data"""
         self.client.force_authenticate(user=self.counselor2)
-        url = reverse("bunklog-by-date", kwargs={"bunk_id": self.bunk.id, "date": "2025-06-15"})
+        url = reverse("api:bunklog-by-date", kwargs={"bunk_id": self.bunk.id, "date": "2025-06-15"})
         response = self.client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_admin_can_access_any_bunk(self):
         """Test that an admin can access any bunk's data"""
         self.client.force_authenticate(user=self.admin)
-        url = reverse("bunklog-by-date", kwargs={"bunk_id": self.bunk.id, "date": "2025-06-15"})
+        url = reverse("api:bunklog-by-date", kwargs={"bunk_id": self.bunk.id, "date": "2025-06-15"})
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
 
     def test_counselor_can_create_log_for_own_bunk(self):
         """Test that a counselor can create a log for their own bunk"""
         self.client.force_authenticate(user=self.counselor1)
-        url = reverse("bunklog-list")  # Assuming you have a named URL pattern
+        url = reverse("api:bunklog-list")
         data = {
             "date": date.today().isoformat(),
             "bunk_assignment": self.assignment.id,
@@ -110,7 +110,7 @@ class CounselorPermissionsTest(TestCase):
     def test_counselor_cannot_create_log_for_other_bunk(self):
         """Test that a counselor cannot create a log for another bunk"""
         self.client.force_authenticate(user=self.counselor2)
-        url = reverse("bunklog-list")
+        url = reverse("api:bunklog-list")
         data = {
             "date": date.today().isoformat(),
             "bunk_assignment": self.assignment.id,

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -2,11 +2,16 @@ from django.urls import include
 from django.urls import path
 from rest_framework.routers import DefaultRouter
 
+from bunk_logs.users.api.views import UserViewSet
+
 from . import views
 
 router = DefaultRouter()
-router.register(r"users", views.UserDetailsView, basename="user")
-# Add other viewsets to the router
+
+# Users
+router.register(r"users", UserViewSet, basename="user")
+
+# Core bunk logs
 router.register(r"bunks", views.BunkViewSet, basename="bunk")
 router.register(r"units", views.UnitViewSet, basename="unit")
 router.register(r"unit-staff-assignments", views.UnitStaffAssignmentViewSet, basename="unit-staff-assignment")
@@ -14,37 +19,43 @@ router.register(r"campers", views.CamperViewSet, basename="camper")
 router.register(r"camper-bunk-assignments", views.CamperBunkAssignmentViewSet, basename="camper-bunk-assignment")
 router.register(r"bunklogs", views.BunkLogViewSet, basename="bunklog")
 router.register(r"counselorlogs", views.CounselorLogViewSet, basename="counselorlog")
-# router.register(r'orders', views.OrderViewSet, basename='order')
-# router.register(r'items', views.ItemViewSet, basename='item')
+
+# Ordering system
+router.register(r"orders", views.OrderViewSet, basename="order")
+router.register(r"items", views.ItemViewSet, basename="item")
+router.register(r"item-categories", views.ItemCategoryViewSet, basename="item-category")
+router.register(r"order-types", views.OrderTypeViewSet, basename="order-type")
 
 urlpatterns = [
     path("", include(router.urls)),
-    # Add a URL pattern for an individual bunk
-    path("bunk/<str:id>/", views.BunkViewSet.as_view({"get": "retrieve"}), name="bunk-detail"),
 
-    # User registration endpoint
+    # Non-standard bunk detail path used by BunkCard.jsx — kept for compat while
+    # callers are migrated to the standard /bunks/{id}/ route
+    path("bunk/<str:id>/", views.BunkViewSet.as_view({"get": "retrieve"}), name="bunk-detail-compat"),
+
+    # User registration (public)
     path("users/create/", views.UserCreate.as_view(), name="user-create"),
 
-    # Add dedicated endpoint for email-based user retrieval
+    # User lookup by email (used by several frontend components)
     path("users/email/<str:email>/", views.get_user_by_email, name="user-by-email"),
-    # Add a URL pattern for the BunkLogsInfoByDateViewSet
-    path("users/<str:user_id>", views.get_user_by_id, name="user-by-id"),
 
-    # Bunklogs by date endpoint - returns all bunklogs for a specific date (must come before bunk-specific endpoint)
-    path("bunklogs/all/<str:date>/", views.BunkLogsAllByDateViewSet.as_view(), name="bunklogs-all-by-date"),
+    # Messaging system
+    path("messaging/", include("bunk_logs.messaging.urls")),
 
+    # Ordering system helpers
+    path("order-types/<int:order_type_id>/items/", views.get_items_for_order_type, name="order-type-items"),
+    path("orders/statistics/", views.get_order_statistics, name="order-statistics"),
+
+    # Bunk-log date-scoped views
+    path("bunklogs/all/<str:date>/", views.BunkLogsAllByDateViewSet.as_view(), name="all-bunk-logs-by-date"),
     path("bunklogs/<str:bunk_id>/logs/<str:date>/", views.BunkLogsInfoByDateViewSet.as_view(), name="bunklog-by-date"),
-    # URL for camper bunk logs
+
+    # Camper logs history
     path("campers/<str:camper_id>/logs/", views.CamperBunkLogViewSet.as_view(), name="camper-bunklogs"),
 
-    # Unit Head and Camper Care endpoints
+    # Unit head and camper care dashboard endpoints
     path("unithead/<str:unithead_id>/<str:date>/", views.get_unit_head_bunks, name="unit-head-bunks"),
     path("campercare/<str:camper_care_id>/<str:date>/", views.get_camper_care_bunks, name="camper-care-bunks"),
-
-    # Debug endpoints
-    path("debug/user-bunks/", views.debug_user_bunks, name="debug-user-bunks"),
-    path("debug/fix-social-apps/", views.FixSocialAppsView.as_view(), name="fix-social-apps"),
-    path("debug/auth/", views.auth_debug_view, name="auth-debug"),
 ]
 
-
+app_name = "api"

--- a/backend/bunk_logs/bunklogs/tests/test_staff_logs.py
+++ b/backend/bunk_logs/bunklogs/tests/test_staff_logs.py
@@ -261,7 +261,7 @@ class TestStaffLogAPI(TestCase):
 
     def setUp(self):
         self.client = APIClient()
-        self.list_url = reverse("counselorlog-list")
+        self.list_url = reverse("api:counselorlog-list")
 
         self.admin = UserFactory(admin=True, is_staff=True)
         self.counselor1 = UserFactory(counselor=True)
@@ -367,7 +367,7 @@ class TestStaffLogAPI(TestCase):
 
     def test_counselor_can_retrieve_own_log(self):
         self.client.force_authenticate(user=self.counselor1)
-        url = reverse("counselorlog-detail", kwargs={"pk": self.counselor1_log.pk})
+        url = reverse("api:counselorlog-detail", kwargs={"pk": self.counselor1_log.pk})
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
 
@@ -375,19 +375,19 @@ class TestStaffLogAPI(TestCase):
 
     def test_counselor_can_update_own_log_same_day(self):
         self.client.force_authenticate(user=self.counselor1)
-        url = reverse("counselorlog-detail", kwargs={"pk": self.counselor1_log.pk})
+        url = reverse("api:counselorlog-detail", kwargs={"pk": self.counselor1_log.pk})
         response = self.client.patch(url, {"elaboration": "Updated text."}, format="json")
         assert response.status_code == status.HTTP_200_OK
 
     def test_leadership_can_update_own_log_same_day(self):
         self.client.force_authenticate(user=self.leader)
-        url = reverse("counselorlog-detail", kwargs={"pk": self.leader_log.pk})
+        url = reverse("api:counselorlog-detail", kwargs={"pk": self.leader_log.pk})
         response = self.client.patch(url, {"elaboration": "Updated leadership text."}, format="json")
         assert response.status_code == status.HTTP_200_OK
 
     def test_kitchen_staff_can_update_own_log_same_day(self):
         self.client.force_authenticate(user=self.kitchen)
-        url = reverse("counselorlog-detail", kwargs={"pk": self.kitchen_log.pk})
+        url = reverse("api:counselorlog-detail", kwargs={"pk": self.kitchen_log.pk})
         response = self.client.patch(url, {"elaboration": "Updated kitchen text."}, format="json")
         assert response.status_code == status.HTTP_200_OK
 
@@ -398,26 +398,26 @@ class TestStaffLogAPI(TestCase):
             created_at=timezone.now() - timedelta(days=1),
         )
         self.client.force_authenticate(user=self.counselor1)
-        url = reverse("counselorlog-detail", kwargs={"pk": self.counselor1_log.pk})
+        url = reverse("api:counselorlog-detail", kwargs={"pk": self.counselor1_log.pk})
         response = self.client.patch(url, {"elaboration": "Too late."}, format="json")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_admin_can_update_any_log(self):
         self.client.force_authenticate(user=self.admin)
-        url = reverse("counselorlog-detail", kwargs={"pk": self.counselor1_log.pk})
+        url = reverse("api:counselorlog-detail", kwargs={"pk": self.counselor1_log.pk})
         response = self.client.patch(url, {"elaboration": "Admin update."}, format="json")
         assert response.status_code == status.HTTP_200_OK
 
     def test_counselor_cannot_update_another_counselors_log(self):
         self.client.force_authenticate(user=self.counselor2)
-        url = reverse("counselorlog-detail", kwargs={"pk": self.counselor1_log.pk})
+        url = reverse("api:counselorlog-detail", kwargs={"pk": self.counselor1_log.pk})
         response = self.client.patch(url, {"elaboration": "Sneaky edit."}, format="json")
         # counselor2 cannot see counselor1's log so should get 404
         assert response.status_code in (status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND)
 
     def test_unit_head_cannot_edit_staff_log(self):
         self.client.force_authenticate(user=self.unit_head)
-        url = reverse("counselorlog-detail", kwargs={"pk": self.counselor1_log.pk})
+        url = reverse("api:counselorlog-detail", kwargs={"pk": self.counselor1_log.pk})
         response = self.client.patch(url, {"elaboration": "Unit head edit attempt."}, format="json")
         assert response.status_code in (status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND)
 
@@ -425,7 +425,7 @@ class TestStaffLogAPI(TestCase):
 
     def test_response_includes_staff_member_fields(self):
         self.client.force_authenticate(user=self.counselor1)
-        url = reverse("counselorlog-detail", kwargs={"pk": self.counselor1_log.pk})
+        url = reverse("api:counselorlog-detail", kwargs={"pk": self.counselor1_log.pk})
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
         assert "staff_member" in response.data
@@ -435,7 +435,7 @@ class TestStaffLogAPI(TestCase):
     def test_response_includes_legacy_counselor_fields(self):
         """Backward-compat: frontend still expects counselor_* fields."""
         self.client.force_authenticate(user=self.counselor1)
-        url = reverse("counselorlog-detail", kwargs={"pk": self.counselor1_log.pk})
+        url = reverse("api:counselorlog-detail", kwargs={"pk": self.counselor1_log.pk})
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
         assert "counselor" in response.data
@@ -474,7 +474,7 @@ class TestStaffLogQueryCount(TestCase):
         from datetime import timedelta
 
         self.client = APIClient()
-        self.list_url = reverse("counselorlog-list")
+        self.list_url = reverse("api:counselorlog-list")
         self.admin = UserFactory(admin=True, is_staff=True)
         self.counselor = UserFactory(counselor=True)
 
@@ -541,7 +541,7 @@ class TestStaffLogResultLimit(TestCase):
         from datetime import timedelta
 
         self.client = APIClient()
-        self.list_url = reverse("counselorlog-list")
+        self.list_url = reverse("api:counselorlog-list")
         self.admin = UserFactory(admin=True, is_staff=True)
         self.counselor = UserFactory(counselor=True)
 

--- a/backend/bunk_logs/users/tests/api/test_urls.py
+++ b/backend/bunk_logs/users/tests/api/test_urls.py
@@ -6,16 +6,16 @@ from bunk_logs.users.models import User
 
 def test_user_detail(user: User):
     assert (
-        reverse("api:user-detail", kwargs={"pk": user.pk}) == f"/api/users/{user.pk}/"
+        reverse("api:user-detail", kwargs={"pk": user.pk}) == f"/api/v1/users/{user.pk}/"
     )
-    assert resolve(f"/api/users/{user.pk}/").view_name == "api:user-detail"
+    assert resolve(f"/api/v1/users/{user.pk}/").view_name == "api:user-detail"
 
 
 def test_user_list():
-    assert reverse("api:user-list") == "/api/users/"
-    assert resolve("/api/users/").view_name == "api:user-list"
+    assert reverse("api:user-list") == "/api/v1/users/"
+    assert resolve("/api/v1/users/").view_name == "api:user-list"
 
 
 def test_user_me():
-    assert reverse("api:user-me") == "/api/users/me/"
-    assert resolve("/api/users/me/").view_name == "api:user-me"
+    assert reverse("api:user-me") == "/api/v1/users/me/"
+    assert resolve("/api/v1/users/me/").view_name == "api:user-me"

--- a/backend/config/api_router.py
+++ b/backend/config/api_router.py
@@ -1,77 +1,91 @@
-from django.conf import settings
-from django.urls import include
+"""
+config/api_router.py — redirect shim only.
+
+All data endpoints have been consolidated under /api/v1/ (bunk_logs/api/urls.py).
+This module keeps the old /api/<resource>/ paths alive as 302 redirects so that
+any bookmark or cached call still resolves, but the canonical URL is /api/v1/*.
+
+Once all callers (frontend + any external integrations) have been confirmed to
+use /api/v1/ exclusively, this file can be replaced with an empty urlpatterns=[].
+"""
+
+from django.http import HttpResponseRedirect
 from django.urls import path
-from rest_framework.routers import DefaultRouter
-from rest_framework.routers import SimpleRouter
+from django.urls import re_path
 
-from bunk_logs.api.views import BunkLogsAllByDateViewSet
-from bunk_logs.api.views import BunkLogsInfoByDateViewSet  # API views for specific endpoints
-from bunk_logs.api.views import BunkLogViewSet
-from bunk_logs.api.views import BunkViewSet
-from bunk_logs.api.views import CamperBunkAssignmentViewSet
-from bunk_logs.api.views import CamperBunkLogViewSet
-from bunk_logs.api.views import CamperViewSet
-from bunk_logs.api.views import CounselorLogViewSet
-from bunk_logs.api.views import FixSocialAppsView
-from bunk_logs.api.views import ItemCategoryViewSet
-from bunk_logs.api.views import ItemViewSet
-from bunk_logs.api.views import OrderTypeViewSet
-from bunk_logs.api.views import OrderViewSet  # Ordering system views
-from bunk_logs.api.views import UnitStaffAssignmentViewSet
-from bunk_logs.api.views import UnitViewSet  # Core bunk logs views
-from bunk_logs.api.views import UserDetailsView
-from bunk_logs.api.views import debug_user_bunks
-from bunk_logs.api.views import get_camper_care_bunks
-from bunk_logs.api.views import get_items_for_order_type
-from bunk_logs.api.views import get_order_statistics
-from bunk_logs.api.views import get_unit_head_bunks
-from bunk_logs.api.views import get_user_by_email
-from bunk_logs.users.api.views import UserViewSet
 
-router = DefaultRouter() if settings.DEBUG else SimpleRouter()
+def _r(v1_path):
+    """Return a redirect view function targeting /api/v1/<v1_path>."""
+    def view(request, **kwargs):
+        target = f"/api/v1/{v1_path.format(**kwargs)}"
+        qs = request.META.get("QUERY_STRING", "")
+        if qs:
+            target = f"{target}?{qs}"
+        return HttpResponseRedirect(target)
+    return view
 
-# User management
-router.register("users", UserViewSet, basename="user")
 
-# Core bunk logs functionality
-router.register("units", UnitViewSet, basename="unit")
-router.register("unit-staff-assignments", UnitStaffAssignmentViewSet, basename="unit-staff-assignment")
-router.register("bunks", BunkViewSet, basename="bunk")
-router.register("campers", CamperViewSet, basename="camper")
-router.register("camper-bunk-assignments", CamperBunkAssignmentViewSet, basename="camper-bunk-assignment")
-router.register("bunk-logs", BunkLogViewSet, basename="bunk-log")
-router.register("counselor-logs", CounselorLogViewSet, basename="counselor-log")
+urlpatterns = [
+    # --- Users ---
+    path("users/", _r("users/"), name="redirect-users-list"),
+    re_path(r"^users/(?P<pk>[^/]+)/$", _r("users/{pk}/"), name="redirect-users-detail"),
+    path("users/me/", _r("users/me/"), name="redirect-users-me"),
+    re_path(r"^users/email/(?P<email>[^/]+)/$", _r("users/email/{email}/"), name="redirect-users-by-email"),
 
-# Ordering system
-router.register("orders", OrderViewSet, basename="order")
-router.register("items", ItemViewSet, basename="item")
-router.register("item-categories", ItemCategoryViewSet, basename="item-category")
-router.register("order-types", OrderTypeViewSet, basename="order-type")
+    # --- Bunks ---
+    path("bunks/", _r("bunks/"), name="redirect-bunks-list"),
+    re_path(r"^bunks/(?P<pk>[^/]+)/$", _r("bunks/{pk}/"), name="redirect-bunks-detail"),
+    re_path(r"^bunk/(?P<id>[^/]+)/$", _r("bunk/{id}/"), name="redirect-bunk-detail-alt"),
 
-# Custom URL patterns for additional endpoints
-custom_urlpatterns = [
-    # Messaging system
-    path("messaging/", include("bunk_logs.messaging.urls")),
+    # --- Units ---
+    path("units/", _r("units/"), name="redirect-units-list"),
+    re_path(r"^units/(?P<pk>[^/]+)/$", _r("units/{pk}/"), name="redirect-units-detail"),
 
-    # Ordering system endpoints
-    path("order-types/<int:order_type_id>/items/", get_items_for_order_type, name="order-type-items"),
-    path("orders/statistics/", get_order_statistics, name="order-statistics"),
+    # --- Unit staff assignments ---
+    path("unit-staff-assignments/", _r("unit-staff-assignments/"), name="redirect-usa-list"),
+    re_path(r"^unit-staff-assignments/(?P<pk>[^/]+)/$", _r("unit-staff-assignments/{pk}/"), name="redirect-usa-detail"),
 
-    # Bunk logs specific endpoints
-    path("bunklogs/<str:bunk_id>/logs/<str:date>/", BunkLogsInfoByDateViewSet.as_view(), name="bunk-logs-by-date"),
-    path("bunklogs/all/<str:date>/", BunkLogsAllByDateViewSet.as_view(), name="all-bunk-logs-by-date"),
-    path("campers/<str:camper_id>/logs/", CamperBunkLogViewSet.as_view(), name="camper-bunk-logs"),
+    # --- Campers ---
+    path("campers/", _r("campers/"), name="redirect-campers-list"),
+    re_path(r"^campers/(?P<pk>[^/]+)/$", _r("campers/{pk}/"), name="redirect-campers-detail"),
+    re_path(r"^campers/(?P<camper_id>[^/]+)/logs/$", _r("campers/{camper_id}/logs/"), name="redirect-camper-logs"),
 
-    # User and staff management endpoints
-    path("users/email/<str:email>/", get_user_by_email, name="user-by-email"),
-    path("users/details/", UserDetailsView.as_view({"get": "list"}), name="user-details"),
-    path("debug/user-bunks/", debug_user_bunks, name="debug-user-bunks"),
-    path("debug/fix-social-apps/", FixSocialAppsView.as_view(), name="fix-social-apps"),
+    # --- Camper bunk assignments ---
+    path("camper-bunk-assignments/", _r("camper-bunk-assignments/"), name="redirect-cba-list"),
+    re_path(r"^camper-bunk-assignments/(?P<pk>[^/]+)/$", _r("camper-bunk-assignments/{pk}/"), name="redirect-cba-detail"),
 
-    # Unit and staff specific endpoints
-    path("unithead/<str:unithead_id>/<str:date>/", get_unit_head_bunks, name="unit-head-bunks"),
-    path("campercare/<str:camper_care_id>/<str:date>/", get_camper_care_bunks, name="camper-care-bunks"),
+    # --- Bunk logs ---
+    path("bunk-logs/", _r("bunklogs/"), name="redirect-bunk-logs-list"),
+    re_path(r"^bunk-logs/(?P<pk>[^/]+)/$", _r("bunklogs/{pk}/"), name="redirect-bunk-logs-detail"),
+    re_path(r"^bunklogs/all/(?P<date>[^/]+)/$", _r("bunklogs/all/{date}/"), name="redirect-bunklogs-all"),
+    re_path(r"^bunklogs/(?P<bunk_id>[^/]+)/logs/(?P<date>[^/]+)/$", _r("bunklogs/{bunk_id}/logs/{date}/"), name="redirect-bunklogs-by-date"),
+
+    # --- Counselor logs ---
+    path("counselor-logs/", _r("counselorlogs/"), name="redirect-counselor-logs-list"),
+    re_path(r"^counselor-logs/(?P<pk>[^/]+)/$", _r("counselorlogs/{pk}/"), name="redirect-counselor-logs-detail"),
+
+    # --- Orders (previously only on /api/, now on /api/v1/) ---
+    path("orders/", _r("orders/"), name="redirect-orders-list"),
+    path("orders/statistics/", _r("orders/statistics/"), name="redirect-orders-stats"),
+    re_path(r"^orders/(?P<pk>[^/]+)/$", _r("orders/{pk}/"), name="redirect-orders-detail"),
+
+    # --- Items ---
+    path("items/", _r("items/"), name="redirect-items-list"),
+    re_path(r"^items/(?P<pk>[^/]+)/$", _r("items/{pk}/"), name="redirect-items-detail"),
+
+    # --- Item categories ---
+    path("item-categories/", _r("item-categories/"), name="redirect-item-cats-list"),
+    re_path(r"^item-categories/(?P<pk>[^/]+)/$", _r("item-categories/{pk}/"), name="redirect-item-cats-detail"),
+
+    # --- Order types ---
+    path("order-types/", _r("order-types/"), name="redirect-order-types-list"),
+    re_path(r"^order-types/(?P<pk>[^/]+)/$", _r("order-types/{pk}/"), name="redirect-order-types-detail"),
+    re_path(r"^order-types/(?P<order_type_id>[^/]+)/items/$", _r("order-types/{order_type_id}/items/"), name="redirect-order-type-items"),
+
+    # --- Messaging ---
+    re_path(r"^messaging/(?P<rest>.*)$", _r("messaging/{rest}"), name="redirect-messaging"),
+
+    # --- Unit head / camper care dashboards ---
+    re_path(r"^unithead/(?P<unithead_id>[^/]+)/(?P<date>[^/]+)/$", _r("unithead/{unithead_id}/{date}/"), name="redirect-unithead"),
+    re_path(r"^campercare/(?P<camper_care_id>[^/]+)/(?P<date>[^/]+)/$", _r("campercare/{camper_care_id}/{date}/"), name="redirect-campercare"),
 ]
-
-app_name = "api"
-urlpatterns = router.urls + custom_urlpatterns

--- a/docs/api-consolidation-plan.md
+++ b/docs/api-consolidation-plan.md
@@ -1,0 +1,205 @@
+# API Consolidation Plan
+
+## Background
+
+The codebase has two parallel API trees:
+
+- **`/api/`** — registered via `config/api_router.py` (mounted at `path("api/", include("config.api_router"))`)
+- **`/api/v1/`** — registered via `bunk_logs/api/urls.py` (mounted at `path("api/v1/", include("bunk_logs.api.urls"))`)
+
+Both trees import from the same viewset classes in `bunk_logs/api/views.py`, so there is no functional divergence — only URL-level duplication and naming inconsistency (`bunk-logs` vs `bunklogs`, etc.).
+
+Additional top-level endpoints outside both trees live directly in `config/urls.py` (auth, schema, CSRF, Google OAuth).
+
+**Target state**: all data endpoints live under `/api/v1/`. The `/api/` router retains only endpoints with no `/api/v1/` counterpart until those are individually migrated.
+
+---
+
+## Inventory
+
+### Authentication & Session
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/auth/token/` | — | `CustomTokenObtainPairView` | POST | Yes (`Signin.jsx`) | No | KEEP; move to `api/v1/auth/token/` in a future PR |
+| `api/auth/token/refresh/` | — | `TokenRefreshView` | POST | Yes (`api.js`) | No | KEEP; move to `api/v1/auth/token/refresh/` in a future PR |
+| `api/auth/token/verify/` | — | `TokenVerifyView` | POST | No | No | KEEP with refresh migration |
+| `api/auth-token/` | — | `obtain_auth_token` (DRF session token) | POST | No | No | DELETE — superseded by JWT; not called anywhere in the frontend |
+| `api/auth/google/` | — | `google_login` | GET | Yes (`GoogleLoginButton.jsx`) | No | KEEP at current path (OAuth redirect URI is registered) |
+| `api/auth/google/callback/` | — | `google_callback` | GET | No (server-side callback) | No | KEEP at current path |
+| `api/auth/google/callback/token/` | — | `google_login_callback` | GET | No (server-side) | No | KEEP at current path |
+| `api/get-csrf-token/` | — | `get_csrf_token` | GET | Yes (`api.js`) | No | KEEP; rename to `api/v1/csrf-token/` in a future PR |
+
+### Users
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/users/` | `api/v1/users/` | `/api/`: `UserViewSet` (users/api/views); `/api/v1/`: `UserDetailsView` (ReadOnly) | GET, POST | No (neither path hit directly) | No | `/api/` version is richer (staff-filtered list). MIGRATE: expose `UserViewSet` under `/api/v1/users/` and delete `/api/users/`. The `/api/v1/users/` currently maps to the wrong class (`UserDetailsView` returns current user only). |
+| `api/users/{id}/` | `api/v1/users/{id}/` | Same divergence as above | GET | No | No | MIGRATE (same as above) |
+| `api/users/me/` | — | `UserViewSet.me` | GET | No (uses email lookup instead) | No | MIGRATE to `api/v1/users/me/` |
+| `api/users/details/` | — | `UserDetailsView.list` | GET | No (superseded by email lookup) | No | DELETE — redundant; callers use `/api/v1/users/email/{email}/` |
+| `api/users/email/{email}/` | `api/v1/users/email/{email}/` | `get_user_by_email` | GET | Yes (`UserInfo.jsx`, `BunkGrid.jsx`, `AuthContext.jsx`) | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| — | `api/v1/users/create/` | `UserCreate` (registration) | POST | Yes (`Signup.jsx`) | No | KEEP under `/api/v1/` |
+| — | `api/v1/users/{user_id}` | `get_user_by_id` (no trailing slash) | GET | No | No | DELETE — missing trailing slash, no frontend caller; functionality covered by `/api/v1/users/email/{email}/` and `UserViewSet` |
+
+### Bunks
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/bunks/` | `api/v1/bunks/` | `BunkViewSet` (same class) | GET, POST | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/bunks/{id}/` | `api/v1/bunks/{id}/` | `BunkViewSet` (same class) | GET, PUT, PATCH, DELETE | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| — | `api/v1/bunk/{id}/` | `BunkViewSet.retrieve` (non-standard path) | GET | Yes (`BunkCard.jsx` calls `/api/v1/bunk/${bunk_id}`) | No | KEEP temporarily (active frontend caller); add to `/api/v1/bunks/{id}/` eventually and update `BunkCard.jsx` to use standard path, then DELETE |
+
+### Units
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/units/` | `api/v1/units/` | `UnitViewSet` (same class) | GET, POST | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/units/{id}/` | `api/v1/units/{id}/` | `UnitViewSet` (same class) | GET, PUT, PATCH, DELETE | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/units/{id}/assign_staff/` | — | `UnitViewSet.assign_staff` | POST | No | No | MIGRATE to `/api/v1/units/{id}/assign_staff/` |
+| `api/units/{id}/remove_staff/` | — | `UnitViewSet.remove_staff` | DELETE | No | No | MIGRATE to `/api/v1/units/{id}/remove_staff/` |
+
+### Unit Staff Assignments
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/unit-staff-assignments/` | `api/v1/unit-staff-assignments/` | `UnitStaffAssignmentViewSet` (same class) | GET, POST | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/unit-staff-assignments/{id}/` | `api/v1/unit-staff-assignments/{id}/` | `UnitStaffAssignmentViewSet` (same class) | GET, PUT, PATCH, DELETE | Yes — `/api/v1/unit-staff-assignments/${userId}/` (`api.js`, `BunkDashboard.jsx`) | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+
+### Campers
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/campers/` | `api/v1/campers/` | `CamperViewSet` (same class) | GET, POST | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/campers/{id}/` | `api/v1/campers/{id}/` | `CamperViewSet` (same class) | GET, PUT, PATCH, DELETE | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/campers/{camper_id}/logs/` | `api/v1/campers/{camper_id}/logs/` | `CamperBunkLogViewSet` (same class) | GET | Yes — `/api/v1/campers/${camper_id}/logs` (`CamperDashboard.jsx`, note: no trailing slash in call site) | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+
+### Camper Bunk Assignments
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/camper-bunk-assignments/` | `api/v1/camper-bunk-assignments/` | `CamperBunkAssignmentViewSet` (same class) | GET, POST | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/camper-bunk-assignments/{id}/` | `api/v1/camper-bunk-assignments/{id}/` | `CamperBunkAssignmentViewSet` (same class) | GET, PUT, PATCH, DELETE | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+
+### Bunk Logs
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/bunk-logs/` | `api/v1/bunklogs/` | `BunkLogViewSet` (same class, different URL slug) | GET, POST | Yes — `/api/v1/bunklogs/` (`BunkLogForm.jsx` POST) | No | KEEP `/api/v1/` version; DELETE `/api/bunk-logs/` |
+| `api/bunk-logs/{id}/` | `api/v1/bunklogs/{id}/` | `BunkLogViewSet` (same class) | GET, PUT, PATCH, DELETE | Yes — `/api/v1/bunklogs/${id}/` (`BunkLogForm.jsx` PUT) | No | KEEP `/api/v1/` version; DELETE `/api/bunk-logs/{id}/` |
+| `api/bunklogs/{bunk_id}/logs/{date}/` | `api/v1/bunklogs/{bunk_id}/logs/{date}/` | `BunkLogsInfoByDateViewSet` (same class) | GET | Yes — `/api/v1/bunklogs/${bunk_id}/logs/${date}/` (`CamperList.jsx`, `BunkLogForm.jsx`) | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/bunklogs/all/{date}/` | `api/v1/bunklogs/all/{date}/` | `BunkLogsAllByDateViewSet` (same class) | GET | Yes — `/api/v1/bunklogs/all/${date}/` (`AdminBunkLogs.jsx`) | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+
+### Counselor / Staff Logs
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/counselor-logs/` | `api/v1/counselorlogs/` | `CounselorLogViewSet` (same class, different URL slug) | GET, POST | Yes — `/api/v1/counselorlogs/` (`CounselorDashboard.jsx`, `StaffMemberHistory.jsx`, `CounselorLogForm.jsx`) | No | KEEP `/api/v1/` version; DELETE `/api/counselor-logs/` |
+| `api/counselor-logs/{id}/` | `api/v1/counselorlogs/{id}/` | `CounselorLogViewSet` (same class) | GET, PUT, PATCH, DELETE | Yes — `/api/v1/counselorlogs/${id}/` (`CounselorLogForm.jsx` PUT) | No | KEEP `/api/v1/` version; DELETE `/api/counselor-logs/{id}/` |
+| — | `api/v1/counselorlogs/{date}/` | `CounselorLogViewSet.by_date` (@action) | GET | Yes — `/api/v1/counselorlogs/${date}/` (`UnitHeadBunkGrid.jsx`, `AdminDashboard.jsx`) | No | KEEP under `/api/v1/` |
+
+### Unit Head & Camper Care Dashboard
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/unithead/{unithead_id}/{date}/` | `api/v1/unithead/{unithead_id}/{date}/` | `get_unit_head_bunks` (same function) | GET | Yes — `/api/v1/unithead/${user.id}/${date}/` (`UnitHeadBunkGrid.jsx`) | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/campercare/{camper_care_id}/{date}/` | `api/v1/campercare/{camper_care_id}/{date}/` | `get_camper_care_bunks` (same function) | GET | Yes — `/api/v1/campercare/${user.id}/${date}/` (`CamperCareBunkLogsList.jsx`, `CamperCareNeedsAttentionList.jsx`, `CamperCareBunkGrid.jsx`) | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+
+### CSV Import
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| — | — (not registered in either router) | `UnitStaffAssignmentCSVImportView` (defined but no URL) | POST | No | No | DELETE the class or register at `api/v1/unit-staff-assignments/import/` if needed |
+
+### Orders
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/orders/` | — | `OrderViewSet` | GET, POST | Yes (`Orders.jsx`, `OrdersList.jsx`, `CreateOrderModal.jsx`) | No | MIGRATE to `/api/v1/orders/` and update frontend callers |
+| `api/orders/{id}/` | — | `OrderViewSet` | GET, PUT, PATCH, DELETE | Yes (`OrderDetail.jsx`, `OrderEdit.jsx`, `BunkOrderDetail.jsx`, `BunkOrderEdit.jsx`, `StatusDropdown.jsx`) | No | MIGRATE to `/api/v1/orders/{id}/` and update frontend callers |
+| `api/orders/statistics/` | — | `get_order_statistics` | GET | No | No | MIGRATE to `/api/v1/orders/statistics/` |
+| `api/items/` | — | `ItemViewSet` | GET, POST | Yes (`OrderEdit.jsx` — `?order_type=…` filter) | No | MIGRATE to `/api/v1/items/` |
+| `api/items/{id}/` | — | `ItemViewSet` | GET, PUT, PATCH, DELETE | No | No | MIGRATE to `/api/v1/items/{id}/` |
+| `api/item-categories/` | — | `ItemCategoryViewSet` | GET, POST | No | No | MIGRATE to `/api/v1/item-categories/` |
+| `api/item-categories/{id}/` | — | `ItemCategoryViewSet` | GET, PUT, PATCH, DELETE | No | No | MIGRATE to `/api/v1/item-categories/{id}/` |
+| `api/order-types/` | — | `OrderTypeViewSet` | GET, POST | Yes (`OrderFilters.jsx`, `CreateOrderModal.jsx`, `OrderEdit.jsx`) | No | MIGRATE to `/api/v1/order-types/` |
+| `api/order-types/{id}/` | — | `OrderTypeViewSet` | GET, PUT, PATCH, DELETE | No | No | MIGRATE to `/api/v1/order-types/{id}/` |
+| `api/order-types/{id}/items/` | — | `get_items_for_order_type` | GET | Yes (`BunkOrderEdit.jsx`, `CreateOrderModal.jsx`) | No | MIGRATE to `/api/v1/order-types/{id}/items/` |
+
+### Messaging
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/messaging/templates/` | — | `EmailTemplateViewSet` | GET, POST, PUT, PATCH, DELETE | Unknown | No | MIGRATE to `/api/v1/messaging/templates/` |
+| `api/messaging/recipient-groups/` | — | `EmailRecipientGroupViewSet` | GET, POST, PUT, PATCH, DELETE | Unknown | No | MIGRATE to `/api/v1/messaging/recipient-groups/` |
+| `api/messaging/recipients/` | — | `EmailRecipientViewSet` | GET, POST, PUT, PATCH, DELETE | Unknown | No | MIGRATE to `/api/v1/messaging/recipients/` |
+| `api/messaging/schedules/` | — | `EmailScheduleViewSet` | GET, POST, PUT, PATCH, DELETE | Unknown | No | MIGRATE to `/api/v1/messaging/schedules/` |
+| `api/messaging/logs/` | — | `EmailLogViewSet` | GET | Unknown | No | MIGRATE to `/api/v1/messaging/logs/` |
+| `api/messaging/preview/` | — | `EmailPreviewViewSet` | GET, POST | Unknown | No | MIGRATE to `/api/v1/messaging/preview/` |
+
+### Debug
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/debug/user-bunks/` | `api/v1/debug/user-bunks/` | `debug_user_bunks` (same function) | GET | No | No | DELETE both — debug-only, no active frontend caller |
+| `api/debug/fix-social-apps/` | `api/v1/debug/fix-social-apps/` | `FixSocialAppsView` (same class) | GET, POST | No | No | DELETE both — one-time diagnostic, shouldn't be a permanent endpoint |
+| — | `api/v1/debug/auth/` | `auth_debug_view` | GET | No | No | DELETE — debug-only |
+
+### Schema & Meta
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/schema/` | — | `SpectacularAPIView` | GET | No | No | KEEP for dev tooling |
+| `api/docs/` | — | `SpectacularSwaggerView` | GET | No | No | KEEP for dev tooling |
+| `api/migration-status/` | — | `migration_views.migration_status` | GET | No (internal monitoring) | No | KEEP at current path |
+
+---
+
+## Summary by Recommendation
+
+### KEEP under `/api/v1/` (already there, actively used)
+
+- `api/v1/unit-staff-assignments/{id}/`
+- `api/v1/bunklogs/`, `api/v1/bunklogs/{id}/`
+- `api/v1/bunklogs/{bunk_id}/logs/{date}/`
+- `api/v1/bunklogs/all/{date}/`
+- `api/v1/counselorlogs/`, `api/v1/counselorlogs/{id}/`, `api/v1/counselorlogs/{date}/`
+- `api/v1/unithead/{id}/{date}/`
+- `api/v1/campercare/{id}/{date}/`
+- `api/v1/users/email/{email}/`
+- `api/v1/users/create/`
+- `api/v1/campers/{id}/logs/`
+- `api/v1/bunk/{id}/` (keep temporarily; normalise to `api/v1/bunks/{id}/` + update `BunkCard.jsx`)
+
+### MIGRATE from `/api/` to `/api/v1/`
+
+- All ordering endpoints: `orders/`, `items/`, `item-categories/`, `order-types/`, `order-types/{id}/items/`, `orders/statistics/`
+- All messaging endpoints: `messaging/*`
+- Unit actions: `units/{id}/assign_staff/`, `units/{id}/remove_staff/`
+- Users list / me: `users/`, `users/{id}/`, `users/me/`
+- Auth tokens: `auth/token/`, `auth/token/refresh/`, `auth/token/verify/`
+- CSRF helper: `get-csrf-token/`
+
+### DELETE
+
+- `api/auth-token/` — DRF session token, superseded by JWT
+- `api/users/details/` — redundant (email-based lookup preferred)
+- `api/v1/users/{user_id}` — no trailing slash, no callers, duplicates email lookup
+- All `/api/` duplicates once the matching `/api/v1/` endpoint is the sole registered path
+- `api/debug/user-bunks/`, `api/v1/debug/user-bunks/`
+- `api/debug/fix-social-apps/`, `api/v1/debug/fix-social-apps/`
+- `api/v1/debug/auth/`
+
+---
+
+## Known Issues to Fix Alongside Migration
+
+1. **`/api/v1/users/` maps to `UserDetailsView` (wrong class)** — should map to the richer `UserViewSet` from `bunk_logs/users/api/views.py`. Currently `/api/v1/users/` is a `ReadOnlyModelViewSet` that only returns the calling user; the `/api/` version returns the full staff-filtered list.
+
+2. **`BunkCard.jsx` calls `/api/v1/bunk/${bunk_id}` (missing trailing slash)** — this succeeds only because Django's `APPEND_SLASH=True` issues a redirect. Should be normalised to `/api/v1/bunks/{id}/` once the standard router URL is confirmed to be live.
+
+3. **`CamperDashboard.jsx` calls `/api/v1/campers/${camper_id}/logs` (missing trailing slash)** — same issue as above.
+
+4. **`src/auth.jsx` contains dead API calls** — `/api/token/`, `/api/token/refresh/`, `/api/google/login/`, `/api/google/validate_token/` are not registered URLs and belong to an old auth flow. This file appears to be superseded by `AuthContext.jsx` + `api.js` and can likely be removed.
+
+5. **`/api/auth/user/` referenced in `api.js:checkUserRole`** — this URL does not exist in the backend. Dead code; callers should use `/api/v1/users/email/{email}/` or `/_allauth/browser/v1/auth/session`.

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -182,17 +182,6 @@ export const fetchStaffAssignmentSafe = async (userId) => {
   }
 };
 
-// Check user role/permissions
-export const checkUserRole = async () => {
-  try {
-    const response = await api.get('/api/auth/user/');
-    return response.data;
-  } catch (error) {
-    console.error('Error checking user role:', error);
-    throw error;
-  }
-};
-
 // Get appropriate date range based on user role
 export const getDateRangeForUser = (user) => {
   // Use local timezone date to avoid off-by-one errors

--- a/frontend/src/components/OrderFilters.jsx
+++ b/frontend/src/components/OrderFilters.jsx
@@ -29,8 +29,8 @@ function OrderFilters({
         
         // Fetch orders and order types in parallel
         const [ordersResponse, orderTypesResponse] = await Promise.all([
-          api.get('/api/orders/'),
-          api.get('/api/order-types/')
+          api.get('/api/v1/orders/'),
+          api.get('/api/v1/order-types/')
         ]);
 
         // Extract unique bunks from orders data

--- a/frontend/src/components/StatusDropdown.jsx
+++ b/frontend/src/components/StatusDropdown.jsx
@@ -30,7 +30,7 @@ function StatusDropdown({ orderId, currentStatus, onStatusUpdate, userRole, disa
     
     setIsUpdating(true);
     try {
-      const response = await api.patch(`/api/orders/${orderId}/`, {
+      const response = await api.patch(`/api/v1/orders/${orderId}/`, {
         order_status: newStatus
       });
       

--- a/frontend/src/components/modals/CreateOrderModal.jsx
+++ b/frontend/src/components/modals/CreateOrderModal.jsx
@@ -33,7 +33,7 @@ function CreateOrderModal({ isOpen, onClose, bunkId, date, onOrderCreated }) {
   const fetchOrderTypes = async () => {
     try {
       setLoading(true);
-      const response = await api.get('/api/order-types/');
+      const response = await api.get('/api/v1/order-types/');
       setOrderTypes(response.data);
     } catch (error) {
       console.error('Error fetching order types:', error);
@@ -46,7 +46,7 @@ function CreateOrderModal({ isOpen, onClose, bunkId, date, onOrderCreated }) {
   const fetchAvailableItems = async (orderTypeId) => {
     try {
       setLoading(true);
-      const response = await api.get(`/api/order-types/${orderTypeId}/items/`);
+      const response = await api.get(`/api/v1/order-types/${orderTypeId}/items/`);
       setAvailableItems(response.data);
       setSelectedItems([]);
     } catch (error) {
@@ -123,7 +123,7 @@ function CreateOrderModal({ isOpen, onClose, bunkId, date, onOrderCreated }) {
         narrative_description: narrativeDescription
       };
 
-      const response = await api.post('/api/orders/', orderData);
+      const response = await api.post('/api/v1/orders/', orderData);
       
       // Call the callback to refresh orders or notify parent
       if (onOrderCreated) {

--- a/frontend/src/pages/OrderDetail.jsx
+++ b/frontend/src/pages/OrderDetail.jsx
@@ -25,7 +25,7 @@ function OrderDetail() {
         setLoading(true);
         setError(null);
         
-        const response = await api.get(`/api/orders/${orderId}/`);
+        const response = await api.get(`/api/v1/orders/${orderId}/`);
         
         setOrder(response.data);
       } catch (error) {

--- a/frontend/src/pages/OrderEdit.jsx
+++ b/frontend/src/pages/OrderEdit.jsx
@@ -37,7 +37,7 @@ function OrderEdit() {
         setError(null);
         
         // Fetch order details
-        const orderResponse = await api.get(`/api/orders/${orderId}/`);
+        const orderResponse = await api.get(`/api/v1/orders/${orderId}/`);
         
         const orderData = orderResponse.data;
         setOrder(orderData);
@@ -50,13 +50,13 @@ function OrderEdit() {
         }
         
         // Fetch order types
-        const orderTypesResponse = await api.get('/api/order-types/');
+        const orderTypesResponse = await api.get('/api/v1/order-types/');
         setOrderTypes(orderTypesResponse.data);
         console.log('Fetched order types:', orderTypesResponse.data);
         
         // Fetch items for the current order type
         if (orderData.order_type) {
-          const itemsResponse = await api.get(`/api/items/?order_type=${orderData.order_type}`);
+          const itemsResponse = await api.get(`/api/v1/items/?order_type=${orderData.order_type}`);
           setItems(itemsResponse.data);
           
           // Set form data with all items for this order type
@@ -169,7 +169,7 @@ function OrderEdit() {
         narrative_description: formData.narrative_description
       };
       
-      await api.patch(`/api/orders/${orderId}/`, updateData);
+      await api.patch(`/api/v1/orders/${orderId}/`, updateData);
       
       // Navigate back to order detail page
       navigate(`/orders/${orderId}`);

--- a/frontend/src/partials/bunk-dashboard/BunkOrderDetail.jsx
+++ b/frontend/src/partials/bunk-dashboard/BunkOrderDetail.jsx
@@ -20,7 +20,7 @@ function BunkOrderDetail({ orderId, bunk_id, date }) {
         setLoading(true);
         setError(null);
         
-        const response = await api.get(`/api/orders/${orderId}/`);
+        const response = await api.get(`/api/v1/orders/${orderId}/`);
         
         setOrder(response.data);
       } catch (error) {

--- a/frontend/src/partials/bunk-dashboard/BunkOrderEdit.jsx
+++ b/frontend/src/partials/bunk-dashboard/BunkOrderEdit.jsx
@@ -31,7 +31,7 @@ function BunkOrderEdit({ orderId, bunk_id, date }) {
         setLoading(true);
         setError(null);
         
-        const response = await api.get(`/api/orders/${orderId}/`);
+        const response = await api.get(`/api/v1/orders/${orderId}/`);
         
         const orderData = response.data;
         setOrder(orderData);
@@ -45,7 +45,7 @@ function BunkOrderEdit({ orderId, bunk_id, date }) {
         // Fetch available items for this order type if it exists
         if (orderData.order_type) {
           try {
-            const itemsResponse = await api.get(`/api/order-types/${orderData.order_type}/items/`);
+            const itemsResponse = await api.get(`/api/v1/order-types/${orderData.order_type}/items/`);
             setAvailableItems(itemsResponse.data);
           } catch (itemsError) {
             console.error('Error fetching available items:', itemsError);
@@ -148,7 +148,7 @@ function BunkOrderEdit({ orderId, bunk_id, date }) {
 
       console.log('Sending update data:', updateData);
 
-      const response = await api.put(`/api/orders/${orderId}/`, updateData);
+      const response = await api.put(`/api/v1/orders/${orderId}/`, updateData);
 
       // Navigate back to order detail view
       navigate(`/bunk/${bunk_id}/${date}/orders/${orderId}`);

--- a/frontend/src/partials/bunk-dashboard/OrdersList.jsx
+++ b/frontend/src/partials/bunk-dashboard/OrdersList.jsx
@@ -26,7 +26,7 @@ function OrdersList({ bunk_id, date, refreshTrigger }) {
         setError(null);
         
         // Fetch orders for the specific bunk
-        const response = await api.get(`/api/orders/?bunk=${bunk_id}`);
+        const response = await api.get(`/api/v1/orders/?bunk=${bunk_id}`);
         
         // Sort orders by date in descending order (newest first)
         const sortedOrders = response.data.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));


### PR DESCRIPTION
## Summary

- All data endpoints are now canonical under `/api/v1/`; the old `/api/` router has become a pure 302-redirect shim
- Orders, items, item-categories, order-types, and messaging were previously **only** on `/api/` — they are now registered under `/api/v1/` and the frontend has been updated to call them there directly
- `/api/v1/users/` is now backed by the richer `UserViewSet` (staff-filtered list, `/users/me/` action) instead of the read-only `UserDetailsView`
- Dead code removed: `src/auth.jsx` (unused legacy file), `checkUserRole` helper (called a non-existent endpoint), all backend debug endpoints

## Changes

### Backend
| File | What changed |
|---|---|
| `bunk_logs/api/urls.py` | Added orders/items/item-categories/order-types/messaging; fixed user viewset; set `app_name="api"`; removed debug endpoints |
| `config/api_router.py` | Replaced real viewset router with 302-redirect shim for every previously registered path |
| `bunk_logs/api/tests/test_permissions.py` | Update `reverse()` calls to use `api:` namespace |
| `bunk_logs/bunklogs/tests/test_staff_logs.py` | Update `reverse()` calls to use `api:` namespace |
| `bunk_logs/users/tests/api/test_urls.py` | Update expected URL strings from `/api/` to `/api/v1/` |

### Frontend
| File | What changed |
|---|---|
| OrderFilters, Orders, OrderDetail, OrderEdit | `/api/orders/` → `/api/v1/orders/` |
| BunkOrderDetail, BunkOrderEdit, OrdersList, StatusDropdown | Same order migration |
| CreateOrderModal, BunkOrderEdit | `/api/order-types/` → `/api/v1/order-types/` |
| OrderEdit | `/api/items/` → `/api/v1/items/` |
| `api.js` | Removed dead `checkUserRole` (called `/api/auth/user/` which never existed) |
| `auth.jsx` | Deleted (dead file, imported nowhere, superseded by `auth/AuthContext.jsx`) |

## Test plan

- [x] `make test-backend` — 130 passed, 0 failed
- [x] `npm run build` — clean build, no errors
- [ ] Smoke test: login → view bunk dashboard → submit a bunk log
- [ ] Smoke test: login as counselor → submit an order → check order appears in Orders page

Made with [Cursor](https://cursor.com)