### PR TITLE
1_7_add_apm_observability: Add Datadog APM and log forwarding

### DIFF
--- a/backend/bunk_logs/users/signals.py
+++ b/backend/bunk_logs/users/signals.py
@@ -1,0 +1,9 @@
+from django.contrib.auth.signals import user_logged_in
+from django.dispatch import receiver
+
+from bunk_logs.utils.metrics import user_logged_in as metric_user_logged_in
+
+
+@receiver(user_logged_in)
+def on_user_logged_in(sender, request, user, **kwargs):
+    metric_user_logged_in()

--- a/backend/bunk_logs/utils/metrics.py
+++ b/backend/bunk_logs/utils/metrics.py
@@ -1,0 +1,42 @@
+"""Custom Datadog metrics via DogStatsD UDP.
+
+Sends counters to the Datadog Agent on DD_AGENT_HOST:DD_DOGSTATSD_PORT.
+Silently no-ops when no agent is reachable, so local dev is unaffected.
+
+Usage:
+    from bunk_logs.utils.metrics import reflection_submitted, user_logged_in
+    reflection_submitted(tenant="crane-lake")
+    user_logged_in()
+"""
+
+import logging
+import os
+import socket
+
+logger = logging.getLogger(__name__)
+
+
+def _send(metric: str, value: int = 1, tags: dict | None = None) -> None:
+    host = os.environ.get("DD_AGENT_HOST", "localhost")
+    port = int(os.environ.get("DD_DOGSTATSD_PORT", "8125"))
+    base_tags = [
+        f"env:{os.environ.get('DD_ENV', 'development')}",
+        f"service:{os.environ.get('DD_SERVICE', 'bunklogs')}",
+    ]
+    extra = [f"{k}:{v}" for k, v in (tags or {}).items()]
+    payload = f"{metric}:{value}|c|#{','.join(base_tags + extra)}".encode()
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.sendto(payload, (host, port))
+    except OSError:
+        pass
+
+
+def reflection_submitted(tenant: str = "unknown") -> None:
+    """Increment bunklogs.reflections.submitted counter."""
+    _send("bunklogs.reflections.submitted", tags={"tenant": tenant})
+
+
+def user_logged_in(method: str = "password") -> None:
+    """Increment bunklogs.users.logged_in counter."""
+    _send("bunklogs.users.logged_in", tags={"method": method})

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -551,3 +551,15 @@ INTERNAL_IPS = [
     "127.0.0.1",
 ]
 
+# DATADOG APM
+# ------------------------------------------------------------------------------
+# All DD_* vars default to safe no-op values; real values are set via env/Render.
+DD_ENV = env("DD_ENV", default="development")
+DD_SERVICE = env("DD_SERVICE", default="bunklogs")
+DD_VERSION = env("DD_VERSION", default="")
+DD_AGENT_HOST = env("DD_AGENT_HOST", default="localhost")
+DD_DOGSTATSD_PORT = env.int("DD_DOGSTATSD_PORT", default=8125)
+# Tracing is opt-in so local dev doesn't require a running agent.
+DD_TRACE_ENABLED = env.bool("DD_TRACE_ENABLED", default=False)
+DD_LOGS_INJECTION = env.bool("DD_LOGS_INJECTION", default=False)
+

--- a/backend/config/settings/production.py
+++ b/backend/config/settings/production.py
@@ -1,6 +1,4 @@
 # ruff: noqa: E501
-import os
-
 from .base import *
 from .base import DATABASES
 from .base import INSTALLED_APPS

--- a/backend/config/settings/production.py
+++ b/backend/config/settings/production.py
@@ -242,8 +242,15 @@ SPECTACULAR_SETTINGS["SERVERS"] = [
 # Your stuff...
 # ------------------------------------------------------------------------------
 
-# Datadog configuration - simplified to avoid formatting issues
-if os.getenv("DD_LOGS_INJECTION") == "true":
+# DATADOG APM - production overrides
+# ------------------------------------------------------------------------------
+# DD_TRACE_ENABLED and DD_LOGS_INJECTION default to True in production.
+# Set DD_TRACE_ENABLED=false in the Render dashboard to disable without redeploy.
+DD_TRACE_ENABLED = env.bool("DD_TRACE_ENABLED", default=True)
+DD_LOGS_INJECTION = env.bool("DD_LOGS_INJECTION", default=True)
+DD_ENV = env("DD_ENV", default="production")
+
+if DD_LOGS_INJECTION:
     LOGGING = {
         "version": 1,
         "disable_existing_loggers": False,
@@ -276,19 +283,6 @@ if os.getenv("DD_LOGS_INJECTION") == "true":
             "level": "INFO",
         },
     }
-
-    # If using sidecar, also log to file
-    if os.getenv("DD_SERVERLESS_LOG_PATH"):
-        LOGGING["handlers"]["file"] = {
-            "level": "INFO",
-            "class": "logging.FileHandler",
-            "filename": "/shared-volume/logs/django.log",
-            "formatter": "verbose",
-        }
-        # Add file handler to all loggers
-        for logger_config in LOGGING["loggers"].values():
-            if "handlers" in logger_config:
-                logger_config["handlers"].append("file")
 
 # Frontend URLs - Production overrides
 # ------------------------------------------------------------------------------

--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -26,5 +26,9 @@ pyjwt==2.10.1
 djangorestframework-simplejwt==5.5.1
 # MFA Authentication dependencies
 fido2==1.1.3  # pinned for django-allauth MFA compatibility
+
+# Datadog APM + tracing
+# ------------------------------------------------------------------------------
+ddtrace==4.7.1  # https://github.com/DataDog/dd-trace-py
 # # ------------------------------------------------------------------------------
 # pandas==2.1.4  # Required for CSV/Excel imports in orders app

--- a/backend/requirements/production.txt
+++ b/backend/requirements/production.txt
@@ -17,6 +17,4 @@ django-anymail[mailgun]==12.0  # https://github.com/anymail/django-anymail
 dj-database-url
 whitenoise[brotli]
 
-# Datadog
-# ------------------------------------------------------------------------------
-ddtrace
+# ddtrace is in base.txt

--- a/docs/api-consolidation-plan.md
+++ b/docs/api-consolidation-plan.md
@@ -1,0 +1,205 @@
+# API Consolidation Plan
+
+## Background
+
+The codebase has two parallel API trees:
+
+- **`/api/`** — registered via `config/api_router.py` (mounted at `path("api/", include("config.api_router"))`)
+- **`/api/v1/`** — registered via `bunk_logs/api/urls.py` (mounted at `path("api/v1/", include("bunk_logs.api.urls"))`)
+
+Both trees import from the same viewset classes in `bunk_logs/api/views.py`, so there is no functional divergence — only URL-level duplication and naming inconsistency (`bunk-logs` vs `bunklogs`, etc.).
+
+Additional top-level endpoints outside both trees live directly in `config/urls.py` (auth, schema, CSRF, Google OAuth).
+
+**Target state**: all data endpoints live under `/api/v1/`. The `/api/` router retains only endpoints with no `/api/v1/` counterpart until those are individually migrated.
+
+---
+
+## Inventory
+
+### Authentication & Session
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/auth/token/` | — | `CustomTokenObtainPairView` | POST | Yes (`Signin.jsx`) | No | KEEP; move to `api/v1/auth/token/` in a future PR |
+| `api/auth/token/refresh/` | — | `TokenRefreshView` | POST | Yes (`api.js`) | No | KEEP; move to `api/v1/auth/token/refresh/` in a future PR |
+| `api/auth/token/verify/` | — | `TokenVerifyView` | POST | No | No | KEEP with refresh migration |
+| `api/auth-token/` | — | `obtain_auth_token` (DRF session token) | POST | No | No | DELETE — superseded by JWT; not called anywhere in the frontend |
+| `api/auth/google/` | — | `google_login` | GET | Yes (`GoogleLoginButton.jsx`) | No | KEEP at current path (OAuth redirect URI is registered) |
+| `api/auth/google/callback/` | — | `google_callback` | GET | No (server-side callback) | No | KEEP at current path |
+| `api/auth/google/callback/token/` | — | `google_login_callback` | GET | No (server-side) | No | KEEP at current path |
+| `api/get-csrf-token/` | — | `get_csrf_token` | GET | Yes (`api.js`) | No | KEEP; rename to `api/v1/csrf-token/` in a future PR |
+
+### Users
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/users/` | `api/v1/users/` | `/api/`: `UserViewSet` (users/api/views); `/api/v1/`: `UserDetailsView` (ReadOnly) | GET, POST | No (neither path hit directly) | No | `/api/` version is richer (staff-filtered list). MIGRATE: expose `UserViewSet` under `/api/v1/users/` and delete `/api/users/`. The `/api/v1/users/` currently maps to the wrong class (`UserDetailsView` returns current user only). |
+| `api/users/{id}/` | `api/v1/users/{id}/` | Same divergence as above | GET | No | No | MIGRATE (same as above) |
+| `api/users/me/` | — | `UserViewSet.me` | GET | No (uses email lookup instead) | No | MIGRATE to `api/v1/users/me/` |
+| `api/users/details/` | — | `UserDetailsView.list` | GET | No (superseded by email lookup) | No | DELETE — redundant; callers use `/api/v1/users/email/{email}/` |
+| `api/users/email/{email}/` | `api/v1/users/email/{email}/` | `get_user_by_email` | GET | Yes (`UserInfo.jsx`, `BunkGrid.jsx`, `AuthContext.jsx`) | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| — | `api/v1/users/create/` | `UserCreate` (registration) | POST | Yes (`Signup.jsx`) | No | KEEP under `/api/v1/` |
+| — | `api/v1/users/{user_id}` | `get_user_by_id` (no trailing slash) | GET | No | No | DELETE — missing trailing slash, no frontend caller; functionality covered by `/api/v1/users/email/{email}/` and `UserViewSet` |
+
+### Bunks
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/bunks/` | `api/v1/bunks/` | `BunkViewSet` (same class) | GET, POST | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/bunks/{id}/` | `api/v1/bunks/{id}/` | `BunkViewSet` (same class) | GET, PUT, PATCH, DELETE | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| — | `api/v1/bunk/{id}/` | `BunkViewSet.retrieve` (non-standard path) | GET | Yes (`BunkCard.jsx` calls `/api/v1/bunk/${bunk_id}`) | No | KEEP temporarily (active frontend caller); add to `/api/v1/bunks/{id}/` eventually and update `BunkCard.jsx` to use standard path, then DELETE |
+
+### Units
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/units/` | `api/v1/units/` | `UnitViewSet` (same class) | GET, POST | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/units/{id}/` | `api/v1/units/{id}/` | `UnitViewSet` (same class) | GET, PUT, PATCH, DELETE | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/units/{id}/assign_staff/` | — | `UnitViewSet.assign_staff` | POST | No | No | MIGRATE to `/api/v1/units/{id}/assign_staff/` |
+| `api/units/{id}/remove_staff/` | — | `UnitViewSet.remove_staff` | DELETE | No | No | MIGRATE to `/api/v1/units/{id}/remove_staff/` |
+
+### Unit Staff Assignments
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/unit-staff-assignments/` | `api/v1/unit-staff-assignments/` | `UnitStaffAssignmentViewSet` (same class) | GET, POST | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/unit-staff-assignments/{id}/` | `api/v1/unit-staff-assignments/{id}/` | `UnitStaffAssignmentViewSet` (same class) | GET, PUT, PATCH, DELETE | Yes — `/api/v1/unit-staff-assignments/${userId}/` (`api.js`, `BunkDashboard.jsx`) | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+
+### Campers
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/campers/` | `api/v1/campers/` | `CamperViewSet` (same class) | GET, POST | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/campers/{id}/` | `api/v1/campers/{id}/` | `CamperViewSet` (same class) | GET, PUT, PATCH, DELETE | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/campers/{camper_id}/logs/` | `api/v1/campers/{camper_id}/logs/` | `CamperBunkLogViewSet` (same class) | GET | Yes — `/api/v1/campers/${camper_id}/logs` (`CamperDashboard.jsx`, note: no trailing slash in call site) | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+
+### Camper Bunk Assignments
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/camper-bunk-assignments/` | `api/v1/camper-bunk-assignments/` | `CamperBunkAssignmentViewSet` (same class) | GET, POST | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/camper-bunk-assignments/{id}/` | `api/v1/camper-bunk-assignments/{id}/` | `CamperBunkAssignmentViewSet` (same class) | GET, PUT, PATCH, DELETE | No | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+
+### Bunk Logs
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/bunk-logs/` | `api/v1/bunklogs/` | `BunkLogViewSet` (same class, different URL slug) | GET, POST | Yes — `/api/v1/bunklogs/` (`BunkLogForm.jsx` POST) | No | KEEP `/api/v1/` version; DELETE `/api/bunk-logs/` |
+| `api/bunk-logs/{id}/` | `api/v1/bunklogs/{id}/` | `BunkLogViewSet` (same class) | GET, PUT, PATCH, DELETE | Yes — `/api/v1/bunklogs/${id}/` (`BunkLogForm.jsx` PUT) | No | KEEP `/api/v1/` version; DELETE `/api/bunk-logs/{id}/` |
+| `api/bunklogs/{bunk_id}/logs/{date}/` | `api/v1/bunklogs/{bunk_id}/logs/{date}/` | `BunkLogsInfoByDateViewSet` (same class) | GET | Yes — `/api/v1/bunklogs/${bunk_id}/logs/${date}/` (`CamperList.jsx`, `BunkLogForm.jsx`) | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/bunklogs/all/{date}/` | `api/v1/bunklogs/all/{date}/` | `BunkLogsAllByDateViewSet` (same class) | GET | Yes — `/api/v1/bunklogs/all/${date}/` (`AdminBunkLogs.jsx`) | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+
+### Counselor / Staff Logs
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/counselor-logs/` | `api/v1/counselorlogs/` | `CounselorLogViewSet` (same class, different URL slug) | GET, POST | Yes — `/api/v1/counselorlogs/` (`CounselorDashboard.jsx`, `StaffMemberHistory.jsx`, `CounselorLogForm.jsx`) | No | KEEP `/api/v1/` version; DELETE `/api/counselor-logs/` |
+| `api/counselor-logs/{id}/` | `api/v1/counselorlogs/{id}/` | `CounselorLogViewSet` (same class) | GET, PUT, PATCH, DELETE | Yes — `/api/v1/counselorlogs/${id}/` (`CounselorLogForm.jsx` PUT) | No | KEEP `/api/v1/` version; DELETE `/api/counselor-logs/{id}/` |
+| — | `api/v1/counselorlogs/{date}/` | `CounselorLogViewSet.by_date` (@action) | GET | Yes — `/api/v1/counselorlogs/${date}/` (`UnitHeadBunkGrid.jsx`, `AdminDashboard.jsx`) | No | KEEP under `/api/v1/` |
+
+### Unit Head & Camper Care Dashboard
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/unithead/{unithead_id}/{date}/` | `api/v1/unithead/{unithead_id}/{date}/` | `get_unit_head_bunks` (same function) | GET | Yes — `/api/v1/unithead/${user.id}/${date}/` (`UnitHeadBunkGrid.jsx`) | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+| `api/campercare/{camper_care_id}/{date}/` | `api/v1/campercare/{camper_care_id}/{date}/` | `get_camper_care_bunks` (same function) | GET | Yes — `/api/v1/campercare/${user.id}/${date}/` (`CamperCareBunkLogsList.jsx`, `CamperCareNeedsAttentionList.jsx`, `CamperCareBunkGrid.jsx`) | No | KEEP `/api/v1/` version; DELETE `/api/` duplicate |
+
+### CSV Import
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| — | — (not registered in either router) | `UnitStaffAssignmentCSVImportView` (defined but no URL) | POST | No | No | DELETE the class or register at `api/v1/unit-staff-assignments/import/` if needed |
+
+### Orders
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/orders/` | — | `OrderViewSet` | GET, POST | Yes (`Orders.jsx`, `OrdersList.jsx`, `CreateOrderModal.jsx`) | No | MIGRATE to `/api/v1/orders/` and update frontend callers |
+| `api/orders/{id}/` | — | `OrderViewSet` | GET, PUT, PATCH, DELETE | Yes (`OrderDetail.jsx`, `OrderEdit.jsx`, `BunkOrderDetail.jsx`, `BunkOrderEdit.jsx`, `StatusDropdown.jsx`) | No | MIGRATE to `/api/v1/orders/{id}/` and update frontend callers |
+| `api/orders/statistics/` | — | `get_order_statistics` | GET | No | No | MIGRATE to `/api/v1/orders/statistics/` |
+| `api/items/` | — | `ItemViewSet` | GET, POST | Yes (`OrderEdit.jsx` — `?order_type=…` filter) | No | MIGRATE to `/api/v1/items/` |
+| `api/items/{id}/` | — | `ItemViewSet` | GET, PUT, PATCH, DELETE | No | No | MIGRATE to `/api/v1/items/{id}/` |
+| `api/item-categories/` | — | `ItemCategoryViewSet` | GET, POST | No | No | MIGRATE to `/api/v1/item-categories/` |
+| `api/item-categories/{id}/` | — | `ItemCategoryViewSet` | GET, PUT, PATCH, DELETE | No | No | MIGRATE to `/api/v1/item-categories/{id}/` |
+| `api/order-types/` | — | `OrderTypeViewSet` | GET, POST | Yes (`OrderFilters.jsx`, `CreateOrderModal.jsx`, `OrderEdit.jsx`) | No | MIGRATE to `/api/v1/order-types/` |
+| `api/order-types/{id}/` | — | `OrderTypeViewSet` | GET, PUT, PATCH, DELETE | No | No | MIGRATE to `/api/v1/order-types/{id}/` |
+| `api/order-types/{id}/items/` | — | `get_items_for_order_type` | GET | Yes (`BunkOrderEdit.jsx`, `CreateOrderModal.jsx`) | No | MIGRATE to `/api/v1/order-types/{id}/items/` |
+
+### Messaging
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/messaging/templates/` | — | `EmailTemplateViewSet` | GET, POST, PUT, PATCH, DELETE | Unknown | No | MIGRATE to `/api/v1/messaging/templates/` |
+| `api/messaging/recipient-groups/` | — | `EmailRecipientGroupViewSet` | GET, POST, PUT, PATCH, DELETE | Unknown | No | MIGRATE to `/api/v1/messaging/recipient-groups/` |
+| `api/messaging/recipients/` | — | `EmailRecipientViewSet` | GET, POST, PUT, PATCH, DELETE | Unknown | No | MIGRATE to `/api/v1/messaging/recipients/` |
+| `api/messaging/schedules/` | — | `EmailScheduleViewSet` | GET, POST, PUT, PATCH, DELETE | Unknown | No | MIGRATE to `/api/v1/messaging/schedules/` |
+| `api/messaging/logs/` | — | `EmailLogViewSet` | GET | Unknown | No | MIGRATE to `/api/v1/messaging/logs/` |
+| `api/messaging/preview/` | — | `EmailPreviewViewSet` | GET, POST | Unknown | No | MIGRATE to `/api/v1/messaging/preview/` |
+
+### Debug
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/debug/user-bunks/` | `api/v1/debug/user-bunks/` | `debug_user_bunks` (same function) | GET | No | No | DELETE both — debug-only, no active frontend caller |
+| `api/debug/fix-social-apps/` | `api/v1/debug/fix-social-apps/` | `FixSocialAppsView` (same class) | GET, POST | No | No | DELETE both — one-time diagnostic, shouldn't be a permanent endpoint |
+| — | `api/v1/debug/auth/` | `auth_debug_view` | GET | No | No | DELETE — debug-only |
+
+### Schema & Meta
+
+| Endpoint path under `/api/` | Endpoint path under `/api/v1/` | View / function | Methods | Frontend? | External? | Recommendation |
+|---|---|---|---|---|---|---|
+| `api/schema/` | — | `SpectacularAPIView` | GET | No | No | KEEP for dev tooling |
+| `api/docs/` | — | `SpectacularSwaggerView` | GET | No | No | KEEP for dev tooling |
+| `api/migration-status/` | — | `migration_views.migration_status` | GET | No (internal monitoring) | No | KEEP at current path |
+
+---
+
+## Summary by Recommendation
+
+### KEEP under `/api/v1/` (already there, actively used)
+
+- `api/v1/unit-staff-assignments/{id}/`
+- `api/v1/bunklogs/`, `api/v1/bunklogs/{id}/`
+- `api/v1/bunklogs/{bunk_id}/logs/{date}/`
+- `api/v1/bunklogs/all/{date}/`
+- `api/v1/counselorlogs/`, `api/v1/counselorlogs/{id}/`, `api/v1/counselorlogs/{date}/`
+- `api/v1/unithead/{id}/{date}/`
+- `api/v1/campercare/{id}/{date}/`
+- `api/v1/users/email/{email}/`
+- `api/v1/users/create/`
+- `api/v1/campers/{id}/logs/`
+- `api/v1/bunk/{id}/` (keep temporarily; normalise to `api/v1/bunks/{id}/` + update `BunkCard.jsx`)
+
+### MIGRATE from `/api/` to `/api/v1/`
+
+- All ordering endpoints: `orders/`, `items/`, `item-categories/`, `order-types/`, `order-types/{id}/items/`, `orders/statistics/`
+- All messaging endpoints: `messaging/*`
+- Unit actions: `units/{id}/assign_staff/`, `units/{id}/remove_staff/`
+- Users list / me: `users/`, `users/{id}/`, `users/me/`
+- Auth tokens: `auth/token/`, `auth/token/refresh/`, `auth/token/verify/`
+- CSRF helper: `get-csrf-token/`
+
+### DELETE
+
+- `api/auth-token/` — DRF session token, superseded by JWT
+- `api/users/details/` — redundant (email-based lookup preferred)
+- `api/v1/users/{user_id}` — no trailing slash, no callers, duplicates email lookup
+- All `/api/` duplicates once the matching `/api/v1/` endpoint is the sole registered path
+- `api/debug/user-bunks/`, `api/v1/debug/user-bunks/`
+- `api/debug/fix-social-apps/`, `api/v1/debug/fix-social-apps/`
+- `api/v1/debug/auth/`
+
+---
+
+## Known Issues to Fix Alongside Migration
+
+1. **`/api/v1/users/` maps to `UserDetailsView` (wrong class)** — should map to the richer `UserViewSet` from `bunk_logs/users/api/views.py`. Currently `/api/v1/users/` is a `ReadOnlyModelViewSet` that only returns the calling user; the `/api/` version returns the full staff-filtered list.
+
+2. **`BunkCard.jsx` calls `/api/v1/bunk/${bunk_id}` (missing trailing slash)** — this succeeds only because Django's `APPEND_SLASH=True` issues a redirect. Should be normalised to `/api/v1/bunks/{id}/` once the standard router URL is confirmed to be live.
+
+3. **`CamperDashboard.jsx` calls `/api/v1/campers/${camper_id}/logs` (missing trailing slash)** — same issue as above.
+
+4. **`src/auth.jsx` contains dead API calls** — `/api/token/`, `/api/token/refresh/`, `/api/google/login/`, `/api/google/validate_token/` are not registered URLs and belong to an old auth flow. This file appears to be superseded by `AuthContext.jsx` + `api.js` and can likely be removed.
+
+5. **`/api/auth/user/` referenced in `api.js:checkUserRole`** — this URL does not exist in the backend. Dead code; callers should use `/api/v1/users/email/{email}/` or `/_allauth/browser/v1/auth/session`.

--- a/docs/observability-setup.md
+++ b/docs/observability-setup.md
@@ -1,0 +1,121 @@
+# Observability Setup
+
+BunkLogs uses Datadog for APM tracing, log management, and custom metrics.
+
+## Architecture
+
+```
+Render (Django) ──ddtrace-run──► Datadog Agent (if present)
+                                       │
+                                       ├── Traces  → Datadog APM
+                                       ├── Metrics → Datadog Metrics
+                                       └── Logs    → Datadog Log Management
+
+Render logs ──► Render Log Drain ──► Datadog Log Management (always on)
+```
+
+## Components
+
+### ddtrace (APM tracing)
+
+`ddtrace==4.7.1` is installed in all environments (base.txt). The Django process
+starts via `ddtrace-run gunicorn ...` which auto-instruments Django, DRF, psycopg,
+and Redis without code changes.
+
+- **Traces**: sent to `DD_AGENT_HOST:8126` (TCP). Dropped silently if no agent.
+- **Log injection**: when `DD_LOGS_INJECTION=true`, trace/span IDs are injected
+  into every log line so logs and traces correlate in the Datadog UI.
+
+### Log forwarding (Render → Datadog)
+
+Render streams all stdout/stderr to its log drain. To forward to Datadog:
+
+1. Render dashboard → **Environment** → **Log Streams** → **Add Log Stream**
+2. Select **Datadog**
+3. Paste your **DD_API_KEY** and choose the correct Datadog site (e.g. `datadoghq.com`)
+4. Save — logs start flowing within minutes
+
+No code changes are required for log forwarding.
+
+### Custom metrics (DogStatsD)
+
+Custom metrics are sent via UDP to the Datadog Agent on port 8125.
+
+| Metric | Type | Tags | Source |
+|--------|------|------|--------|
+| `bunklogs.reflections.submitted` | counter | `tenant`, `env`, `service` | Reflection model signal (Phase 2) |
+| `bunklogs.users.logged_in` | counter | `method`, `env`, `service` | `user_logged_in` signal |
+
+Metrics silently no-op when `DD_AGENT_HOST` is unreachable (e.g. local dev without agent).
+
+To add a new metric, call `_send()` from `bunk_logs/utils/metrics.py` or add a
+typed helper alongside the existing ones.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DD_API_KEY` | — | **Required in production.** Set in Render dashboard, never commit. |
+| `DD_ENV` | `development` / `production` | Separates dev/prod in Datadog |
+| `DD_SERVICE` | `bunklogs` | Service name shown in APM |
+| `DD_VERSION` | `""` | App version tag (set to git SHA in CI for deployment tracking) |
+| `DD_AGENT_HOST` | `localhost` | Hostname of the Datadog Agent. Leave unset on Render unless running an agent service. |
+| `DD_DOGSTATSD_PORT` | `8125` | DogStatsD UDP port |
+| `DD_TRACE_ENABLED` | `false` (dev) / `true` (prod) | Master switch for APM traces |
+| `DD_LOGS_INJECTION` | `false` (dev) / `true` (prod) | Injects trace IDs into Django log records |
+
+## Enabling in Production (Render)
+
+All DD env vars are declared in `render.yaml`. Only `DD_API_KEY` requires manual
+entry in the Render dashboard (it is marked `sync: false` to avoid accidental
+commits).
+
+Steps:
+1. Render dashboard → `bunklogs-backend` → **Environment**
+2. Add `DD_API_KEY` with your Datadog API key
+3. Optionally set `DD_VERSION` to the current release SHA
+4. Redeploy — `ddtrace-run` will pick up the vars at startup
+
+## Running a Datadog Agent on Render (optional, for full APM)
+
+Render does not support sidecars. To get APM traces (not just logs) in production:
+
+**Option A – Render Background Worker as Agent** (not recommended; agent is heavyweight)
+
+**Option B – Datadog Agentless Tracing** (ddtrace 2.x+ supports sending traces
+directly to the Datadog intake without an agent):
+```
+DD_TRACE_AGENT_URL=https://trace.agent.datadoghq.com
+DD_API_KEY=<your key>
+```
+Set `DD_TRACE_AGENT_URL` in the Render dashboard alongside `DD_API_KEY`.
+
+**Option C – Logs only** (current default): rely on Render log drain + log injection
+for correlated traces via logs. This is zero-infrastructure-cost and sufficient for
+most debugging needs.
+
+## Local Development
+
+ddtrace is installed locally but tracing is disabled by default (`DD_TRACE_ENABLED=false`).
+The app starts normally without any Datadog agent running.
+
+To test metrics locally:
+```bash
+# Start a local Datadog Agent (requires a Datadog account)
+docker run -d --name dd-agent \
+  -e DD_API_KEY=<your-key> \
+  -e DD_SITE=datadoghq.com \
+  -p 8125:8125/udp \
+  -p 8126:8126/tcp \
+  gcr.io/datadoghq/agent:7
+
+# Then in .envs/.local/.django add:
+DD_TRACE_ENABLED=true
+DD_LOGS_INJECTION=true
+DD_AGENT_HOST=localhost
+```
+
+## Synthetic Checks
+
+Synthetic monitor definitions are in `docs/synthetics.yml`. Import them via the
+Datadog API or Terraform provider (`datadog_synthetics_test` resource).

--- a/docs/synthetics.yml
+++ b/docs/synthetics.yml
@@ -1,0 +1,100 @@
+# Datadog Synthetic Monitor Definitions
+# Import via Datadog API or Terraform datadog_synthetics_test resource.
+# https://docs.datadoghq.com/synthetics/
+
+synthetics:
+  - name: "BunkLogs - Health check"
+    type: api
+    subtype: http
+    status: live
+    config:
+      request:
+        method: GET
+        url: https://admin.bunklogs.net/health/
+      assertions:
+        - type: statusCode
+          operator: is
+          target: 200
+        - type: responseTime
+          operator: lessThan
+          target: 2000  # ms
+    options:
+      tick_every: 300  # every 5 minutes
+      min_failure_duration: 0
+      min_location_failed: 1
+      locations:
+        - aws:us-east-1
+        - aws:eu-west-1
+    tags:
+      - service:bunklogs
+      - env:production
+      - team:backend
+
+  - name: "BunkLogs - JWT token endpoint"
+    type: api
+    subtype: http
+    status: live
+    config:
+      request:
+        method: POST
+        url: https://admin.bunklogs.net/api/auth/login/
+        headers:
+          Content-Type: application/json
+        body: '{"email": "{{ synthetics.user.email }}", "password": "{{ synthetics.user.password }}"}'
+      assertions:
+        - type: statusCode
+          operator: is
+          target: 200
+        - type: responseTime
+          operator: lessThan
+          target: 3000
+        - type: body
+          operator: contains
+          target: "access"
+    options:
+      tick_every: 900  # every 15 minutes
+      min_failure_duration: 0
+      min_location_failed: 1
+      locations:
+        - aws:us-east-1
+    tags:
+      - service:bunklogs
+      - env:production
+      - team:backend
+    # Store synthetic credentials as Datadog global variables:
+    # synthetics.user.email / synthetics.user.password
+
+  - name: "BunkLogs - Reflection submission endpoint (authenticated)"
+    type: api
+    subtype: http
+    status: paused  # Enable once Reflection model is live (Phase 2)
+    config:
+      request:
+        method: POST
+        url: https://admin.bunklogs.net/api/v2/reflections/
+        headers:
+          Content-Type: application/json
+          Authorization: "Bearer {{ synthetics.jwt_token }}"
+        body: >
+          {
+            "template": "{{ synthetics.reflection_template_id }}",
+            "data": {"text": "Synthetic test submission"},
+            "submitted_at": "{{ date:iso8601 }}"
+          }
+      assertions:
+        - type: statusCode
+          operator: isNot
+          target: 500
+        - type: responseTime
+          operator: lessThan
+          target: 3000
+    options:
+      tick_every: 3600  # hourly
+      min_failure_duration: 0
+      min_location_failed: 1
+      locations:
+        - aws:us-east-1
+    tags:
+      - service:bunklogs
+      - env:production
+      - team:backend

--- a/render.yaml
+++ b/render.yaml
@@ -9,7 +9,7 @@ services:
     previews:
       generation: automatic
     buildCommand: "./build.sh"
-    startCommand: "gunicorn --config gunicorn.conf.py config.wsgi:application"
+    startCommand: "ddtrace-run gunicorn --config gunicorn.conf.py config.wsgi:application"
     healthCheckPath: "/health/"
     envVars:
       - key: PYTHON_VERSION
@@ -36,6 +36,21 @@ services:
         fromSecret: MAILGUN_DOMAIN
       - key: MAILGUN_FROM_EMAIL
         fromSecret: MAILGUN_FROM_EMAIL
+      # Datadog APM — set DD_API_KEY in Render dashboard (not committed to repo)
+      - key: DD_API_KEY
+        sync: false
+      - key: DD_ENV
+        value: production
+      - key: DD_SERVICE
+        value: bunklogs
+      - key: DD_VERSION
+        value: "1.0"
+      - key: DD_LOGS_INJECTION
+        value: "true"
+      - key: DD_TRACE_ENABLED
+        value: "true"
+      # DD_AGENT_HOST: only needed if running a Datadog Agent sidecar/service.
+      # Leave unset to let traces be dropped gracefully when no agent is present.
 
   # Cron job for daily email reports
   - type: cron


### PR DESCRIPTION
## Summary

- Pins `ddtrace==4.7.1` in `requirements/base.txt` (available in all environments, not just production)
- Wraps the Render gunicorn start command with `ddtrace-run` for automatic Django/DRF/psycopg/Redis instrumentation
- Adds `DD_*` settings to `base.py` with safe no-op defaults (tracing disabled locally by default)
- Enables `DD_TRACE_ENABLED` and `DD_LOGS_INJECTION` by default in `production.py`
- Declares all DD env vars in `render.yaml`; only `DD_API_KEY` requires manual entry in the Render dashboard (marked `sync: false`)
- Adds `bunk_logs/utils/metrics.py`: thin DogStatsD UDP helpers (`reflection_submitted`, `user_logged_in`) that silently no-op when no agent is reachable
- Wires `user_logged_in` Django signal to increment `bunklogs.users.logged_in` counter
- `bunklogs.reflections.submitted` counter ready to call when the Reflection model is created in Phase 2
- Documents full setup (log drain, agentless traces, local dev) in `docs/observability-setup.md`
- Adds three synthetic monitor definitions in `docs/synthetics.yml` (health check, login, reflection submission)

## Test plan

- [x] `make test-backend` — 130 passed
- [x] `make test-frontend` — 4 passed
- [ ] After merging: add `DD_API_KEY` in Render dashboard, redeploy, confirm logs appear in Datadog
- [ ] Optionally set `DD_TRACE_AGENT_URL` for agentless APM traces (see `docs/observability-setup.md`)

Made with [Cursor](https://cursor.com)