### PR TITLE
2_7_add_multitenant_middleware: multi-tenant middleware and OrgScopedManager

### DIFF
--- a/backend/bunk_logs/core/admin.py
+++ b/backend/bunk_logs/core/admin.py
@@ -21,6 +21,9 @@ class OrganizationAdmin(admin.ModelAdmin):
 
 @admin.register(Person)
 class PersonAdmin(admin.ModelAdmin):
+    def get_queryset(self, request):
+        return Person.all_objects.all()
+
     list_display = [
         "full_name",
         "organization",
@@ -36,6 +39,9 @@ class PersonAdmin(admin.ModelAdmin):
 
 @admin.register(Program)
 class ProgramAdmin(admin.ModelAdmin):
+    def get_queryset(self, request):
+        return Program.all_objects.all()
+
     list_display = [
         "name",
         "slug",
@@ -72,6 +78,9 @@ class ReflectionTemplateAdminForm(forms.ModelForm):
 
 @admin.register(ReflectionTemplate)
 class ReflectionTemplateAdmin(admin.ModelAdmin):
+    def get_queryset(self, request):
+        return ReflectionTemplate.all_objects.all()
+
     form = ReflectionTemplateAdminForm
     formfield_overrides = {
         models.JSONField: {
@@ -104,6 +113,9 @@ class ReflectionTemplateAdmin(admin.ModelAdmin):
 
 @admin.register(Reflection)
 class ReflectionAdmin(admin.ModelAdmin):
+    def get_queryset(self, request):
+        return Reflection.all_objects.all()
+
     list_display = [
         "person",
         "program",
@@ -137,6 +149,9 @@ class ReflectionAdmin(admin.ModelAdmin):
 
 @admin.register(Membership)
 class MembershipAdmin(admin.ModelAdmin):
+    def get_queryset(self, request):
+        return Membership.all_objects.all()
+
     list_display = [
         "person",
         "program",

--- a/backend/bunk_logs/core/context.py
+++ b/backend/bunk_logs/core/context.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from asgiref.local import Local
+
+if TYPE_CHECKING:
+    from bunk_logs.core.models import Organization
+
+_org_local = Local()
+
+
+def get_current_organization() -> Organization | None:
+    return getattr(_org_local, "organization", None)
+
+
+def set_current_organization(organization: Organization | None) -> None:
+    _org_local.organization = organization
+
+
+def clear_current_organization() -> None:
+    if hasattr(_org_local, "organization"):
+        delattr(_org_local, "organization")
+
+
+@contextmanager
+def organization_context(organization: Organization | None):
+    previous = get_current_organization()
+    set_current_organization(organization)
+    try:
+        yield
+    finally:
+        if previous is None:
+            clear_current_organization()
+        else:
+            set_current_organization(previous)

--- a/backend/bunk_logs/core/managers.py
+++ b/backend/bunk_logs/core/managers.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from django.db import models
+from django.db.models import Q
+
+from bunk_logs.core.context import get_current_organization
+
+
+class OrgScopedManager(models.Manager):
+    """Default manager: tenant-scoped by ``organization`` FK. Fail-closed when no org context."""
+
+    def get_queryset(self):
+        org = get_current_organization()
+        qs = super().get_queryset()
+        if org is None:
+            return qs.none()
+        return qs.filter(organization=org)
+
+
+class MembershipScopedManager(models.Manager):
+    """Scope by program.organization (Membership has no direct organization FK)."""
+
+    def get_queryset(self):
+        org = get_current_organization()
+        qs = super().get_queryset()
+        if org is None:
+            return qs.none()
+        return qs.filter(program__organization=org)
+
+
+class ReflectionTemplateScopedManager(models.Manager):
+    """Org-specific rows plus global templates (organization IS NULL)."""
+
+    def get_queryset(self):
+        org = get_current_organization()
+        qs = super().get_queryset()
+        if org is None:
+            return qs.none()
+        return qs.filter(Q(organization=org) | Q(organization__isnull=True))

--- a/backend/bunk_logs/core/middleware.py
+++ b/backend/bunk_logs/core/middleware.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.core.exceptions import ObjectDoesNotExist
+
+from bunk_logs.core.context import clear_current_organization
+from bunk_logs.core.context import set_current_organization
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
+    from django.http import HttpResponse
+
+    from bunk_logs.core.models import Organization
+
+# First label of host must match Organization.slug (e.g. clc.bunklogs.net → slug "clc").
+_SUBDOMAIN_SKIP = frozenset({"", "www", "admin", "api", "localhost"})
+
+
+def _raw_request_host(request: HttpRequest) -> str:
+    """Host for tenant routing without triggering ALLOWED_HOSTS (see get_host())."""
+    raw = request.META.get("HTTP_HOST", "")
+    return raw.split(":")[0] if raw else ""
+
+
+def _host_subdomain_label(host: str) -> str | None:
+    host = host.lower().strip(".")
+    parts = host.split(".")
+    if len(parts) < 3:
+        return None
+    # e.g. clc.bunklogs.net → clc
+    if parts[-2:] != ["bunklogs", "net"]:
+        return None
+    label = parts[0]
+    if label in _SUBDOMAIN_SKIP:
+        return None
+    return label
+
+
+class OrganizationMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        from bunk_logs.core.models import Organization
+        from bunk_logs.core.models import Person
+
+        org: Organization | None = None
+        try:
+            label = _host_subdomain_label(_raw_request_host(request))
+            if label:
+                try:
+                    org = Organization.objects.get(slug=label, is_active=True)
+                except ObjectDoesNotExist:
+                    org = None
+
+            user = getattr(request, "user", None)
+            if org is None and user is not None and user.is_authenticated:
+                person = (
+                    Person.all_objects.select_related("organization")
+                    .filter(user=user)
+                    .first()
+                )
+                if person is not None:
+                    org = person.organization if person.organization.is_active else None
+
+            request.organization = org
+            set_current_organization(org)
+            return self.get_response(request)
+        finally:
+            clear_current_organization()

--- a/backend/bunk_logs/core/models.py
+++ b/backend/bunk_logs/core/models.py
@@ -6,6 +6,10 @@ from django.db import models
 from django.db.models import F
 from django.db.models import Q
 
+from bunk_logs.core.managers import MembershipScopedManager
+from bunk_logs.core.managers import OrgScopedManager
+from bunk_logs.core.managers import ReflectionTemplateScopedManager
+
 REFLECTION_FIELD_TYPES = frozenset(
     {"text", "textarea", "text_list", "rating_group", "multiple_choice", "single_choice"},
 )
@@ -168,6 +172,9 @@ class Program(models.Model):
     settings = models.JSONField(default=dict, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
+    objects = OrgScopedManager()
+    all_objects = models.Manager()  # noqa: DJ012
+
     class Meta:
         unique_together = [("organization", "slug")]
         ordering = ["-start_date"]
@@ -210,6 +217,9 @@ class Person(models.Model):
     external_ids = models.JSONField(default=dict, blank=True)
     notes = models.TextField(blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
+
+    objects = OrgScopedManager()
+    all_objects = models.Manager()  # noqa: DJ012
 
     class Meta:
         ordering = ["last_name", "first_name"]
@@ -260,6 +270,9 @@ class Membership(models.Model):
     is_active = models.BooleanField(default=True)
     metadata = models.JSONField(default=dict, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
+
+    objects = MembershipScopedManager()
+    all_objects = models.Manager()  # noqa: DJ012
 
     class Meta:
         unique_together = [("program", "person", "role")]
@@ -322,6 +335,9 @@ class ReflectionTemplate(models.Model):
     )
     created_at = models.DateTimeField(auto_now_add=True)
 
+    objects = ReflectionTemplateScopedManager()
+    all_objects = models.Manager()  # noqa: DJ012
+
     class Meta:
         unique_together = [("organization", "slug", "version")]
         ordering = ["organization_id", "slug", "-version"]
@@ -375,6 +391,9 @@ class Reflection(models.Model):
     submitted_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     is_complete = models.BooleanField(default=True)
+
+    objects = OrgScopedManager()
+    all_objects = models.Manager()  # noqa: DJ012
 
     class Meta:
         ordering = ["-period_end"]

--- a/backend/bunk_logs/core/test_multitenancy.py
+++ b/backend/bunk_logs/core/test_multitenancy.py
@@ -1,0 +1,200 @@
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.http import HttpResponse
+from django.test import RequestFactory
+
+from bunk_logs.core.context import get_current_organization
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.middleware import OrganizationMiddleware
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+
+User = get_user_model()
+
+
+def _field_schema(key: str = "n") -> dict:
+    return {"key": key, "type": "text", "prompts": {"en": "Q"}}
+
+
+@pytest.fixture
+def org_alpha(db):
+    return Organization.objects.create(name="Alpha Camp", slug="alpha-mt")
+
+
+@pytest.fixture
+def org_beta(db):
+    return Organization.objects.create(name="Beta Camp", slug="beta-mt")
+
+
+@pytest.fixture
+def program_alpha(org_alpha):
+    return Program.all_objects.create(
+        organization=org_alpha,
+        name="P Alpha",
+        slug="p-alpha",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 1),
+    )
+
+
+@pytest.fixture
+def program_beta(org_beta):
+    return Program.all_objects.create(
+        organization=org_beta,
+        name="P Beta",
+        slug="p-beta",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 1),
+    )
+
+
+@pytest.mark.django_db
+def test_no_org_context_scoped_querysets_empty(org_alpha, program_alpha):
+    assert not Program.objects.exists()
+    assert not Person.objects.exists()
+    assert not Membership.objects.exists()
+    assert not ReflectionTemplate.objects.exists()
+    assert not Reflection.objects.exists()
+    assert Organization.objects.filter(pk=org_alpha.pk).exists()
+
+
+@pytest.mark.django_db
+def test_with_org_context_only_that_org_data(org_alpha, org_beta, program_alpha, program_beta):
+    with organization_context(org_alpha):
+        ids = set(Program.objects.values_list("id", flat=True))
+        assert ids == {program_alpha.id}
+    with organization_context(org_beta):
+        ids = set(Program.objects.values_list("id", flat=True))
+        assert ids == {program_beta.id}
+
+
+@pytest.mark.django_db
+def test_all_objects_bypasses_scoping(org_alpha, org_beta, program_alpha, program_beta):
+    assert set(Program.all_objects.values_list("id", flat=True)) == {program_alpha.id, program_beta.id}
+
+
+@pytest.mark.django_db
+def test_two_orgs_person_isolation(org_alpha, org_beta):
+    pa = Person.all_objects.create(organization=org_alpha, first_name="A", last_name="One")
+    pb = Person.all_objects.create(organization=org_beta, first_name="B", last_name="Two")
+    with organization_context(org_alpha):
+        assert set(Person.objects.values_list("id", flat=True)) == {pa.id}
+    with organization_context(org_beta):
+        assert set(Person.objects.values_list("id", flat=True)) == {pb.id}
+
+
+@pytest.mark.django_db
+def test_membership_scoped_by_program_organization(org_alpha, org_beta, program_alpha, program_beta):
+    pa = Person.all_objects.create(organization=org_alpha, first_name="A", last_name="Camper")
+    mb_alpha = Membership.all_objects.create(program=program_alpha, person=pa, role="camper")
+    Membership.all_objects.create(program=program_beta, person=pa, role="madrich")
+
+    with organization_context(org_alpha):
+        assert list(Membership.objects.values_list("id", flat=True)) == [mb_alpha.id]
+
+
+@pytest.mark.django_db
+def test_reflection_template_includes_global_for_org(org_alpha):
+    global_t = ReflectionTemplate.all_objects.create(
+        organization=None,
+        name="Global",
+        slug="global-tpl-mt",
+        cadence="daily",
+        schema={"fields": [_field_schema()]},
+    )
+    org_t = ReflectionTemplate.all_objects.create(
+        organization=org_alpha,
+        name="Org",
+        slug="org-tpl-mt",
+        cadence="daily",
+        schema={"fields": [_field_schema("o")]},
+    )
+    other = Organization.objects.create(name="Other", slug="other-mt")
+    ReflectionTemplate.all_objects.create(
+        organization=other,
+        name="Other",
+        slug="other-tpl-mt",
+        cadence="daily",
+        schema={"fields": [_field_schema("x")]},
+    )
+    with organization_context(org_alpha):
+        slugs = set(ReflectionTemplate.objects.values_list("slug", flat=True))
+        assert slugs == {"global-tpl-mt", "org-tpl-mt"}
+        assert global_t.slug in slugs
+        assert org_t.slug in slugs
+
+
+@pytest.mark.django_db
+def test_subdomain_resolves_organization():
+    org = Organization.objects.create(name="Temple", slug="tbe")
+
+    def get_response(request):
+        return HttpResponse("ok")
+
+    rf = RequestFactory()
+    request = rf.get("/", HTTP_HOST="tbe.bunklogs.net")
+    request.user = AnonymousUser()
+    OrganizationMiddleware(get_response)(request)
+
+    assert request.organization == org
+
+
+@pytest.mark.django_db
+def test_subdomain_skips_admin_host():
+    Organization.objects.create(name="X", slug="admin-should-not-match")
+
+    def get_response(request):
+        return HttpResponse("ok")
+
+    rf = RequestFactory()
+    request = rf.get("/", HTTP_HOST="admin.bunklogs.net")
+    request.user = AnonymousUser()
+    OrganizationMiddleware(get_response)(request)
+
+    assert request.organization is None
+
+
+@pytest.mark.django_db
+def test_middleware_clears_thread_local_after_request():
+    org = Organization.objects.create(name="Clear", slug="clear-mt")
+
+    def get_response(request):
+        assert get_current_organization() == org
+        return HttpResponse("ok")
+
+    rf = RequestFactory()
+    request = rf.get("/", HTTP_HOST="clear-mt.bunklogs.net")
+    request.user = AnonymousUser()
+    OrganizationMiddleware(get_response)(request)
+
+    assert get_current_organization() is None
+
+
+@pytest.mark.django_db
+def test_authenticated_fallback_when_host_has_no_tenant(org_alpha):
+    user = User.objects.create_user(email="staff@example.com", password="pw")
+    Person.all_objects.create(
+        organization=org_alpha,
+        first_name="S",
+        last_name="Taff",
+        user=user,
+    )
+
+    def get_response(request):
+        return HttpResponse("ok")
+
+    rf = RequestFactory()
+    request = rf.get("/", HTTP_HOST="bunklogs.net")
+    request.user = user
+    OrganizationMiddleware(get_response)(request)
+
+    assert request.organization == org_alpha

--- a/backend/bunk_logs/core/tests.py
+++ b/backend/bunk_logs/core/tests.py
@@ -60,7 +60,7 @@ class TestProgram:
     def test_create_program(self, org):
         start = date(2026, 6, 15)
         end = date(2026, 8, 15)
-        program = Program.objects.create(
+        program = Program.all_objects.create(
             organization=org,
             name="Summer 2026",
             slug="summer-2026",
@@ -75,7 +75,7 @@ class TestProgram:
     def test_cannot_duplicate_slug_within_org(self, org):
         start = date(2026, 6, 1)
         end = date(2026, 8, 1)
-        Program.objects.create(
+        Program.all_objects.create(
             organization=org,
             name="First",
             slug="shared-slug",
@@ -84,7 +84,7 @@ class TestProgram:
             end_date=end,
         )
         with pytest.raises(IntegrityError):
-            Program.objects.create(
+            Program.all_objects.create(
                 organization=org,
                 name="Second",
                 slug="shared-slug",
@@ -98,7 +98,7 @@ class TestProgram:
         org_b = Organization.objects.create(name="Camp B", slug="camp-b")
         start = date(2026, 6, 1)
         end = date(2026, 8, 1)
-        p_a = Program.objects.create(
+        p_a = Program.all_objects.create(
             organization=org_a,
             name="Program A",
             slug="fall",
@@ -106,7 +106,7 @@ class TestProgram:
             start_date=start,
             end_date=end,
         )
-        p_b = Program.objects.create(
+        p_b = Program.all_objects.create(
             organization=org_b,
             name="Program B",
             slug="fall",
@@ -131,7 +131,7 @@ class TestProgram:
         with pytest.raises(ValidationError):
             program.full_clean()
         with pytest.raises(IntegrityError):
-            Program.objects.create(
+            Program.all_objects.create(
                 organization=org,
                 name="Bad",
                 slug="bad-dates-orm",
@@ -148,7 +148,7 @@ class TestPerson:
         return Organization.objects.create(name="Crane Lake", slug="crane-lake")
 
     def test_create_without_user(self, org):
-        person = Person.objects.create(
+        person = Person.all_objects.create(
             organization=org,
             first_name="Alex",
             last_name="Rivera",
@@ -158,17 +158,17 @@ class TestPerson:
 
     def test_create_linked_to_user(self, org):
         user = User.objects.create_user(email="counselor@example.com", password="testpass123")
-        person = Person.objects.create(
+        person = Person.all_objects.create(
             organization=org,
             first_name="Sam",
             last_name="Lee",
             user=user,
         )
         assert person.user_id == user.pk
-        assert user.person_record == person
+        assert Person.all_objects.get(user=user) == person
 
     def test_full_name_uses_preferred_when_set(self, org):
-        person = Person.objects.create(
+        person = Person.all_objects.create(
             organization=org,
             first_name="Robert",
             last_name="Smith",
@@ -177,7 +177,7 @@ class TestPerson:
         assert person.full_name == "Bob Smith"
 
     def test_full_name_falls_back_to_first_name(self, org):
-        person = Person.objects.create(
+        person = Person.all_objects.create(
             organization=org,
             first_name="Jane",
             last_name="Doe",
@@ -186,7 +186,7 @@ class TestPerson:
 
     def test_external_ids_arbitrary_keys(self, org):
         payload = {"campminder_id": "12345", "other_system": "abc"}
-        person = Person.objects.create(
+        person = Person.all_objects.create(
             organization=org,
             first_name="Kid",
             last_name="Camper",
@@ -201,9 +201,9 @@ class TestPerson:
             person.save()
 
     def test_ordering_by_last_then_first_name(self, org):
-        Person.objects.create(organization=org, first_name="Ann", last_name="Zed")
-        Person.objects.create(organization=org, first_name="Bob", last_name="Ayer")
-        names = list(Person.objects.values_list("last_name", "first_name"))
+        Person.all_objects.create(organization=org, first_name="Ann", last_name="Zed")
+        Person.all_objects.create(organization=org, first_name="Bob", last_name="Ayer")
+        names = list(Person.all_objects.values_list("last_name", "first_name"))
         assert names == [("Ayer", "Bob"), ("Zed", "Ann")]
 
 
@@ -215,7 +215,7 @@ class TestMembership:
 
     @pytest.fixture
     def program(self, org):
-        return Program.objects.create(
+        return Program.all_objects.create(
             organization=org,
             name="Summer 2026",
             slug="summer-2026",
@@ -227,7 +227,7 @@ class TestMembership:
     @pytest.fixture
     def other_org_program(self):
         other = Organization.objects.create(name="Other", slug="other-org")
-        return Program.objects.create(
+        return Program.all_objects.create(
             organization=other,
             name="Fall 2026",
             slug="fall-2026",
@@ -238,31 +238,31 @@ class TestMembership:
 
     @pytest.fixture
     def person(self, org):
-        return Person.objects.create(
+        return Person.all_objects.create(
             organization=org,
             first_name="Jamie",
             last_name="Cohen",
         )
 
     def test_cannot_duplicate_program_person_role(self, program, person):
-        Membership.objects.create(program=program, person=person, role="counselor")
+        Membership.all_objects.create(program=program, person=person, role="counselor")
         with pytest.raises(IntegrityError):
-            Membership.objects.create(program=program, person=person, role="counselor")
+            Membership.all_objects.create(program=program, person=person, role="counselor")
 
     def test_same_person_multiple_programs(self, program, other_org_program, person):
-        Membership.objects.create(program=program, person=person, role="counselor")
-        Membership.objects.create(program=other_org_program, person=person, role="madrich")
-        assert Membership.objects.filter(person=person).count() == 2
+        Membership.all_objects.create(program=program, person=person, role="counselor")
+        Membership.all_objects.create(program=other_org_program, person=person, role="madrich")
+        assert Membership.all_objects.filter(person=person).count() == 2
 
     def test_same_person_multiple_roles_one_program(self, program, person):
-        Membership.objects.create(program=program, person=person, role="counselor")
-        Membership.objects.create(program=program, person=person, role="admin")
-        rows = list(Membership.objects.filter(program=program, person=person).values_list("role", flat=True))
+        Membership.all_objects.create(program=program, person=person, role="counselor")
+        Membership.all_objects.create(program=program, person=person, role="admin")
+        rows = list(Membership.all_objects.filter(program=program, person=person).values_list("role", flat=True))
         assert set(rows) == {"counselor", "admin"}
 
     def test_tags_list_of_strings(self, program, person):
         tags = ["international", "israeli", "specialist:waterfront"]
-        m = Membership.objects.create(
+        m = Membership.all_objects.create(
             program=program,
             person=person,
             role="specialist",
@@ -273,9 +273,9 @@ class TestMembership:
 
     def test_all_role_choices_queryable(self, program, person):
         for value, _label in Membership.ROLES:
-            Membership.objects.create(program=program, person=person, role=value)
+            Membership.all_objects.create(program=program, person=person, role=value)
         for value, _label in Membership.ROLES:
-            assert Membership.objects.filter(role=value).exists()
+            assert Membership.all_objects.filter(role=value).exists()
 
 
 def _minimal_prompts_field(ftype: str, key: str) -> dict:
@@ -310,7 +310,7 @@ class TestReflectionTemplate:
     )
     def test_create_with_each_prompt_field_type(self, org, ftype):
         fields = [_minimal_prompts_field(ftype, "f1")]
-        t = ReflectionTemplate.objects.create(
+        t = ReflectionTemplate.all_objects.create(
             organization=org,
             name="Weekly",
             slug=f"weekly-{ftype}",
@@ -322,7 +322,7 @@ class TestReflectionTemplate:
         assert t.pk is not None
 
     def test_create_rating_group(self, org):
-        t = ReflectionTemplate.objects.create(
+        t = ReflectionTemplate.all_objects.create(
             organization=org,
             name="Ratings",
             slug="ratings-weekly",
@@ -356,7 +356,7 @@ class TestReflectionTemplate:
             t.full_clean()
 
     def test_parent_template_version_chain(self, org):
-        v1 = ReflectionTemplate.objects.create(
+        v1 = ReflectionTemplate.all_objects.create(
             organization=org,
             name="Same",
             slug="same-template",
@@ -364,7 +364,7 @@ class TestReflectionTemplate:
             cadence="weekly",
             schema={"fields": [_minimal_prompts_field("text", "note")]},
         )
-        v2 = ReflectionTemplate.objects.create(
+        v2 = ReflectionTemplate.all_objects.create(
             organization=org,
             name="Same",
             slug="same-template",
@@ -374,11 +374,11 @@ class TestReflectionTemplate:
             schema={"fields": [_minimal_prompts_field("textarea", "note")]},
         )
         v1.refresh_from_db()
-        assert list(v1.versions.all()) == [v2]
+        assert list(ReflectionTemplate.all_objects.filter(parent_template=v1)) == [v2]
         assert v2.parent_template_id == v1.pk
 
     def test_unique_org_slug_version(self, org):
-        ReflectionTemplate.objects.create(
+        ReflectionTemplate.all_objects.create(
             organization=org,
             name="A",
             slug="shared",
@@ -387,7 +387,7 @@ class TestReflectionTemplate:
             schema={"fields": [_minimal_prompts_field("text", "a")]},
         )
         with pytest.raises(IntegrityError):
-            ReflectionTemplate.objects.create(
+            ReflectionTemplate.all_objects.create(
                 organization=org,
                 name="B",
                 slug="shared",
@@ -397,7 +397,7 @@ class TestReflectionTemplate:
             )
 
     def test_global_template_str(self):
-        t = ReflectionTemplate.objects.create(
+        t = ReflectionTemplate.all_objects.create(
             organization=None,
             name="Global",
             slug="global-daily",
@@ -415,7 +415,7 @@ class TestReflection:
 
     @pytest.fixture
     def program(self, org):
-        return Program.objects.create(
+        return Program.all_objects.create(
             organization=org,
             name="Summer 2026",
             slug="summer-2026",
@@ -426,7 +426,7 @@ class TestReflection:
 
     @pytest.fixture
     def person(self, org):
-        return Person.objects.create(
+        return Person.all_objects.create(
             organization=org,
             first_name="Jamie",
             last_name="Cohen",
@@ -434,7 +434,7 @@ class TestReflection:
 
     @pytest.fixture
     def template(self, org):
-        return ReflectionTemplate.objects.create(
+        return ReflectionTemplate.all_objects.create(
             organization=org,
             name="Weekly check-in",
             slug="weekly-checkin",
@@ -445,7 +445,7 @@ class TestReflection:
 
     @pytest.fixture
     def other_role_template(self, org):
-        return ReflectionTemplate.objects.create(
+        return ReflectionTemplate.all_objects.create(
             organization=org,
             name="Kitchen weekly",
             slug="kitchen-weekly",
@@ -519,7 +519,7 @@ class TestReflection:
             r.full_clean()
 
     def test_optional_field_may_be_omitted(self, org, program, person):
-        tmpl = ReflectionTemplate.objects.create(
+        tmpl = ReflectionTemplate.all_objects.create(
             organization=org,
             name="Optional extra",
             slug="optional-extra",
@@ -559,7 +559,7 @@ class TestReflection:
 
     def test_period_end_before_start_rejected_at_db(self, org, program, person, template):
         with pytest.raises(IntegrityError):
-            Reflection.objects.create(
+            Reflection.all_objects.create(
                 organization=org,
                 program=program,
                 person=person,
@@ -571,14 +571,14 @@ class TestReflection:
 
     def test_query_by_person(self, org, program, person, template):
         self._make_reflection(org, program, person, template)
-        other = Person.objects.create(organization=org, first_name="Other", last_name="Person")
+        other = Person.all_objects.create(organization=org, first_name="Other", last_name="Person")
         self._make_reflection(org, program, other, template, answers={"highlight": "other"})
-        qs = Reflection.objects.filter(person=person)
+        qs = Reflection.all_objects.filter(person=person)
         assert qs.count() == 1
         assert qs.get().person_id == person.pk
 
     def test_query_by_program(self, org, program, person, template):
-        p2 = Program.objects.create(
+        p2 = Program.all_objects.create(
             organization=org,
             name="Fall",
             slug="fall-2026",
@@ -588,7 +588,7 @@ class TestReflection:
         )
         self._make_reflection(org, program, person, template)
         self._make_reflection(org, p2, person, template, answers={"highlight": "fall"})
-        assert Reflection.objects.filter(program=program).count() == 1
+        assert Reflection.all_objects.filter(program=program).count() == 1
 
     def test_query_by_date_range(self, org, program, person, template):
         self._make_reflection(
@@ -609,9 +609,9 @@ class TestReflection:
             period_end=date(2026, 8, 7),
             answers={"highlight": "week2"},
         )
-        qs = Reflection.objects.filter(period_end__gte=date(2026, 7, 1), period_end__lte=date(2026, 7, 31))
+        qs = Reflection.all_objects.filter(period_end__gte=date(2026, 7, 1), period_end__lte=date(2026, 7, 31))
         assert qs.count() == 0
-        qs2 = Reflection.objects.filter(period_end__gte=date(2026, 6, 1), period_end__lte=date(2026, 6, 30))
+        qs2 = Reflection.all_objects.filter(period_end__gte=date(2026, 6, 1), period_end__lte=date(2026, 6, 30))
         assert qs2.count() == 1
 
     def test_query_by_template_role(self, org, program, person, template, other_role_template):
@@ -623,7 +623,7 @@ class TestReflection:
             other_role_template,
             answers={"shift": "ok"},
         )
-        counselor_only = Reflection.objects.filter(template__role="counselor")
+        counselor_only = Reflection.all_objects.filter(template__role="counselor")
         assert counselor_only.count() == 1
         assert counselor_only.get().template_id == template.pk
 

--- a/backend/config/settings/admin_only.py
+++ b/backend/config/settings/admin_only.py
@@ -28,6 +28,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "bunk_logs.core.middleware.OrganizationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "debug_toolbar.middleware.DebugToolbarMiddleware",

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -165,6 +165,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "bunk_logs.core.middleware.OrganizationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "allauth.account.middleware.AccountMiddleware",


### PR DESCRIPTION
## Summary
Implements migration step `2_7_add_multitenant_middleware`: tenant resolution middleware, thread-local org context, scoped managers on Program/Person/Membership/ReflectionTemplate/Reflection (`all_objects` bypass), Django admin unscoped querysets, and tests.

## Testing
- `make test-backend` (passes locally via Podman)

Made with [Cursor](https://cursor.com)