### PR TITLE
3_3_seed_crane_lake_reflection: CLC 2026 role reflection templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ frontend/build/
 github-actions-key.json
 *.json
 !templates/reflection_templates/*.json
+!templates/reflection_templates/**/*.json
 backend/.env
 llm_context/
 

--- a/backend/bunk_logs/core/test_clc_2026_template_files.py
+++ b/backend/bunk_logs/core/test_clc_2026_template_files.py
@@ -1,0 +1,45 @@
+"""CLC 2026 reflection template JSON files validate against ReflectionTemplate schema."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from django.conf import settings
+
+from bunk_logs.core.management.commands.seed_role_template import parse_template_file
+
+
+def _repo_root() -> Path:
+    env = os.environ.get("BUNKLOGS_REPO_ROOT")
+    if env:
+        return Path(env).resolve()
+    return Path(settings.BASE_DIR).resolve().parent
+
+
+CLC_TEMPLATE_DIR = _repo_root() / "templates" / "reflection_templates" / "clc_2026"
+
+ROLE_FILES = [
+    ("counselor", "counselor.json"),
+    ("junior_counselor", "junior_counselor.json"),
+    ("specialist", "specialist.json"),
+    ("general_counselor", "general_counselor.json"),
+    ("leadership_team", "leadership_team.json"),
+    ("kitchen_staff", "kitchen_staff.json"),
+    ("maintenance", "maintenance.json"),
+    ("housekeeping", "housekeeping.json"),
+    ("camper_care", "camper_care.json"),
+    ("health_center", "health_center.json"),
+    ("special_diets", "special_diets.json"),
+]
+
+
+@pytest.mark.parametrize(("role", "filename"), ROLE_FILES)
+def test_clc_2026_template_json_validates(role: str, filename: str):
+    path = CLC_TEMPLATE_DIR / filename
+    assert path.is_file(), f"Missing template file: {path}"
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    parsed = parse_template_file(raw)
+    assert parsed["schema"]
+    assert parsed["cadence"]

--- a/docs/clc-2026-templates.md
+++ b/docs/clc-2026-templates.md
@@ -1,0 +1,62 @@
+# Crane Lake Summer 2026 role reflection templates
+
+JSON definitions live under `templates/reflection_templates/clc_2026/`. They target organization slug **`clc`** (create/update via `setup_crane_lake` before seeding).
+
+## Template index
+
+| File | Membership `--role` | Cadence | Languages | Notes |
+|------|---------------------|---------|-----------|--------|
+| `counselor.json` | `counselor` | daily | `en` | Mirrors legacy BunkLog counselor prompts from `frontend/src/components/form/BunkLogForm.jsx`. Brent may refine for standalone reflection UX. |
+| `junior_counselor.json` | `junior_counselor` | daily | `en` | Placeholder prompts — TODO(BRENT). |
+| `specialist.json` | `specialist` | daily | `en` | Placeholder prompts — TODO(BRENT). |
+| `general_counselor.json` | `general_counselor` | daily | `en` | Placeholder prompts — TODO(BRENT). |
+| `leadership_team.json` | `leadership_team` | biweekly | `en` | Unit pulse / wins & risks — TODO(BRENT). |
+| `kitchen_staff.json` | `kitchen_staff` | daily | `en`, `es` | Placeholder bilingual — TODO(BRENT) + Spanish copy review. |
+| `maintenance.json` | `maintenance` | daily | `en`, `es` | Placeholder bilingual — TODO(BRENT) + Spanish copy review. |
+| `housekeeping.json` | `housekeeping` | daily | `en`, `es` | Placeholder bilingual — TODO(BRENT) + Spanish copy review. |
+| `camper_care.json` | `camper_care` | daily | `en` | Wellness placeholder — TODO(BRENT); avoid PHI in free text. |
+| `health_center.json` | `health_center` | daily | `en` | Placeholder — TODO(BRENT); follow charting policy. |
+| `special_diets.json` | `special_diets` | daily | `en` | Placeholder — TODO(BRENT). |
+
+Schema rules: [reflection-template-schema.md](reflection-template-schema.md). Seeding command: [seeding-templates.md](seeding-templates.md).
+
+## Load all templates (local / container)
+
+Ensure `clc` exists, then run `seed_role_template` once per row (paths resolve from repo root or `backend/`):
+
+```bash
+make shell   # or equivalent Django shell container
+```
+
+```bash
+python manage.py setup_crane_lake
+
+python manage.py seed_role_template --org-slug clc --role counselor \
+  --template-file templates/reflection_templates/clc_2026/counselor.json
+python manage.py seed_role_template --org-slug clc --role junior_counselor \
+  --template-file templates/reflection_templates/clc_2026/junior_counselor.json
+python manage.py seed_role_template --org-slug clc --role specialist \
+  --template-file templates/reflection_templates/clc_2026/specialist.json
+python manage.py seed_role_template --org-slug clc --role general_counselor \
+  --template-file templates/reflection_templates/clc_2026/general_counselor.json
+python manage.py seed_role_template --org-slug clc --role leadership_team \
+  --template-file templates/reflection_templates/clc_2026/leadership_team.json
+python manage.py seed_role_template --org-slug clc --role kitchen_staff \
+  --template-file templates/reflection_templates/clc_2026/kitchen_staff.json
+python manage.py seed_role_template --org-slug clc --role maintenance \
+  --template-file templates/reflection_templates/clc_2026/maintenance.json
+python manage.py seed_role_template --org-slug clc --role housekeeping \
+  --template-file templates/reflection_templates/clc_2026/housekeeping.json
+python manage.py seed_role_template --org-slug clc --role camper_care \
+  --template-file templates/reflection_templates/clc_2026/camper_care.json
+python manage.py seed_role_template --org-slug clc --role health_center \
+  --template-file templates/reflection_templates/clc_2026/health_center.json
+python manage.py seed_role_template --org-slug clc --role special_diets \
+  --template-file templates/reflection_templates/clc_2026/special_diets.json
+```
+
+Use `--dry-run` to validate without writing. Re-running the same file updates the row (org + slug + version).
+
+## Admin verification
+
+After seeding, open Django admin → **Reflection templates** and confirm eleven active templates for organization Crane Lake (`clc`), each with the expected role, cadence, and `languages` list.

--- a/templates/reflection_templates/clc_2026/camper_care.json
+++ b/templates/reflection_templates/clc_2026/camper_care.json
@@ -1,0 +1,37 @@
+{
+  "name": "CLC Summer 2026 — Camper care (wellness) daily",
+  "slug": "clc-2026-camper-care-daily",
+  "version": 1,
+  "cadence": "daily",
+  "program_type": "summer_camp",
+  "description": "TODO(BRENT): Replace with wellness team camper-care prompts (may include different privacy constraints in production).",
+  "languages": ["en"],
+  "schema": {
+    "fields": [
+      {
+        "key": "follow_ups",
+        "type": "textarea",
+        "required": true,
+        "prompts": {
+          "en": "[PLACEHOLDER] Summarize emotional/social follow-ups or consults today (avoid unnecessary PHI in free text)."
+        }
+      },
+      {
+        "key": "patterns",
+        "type": "textarea",
+        "required": false,
+        "prompts": {
+          "en": "[PLACEHOLDER] Patterns or unit-level themes leadership should know about?"
+        }
+      },
+      {
+        "key": "coordination",
+        "type": "textarea",
+        "required": false,
+        "prompts": {
+          "en": "[PLACEHOLDER] Coordination needed with health center, unit heads, or specialists?"
+        }
+      }
+    ]
+  }
+}

--- a/templates/reflection_templates/clc_2026/counselor.json
+++ b/templates/reflection_templates/clc_2026/counselor.json
@@ -1,0 +1,116 @@
+{
+  "name": "CLC Summer 2026 — Counselor daily",
+  "slug": "clc-2026-counselor-daily",
+  "version": 1,
+  "cadence": "daily",
+  "program_type": "summer_camp",
+  "description": "Prompts aligned with the legacy BunkLog counselor flow (frontend BunkLogForm.jsx). TODO(BRENT): Adjust copy if the multi-tenant reflection UX differs from per-camper bunk logs.",
+  "languages": ["en"],
+  "schema": {
+    "fields": [
+      {
+        "key": "not_on_camp",
+        "type": "single_choice",
+        "required": true,
+        "prompts": {
+          "en": "Camper not on camp today"
+        },
+        "options": [
+          {
+            "value": "no",
+            "labels": {
+              "en": "No — camper was on camp"
+            }
+          },
+          {
+            "value": "yes",
+            "labels": {
+              "en": "Yes — camper was absent"
+            }
+          }
+        ]
+      },
+      {
+        "key": "request_unit_head_help",
+        "type": "single_choice",
+        "required": true,
+        "prompts": {
+          "en": "Unit Head Help Requested"
+        },
+        "options": [
+          {
+            "value": "no",
+            "labels": {
+              "en": "No"
+            }
+          },
+          {
+            "value": "yes",
+            "labels": {
+              "en": "Yes"
+            }
+          }
+        ]
+      },
+      {
+        "key": "request_camper_care_help",
+        "type": "single_choice",
+        "required": true,
+        "prompts": {
+          "en": "Camper Care Help Requested"
+        },
+        "options": [
+          {
+            "value": "no",
+            "labels": {
+              "en": "No"
+            }
+          },
+          {
+            "value": "yes",
+            "labels": {
+              "en": "Yes"
+            }
+          }
+        ]
+      },
+      {
+        "key": "camper_scores",
+        "type": "rating_group",
+        "required": false,
+        "scale": [1, 5],
+        "scale_labels": {
+          "en": ["1 — Poor", "2", "3", "4", "5 — Excellent"]
+        },
+        "categories": [
+          {
+            "key": "behavior",
+            "labels": {
+              "en": "Behavior — How was this camper's behavior today? (5: Very good day. 4: Had a challenge they resolved on their own. 3: One minor challenge. 2: A few challenging moments. 1: Several challenging moments.)"
+            }
+          },
+          {
+            "key": "participation",
+            "labels": {
+              "en": "Participation — How often did the camper participate in the day's activities? (5: Always in all activities. 4: Mostly. 3: Sometimes in activities they enjoyed. 2: Reluctantly or with hesitation. 1: Did not participate.)"
+            }
+          },
+          {
+            "key": "social",
+            "labels": {
+              "en": "Social — Was the camper included socially today? (5: Sense of belonging all day. 4: Mostly included. 3: Sometimes included. 2: Only included with staff encouragement. 1: Rarely or not at all.)"
+            }
+          }
+        ]
+      },
+      {
+        "key": "daily_report",
+        "type": "textarea",
+        "required": false,
+        "prompts": {
+          "en": "Daily Report"
+        }
+      }
+    ]
+  }
+}

--- a/templates/reflection_templates/clc_2026/general_counselor.json
+++ b/templates/reflection_templates/clc_2026/general_counselor.json
@@ -1,0 +1,37 @@
+{
+  "name": "CLC Summer 2026 — General counselor daily",
+  "slug": "clc-2026-general-counselor-daily",
+  "version": 1,
+  "cadence": "daily",
+  "program_type": "summer_camp",
+  "description": "TODO(BRENT): Replace placeholder prompts with approved GC reflection questions.",
+  "languages": ["en"],
+  "schema": {
+    "fields": [
+      {
+        "key": "unit_coverage",
+        "type": "textarea",
+        "required": true,
+        "prompts": {
+          "en": "[PLACEHOLDER] Where did you spend time today and what did you observe?"
+        }
+      },
+      {
+        "key": "counselor_support",
+        "type": "textarea",
+        "required": true,
+        "prompts": {
+          "en": "[PLACEHOLDER] How did you support counselors or address emerging issues?"
+        }
+      },
+      {
+        "key": "follow_up",
+        "type": "textarea",
+        "required": false,
+        "prompts": {
+          "en": "[PLACEHOLDER] What needs follow-up with leadership or another team?"
+        }
+      }
+    ]
+  }
+}

--- a/templates/reflection_templates/clc_2026/health_center.json
+++ b/templates/reflection_templates/clc_2026/health_center.json
@@ -1,0 +1,37 @@
+{
+  "name": "CLC Summer 2026 — Health center daily",
+  "slug": "clc-2026-health-center-daily",
+  "version": 1,
+  "cadence": "daily",
+  "program_type": "summer_camp",
+  "description": "TODO(BRENT): Replace with approved health-center prompts; ensure compliance with charting policies before launch.",
+  "languages": ["en"],
+  "schema": {
+    "fields": [
+      {
+        "key": "operations_note",
+        "type": "textarea",
+        "required": true,
+        "prompts": {
+          "en": "[PLACEHOLDER] High-level operations note for the day (no individualized PHI)."
+        }
+      },
+      {
+        "key": "capacity_staffing",
+        "type": "textarea",
+        "required": false,
+        "prompts": {
+          "en": "[PLACEHOLDER] Capacity, staffing, or supply pressures?"
+        }
+      },
+      {
+        "key": "camp_wide_flags",
+        "type": "textarea",
+        "required": false,
+        "prompts": {
+          "en": "[PLACEHOLDER] Trends or alerts that program leadership should track?"
+        }
+      }
+    ]
+  }
+}

--- a/templates/reflection_templates/clc_2026/housekeeping.json
+++ b/templates/reflection_templates/clc_2026/housekeeping.json
@@ -1,0 +1,57 @@
+{
+  "name": "CLC Summer 2026 — Housekeeping daily",
+  "slug": "clc-2026-housekeeping-daily",
+  "version": 1,
+  "cadence": "daily",
+  "program_type": "summer_camp",
+  "description": "TODO(BRENT): Replace placeholder prompts; TODO(i18n): Have Spanish copy reviewed by fluent housekeeping staff.",
+  "languages": ["en", "es"],
+  "schema": {
+    "fields": [
+      {
+        "key": "areas_serviced",
+        "type": "textarea",
+        "required": true,
+        "prompts": {
+          "en": "[PLACEHOLDER] Which areas did you service today and what was the focus?",
+          "es": "[PLACEHOLDER] ¿Qué áreas atendió hoy y cuál fue el enfoque?"
+        }
+      },
+      {
+        "key": "cleanliness_supply",
+        "type": "rating_group",
+        "required": true,
+        "scale": [1, 4],
+        "scale_labels": {
+          "en": ["Behind", "Caught up", "Good", "Ahead"],
+          "es": ["Atrasado", "Al día", "Bueno", "Adelantado"]
+        },
+        "categories": [
+          {
+            "key": "public_spaces",
+            "labels": {
+              "en": "[PLACEHOLDER] Cleanliness of assigned public spaces",
+              "es": "[PLACEHOLDER] Limpieza de espacios públicos asignados"
+            }
+          },
+          {
+            "key": "supplies",
+            "labels": {
+              "en": "[PLACEHOLDER] Supplies stocked for next cycle",
+              "es": "[PLACEHOLDER] Suministros abastecidos para el siguiente ciclo"
+            }
+          }
+        ]
+      },
+      {
+        "key": "guest_requests",
+        "type": "textarea",
+        "required": false,
+        "prompts": {
+          "en": "[PLACEHOLDER] Special requests or incidents to pass on.",
+          "es": "[PLACEHOLDER] Solicitudes especiales o incidentes a comunicar."
+        }
+      }
+    ]
+  }
+}

--- a/templates/reflection_templates/clc_2026/junior_counselor.json
+++ b/templates/reflection_templates/clc_2026/junior_counselor.json
@@ -1,0 +1,37 @@
+{
+  "name": "CLC Summer 2026 — Junior counselor daily",
+  "slug": "clc-2026-junior-counselor-daily",
+  "version": 1,
+  "cadence": "daily",
+  "program_type": "summer_camp",
+  "description": "TODO(BRENT): Replace placeholder prompts with approved JC reflection questions.",
+  "languages": ["en"],
+  "schema": {
+    "fields": [
+      {
+        "key": "highlight",
+        "type": "textarea",
+        "required": true,
+        "prompts": {
+          "en": "[PLACEHOLDER] What was one highlight of supporting your bunk or activity today?"
+        }
+      },
+      {
+        "key": "challenge",
+        "type": "textarea",
+        "required": true,
+        "prompts": {
+          "en": "[PLACEHOLDER] What felt challenging, and what did you try?"
+        }
+      },
+      {
+        "key": "support_needed",
+        "type": "textarea",
+        "required": false,
+        "prompts": {
+          "en": "[PLACEHOLDER] What support would help you tomorrow?"
+        }
+      }
+    ]
+  }
+}

--- a/templates/reflection_templates/clc_2026/kitchen_staff.json
+++ b/templates/reflection_templates/clc_2026/kitchen_staff.json
@@ -1,0 +1,57 @@
+{
+  "name": "CLC Summer 2026 — Kitchen staff daily",
+  "slug": "clc-2026-kitchen-daily",
+  "version": 1,
+  "cadence": "daily",
+  "program_type": "summer_camp",
+  "description": "TODO(BRENT): Replace placeholder prompts; TODO(i18n): Have Spanish copy reviewed by fluent kitchen staff.",
+  "languages": ["en", "es"],
+  "schema": {
+    "fields": [
+      {
+        "key": "service_summary",
+        "type": "textarea",
+        "required": true,
+        "prompts": {
+          "en": "[PLACEHOLDER] Summarize today's meals service (timing, volume, issues).",
+          "es": "[PLACEHOLDER] Resume el servicio de comidas de hoy (tiempo, volumen, problemas)."
+        }
+      },
+      {
+        "key": "safety_sanitation",
+        "type": "rating_group",
+        "required": true,
+        "scale": [1, 4],
+        "scale_labels": {
+          "en": ["Concern", "Fair", "Good", "Excellent"],
+          "es": ["Preocupación", "Regular", "Bueno", "Excelente"]
+        },
+        "categories": [
+          {
+            "key": "food_safety",
+            "labels": {
+              "en": "[PLACEHOLDER] Food safety & sanitation",
+              "es": "[PLACEHOLDER] Seguridad alimentaria e higiene"
+            }
+          },
+          {
+            "key": "workflow",
+            "labels": {
+              "en": "[PLACEHOLDER] Kitchen workflow / teamwork",
+              "es": "[PLACEHOLDER] Flujo de trabajo / trabajo en equipo"
+            }
+          }
+        ]
+      },
+      {
+        "key": "equipment_supply",
+        "type": "textarea",
+        "required": false,
+        "prompts": {
+          "en": "[PLACEHOLDER] Equipment or supply needs to report.",
+          "es": "[PLACEHOLDER] Necesidades de equipo o suministros a reportar."
+        }
+      }
+    ]
+  }
+}

--- a/templates/reflection_templates/clc_2026/leadership_team.json
+++ b/templates/reflection_templates/clc_2026/leadership_team.json
@@ -1,0 +1,60 @@
+{
+  "name": "CLC Summer 2026 — Leadership team check-in",
+  "slug": "clc-2026-leadership-biweekly",
+  "version": 1,
+  "cadence": "biweekly",
+  "program_type": "summer_camp",
+  "description": "Biweekly unit-focused reflection (migration spec: 1–2x per week / biweekly cadence). TODO(BRENT): Confirm exact schedule and questions.",
+  "languages": ["en"],
+  "schema": {
+    "fields": [
+      {
+        "key": "unit_pulse",
+        "type": "textarea",
+        "required": true,
+        "prompts": {
+          "en": "[PLACEHOLDER] How is the unit doing overall right now (morale, behavior trends, staffing)?"
+        }
+      },
+      {
+        "key": "wins_and_risks",
+        "type": "textarea",
+        "required": true,
+        "prompts": {
+          "en": "[PLACEHOLDER] What are the biggest wins since last check-in, and what risks are you watching?"
+        }
+      },
+      {
+        "key": "leadership_actions",
+        "type": "rating_group",
+        "required": false,
+        "scale": [1, 4],
+        "scale_labels": {
+          "en": ["Needs attention", "Developing", "Stable", "Strong"]
+        },
+        "categories": [
+          {
+            "key": "communication",
+            "labels": {
+              "en": "[PLACEHOLDER] Communication within the unit team"
+            }
+          },
+          {
+            "key": "camper_experience",
+            "labels": {
+              "en": "[PLACEHOLDER] Overall camper experience in the unit"
+            }
+          }
+        ]
+      },
+      {
+        "key": "next_steps",
+        "type": "textarea",
+        "required": false,
+        "prompts": {
+          "en": "[PLACEHOLDER] What decisions or support do you need from camp leadership?"
+        }
+      }
+    ]
+  }
+}

--- a/templates/reflection_templates/clc_2026/maintenance.json
+++ b/templates/reflection_templates/clc_2026/maintenance.json
@@ -1,0 +1,50 @@
+{
+  "name": "CLC Summer 2026 — Maintenance daily",
+  "slug": "clc-2026-maintenance-daily",
+  "version": 1,
+  "cadence": "daily",
+  "program_type": "summer_camp",
+  "description": "TODO(BRENT): Replace placeholder prompts; TODO(i18n): Have Spanish copy reviewed by fluent maintenance staff.",
+  "languages": ["en", "es"],
+  "schema": {
+    "fields": [
+      {
+        "key": "work_completed",
+        "type": "textarea",
+        "required": true,
+        "prompts": {
+          "en": "[PLACEHOLDER] What work did you complete or advance today?",
+          "es": "[PLACEHOLDER] ¿Qué trabajo completó o avanzó hoy?"
+        }
+      },
+      {
+        "key": "open_issues",
+        "type": "textarea",
+        "required": false,
+        "prompts": {
+          "en": "[PLACEHOLDER] Open issues, hazards, or repeat repairs.",
+          "es": "[PLACEHOLDER] Problemas abiertos, riesgos o reparaciones repetidas."
+        }
+      },
+      {
+        "key": "priority_areas",
+        "type": "rating_group",
+        "required": false,
+        "scale": [1, 4],
+        "scale_labels": {
+          "en": ["Low", "Medium", "High", "Urgent"],
+          "es": ["Bajo", "Medio", "Alto", "Urgente"]
+        },
+        "categories": [
+          {
+            "key": "grounds_facilities",
+            "labels": {
+              "en": "[PLACEHOLDER] Priority: grounds & facilities condition",
+              "es": "[PLACEHOLDER] Prioridad: estado de instalaciones y terrenos"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/templates/reflection_templates/clc_2026/special_diets.json
+++ b/templates/reflection_templates/clc_2026/special_diets.json
@@ -1,0 +1,37 @@
+{
+  "name": "CLC Summer 2026 — Special diets daily",
+  "slug": "clc-2026-special-diets-daily",
+  "version": 1,
+  "cadence": "daily",
+  "program_type": "summer_camp",
+  "description": "TODO(BRENT): Replace with approved special-diets / nutrition prompts.",
+  "languages": ["en"],
+  "schema": {
+    "fields": [
+      {
+        "key": "meal_execution",
+        "type": "textarea",
+        "required": true,
+        "prompts": {
+          "en": "[PLACEHOLDER] How did special dietary accommodations go today (accuracy, communication with kitchen)?"
+        }
+      },
+      {
+        "key": "new_or_changed",
+        "type": "textarea",
+        "required": false,
+        "prompts": {
+          "en": "[PLACEHOLDER] New allergies, changes, or incidents to track?"
+        }
+      },
+      {
+        "key": "process_improvements",
+        "type": "textarea",
+        "required": false,
+        "prompts": {
+          "en": "[PLACEHOLDER] What would improve the workflow tomorrow?"
+        }
+      }
+    ]
+  }
+}

--- a/templates/reflection_templates/clc_2026/specialist.json
+++ b/templates/reflection_templates/clc_2026/specialist.json
@@ -1,0 +1,37 @@
+{
+  "name": "CLC Summer 2026 — Specialist daily",
+  "slug": "clc-2026-specialist-daily",
+  "version": 1,
+  "cadence": "daily",
+  "program_type": "summer_camp",
+  "description": "TODO(BRENT): Replace placeholder prompts with approved specialist reflection questions.",
+  "languages": ["en"],
+  "schema": {
+    "fields": [
+      {
+        "key": "program_delivery",
+        "type": "textarea",
+        "required": true,
+        "prompts": {
+          "en": "[PLACEHOLDER] Briefly describe how your area ran today (safety, quality, camper experience)."
+        }
+      },
+      {
+        "key": "collaboration",
+        "type": "textarea",
+        "required": false,
+        "prompts": {
+          "en": "[PLACEHOLDER] How did you coordinate with unit staff or leadership?"
+        }
+      },
+      {
+        "key": "tomorrow_focus",
+        "type": "textarea",
+        "required": false,
+        "prompts": {
+          "en": "[PLACEHOLDER] What is your top priority for tomorrow?"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Implements migration step `3_3_seed_crane_lake_reflection`: JSON templates per Crane Lake Summer 2026 role under `templates/reflection_templates/clc_2026/`, seeding docs in `docs/clc-2026-templates.md`, and `pytest` validation via `parse_template_file`.

## Notes
- Counselor template mirrors legacy BunkLog UI copy; other roles use `TODO(BRENT)` placeholders where content is pending.
- `.gitignore`: allow nested `*.json` under `templates/reflection_templates/` so role subfolders are tracked.

## Testing
- `make test` (backend + frontend) passed locally.

Made with [Cursor](https://cursor.com)