### PR TITLE
feat(migration-dashboard): restore staff migration status UI on main

### DIFF
--- a/backend/config/migration_views.py
+++ b/backend/config/migration_views.py
@@ -1,10 +1,17 @@
+import os
 import re
 import subprocess
 from pathlib import Path
 
 from django.conf import settings
-from django.http import JsonResponse
-from django.views.decorators.http import require_GET
+from rest_framework import status
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.decorators import api_view
+from rest_framework.decorators import authentication_classes
+from rest_framework.decorators import permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework_simplejwt.authentication import JWTAuthentication
 
 PHASE_NAMES = {
     0: "Setup & Context",
@@ -18,18 +25,57 @@ PHASE_NAMES = {
 
 SKIP_FILES = {"prefix.md"}
 
-# In the Docker container the repo root is mounted at /repo.
-# In production (Render) BASE_DIR is backend/ so parent is the repo root.
-_CONTAINER_REPO = Path("/repo")
-_REPO_ROOT = _CONTAINER_REPO if (_CONTAINER_REPO / ".git").exists() else Path(settings.BASE_DIR).parent
-PROMPTS_DIR = _REPO_ROOT / "migration_prompts"
+# When the deliverable merged under a later step's commit (e.g. 1_5 doc in 1_6 PR),
+# git log main will not mention the earlier step id — treat as done if these paths exist on main.
+STEP_COMPLETION_ARTIFACTS: dict[str, tuple[str, ...]] = {
+    "1_5": ("docs/api-consolidation-plan.md",),
+}
+
+
+def _backend_dir() -> Path:
+    return Path(settings.BASE_DIR).resolve()
+
+
+def _git_cwd() -> Path:
+    """Directory that contains the repo .git (used for git log / cat-file)."""
+    raw_env = os.environ.get("BUNKLOGS_REPO_ROOT", "").strip()
+    if raw_env:
+        er = Path(raw_env).resolve()
+        if (er / ".git").exists():
+            return er
+    backend = _backend_dir()
+    if (backend.parent / ".git").exists():
+        return backend.parent
+    if (backend / ".git").exists():
+        return backend
+    container = Path("/repo")
+    if (container / ".git").exists():
+        return container
+    return backend.parent
+
+
+def _migration_prompts_dir() -> Path | None:
+    """Where migration_prompts/*.md live (monorepo sibling, bundled under backend, or env override)."""
+    raw_env = os.environ.get("BUNKLOGS_REPO_ROOT", "").strip()
+    if raw_env:
+        mp = Path(raw_env).resolve() / "migration_prompts"
+        if mp.is_dir():
+            return mp
+    backend = _backend_dir()
+    for cand in (backend / "migration_prompts", backend.parent / "migration_prompts"):
+        if cand.is_dir():
+            return cand
+    container = Path("/repo")
+    if (container / "migration_prompts").is_dir():
+        return container / "migration_prompts"
+    return None
 
 
 def _run_git(args: list[str]) -> str:
     try:
         result = subprocess.run(  # noqa: S603
             ["git", *args],  # noqa: S607
-            cwd=str(_REPO_ROOT),
+            cwd=str(_git_cwd()),
             capture_output=True,
             text=True,
             timeout=10,
@@ -51,7 +97,6 @@ def _parse_step_id(filename: str) -> tuple[str, int, int]:
     m2 = re.match(r"^(\d+)_", stem)
     if m2:
         phase = int(m2.group(1))
-        # non-numeric second segment; use 0 as sort key so it sorts before 0_1
         return stem, phase, 0
     return stem, 0, 0
 
@@ -65,30 +110,68 @@ def _parse_title(path: Path) -> str:
     return path.stem
 
 
+def _artifacts_satisfied_on_main(step_id: str) -> bool:
+    rels = STEP_COMPLETION_ARTIFACTS.get(step_id)
+    if not rels:
+        return False
+    for rel in rels:
+        result = subprocess.run(  # noqa: S603
+            ["git", "cat-file", "-e", f"main:{rel}"],  # noqa: S607
+            cwd=str(_git_cwd()),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if result.returncode != 0:
+            return False
+    return True
+
+
 def _determine_status(step_id: str, main_log: str, branch_names: set, merged_branches: set) -> tuple[str, str | None]:
     """Return (status, branch_name_or_None)."""
-    # A step is completed if the step_id appears in a main-branch commit message.
-    # Use (?![0-9]) instead of trailing \b because _ is a word char, so
-    # \b1_2\b would NOT match "1_2_resolve_..." in commit messages.
     if re.search(rf"\b{re.escape(step_id)}(?![0-9])", main_log):
         return "completed", None
-    # Or if a matching branch has been merged into main
+    if _artifacts_satisfied_on_main(step_id):
+        return "completed", None
     for branch in merged_branches:
         if step_id in branch and branch not in ("main", "HEAD"):
             return "completed", None
-    # In-progress: a live unmerged branch exists that references this step
     for branch in branch_names - merged_branches:
         if step_id in branch:
             return "in_progress", branch
     return "pending", None
 
 
-@require_GET
+@api_view(["GET"])
+@authentication_classes([JWTAuthentication, SessionAuthentication])
+@permission_classes([IsAuthenticated])
 def migration_status(request):
-    if not PROMPTS_DIR.exists():
-        return JsonResponse({"error": "migration_prompts directory not accessible", "steps": []}, status=200)
+    if not request.user.is_staff:
+        return Response(
+            {
+                "error": "Staff only",
+                "steps": [],
+                "git_available": False,
+                "has_uncommitted_changes": False,
+            },
+            status=status.HTTP_403_FORBIDDEN,
+        )
 
-    files = sorted(f for f in PROMPTS_DIR.glob("*.md") if f.name not in SKIP_FILES)
+    prompts_dir = _migration_prompts_dir()
+    if not prompts_dir:
+        return Response(
+            {
+                "error": "migration_prompts directory not accessible",
+                "steps": [],
+                "git_available": False,
+                "has_uncommitted_changes": False,
+                "prompts_path_checked": str(_backend_dir() / "migration_prompts"),
+            },
+            status=status.HTTP_200_OK,
+        )
+
+    files = sorted(f for f in prompts_dir.glob("*.md") if f.name not in SKIP_FILES)
 
     main_log = _run_git(["log", "main", "--oneline"])
     all_branches_raw = _run_git(["branch", "--all"])
@@ -114,7 +197,7 @@ def migration_status(request):
     for path in files:
         step_id, phase, step_num = _parse_step_id(path.name)
         title = _parse_title(path)
-        status, branch = _determine_status(step_id, main_log, branch_names, merged_branches)
+        step_status, branch = _determine_status(step_id, main_log, branch_names, merged_branches)
         steps.append({
             "id": step_id,
             "phase": phase,
@@ -122,15 +205,16 @@ def migration_status(request):
             "step_num": step_num,
             "file": path.name,
             "title": title,
-            "status": status,
+            "status": step_status,
             "branch": branch,
         })
 
     steps.sort(key=lambda s: (s["phase"], s["step_num"], s["file"]))
 
-    return JsonResponse({
+    return Response({
         "steps": steps,
         "git_available": git_available,
         "has_uncommitted_changes": bool(git_status),
-        "repo_root": str(_REPO_ROOT),
+        "repo_root": str(_git_cwd()),
+        "migration_prompts_dir": str(prompts_dir),
     })

--- a/backend/config/migration_views.py
+++ b/backend/config/migration_views.py
@@ -54,6 +54,23 @@ def _git_cwd() -> Path:
     return backend.parent
 
 
+def _git_mainline_ref() -> str:
+    """Ref treated as 'main' for log/cat-file (CI often has no local ``main``, only ``origin/main``)."""
+    cwd = str(_git_cwd())
+    for candidate in ("main", "origin/main"):
+        result = subprocess.run(  # noqa: S603
+            ["git", "rev-parse", "--verify", candidate],  # noqa: S607
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if result.returncode == 0:
+            return candidate
+    return "HEAD"
+
+
 def _migration_prompts_dir() -> Path | None:
     """Where migration_prompts/*.md live (monorepo sibling, bundled under backend, or env override)."""
     raw_env = os.environ.get("BUNKLOGS_REPO_ROOT", "").strip()
@@ -114,10 +131,12 @@ def _artifacts_satisfied_on_main(step_id: str) -> bool:
     rels = STEP_COMPLETION_ARTIFACTS.get(step_id)
     if not rels:
         return False
+    base = _git_mainline_ref()
+    cwd = str(_git_cwd())
     for rel in rels:
         result = subprocess.run(  # noqa: S603
-            ["git", "cat-file", "-e", f"main:{rel}"],  # noqa: S607
-            cwd=str(_git_cwd()),
+            ["git", "cat-file", "-e", f"{base}:{rel}"],  # noqa: S607
+            cwd=cwd,
             capture_output=True,
             text=True,
             timeout=10,
@@ -173,9 +192,10 @@ def migration_status(request):
 
     files = sorted(f for f in prompts_dir.glob("*.md") if f.name not in SKIP_FILES)
 
-    main_log = _run_git(["log", "main", "--oneline"])
+    mainline = _git_mainline_ref()
+    main_log = _run_git(["log", mainline, "--oneline"])
     all_branches_raw = _run_git(["branch", "--all"])
-    merged_raw = _run_git(["branch", "--all", "--merged", "main"])
+    merged_raw = _run_git(["branch", "--all", "--merged", mainline])
     git_status = _run_git(["status", "--porcelain"])
     git_available = bool(all_branches_raw)
 

--- a/backend/config/tests/test_migration_status.py
+++ b/backend/config/tests/test_migration_status.py
@@ -1,0 +1,68 @@
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_migration_status_requires_authentication():
+    client = APIClient()
+    response = client.get("/api/migration-status/")
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_migration_status_forbidden_for_non_staff():
+    client = APIClient()
+    user = User.objects.create_user(
+        email="counselor@example.com",
+        password="pass12345",
+        role=User.COUNSELOR,
+        is_staff=False,
+    )
+    client.force_authenticate(user=user)
+    response = client.get("/api/migration-status/")
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_migration_status_ok_for_staff():
+    client = APIClient()
+    user = User.objects.create_user(
+        email="admin@example.com",
+        password="pass12345",
+        role=User.ADMIN,
+        is_staff=True,
+    )
+    client.force_authenticate(user=user)
+    response = client.get("/api/migration-status/")
+    assert response.status_code == 200
+    body = response.json()
+    assert "steps" in body
+    assert isinstance(body["steps"], list)
+
+
+@pytest.mark.django_db
+def test_migration_status_marks_1_5_complete_via_artifact_on_main():
+    """1_5 inventory landed in a 1_6 commit message; artifact-based rule still marks it completed."""
+    from config.migration_views import STEP_COMPLETION_ARTIFACTS
+    from config.migration_views import _artifacts_satisfied_on_main
+
+    assert "1_5" in STEP_COMPLETION_ARTIFACTS
+    assert _artifacts_satisfied_on_main("1_5") is True
+
+    client = APIClient()
+    user = User.objects.create_user(
+        email="admin2@example.com",
+        password="pass12345",
+        role=User.ADMIN,
+        is_staff=True,
+    )
+    client.force_authenticate(user=user)
+    response = client.get("/api/migration-status/")
+    assert response.status_code == 200
+    steps = response.json()["steps"]
+    row = next((s for s in steps if s["id"] == "1_5"), None)
+    assert row is not None
+    assert row["status"] == "completed"

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -10,6 +10,7 @@ from drf_spectacular.views import SpectacularSwaggerView
 from rest_framework.authtoken.views import obtain_auth_token
 
 from config import views
+from config.migration_views import migration_status
 
 urlpatterns = [
     path("", TemplateView.as_view(template_name="pages/home.html"), name="home"),
@@ -55,6 +56,7 @@ urlpatterns += [
     path("api/auth/google/callback/", views.google_callback, name="google_callback"),
     path("api/auth/google/callback/token/", views.google_login_callback, name="google_login_callback"),
     path("api/get-csrf-token/", views.get_csrf_token, name="get-csrf-token"),
+    path("api/migration-status/", migration_status, name="migration-status"),
 ]
 
 if settings.DEBUG:

--- a/backend/docker-compose.local.yml
+++ b/backend/docker-compose.local.yml
@@ -13,6 +13,8 @@ services:
       - mailpit
     volumes:
       - .:/app:z
+      # Full monorepo (includes .git) so /api/migration-status/ can read git history and branches.
+      - ..:/repo:z
       - static_volume:/app/staticfiles
       - media_volume:/app/media
     env_file:
@@ -23,6 +25,8 @@ services:
     command: /start
     environment:
       - USE_DOCKER=yes
+      # migration_views._git_cwd / _migration_prompts_dir (not set on host pytest — BASE_DIR parent has .git)
+      - BUNKLOGS_REPO_ROOT=/repo
 
   postgres:
     image: postgres:16

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -2,7 +2,7 @@
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "--ds=config.settings.test --reuse-db --import-mode=importlib"
-testpaths = ["bunk_logs"]
+testpaths = ["bunk_logs", "config/tests"]
 python_files = [
     "tests.py",
     "test_*.py",

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
         document.querySelector('html').style.colorScheme = 'light';
       }        
     </script>      
-    <script type="module" crossorigin src="/assets/index-DCfQuyK_.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DP1_GI0p.css">
+    <script type="module" crossorigin src="/assets/index-bIPYocwW.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BdAWbDtO.css">
   </head>
   <body class="font-inter antialiased bg-gray-100 dark:bg-gray-900 text-gray-600 dark:text-gray-400">
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -21,6 +21,7 @@ import OrderDetail from './pages/OrderDetail';
 import OrderEdit from './pages/OrderEdit';
 import AdminBunkLogs from './pages/AdminBunkLogs';
 import StaffMemberHistory from './pages/StaffMemberHistory';
+import MigrationDashboard from './pages/MigrationDashboard';
 import { useBunk } from './contexts/BunkContext';
 
 // Protected route component
@@ -247,7 +248,16 @@ function Router() {
         />
 
         <Route path="/test-datepicker" element={<DatePickerTest />} />
-        
+
+        <Route
+          path="/migration-dashboard"
+          element={
+            <ProtectedRoute>
+              <MigrationDashboard />
+            </ProtectedRoute>
+          }
+        />
+
         {/* Default redirect */}
         <Route path="/" element={<Navigate to="/dashboard" />} />
         <Route path="*" element={<Navigate to="/dashboard" />} />

--- a/frontend/src/pages/MigrationDashboard.jsx
+++ b/frontend/src/pages/MigrationDashboard.jsx
@@ -1,0 +1,291 @@
+import { useEffect, useState } from "react";
+
+import api from "../api";
+
+const apiUrl = (import.meta.env.VITE_API_URL || "http://localhost:8000").replace(/['"]/g, "").trim();
+
+const PHASE_ORDER = [0, 1, 2, 3, 4, 5, 6];
+
+const STATUS_CONFIG = {
+  completed: {
+    label: "Completed",
+    bg: "bg-emerald-50 border-emerald-200",
+    badge: "bg-emerald-100 text-emerald-800",
+    icon: (
+      <svg className="w-5 h-5 text-emerald-500 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  },
+  in_progress: {
+    label: "In Progress",
+    bg: "bg-amber-50 border-amber-200",
+    badge: "bg-amber-100 text-amber-800",
+    icon: (
+      <svg className="w-5 h-5 text-amber-500 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6l4 2m6-2a10 10 0 11-20 0 10 10 0 0120 0z" />
+      </svg>
+    ),
+  },
+  pending: {
+    label: "Pending",
+    bg: "bg-white border-gray-200",
+    badge: "bg-gray-100 text-gray-600",
+    icon: (
+      <svg className="w-5 h-5 text-gray-300 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+      </svg>
+    ),
+  },
+  blocked: {
+    label: "Blocked",
+    bg: "bg-red-50 border-red-200",
+    badge: "bg-red-100 text-red-700",
+    icon: (
+      <svg className="w-5 h-5 text-red-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+      </svg>
+    ),
+  },
+};
+
+function ProgressBar({ value, total, colorClass = "bg-emerald-500" }) {
+  const pct = total === 0 ? 0 : Math.round((value / total) * 100);
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
+        <div
+          className={`h-full ${colorClass} transition-all duration-500`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-xs font-medium text-gray-500 w-16 text-right">
+        {value}/{total} ({pct}%)
+      </span>
+    </div>
+  );
+}
+
+function StepCard({ step, blockedBy }) {
+  const isBlocked = blockedBy.length > 0 && step.status === "pending";
+  const effectiveStatus = isBlocked ? "blocked" : step.status;
+  const cfg = STATUS_CONFIG[effectiveStatus];
+
+  return (
+    <div className={`border rounded-lg p-4 ${cfg.bg} transition-colors`}>
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5">{cfg.icon}</div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-xs font-mono text-gray-400">{step.id}</span>
+            <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${cfg.badge}`}>
+              {cfg.label}
+            </span>
+            {step.branch && (
+              <span className="text-xs font-mono bg-blue-50 text-blue-700 px-2 py-0.5 rounded-full border border-blue-100">
+                {step.branch}
+              </span>
+            )}
+          </div>
+          <p className="mt-1 text-sm text-gray-800 leading-snug">{step.title}</p>
+          {isBlocked && (
+            <p className="mt-1.5 text-xs text-red-600">
+              Blocked by: {blockedBy.join(", ")}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PhaseSection({ phaseName, phaseNum, steps }) {
+  const completed = steps.filter((s) => s.status === "completed").length;
+  const inProgress = steps.filter((s) => s.status === "in_progress").length;
+  const total = steps.length;
+
+  // Build a set of completed step IDs in this phase so we can compute blockers
+  const completedIds = new Set(steps.filter((s) => s.status === "completed").map((s) => s.id));
+
+  // A step is blocked if any earlier step in the same phase is not completed
+  const getBlockers = (step) => {
+    return steps
+      .filter((s) => s.step_num < step.step_num && s.status !== "completed")
+      .map((s) => s.id);
+  };
+
+  const phaseColor =
+    completed === total
+      ? "text-emerald-700 bg-emerald-50 border-emerald-200"
+      : inProgress > 0
+      ? "text-amber-700 bg-amber-50 border-amber-200"
+      : "text-gray-600 bg-gray-50 border-gray-200";
+
+  return (
+    <section className="mb-8">
+      <div className={`flex items-center gap-3 mb-3 px-4 py-2.5 rounded-lg border ${phaseColor}`}>
+        <span className="text-sm font-bold">Phase {phaseNum}</span>
+        <span className="text-sm font-semibold">{phaseName}</span>
+        <div className="flex-1 ml-2">
+          <ProgressBar
+            value={completed}
+            total={total}
+            colorClass={completed === total ? "bg-emerald-500" : inProgress > 0 ? "bg-amber-400" : "bg-gray-300"}
+          />
+        </div>
+      </div>
+      <div className="space-y-2 pl-1">
+        {steps.map((step) => (
+          <StepCard key={step.id} step={step} blockedBy={getBlockers(step)} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function MigrationDashboard() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    api
+      .get("/api/migration-status/")
+      .then((res) => {
+        setData(res.data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        const status = err.response?.status;
+        let message = err.message;
+        if (status === 401) {
+          message = "Please sign in (staff required).";
+        } else if (status === 403) {
+          message = "Staff access is required for the migration dashboard.";
+        } else if (status) {
+          message = `HTTP ${status}`;
+        }
+        setError(message);
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-gray-500 text-sm">Loading migration status…</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 max-w-md text-center">
+          <p className="text-red-700 font-medium">Could not load migration status</p>
+          <p className="text-red-500 text-sm mt-1">{error}</p>
+          <p className="text-gray-500 text-xs mt-3">Make sure the backend is running at {apiUrl}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const { steps = [], git_available, has_uncommitted_changes, repo_root, error: apiError } = data;
+
+  const totalSteps = steps.length;
+
+  if (totalSteps === 0 && apiError) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+        <div className="bg-amber-50 border border-amber-200 rounded-lg p-6 max-w-lg text-center">
+          <p className="text-amber-900 font-medium">No migration steps loaded</p>
+          <p className="text-amber-800 text-sm mt-2">{apiError}</p>
+          <p className="text-gray-500 text-xs mt-3">
+            For local Podman, mount the monorepo root at <code className="font-mono">/repo</code> and set{" "}
+            <code className="font-mono">BUNKLOGS_REPO_ROOT=/repo</code> (see{" "}
+            <code className="font-mono">backend/docker-compose.local.yml</code>) so prompts and git metadata are
+            available.
+          </p>
+        </div>
+      </div>
+    );
+  }
+  const completedSteps = steps.filter((s) => s.status === "completed").length;
+  const inProgressSteps = steps.filter((s) => s.status === "in_progress").length;
+  const pendingSteps = totalSteps - completedSteps - inProgressSteps;
+
+  // Group steps by phase
+  const byPhase = {};
+  for (const step of steps) {
+    if (!byPhase[step.phase]) byPhase[step.phase] = { name: step.phase_name, steps: [] };
+    byPhase[step.phase].steps.push(step);
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <div className="bg-white border-b border-gray-200 sticky top-0 z-10">
+        <div className="max-w-4xl mx-auto px-6 py-4 flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-bold text-gray-900">Migration Dashboard</h1>
+            <p className="text-xs text-gray-500 mt-0.5">Strangler-Fig migration to multi-tenant architecture</p>
+          </div>
+          <div className="flex items-center gap-2">
+            {!git_available && (
+              <span className="text-xs bg-yellow-100 text-yellow-700 border border-yellow-200 px-2 py-1 rounded-full">
+                Git unavailable — statuses may be inaccurate
+              </span>
+            )}
+            {has_uncommitted_changes && (
+              <span className="text-xs bg-blue-100 text-blue-700 border border-blue-200 px-2 py-1 rounded-full">
+                Uncommitted changes present
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-4xl mx-auto px-6 py-8">
+        {/* Overall summary */}
+        <div className="grid grid-cols-3 gap-4 mb-8">
+          <div className="bg-white border border-gray-200 rounded-xl p-5 text-center shadow-sm">
+            <div className="text-3xl font-bold text-emerald-600">{completedSteps}</div>
+            <div className="text-xs font-medium text-gray-500 mt-1 uppercase tracking-wide">Completed</div>
+          </div>
+          <div className="bg-white border border-gray-200 rounded-xl p-5 text-center shadow-sm">
+            <div className="text-3xl font-bold text-amber-500">{inProgressSteps}</div>
+            <div className="text-xs font-medium text-gray-500 mt-1 uppercase tracking-wide">In Progress</div>
+          </div>
+          <div className="bg-white border border-gray-200 rounded-xl p-5 text-center shadow-sm">
+            <div className="text-3xl font-bold text-gray-400">{pendingSteps}</div>
+            <div className="text-xs font-medium text-gray-500 mt-1 uppercase tracking-wide">Pending</div>
+          </div>
+        </div>
+
+        {/* Overall progress bar */}
+        <div className="bg-white border border-gray-200 rounded-xl p-5 mb-8 shadow-sm">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm font-semibold text-gray-700">Overall Progress</span>
+          </div>
+          <ProgressBar value={completedSteps} total={totalSteps} />
+        </div>
+
+        {/* Phase sections */}
+        {PHASE_ORDER.filter((p) => byPhase[p]).map((phaseNum) => (
+          <PhaseSection
+            key={phaseNum}
+            phaseNum={phaseNum}
+            phaseName={byPhase[phaseNum].name}
+            steps={byPhase[phaseNum].steps}
+          />
+        ))}
+
+        {/* Footer */}
+        <div className="mt-8 pt-6 border-t border-gray-200 text-xs text-gray-400 text-center space-y-1">
+          <p>Status is inferred from git log and branch names. A step shows "completed" when its ID appears in a commit message or merged branch name.</p>
+          {repo_root && <p>Repo root: <code className="font-mono">{repo_root}</code></p>}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Why
The migration dashboard lived on `feat/3_1-setup-crane-lake-organization` but was never merged; checking out `main` removed the route so unknown paths fell through to `/dashboard` and Admins were redirected to `/admin-dashboard`.

## What
Cherry-picked from that branch:
- `2e1a2363` — migration API + `MigrationDashboard` + Router `/migration-dashboard` + compose mount + tests + dist index
- `acd39407` — pytest `config/tests` discovery for CI

## Test plan
- [x] `make test-backend` (204 passed)

Made with [Cursor](https://cursor.com)