### PR TITLE
2_8_build_subdomain_routing: subdomain organization routing

### DIFF
--- a/backend/bunk_logs/core/middleware.py
+++ b/backend/bunk_logs/core/middleware.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import SuspiciousOperation
 
 from bunk_logs.core.context import clear_current_organization
 from bunk_logs.core.context import set_current_organization
@@ -18,9 +20,32 @@ _SUBDOMAIN_SKIP = frozenset({"", "www", "admin", "api", "localhost"})
 
 
 def _raw_request_host(request: HttpRequest) -> str:
-    """Host for tenant routing without triggering ALLOWED_HOSTS (see get_host())."""
+    """Host from META when get_host() rejects the client (e.g. tests, misconfigured ALLOWED_HOSTS)."""
     raw = request.META.get("HTTP_HOST", "")
     return raw.split(":")[0] if raw else ""
+
+
+def _request_host_for_tenant(request: HttpRequest) -> str:
+    try:
+        return request.get_host().split(":")[0].lower()
+    except SuspiciousOperation:
+        return _raw_request_host(request)
+
+
+def _dev_org_routing_overrides_enabled() -> bool:
+    return bool(settings.DEBUG) or bool(
+        getattr(settings, "ORGANIZATION_ROUTING_DEV_OVERRIDES", False),
+    )
+
+
+def _dev_org_slug_override(request: HttpRequest) -> str | None:
+    if not _dev_org_routing_overrides_enabled():
+        return None
+    header = (request.META.get("HTTP_X_ORGANIZATION_SLUG") or "").strip()
+    if header:
+        return header
+    q = (request.GET.get("org") or "").strip()
+    return q or None
 
 
 def _host_subdomain_label(host: str) -> str | None:
@@ -47,12 +72,20 @@ class OrganizationMiddleware:
 
         org: Organization | None = None
         try:
-            label = _host_subdomain_label(_raw_request_host(request))
+            label = _host_subdomain_label(_request_host_for_tenant(request))
             if label:
                 try:
                     org = Organization.objects.get(slug=label, is_active=True)
                 except ObjectDoesNotExist:
                     org = None
+
+            if org is None:
+                slug = _dev_org_slug_override(request)
+                if slug:
+                    try:
+                        org = Organization.objects.get(slug=slug, is_active=True)
+                    except ObjectDoesNotExist:
+                        org = None
 
             user = getattr(request, "user", None)
             if org is None and user is not None and user.is_authenticated:

--- a/backend/bunk_logs/core/test_multitenancy.py
+++ b/backend/bunk_logs/core/test_multitenancy.py
@@ -180,6 +180,82 @@ def test_middleware_clears_thread_local_after_request():
 
 
 @pytest.mark.django_db
+def test_subdomain_clc_resolves_organization():
+    org = Organization.objects.create(name="Crane Lake", slug="clc")
+
+    def get_response(request):
+        return HttpResponse("ok")
+
+    rf = RequestFactory()
+    request = rf.get("/", HTTP_HOST="clc.bunklogs.net")
+    request.user = AnonymousUser()
+    OrganizationMiddleware(get_response)(request)
+
+    assert request.organization == org
+
+
+@pytest.mark.django_db
+def test_subdomain_unknown_returns_no_organization():
+    Organization.objects.create(name="Real Org", slug="realorg")
+
+    def get_response(request):
+        return HttpResponse("ok")
+
+    rf = RequestFactory()
+    request = rf.get("/", HTTP_HOST="notrealorg.bunklogs.net")
+    request.user = AnonymousUser()
+    OrganizationMiddleware(get_response)(request)
+
+    assert request.organization is None
+
+
+@pytest.mark.django_db
+def test_dev_header_resolves_organization(org_alpha, settings):
+    settings.ORGANIZATION_ROUTING_DEV_OVERRIDES = True
+
+    def get_response(request):
+        return HttpResponse("ok")
+
+    rf = RequestFactory()
+    request = rf.get("/", HTTP_HOST="localhost", HTTP_X_ORGANIZATION_SLUG="alpha-mt")
+    request.user = AnonymousUser()
+    OrganizationMiddleware(get_response)(request)
+
+    assert request.organization == org_alpha
+
+
+@pytest.mark.django_db
+def test_dev_query_param_resolves_organization(org_alpha, settings):
+    settings.ORGANIZATION_ROUTING_DEV_OVERRIDES = True
+
+    def get_response(request):
+        return HttpResponse("ok")
+
+    rf = RequestFactory()
+    request = rf.get("/?org=alpha-mt", HTTP_HOST="localhost")
+    request.user = AnonymousUser()
+    OrganizationMiddleware(get_response)(request)
+
+    assert request.organization == org_alpha
+
+
+@pytest.mark.django_db
+def test_dev_override_disabled_ignores_header(org_alpha, settings):
+    settings.DEBUG = False
+    settings.ORGANIZATION_ROUTING_DEV_OVERRIDES = False
+
+    def get_response(request):
+        return HttpResponse("ok")
+
+    rf = RequestFactory()
+    request = rf.get("/", HTTP_HOST="localhost", HTTP_X_ORGANIZATION_SLUG="alpha-mt")
+    request.user = AnonymousUser()
+    OrganizationMiddleware(get_response)(request)
+
+    assert request.organization is None
+
+
+@pytest.mark.django_db
 def test_authenticated_fallback_when_host_has_no_tenant(org_alpha):
     user = User.objects.create_user(email="staff@example.com", password="pw")
     Person.all_objects.create(

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -437,6 +437,7 @@ if IS_PRODUCTION:
     ALLOWED_HOSTS = [
         "bunklogs.net",
         "www.bunklogs.net",
+        ".bunklogs.net",  # Any *.bunklogs.net tenant subdomain (Django leading-dot rule)
         "*.onrender.com",  # For Render.com deployments
         "*.run.app",  # Keep for any remaining GCP services
         "bunk-logs-backend-461994890254.us-central1.run.app",
@@ -453,7 +454,7 @@ else:
         "http://localhost:5173",
         "https://clc.bunklogs.net",
     ]
-    ALLOWED_HOSTS = ["localhost", "localhost:5173", "127.0.0.1"]
+    ALLOWED_HOSTS = ["localhost", "localhost:5173", "127.0.0.1", ".bunklogs.net"]
 
 from corsheaders.defaults import default_headers
 
@@ -462,6 +463,7 @@ CORS_ALLOW_HEADERS = (
     "x-session-token",
     "x-email-verification-key",
     "x-password-reset-key",
+    "x-organization-slug",
 )
 
 CORS_ALLOW_CREDENTIALS = True

--- a/backend/config/settings/local.py
+++ b/backend/config/settings/local.py
@@ -24,7 +24,7 @@ SECRET_KEY = env(
     default="UwQ4Bqm56JIeEszbx3merf4E5Pcl5Ih9IVOdDjeOsZEDWJ52uovXQTmOuNApPyIm",
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1", "testserver"]
+ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1", "testserver", ".bunklogs.net"]
 
 # CACHES
 # ------------------------------------------------------------------------------

--- a/backend/config/settings/production.py
+++ b/backend/config/settings/production.py
@@ -11,7 +11,10 @@ from .base import env
 # https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
 SECRET_KEY = env("DJANGO_SECRET_KEY")
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["bunklogs.net"])
+ALLOWED_HOSTS = env.list(
+    "DJANGO_ALLOWED_HOSTS",
+    default=["bunklogs.net", "www.bunklogs.net", ".bunklogs.net"],
+)
 
 # DATABASES
 # ------------------------------------------------------------------------------
@@ -310,9 +313,13 @@ CSRF_TRUSTED_ORIGINS = [
 ]
 
 # Update allowed hosts to remove localhost in production
-ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=[
-    "admin.bunklogs.net",      # Your custom domain
-    "bunklogs.onrender.com",   # Original Render URL
-    "bunklogs.net",
-    "www.bunklogs.net",
-])
+ALLOWED_HOSTS = env.list(
+    "DJANGO_ALLOWED_HOSTS",
+    default=[
+        "admin.bunklogs.net",  # Your custom domain
+        "bunklogs.onrender.com",  # Original Render URL
+        "bunklogs.net",
+        "www.bunklogs.net",
+        ".bunklogs.net",  # Any *.bunklogs.net tenant subdomain
+    ],
+)

--- a/backend/config/settings/production_gcs.py
+++ b/backend/config/settings/production_gcs.py
@@ -18,6 +18,7 @@ SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
 ALLOWED_HOSTS = [
     "*.run.app",
     "bunklogs.net",
+    ".bunklogs.net",
     "bunk-logs-backend-koumwfa74a-uc.a.run.app",
     "bunk-logs-backend-461994890254.us-central1.run.app",
     "localhost",
@@ -230,6 +231,7 @@ CSRF_TRUSTED_ORIGINS = [
 ALLOWED_HOSTS = [
     "*.run.app",
     "bunklogs.net",
+    ".bunklogs.net",
     "bunk-logs-backend-koumwfa74a-uc.a.run.app",
     "bunk-logs-backend-461994890254.us-central1.run.app",
     "localhost",

--- a/backend/config/settings/render.py
+++ b/backend/config/settings/render.py
@@ -21,6 +21,7 @@ ALLOWED_HOSTS = env.list(
     default=[
         "bunklogs.net",
         "www.bunklogs.net",
+        ".bunklogs.net",  # Any *.bunklogs.net tenant subdomain
         "admin.bunklogs.net",  # Admin subdomain
         "*.onrender.com",  # Render.com domain pattern
     ],

--- a/backend/config/settings/test.py
+++ b/backend/config/settings/test.py
@@ -56,3 +56,5 @@ HEADLESS_ONLY = False
 MEDIA_URL = "http://media.testserver/"
 # Your stuff...
 # ------------------------------------------------------------------------------
+# OrganizationMiddleware: allow X-Organization-Slug / ?org= in tests (DEBUG is False in CI).
+ORGANIZATION_ROUTING_DEV_OVERRIDES = True

--- a/docs/multi-tenant-routing.md
+++ b/docs/multi-tenant-routing.md
@@ -1,0 +1,42 @@
+# Multi-tenant routing (subdomains)
+
+## How it works
+
+`OrganizationMiddleware` resolves the current organization from the HTTP host:
+
+- Hosts matching `*.bunklogs.net` use the first DNS label as the organization **slug** (e.g. `clc.bunklogs.net` → slug `clc`, `tbe.bunklogs.net` → slug `tbe`).
+- Reserved labels (no tenant lookup): `www`, `admin`, `api`, `localhost`, and the empty label.
+
+If no organization matches the subdomain, `request.organization` is `None`. Authenticated users may still get an organization from their linked `Person` record when the host does not imply a tenant (existing fallback).
+
+The host is read via `request.get_host()` when Django accepts the host; otherwise the middleware falls back to `HTTP_HOST` so tests and edge cases still behave.
+
+## Adding a new organization
+
+1. **Django admin** (or a migration/data script): create an `Organization` with `slug` equal to the subdomain label you will use (e.g. `tbe` for `tbe.bunklogs.net`). Keep `is_active` true.
+2. **DNS**: add a CNAME (or A/AAAA) for `{slug}.bunklogs.net` pointing at the same frontend/backend entrypoints you use today (e.g. Render static site + API on `admin.bunklogs.net` or tenant-specific origins as you roll them out).
+
+If `DJANGO_ALLOWED_HOSTS` is overridden in the environment, include `.bunklogs.net` (leading dot) so Django accepts every tenant subdomain, or list each hostname explicitly.
+
+## Local development
+
+- **Header**: With `DEBUG=True` (local settings) or `ORGANIZATION_ROUTING_DEV_OVERRIDES=True` (set in `config.settings.test` so CI can exercise overrides without turning on `DEBUG`), send `X-Organization-Slug: <slug>` on API requests when using `localhost` or another host without a tenant subdomain.
+- **Query string**: Same conditions: append `?org=<slug>` for quick browser testing.
+- **Real subdomain locally**: Map e.g. `clc.bunklogs.net` to `127.0.0.1` in `/etc/hosts` and include `.bunklogs.net` in `ALLOWED_HOSTS` (already included in `config.settings.local`).
+
+CORS allows the `x-organization-slug` header from browser clients (see `CORS_ALLOW_HEADERS` in base settings).
+
+## Session and CSRF cookies across subdomains
+
+Production (`config.settings.production` and `config.settings.render`) sets:
+
+- `SESSION_COOKIE_DOMAIN = ".bunklogs.net"`
+- `CSRF_COOKIE_DOMAIN = ".bunklogs.net"`
+
+so one session can be shared across `admin.bunklogs.net`, `clc.bunklogs.net`, and other subdomains. That matches the current headless Allauth + browser flows where the API and apps live on different subdomains.
+
+**Tighter isolation (optional):** If you want cookies scoped to a single host only, set `SESSION_COOKIE_DOMAIN` and `CSRF_COOKIE_DOMAIN` to `None` (host-only) and rely on JWT or per-subdomain login. That avoids accidental session sharing between tenants on different subdomains but requires coordinated frontend/API auth changes.
+
+## Tests
+
+See `bunk_logs/core/test_multitenancy.py` for subdomain resolution, dev header/query overrides, unknown subdomains, and thread-local cleanup.


### PR DESCRIPTION
## Summary
Implements migration step **2_8_build_subdomain_routing**: subdomain-based `Organization` resolution, dev overrides, `ALLOWED_HOSTS` for `*.bunklogs.net`, and documentation.

## Changes
- **Middleware**: Tenant from host via `get_host()` with `SuspiciousOperation` → `HTTP_HOST` fallback; dev/test overrides via `X-Organization-Slug` and `?org=` when `DEBUG` or `ORGANIZATION_ROUTING_DEV_OVERRIDES`.
- **Settings**: `.bunklogs.net` in `ALLOWED_HOSTS` (base/local/production/render/production_gcs); `ORGANIZATION_ROUTING_DEV_OVERRIDES` in test settings; `x-organization-slug` in CORS allow list.
- **Docs**: `docs/multi-tenant-routing.md` (DNS, local testing, session cookies).
- **Tests**: `bunk_logs/core/test_multitenancy.py` — clc subdomain, unknown subdomain, header/query, overrides disabled.

## Verification
- `make test-backend` — 195 passed
- `make test-frontend` + `npm run build` (CI parity) — passed locally


Made with [Cursor](https://cursor.com)