### PR TITLE
3_2_build_rolebased_template: role-based reflection template seeding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,7 @@ frontend/dist/
 frontend/build/
 github-actions-key.json
 *.json
+!templates/reflection_templates/*.json
 backend/.env
 llm_context/
 

--- a/backend/bunk_logs/core/management/commands/seed_role_template.py
+++ b/backend/bunk_logs/core/management/commands/seed_role_template.py
@@ -1,0 +1,216 @@
+"""Seed or update a ReflectionTemplate from a JSON file (role-specific)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from django.core.exceptions import ValidationError
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.models import validate_reflection_template_schema
+
+MEMBERSHIP_ROLE_CODES = {code for code, _ in Membership.ROLES}
+CADENCE_CODES = {code for code, _ in ReflectionTemplate.CADENCES}
+PROGRAM_TYPE_CODES = {code for code, _ in Program.PROGRAM_TYPES}
+
+
+def _coerce_positive_int(value: Any, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise CommandError(f'"{field}" must be a positive integer.')
+    if value < 1:
+        raise CommandError(f'"{field}" must be >= 1.')
+    return value
+
+
+def parse_template_file(raw: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise CommandError("Template file must contain a JSON object.")
+    missing = {"name", "slug", "cadence", "schema"} - raw.keys()
+    if missing:
+        raise CommandError(f"Template JSON missing required keys: {', '.join(sorted(missing))}.")
+    version = raw.get("version", 1)
+    version = _coerce_positive_int(version, "version")
+    slug = raw["slug"]
+    if not isinstance(slug, str) or not slug.strip():
+        raise CommandError('"slug" must be a non-empty string.')
+    name = raw["name"]
+    if not isinstance(name, str) or not name.strip():
+        raise CommandError('"name" must be a non-empty string.')
+    cadence = raw["cadence"]
+    if cadence not in CADENCE_CODES:
+        raise CommandError(
+            f'Invalid cadence {cadence!r}; allowed: {", ".join(sorted(CADENCE_CODES))}.',
+        )
+    schema = raw["schema"]
+    validate_reflection_template_schema(schema)
+
+    program_type = raw.get("program_type")
+    if program_type is not None and program_type != "":
+        if program_type not in PROGRAM_TYPE_CODES:
+            raise CommandError(
+                f'Invalid program_type {program_type!r}; '
+                f'allowed: {", ".join(sorted(PROGRAM_TYPE_CODES))} or omit/null.',
+            )
+    else:
+        program_type = None
+
+    description = raw.get("description", "")
+    if description is None:
+        description = ""
+    if not isinstance(description, str):
+        raise CommandError('"description" must be a string.')
+
+    languages = raw.get("languages", [])
+    if languages is None:
+        languages = []
+    if not isinstance(languages, list) or not all(isinstance(x, str) for x in languages):
+        raise CommandError('"languages" must be a list of strings.')
+
+    is_active = raw.get("is_active", True)
+    if not isinstance(is_active, bool):
+        raise CommandError('"is_active" must be a boolean.')
+
+    return {
+        "name": name.strip(),
+        "slug": slug.strip(),
+        "version": version,
+        "cadence": cadence,
+        "program_type": program_type,
+        "description": description,
+        "languages": languages,
+        "is_active": is_active,
+        "schema": schema,
+    }
+
+
+class Command(BaseCommand):
+    help = "Create or update a ReflectionTemplate from a JSON definition (idempotent by org + slug + version)."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--org-slug", required=True, help="Organization slug (e.g. clc).")
+        parser.add_argument(
+            "--role",
+            required=True,
+            help="Membership role code (e.g. counselor, kitchen_staff).",
+        )
+        parser.add_argument(
+            "--template-file",
+            required=True,
+            help="Path to JSON template definition.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Validate only; do not write to the database.",
+        )
+
+    def handle(self, *args, **options):
+        org_slug: str = options["org_slug"]
+        role: str = options["role"]
+        template_path = Path(options["template_file"]).expanduser().resolve()
+        dry_run: bool = options["dry_run"]
+
+        if role not in MEMBERSHIP_ROLE_CODES:
+            raise CommandError(
+                f'Invalid role {role!r}; must be one of: {", ".join(sorted(MEMBERSHIP_ROLE_CODES))}.',
+            )
+
+        try:
+            org = Organization.objects.get(slug=org_slug)
+        except Organization.DoesNotExist as exc:
+            raise CommandError(f'Organization with slug {org_slug!r} does not exist.') from exc
+
+        if not template_path.is_file():
+            raise CommandError(f"Template file not found: {template_path}")
+
+        try:
+            with template_path.open(encoding="utf-8") as fh:
+                raw = json.load(fh)
+        except json.JSONDecodeError as exc:
+            raise CommandError(f"Invalid JSON in template file: {exc}") from exc
+
+        try:
+            parsed = parse_template_file(raw)
+        except ValidationError as exc:
+            raise CommandError(self._format_validation_error(exc)) from exc
+
+        candidate = ReflectionTemplate(
+            organization=org,
+            role=role,
+            name=parsed["name"],
+            slug=parsed["slug"],
+            description=parsed["description"],
+            cadence=parsed["cadence"],
+            program_type=parsed["program_type"],
+            schema=parsed["schema"],
+            languages=parsed["languages"],
+            is_active=parsed["is_active"],
+            version=parsed["version"],
+        )
+        try:
+            candidate.full_clean()
+        except ValidationError as exc:
+            raise CommandError(self._format_validation_error(exc)) from exc
+
+        key = f'{org.slug}/{parsed["slug"]} v{parsed["version"]} (role={role})'
+        if dry_run:
+            existing = ReflectionTemplate.all_objects.filter(
+                organization=org,
+                slug=parsed["slug"],
+                version=parsed["version"],
+            ).first()
+            if existing:
+                self.stdout.write(
+                    self.style.WARNING(f"[dry-run] Would update existing template {key}"),
+                )
+            else:
+                self.stdout.write(
+                    self.style.WARNING(f"[dry-run] Would create template {key}"),
+                )
+            self.stdout.write(f"[dry-run] Loaded and validated {template_path}")
+            return
+
+        existing = ReflectionTemplate.all_objects.filter(
+            organization=org,
+            slug=parsed["slug"],
+            version=parsed["version"],
+        ).first()
+
+        obj, created = ReflectionTemplate.all_objects.update_or_create(
+            organization=org,
+            slug=parsed["slug"],
+            version=parsed["version"],
+            defaults={
+                "role": role,
+                "name": parsed["name"],
+                "description": parsed["description"],
+                "cadence": parsed["cadence"],
+                "program_type": parsed["program_type"],
+                "schema": parsed["schema"],
+                "languages": parsed["languages"],
+                "is_active": parsed["is_active"],
+            },
+        )
+
+        action = "Created" if created else "Updated"
+        self.stdout.write(
+            self.style.SUCCESS(f"{action} reflection template {key} (pk={obj.pk})"),
+        )
+
+    @staticmethod
+    def _format_validation_error(exc: ValidationError) -> str:
+        if hasattr(exc, "error_dict"):
+            parts = []
+            for field, errs in exc.error_dict.items():
+                for e in errs:
+                    parts.append(f"{field}: {e.message}")
+            return "; ".join(parts) if parts else str(exc)
+        if exc.messages:
+            return "; ".join(str(m) for m in exc.messages)
+        return str(exc)

--- a/backend/bunk_logs/core/management/commands/seed_role_template.py
+++ b/backend/bunk_logs/core/management/commands/seed_role_template.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
@@ -18,6 +19,40 @@ from bunk_logs.core.models import validate_reflection_template_schema
 MEMBERSHIP_ROLE_CODES = {code for code, _ in Membership.ROLES}
 CADENCE_CODES = {code for code, _ in ReflectionTemplate.CADENCES}
 PROGRAM_TYPE_CODES = {code for code, _ in Program.PROGRAM_TYPES}
+
+
+def resolve_template_file_path(arg: str) -> Path:
+    """Resolve JSON path: absolute as-is; relative tries cwd, repo root, then Django BASE_DIR."""
+    p = Path(arg).expanduser()
+    if p.is_absolute():
+        resolved = p.resolve()
+        if resolved.is_file():
+            return resolved
+        raise CommandError(f"Template file not found: {resolved}")
+
+    base_dirs: list[Path] = []
+    for raw in (
+        Path.cwd(),
+        Path(settings.BASE_DIR).resolve().parent,
+        Path(settings.BASE_DIR).resolve(),
+    ):
+        try:
+            resolved_base = raw.resolve()
+        except OSError:
+            continue
+        if resolved_base not in base_dirs:
+            base_dirs.append(resolved_base)
+
+    tried: list[Path] = []
+    for base in base_dirs:
+        candidate = (base / p).resolve()
+        tried.append(candidate)
+        if candidate.is_file():
+            return candidate
+
+    raise CommandError(
+        "Template file not found: {!r}. Tried:\n  {}".format(arg, "\n  ".join(str(t) for t in tried)),
+    )
 
 
 def _coerce_positive_int(value: Any, field: str) -> int:
@@ -113,7 +148,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         org_slug: str = options["org_slug"]
         role: str = options["role"]
-        template_path = Path(options["template_file"]).expanduser().resolve()
+        template_path = resolve_template_file_path(options["template_file"])
         dry_run: bool = options["dry_run"]
 
         if role not in MEMBERSHIP_ROLE_CODES:
@@ -125,9 +160,6 @@ class Command(BaseCommand):
             org = Organization.objects.get(slug=org_slug)
         except Organization.DoesNotExist as exc:
             raise CommandError(f'Organization with slug {org_slug!r} does not exist.') from exc
-
-        if not template_path.is_file():
-            raise CommandError(f"Template file not found: {template_path}")
 
         try:
             with template_path.open(encoding="utf-8") as fh:

--- a/backend/bunk_logs/core/management/commands/seed_role_template.py
+++ b/backend/bunk_logs/core/management/commands/seed_role_template.py
@@ -28,7 +28,8 @@ def resolve_template_file_path(arg: str) -> Path:
         resolved = p.resolve()
         if resolved.is_file():
             return resolved
-        raise CommandError(f"Template file not found: {resolved}")
+        msg = f"Template file not found: {resolved}"
+        raise CommandError(msg)
 
     base_dirs: list[Path] = []
     for raw in (
@@ -50,48 +51,52 @@ def resolve_template_file_path(arg: str) -> Path:
         if candidate.is_file():
             return candidate
 
-    raise CommandError(
-        "Template file not found: {!r}. Tried:\n  {}".format(arg, "\n  ".join(str(t) for t in tried)),
-    )
+    tried_lines = "\n  ".join(str(t) for t in tried)
+    msg = f"Template file not found: {arg!r}. Tried:\n  {tried_lines}"
+    raise CommandError(msg)
 
 
 def _coerce_positive_int(value: Any, field: str) -> int:
     if not isinstance(value, int) or isinstance(value, bool):
-        raise CommandError(f'"{field}" must be a positive integer.')
+        msg = f'"{field}" must be a positive integer.'
+        raise CommandError(msg)
     if value < 1:
-        raise CommandError(f'"{field}" must be >= 1.')
+        msg = f'"{field}" must be >= 1.'
+        raise CommandError(msg)
     return value
 
 
 def parse_template_file(raw: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(raw, dict):
-        raise CommandError("Template file must contain a JSON object.")
+        msg = "Template file must contain a JSON object."
+        raise CommandError(msg)
     missing = {"name", "slug", "cadence", "schema"} - raw.keys()
     if missing:
-        raise CommandError(f"Template JSON missing required keys: {', '.join(sorted(missing))}.")
+        msg = f"Template JSON missing required keys: {', '.join(sorted(missing))}."
+        raise CommandError(msg)
     version = raw.get("version", 1)
     version = _coerce_positive_int(version, "version")
     slug = raw["slug"]
     if not isinstance(slug, str) or not slug.strip():
-        raise CommandError('"slug" must be a non-empty string.')
+        msg = '"slug" must be a non-empty string.'
+        raise CommandError(msg)
     name = raw["name"]
     if not isinstance(name, str) or not name.strip():
-        raise CommandError('"name" must be a non-empty string.')
+        msg = '"name" must be a non-empty string.'
+        raise CommandError(msg)
     cadence = raw["cadence"]
     if cadence not in CADENCE_CODES:
-        raise CommandError(
-            f'Invalid cadence {cadence!r}; allowed: {", ".join(sorted(CADENCE_CODES))}.',
-        )
+        msg = f'Invalid cadence {cadence!r}; allowed: {", ".join(sorted(CADENCE_CODES))}.'
+        raise CommandError(msg)
     schema = raw["schema"]
     validate_reflection_template_schema(schema)
 
     program_type = raw.get("program_type")
     if program_type is not None and program_type != "":
         if program_type not in PROGRAM_TYPE_CODES:
-            raise CommandError(
-                f'Invalid program_type {program_type!r}; '
-                f'allowed: {", ".join(sorted(PROGRAM_TYPE_CODES))} or omit/null.',
-            )
+            allowed = ", ".join(sorted(PROGRAM_TYPE_CODES))
+            msg = f"Invalid program_type {program_type!r}; allowed: {allowed} or omit/null."
+            raise CommandError(msg)
     else:
         program_type = None
 
@@ -99,17 +104,20 @@ def parse_template_file(raw: dict[str, Any]) -> dict[str, Any]:
     if description is None:
         description = ""
     if not isinstance(description, str):
-        raise CommandError('"description" must be a string.')
+        msg = '"description" must be a string.'
+        raise CommandError(msg)
 
     languages = raw.get("languages", [])
     if languages is None:
         languages = []
     if not isinstance(languages, list) or not all(isinstance(x, str) for x in languages):
-        raise CommandError('"languages" must be a list of strings.')
+        msg = '"languages" must be a list of strings.'
+        raise CommandError(msg)
 
     is_active = raw.get("is_active", True)
     if not isinstance(is_active, bool):
-        raise CommandError('"is_active" must be a boolean.')
+        msg = '"is_active" must be a boolean.'
+        raise CommandError(msg)
 
     return {
         "name": name.strip(),
@@ -152,25 +160,28 @@ class Command(BaseCommand):
         dry_run: bool = options["dry_run"]
 
         if role not in MEMBERSHIP_ROLE_CODES:
-            raise CommandError(
-                f'Invalid role {role!r}; must be one of: {", ".join(sorted(MEMBERSHIP_ROLE_CODES))}.',
-            )
+            roles_list = ", ".join(sorted(MEMBERSHIP_ROLE_CODES))
+            msg = f"Invalid role {role!r}; must be one of: {roles_list}."
+            raise CommandError(msg)
 
         try:
             org = Organization.objects.get(slug=org_slug)
         except Organization.DoesNotExist as exc:
-            raise CommandError(f'Organization with slug {org_slug!r} does not exist.') from exc
+            msg = f"Organization with slug {org_slug!r} does not exist."
+            raise CommandError(msg) from exc
 
         try:
             with template_path.open(encoding="utf-8") as fh:
                 raw = json.load(fh)
         except json.JSONDecodeError as exc:
-            raise CommandError(f"Invalid JSON in template file: {exc}") from exc
+            msg = f"Invalid JSON in template file: {exc}"
+            raise CommandError(msg) from exc
 
         try:
             parsed = parse_template_file(raw)
         except ValidationError as exc:
-            raise CommandError(self._format_validation_error(exc)) from exc
+            msg = self._format_validation_error(exc)
+            raise CommandError(msg) from exc
 
         candidate = ReflectionTemplate(
             organization=org,
@@ -188,9 +199,10 @@ class Command(BaseCommand):
         try:
             candidate.full_clean()
         except ValidationError as exc:
-            raise CommandError(self._format_validation_error(exc)) from exc
+            msg = self._format_validation_error(exc)
+            raise CommandError(msg) from exc
 
-        key = f'{org.slug}/{parsed["slug"]} v{parsed["version"]} (role={role})'
+        key = f"{org.slug}/{parsed['slug']} v{parsed['version']} (role={role})"
         if dry_run:
             existing = ReflectionTemplate.all_objects.filter(
                 organization=org,

--- a/backend/bunk_logs/core/test_seed_role_template.py
+++ b/backend/bunk_logs/core/test_seed_role_template.py
@@ -128,3 +128,26 @@ class TestSeedRoleTemplateCommand:
                 stdout=StringIO(),
             )
         assert "Invalid role" in str(exc.value)
+
+    def test_relative_path_resolves_from_repo_root(self, tmp_path: Path, settings, monkeypatch):
+        """Paths like templates/... live at repo root; manage.py is often run with cwd=backend/."""
+        repo = tmp_path / "repo"
+        backend = repo / "backend"
+        backend.mkdir(parents=True)
+        rel = "templates/reflection_templates/seed.json"
+        full = repo / rel
+        full.parent.mkdir(parents=True)
+        full.write_text(json.dumps(_minimal_template_payload()), encoding="utf-8")
+
+        settings.BASE_DIR = backend
+        monkeypatch.chdir(backend)
+        Organization.objects.create(name="Test Org", slug="test-org-repo-root")
+
+        call_command(
+            "seed_role_template",
+            org_slug="test-org-repo-root",
+            role="counselor",
+            template_file=rel,
+            stdout=StringIO(),
+        )
+        assert ReflectionTemplate.all_objects.filter(slug="test-weekly-seed").exists()

--- a/backend/bunk_logs/core/test_seed_role_template.py
+++ b/backend/bunk_logs/core/test_seed_role_template.py
@@ -1,0 +1,130 @@
+"""Tests for seed_role_template management command."""
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import ReflectionTemplate
+
+
+def _minimal_template_payload() -> dict:
+    return {
+        "name": "Test weekly",
+        "slug": "test-weekly-seed",
+        "version": 1,
+        "cadence": "weekly",
+        "program_type": "summer_camp",
+        "description": "",
+        "languages": ["en"],
+        "schema": {
+            "fields": [
+                {
+                    "key": "note",
+                    "type": "textarea",
+                    "prompts": {"en": "Notes?"},
+                },
+            ],
+        },
+    }
+
+
+@pytest.mark.django_db
+class TestSeedRoleTemplateCommand:
+    def test_creates_template_from_valid_json(self, tmp_path: Path):
+        org = Organization.objects.create(name="Test Org", slug="test-org-seed")
+        path = tmp_path / "t.json"
+        path.write_text(json.dumps(_minimal_template_payload()), encoding="utf-8")
+        out = StringIO()
+        call_command(
+            "seed_role_template",
+            org_slug="test-org-seed",
+            role="counselor",
+            template_file=str(path),
+            stdout=out,
+        )
+        t = ReflectionTemplate.all_objects.get(organization=org, slug="test-weekly-seed", version=1)
+        assert t.role == "counselor"
+        assert t.name == "Test weekly"
+        assert "Created" in out.getvalue()
+
+    def test_dry_run_does_not_write(self, tmp_path: Path):
+        Organization.objects.create(name="Test Org", slug="test-org-dry")
+        path = tmp_path / "t.json"
+        path.write_text(json.dumps(_minimal_template_payload()), encoding="utf-8")
+        assert ReflectionTemplate.all_objects.count() == 0
+        call_command(
+            "seed_role_template",
+            org_slug="test-org-dry",
+            role="counselor",
+            template_file=str(path),
+            dry_run=True,
+            stdout=StringIO(),
+        )
+        assert ReflectionTemplate.all_objects.count() == 0
+
+    def test_invalid_schema_clear_error(self, tmp_path: Path):
+        Organization.objects.create(name="Test Org", slug="test-org-bad")
+        path = tmp_path / "bad.json"
+        bad = {**_minimal_template_payload(), "schema": {"fields": []}}
+        path.write_text(json.dumps(bad), encoding="utf-8")
+        with pytest.raises(CommandError) as exc:
+            call_command(
+                "seed_role_template",
+                org_slug="test-org-bad",
+                role="counselor",
+                template_file=str(path),
+                stdout=StringIO(),
+            )
+        assert "fields" in str(exc.value).lower()
+
+    def test_idempotent_rerun(self, tmp_path: Path):
+        org = Organization.objects.create(name="Test Org", slug="test-org-idem")
+        path = tmp_path / "t.json"
+        path.write_text(json.dumps(_minimal_template_payload()), encoding="utf-8")
+        call_command(
+            "seed_role_template",
+            org_slug="test-org-idem",
+            role="counselor",
+            template_file=str(path),
+            stdout=StringIO(),
+        )
+        first_pk = ReflectionTemplate.all_objects.get(
+            organization=org,
+            slug="test-weekly-seed",
+        ).pk
+        assert ReflectionTemplate.all_objects.count() == 1
+        out2 = StringIO()
+        call_command(
+            "seed_role_template",
+            org_slug="test-org-idem",
+            role="counselor",
+            template_file=str(path),
+            stdout=out2,
+        )
+        assert ReflectionTemplate.all_objects.count() == 1
+        second_pk = ReflectionTemplate.all_objects.get(
+            organization=org,
+            slug="test-weekly-seed",
+        ).pk
+        assert first_pk == second_pk
+        assert "Updated" in out2.getvalue()
+
+    def test_invalid_role_rejected(self, tmp_path: Path):
+        Organization.objects.create(name="Test Org", slug="test-org-role")
+        path = tmp_path / "t.json"
+        path.write_text(json.dumps(_minimal_template_payload()), encoding="utf-8")
+        with pytest.raises(CommandError) as exc:
+            call_command(
+                "seed_role_template",
+                org_slug="test-org-role",
+                role="not_a_real_role",
+                template_file=str(path),
+                stdout=StringIO(),
+            )
+        assert "Invalid role" in str(exc.value)

--- a/backend/bunk_logs/core/test_seed_role_template.py
+++ b/backend/bunk_logs/core/test_seed_role_template.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 
 import json
 from io import StringIO
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
 from django.core.management import call_command
 from django.core.management.base import CommandError
 

--- a/docs/seeding-templates.md
+++ b/docs/seeding-templates.md
@@ -19,8 +19,18 @@ python manage.py seed_role_template \
 |------|----------|-------------|
 | `--org-slug` | yes | Target `Organization.slug` (org must already exist, e.g. via `setup_crane_lake`). |
 | `--role` | yes | Must match a `Membership` role code (`counselor`, `kitchen_staff`, …). |
-| `--template-file` | yes | Path to JSON file (absolute or relative to current working directory). |
+| `--template-file` | yes | Path to JSON (see **Path resolution** below). |
 | `--dry-run` | no | Validate the file and print what would happen; no database writes. |
+
+### Path resolution
+
+Absolute paths are used as-is. Relative paths are tried in order:
+
+1. Current working directory (often `backend/` when you run `manage.py` there).
+2. **Repository root** — parent of Django `BASE_DIR` (where `templates/reflection_templates/` lives in this repo).
+3. **`BASE_DIR`** (the `backend/` package root).
+
+So `templates/reflection_templates/example_counselor.json` works whether your shell cwd is the repo root or `backend/`. If none of these locations contain the file, the command errors and lists paths it tried.
 
 ### Idempotency
 

--- a/docs/seeding-templates.md
+++ b/docs/seeding-templates.md
@@ -1,0 +1,53 @@
+# Seeding role-based reflection templates
+
+Reflection templates for the multi-tenant `ReflectionTemplate` model can be loaded from JSON files using a Django management command. This keeps prompts in version control and makes Crane Lake / future tenants repeatable.
+
+## Command
+
+Run inside the backend container (see project `Makefile`; use `make shell` or the pattern used for other management commands):
+
+```bash
+python manage.py seed_role_template \
+  --org-slug clc \
+  --role counselor \
+  --template-file templates/reflection_templates/example_counselor.json
+```
+
+### Arguments
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--org-slug` | yes | Target `Organization.slug` (org must already exist, e.g. via `setup_crane_lake`). |
+| `--role` | yes | Must match a `Membership` role code (`counselor`, `kitchen_staff`, …). |
+| `--template-file` | yes | Path to JSON file (absolute or relative to current working directory). |
+| `--dry-run` | no | Validate the file and print what would happen; no database writes. |
+
+### Idempotency
+
+Templates are keyed by **organization + slug + version** (same uniqueness as the model). Re-running with the same file updates the row in place and does not create duplicates.
+
+## JSON file shape
+
+Top-level keys:
+
+| Key | Required | Notes |
+|-----|----------|--------|
+| `name` | yes | Display name. |
+| `slug` | yes | Stable slug within the org. |
+| `cadence` | yes | One of: `daily`, `weekly`, `biweekly`, `monthly`, `on_demand`. |
+| `schema` | yes | Object validated like `ReflectionTemplate.schema` (see [reflection-template-schema.md](reflection-template-schema.md)). |
+| `version` | no | Integer ≥ 1; default `1`. |
+| `program_type` | no | `summer_camp` or `religious_school`, or omit / null for any program type. |
+| `description` | no | Default empty string. |
+| `languages` | no | List of BCP 47 codes; default `[]`. |
+| `is_active` | no | Default `true`. |
+
+The **role** is not stored in the JSON file; it is supplied with `--role` so one schema file can be reused only if you intentionally use the same role when invoking the command.
+
+## Sample file
+
+See `templates/reflection_templates/example_counselor.json` for a minimal counselor placeholder.
+
+## Related
+
+- [Reflection template schema](reflection-template-schema.md) — field types and localized prompts (`en` / `es`).

--- a/templates/reflection_templates/example_counselor.json
+++ b/templates/reflection_templates/example_counselor.json
@@ -1,0 +1,29 @@
+{
+  "name": "Counselor weekly reflection (example)",
+  "slug": "counselor-weekly-example",
+  "version": 1,
+  "cadence": "weekly",
+  "program_type": "summer_camp",
+  "description": "Placeholder counselor reflection — replace with Brent's finalized prompts.",
+  "languages": ["en"],
+  "schema": {
+    "fields": [
+      {
+        "key": "highlight",
+        "type": "textarea",
+        "required": true,
+        "prompts": {
+          "en": "What was your biggest highlight with campers this week?"
+        }
+      },
+      {
+        "key": "challenge",
+        "type": "textarea",
+        "required": false,
+        "prompts": {
+          "en": "What was most challenging, and how did you respond?"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Implements migration step **3_2_build_rolebased_template**: JSON-driven seeding for role-specific `ReflectionTemplate` rows.

## Changes
- Management command `seed_role_template` (`--org-slug`, `--role`, `--template-file`, `--dry-run`) using `validate_reflection_template_schema` and idempotent `update_or_create` on org + slug + version
- Repo directory `templates/reflection_templates/` with `example_counselor.json`
- `.gitignore` exception so tracked reflection template JSON is not excluded by `*.json`
- Tests: create, dry-run, invalid schema → clear `CommandError`, idempotent rerun
- `docs/seeding-templates.md`

## Verification
- `make test-backend` (214 passed)
- `make test-frontend`

Made with [Cursor](https://cursor.com)