### PR TITLE
3_4_reflection_submission_api: Reflection API with role and language support

### DIFF
--- a/backend/bunk_logs/api/reflections.py
+++ b/backend/bunk_logs/api/reflections.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+from functools import reduce
+from operator import or_
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db.models import Exists
+from django.db.models import OuterRef
+from django.db.models import Q
+from rest_framework import permissions
+from rest_framework import serializers
+from rest_framework import status
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.models import validate_reflection_answers
+
+WELLNESS_ROLES = frozenset({"camper_care", "health_center", "special_diets"})
+LEADERSHIP_ROLES = frozenset({"faculty", "leadership_team"})
+
+
+def _person_for_request(request):
+    if not getattr(request, "organization", None) or not request.user.is_authenticated:
+        return None
+    return Person.objects.filter(user=request.user).first()
+
+
+def _has_tenant_admin(person: Person) -> bool:
+    return Membership.objects.filter(person=person, role="admin", is_active=True).exists()
+
+
+def _has_wellness_membership(person: Person) -> bool:
+    return Membership.objects.filter(
+        person=person,
+        role__in=WELLNESS_ROLES,
+        is_active=True,
+    ).exists()
+
+
+def _validate_language_coverage(schema: dict, lang: str) -> None:
+    fields = schema.get("fields")
+    if not isinstance(fields, list):
+        raise serializers.ValidationError({"language": "Template schema is invalid."})
+    for i, field in enumerate(fields):
+        if not isinstance(field, dict):
+            continue
+        loc = f"field index {i}"
+        ftype = field.get("type")
+        if ftype == "rating_group":
+            labels = field.get("scale_labels") or {}
+            if lang not in labels:
+                raise serializers.ValidationError(
+                    {"language": f'Template scale_labels missing "{lang}" ({loc}).'},
+                )
+            for j, cat in enumerate(field.get("categories") or []):
+                if not isinstance(cat, dict):
+                    continue
+                clabels = cat.get("labels") or {}
+                if lang not in clabels:
+                    raise serializers.ValidationError(
+                        {"language": f'Template category labels missing "{lang}" ({loc}, category {j}).'},
+                    )
+        else:
+            prompts = field.get("prompts") or {}
+            if lang not in prompts:
+                raise serializers.ValidationError(
+                    {"language": f'Template prompts missing "{lang}" ({loc}).'},
+                )
+
+
+def _localize_schema(schema: dict, lang: str) -> dict:
+    out: dict = {"fields": []}
+    for field in schema.get("fields") or []:
+        if not isinstance(field, dict):
+            continue
+        f = dict(field)
+        ftype = f.get("type")
+        if ftype == "rating_group":
+            sl = f.get("scale_labels") or {}
+            if lang in sl:
+                f["scale_labels"] = {lang: sl[lang]}
+            cats = []
+            for c in f.get("categories") or []:
+                if not isinstance(c, dict):
+                    cats.append(c)
+                    continue
+                nc = dict(c)
+                lbls = c.get("labels") or {}
+                if lang in lbls:
+                    nc["labels"] = {lang: lbls[lang]}
+                cats.append(nc)
+            f["categories"] = cats
+        else:
+            pr = f.get("prompts") or {}
+            if lang in pr:
+                f["prompts"] = {lang: pr[lang]}
+        out["fields"].append(f)
+    return out
+
+
+def leadership_visibility_q(viewer: Person) -> Q | None:
+    memberships = list(
+        Membership.objects.filter(
+            person=viewer,
+            role__in=LEADERSHIP_ROLES,
+            is_active=True,
+        ),
+    )
+    if not memberships:
+        return None
+    program_specs: dict[int, dict] = {}
+    for m in memberships:
+        pid = m.program_id
+        raw = m.metadata.get("assigned_unit_slugs")
+        if raw is None:
+            raw = m.metadata.get("unit_slugs")
+        entry = program_specs.setdefault(pid, {"unrestricted": False, "units": set()})
+        if not raw:
+            entry["unrestricted"] = True
+        else:
+            entry["units"].update(str(x) for x in raw)
+
+    q_acc = Q(pk__in=[])
+    for pid, spec in program_specs.items():
+        if spec["unrestricted"]:
+            q_acc |= Q(program_id=pid)
+            continue
+        unit_slugs = spec["units"]
+        if not unit_slugs:
+            continue
+        person_ids = [
+            mem.person_id
+            for mem in Membership.all_objects.filter(program_id=pid, is_active=True)
+            if str(mem.metadata.get("unit_slug") or "") in unit_slugs
+        ]
+        if person_ids:
+            q_acc |= Q(program_id=pid, person_id__in=person_ids)
+    return q_acc
+
+
+class ReflectionTemplateSummarySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ReflectionTemplate
+        fields = [
+            "id",
+            "name",
+            "slug",
+            "cadence",
+            "role",
+            "program_type",
+            "version",
+            "languages",
+            "description",
+        ]
+
+
+class ReflectionSerializer(serializers.ModelSerializer):
+    template_meta = ReflectionTemplateSummarySerializer(source="template", read_only=True)
+    program_slug = serializers.SlugField(write_only=True, required=False)
+    answers = serializers.JSONField()
+
+    class Meta:
+        model = Reflection
+        fields = [
+            "id",
+            "organization",
+            "program",
+            "program_slug",
+            "person",
+            "template",
+            "template_meta",
+            "submitted_by",
+            "period_start",
+            "period_end",
+            "answers",
+            "language",
+            "submitted_at",
+            "updated_at",
+            "is_complete",
+        ]
+        read_only_fields = [
+            "id",
+            "organization",
+            "program",
+            "person",
+            "submitted_by",
+            "submitted_at",
+            "updated_at",
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance is not None:
+            self.fields["program_slug"].read_only = True
+            self.fields["template"].read_only = True
+
+    def validate(self, attrs):
+        if self.instance is None and not attrs.get("program_slug"):
+            raise serializers.ValidationError({"program_slug": "This field is required."})
+        language = attrs.get("language", getattr(self.instance, "language", None) or "en")
+        template = attrs.get("template", getattr(self.instance, "template", None))
+        answers = attrs.get("answers", getattr(self.instance, "answers", None))
+        if template is not None and answers is not None:
+            try:
+                validate_reflection_answers(template.schema, answers)
+            except DjangoValidationError as e:
+                raise serializers.ValidationError(e.message_dict if hasattr(e, "message_dict") else str(e))
+            _validate_language_coverage(template.schema, language)
+        return attrs
+
+    def create(self, validated_data):
+        request = self.context["request"]
+        org = request.organization
+        viewer = _person_for_request(request)
+        if viewer is None or org is None:
+            msg = "Missing organization or person profile."
+            raise serializers.ValidationError({"detail": msg})
+        program_slug = validated_data.pop("program_slug")
+        try:
+            program = Program.objects.get(slug=program_slug)
+        except Program.DoesNotExist as e:
+            raise serializers.ValidationError({"program_slug": "Program not found."}) from e
+        template = validated_data["template"]
+        if template.program_type and template.program_type != program.program_type:
+            raise serializers.ValidationError({"template": "Template does not match program type."})
+        if template.role:
+            allowed = Membership.objects.filter(
+                person=viewer,
+                program=program,
+                role=template.role,
+                is_active=True,
+            ).exists()
+            if not allowed:
+                raise serializers.ValidationError(
+                    {"template": "Your membership role does not match this template."},
+                )
+        else:
+            allowed = Membership.objects.filter(person=viewer, program=program, is_active=True).exists()
+            if not allowed:
+                raise serializers.ValidationError({"program_slug": "No active membership in this program."})
+
+        validated_data["organization"] = org
+        validated_data["program"] = program
+        validated_data["person"] = viewer
+        validated_data["submitted_by"] = request.user
+        try:
+            instance = Reflection(**validated_data)
+            instance.full_clean()
+        except DjangoValidationError as e:
+            raise serializers.ValidationError(e.message_dict if hasattr(e, "message_dict") else str(e))
+        instance.save()
+        return instance
+
+    def update(self, instance, validated_data):
+        if instance.is_complete:
+            raise serializers.ValidationError({"detail": "Completed reflections cannot be updated."})
+        validated_data.pop("program_slug", None)
+        for k, v in validated_data.items():
+            setattr(instance, k, v)
+        try:
+            instance.full_clean()
+        except DjangoValidationError as e:
+            raise serializers.ValidationError(e.message_dict if hasattr(e, "message_dict") else str(e))
+        instance.save()
+        return instance
+
+
+class ReflectionPermission(permissions.BasePermission):
+    message = "Organization context or permission missing."
+
+    def has_permission(self, request, view):
+        return bool(
+            request.user
+            and request.user.is_authenticated
+            and getattr(request, "organization", None),
+        )
+
+    def has_object_permission(self, request, view, obj):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        viewer = _person_for_request(request)
+        if viewer is None:
+            return False
+        return obj.person_id == viewer.id
+
+
+class ReflectionViewSet(viewsets.ModelViewSet):
+    serializer_class = ReflectionSerializer
+    permission_classes = [ReflectionPermission]
+    http_method_names = ["get", "post", "patch", "head", "options"]
+
+    def get_queryset(self):
+        qs = Reflection.objects.select_related("person", "program", "template", "organization")
+        viewer = _person_for_request(self.request)
+        if viewer is None:
+            return qs.none()
+        if _has_tenant_admin(viewer):
+            return self._filter_query_params(qs)
+
+        parts: list[Q] = [Q(person=viewer)]
+        lq = leadership_visibility_q(viewer)
+        if lq is not None:
+            parts.append(lq)
+        if _has_wellness_membership(viewer):
+            parts.append(Q(template__role__in=WELLNESS_ROLES))
+
+        expr = reduce(or_, parts)
+        return self._filter_query_params(qs.filter(expr).distinct())
+
+    def _filter_query_params(self, qs):
+        p = self.request.query_params
+        program_slug = (p.get("program") or "").strip()
+        if program_slug:
+            qs = qs.filter(program__slug=program_slug)
+        tid = (p.get("template") or "").strip()
+        if tid.isdigit():
+            qs = qs.filter(template_id=int(tid))
+        ps_after = (p.get("period_start_after") or "").strip()
+        ps_before = (p.get("period_start_before") or "").strip()
+        if ps_after:
+            qs = qs.filter(period_start__gte=ps_after)
+        if ps_before:
+            qs = qs.filter(period_start__lte=ps_before)
+        mrole = (p.get("membership_role") or "").strip()
+        if mrole:
+            qs = qs.filter(
+                Exists(
+                    Membership.objects.filter(
+                        person_id=OuterRef("person_id"),
+                        program_id=OuterRef("program_id"),
+                        role=mrole,
+                    ),
+                ),
+            )
+        return qs
+
+    @action(detail=False, methods=["get"], url_path="template-for-me")
+    def template_for_me(self, request):
+        viewer = _person_for_request(request)
+        if viewer is None:
+            return Response({"detail": "Person profile required."}, status=status.HTTP_403_FORBIDDEN)
+        program_slug = (request.query_params.get("program") or "").strip()
+        language = (request.query_params.get("language") or "en").strip()
+        memberships = Membership.objects.filter(person=viewer, is_active=True).select_related("program")
+        if program_slug:
+            memberships = memberships.filter(program__slug=program_slug)
+        m = memberships.order_by("-created_at").first()
+        if m is None:
+            return Response({"detail": "No active membership found."}, status=status.HTTP_404_NOT_FOUND)
+        prog = m.program
+        tpl = (
+            ReflectionTemplate.objects.filter(role=m.role, is_active=True)
+            .filter(Q(program_type=prog.program_type) | Q(program_type__isnull=True))
+            .order_by("-version")
+            .first()
+        )
+        if tpl is None:
+            return Response({"detail": "No template for this role."}, status=status.HTTP_404_NOT_FOUND)
+        try:
+            _validate_language_coverage(tpl.schema, language)
+        except serializers.ValidationError as e:
+            detail = getattr(e, "detail", str(e))
+            return Response(detail, status=status.HTTP_400_BAD_REQUEST)
+        payload = ReflectionTemplateSummarySerializer(tpl).data
+        payload["schema"] = _localize_schema(tpl.schema, language)
+        payload["language"] = language
+        return Response(payload)

--- a/backend/bunk_logs/api/tests/test_reflection_api.py
+++ b/backend/bunk_logs/api/tests/test_reflection_api.py
@@ -1,0 +1,385 @@
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+
+User = get_user_model()
+
+
+def _tpl_schema_bilingual(key: str = "note") -> dict:
+    return {"fields": [{"key": key, "type": "text", "prompts": {"en": "English", "es": "Español"}}]}
+
+
+@pytest.fixture
+def org_a(db):
+    return Organization.objects.create(name="Alpha Ref", slug="org-ref-a")
+
+
+@pytest.fixture
+def org_b(db):
+    return Organization.objects.create(name="Beta Ref", slug="org-ref-b")
+
+
+@pytest.fixture
+def program_a(org_a):
+    return Program.all_objects.create(
+        organization=org_a,
+        name="Alpha Ref Summer",
+        slug="prog-ref-a",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def program_b(org_b):
+    return Program.all_objects.create(
+        organization=org_b,
+        name="Beta Ref Summer",
+        slug="prog-ref-b",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def api():
+    return APIClient()
+
+
+@pytest.fixture
+def counselor_template(org_a):
+    return ReflectionTemplate.all_objects.create(
+        organization=org_a,
+        name="Counselor weekly",
+        slug="cns-weekly",
+        cadence="weekly",
+        role="counselor",
+        program_type="summer_camp",
+        schema=_tpl_schema_bilingual(),
+        languages=["en", "es"],
+    )
+
+
+@pytest.fixture
+def counselor_user(org_a, program_a):
+    u = User.objects.create_user(email="cns@example.com", password="pw")
+    p = Person.all_objects.create(organization=org_a, first_name="C", last_name="One", user=u)
+    Membership.all_objects.create(program=program_a, person=p, role="counselor", is_active=True)
+    return u, p
+
+
+@pytest.fixture
+def other_counselor(org_a, program_a):
+    u = User.objects.create_user(email="cns2@example.com", password="pw")
+    p = Person.all_objects.create(organization=org_a, first_name="C", last_name="Two", user=u)
+    Membership.all_objects.create(program=program_a, person=p, role="counselor", is_active=True)
+    return u, p
+
+
+def _hdr_org(slug: str):
+    return {"HTTP_X_ORGANIZATION_SLUG": slug}
+
+
+@pytest.mark.django_db
+def test_person_can_submit(api, org_a, program_a, counselor_template, counselor_user):
+    user, _person = counselor_user
+    api.force_authenticate(user=user)
+    resp = api.post(
+        "/api/v1/reflections/",
+        {
+            "program_slug": program_a.slug,
+            "template": counselor_template.id,
+            "period_start": "2026-06-01",
+            "period_end": "2026-06-07",
+            "answers": {"note": "did well"},
+            "language": "en",
+        },
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 201, resp.content
+    assert resp.json()["answers"] == {"note": "did well"}
+
+
+@pytest.mark.django_db
+def test_person_cannot_see_other_reflection(
+    api,
+    org_a,
+    program_a,
+    counselor_template,
+    counselor_user,
+    other_counselor,
+):
+    user_a, person_a = counselor_user
+    _user_b, person_b = other_counselor
+    ref_b = Reflection.all_objects.create(
+        organization=org_a,
+        program=program_a,
+        person=person_b,
+        template=counselor_template,
+        period_start=date(2026, 6, 1),
+        period_end=date(2026, 6, 7),
+        answers={"note": "b"},
+        language="en",
+    )
+    api.force_authenticate(user=user_a)
+    r = api.get(f"/api/v1/reflections/{ref_b.id}/", **_hdr_org(org_a.slug))
+    assert r.status_code == 404
+
+
+@pytest.mark.django_db
+def test_leadership_sees_unit_level_reflections(
+    api,
+    org_a,
+    program_a,
+    counselor_template,
+    counselor_user,
+):
+    user_c, person_c = counselor_user
+    Membership.all_objects.filter(person=person_c, program=program_a).update(
+        metadata={"unit_slug": "tsofim"},
+    )
+    leader = User.objects.create_user(email="lead@example.com", password="pw")
+    person_l = Person.all_objects.create(organization=org_a, first_name="L", last_name="T", user=leader)
+    Membership.all_objects.create(
+        program=program_a,
+        person=person_l,
+        role="leadership_team",
+        is_active=True,
+        metadata={"assigned_unit_slugs": ["tsofim"]},
+    )
+    api.force_authenticate(user=user_c)
+    rc = api.post(
+        "/api/v1/reflections/",
+        {
+            "program_slug": program_a.slug,
+            "template": counselor_template.id,
+            "period_start": "2026-06-01",
+            "period_end": "2026-06-07",
+            "answers": {"note": "hello"},
+            "language": "en",
+        },
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert rc.status_code == 201
+    rid = rc.json()["id"]
+
+    api.force_authenticate(user=leader)
+    rr = api.get(f"/api/v1/reflections/{rid}/", **_hdr_org(org_a.slug))
+    assert rr.status_code == 200
+    assert rr.json()["answers"]["note"] == "hello"
+
+
+@pytest.mark.django_db
+def test_cross_org_access_impossible(
+    api,
+    org_a,
+    org_b,
+    program_a,
+    program_b,
+    counselor_user,
+):
+    user_a, person_a = counselor_user
+    tpl_b = ReflectionTemplate.all_objects.create(
+        organization=org_b,
+        name="Other",
+        slug="other-tpl",
+        cadence="weekly",
+        role="counselor",
+        program_type="summer_camp",
+        schema=_tpl_schema_bilingual("x"),
+        languages=["en"],
+    )
+    ref_b = Reflection.all_objects.create(
+        organization=org_b,
+        program=program_b,
+        person=Person.all_objects.create(organization=org_b, first_name="X", last_name="Y"),
+        template=tpl_b,
+        period_start=date(2026, 6, 1),
+        period_end=date(2026, 6, 7),
+        answers={"x": "secret"},
+        language="en",
+    )
+    api.force_authenticate(user=user_a)
+    r = api.get(f"/api/v1/reflections/{ref_b.id}/", **_hdr_org(org_a.slug))
+    assert r.status_code == 404
+
+
+@pytest.mark.django_db
+def test_schema_validation_rejects_malformed_answers(
+    api,
+    org_a,
+    program_a,
+    counselor_template,
+    counselor_user,
+):
+    user, _ = counselor_user
+    api.force_authenticate(user=user)
+    resp = api.post(
+        "/api/v1/reflections/",
+        {
+            "program_slug": program_a.slug,
+            "template": counselor_template.id,
+            "period_start": "2026-06-01",
+            "period_end": "2026-06-07",
+            "answers": {},
+            "language": "en",
+        },
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_template_for_me_language_parameter(api, org_a, program_a, counselor_template, counselor_user):
+    user, _ = counselor_user
+    api.force_authenticate(user=user)
+    resp = api.get(
+        "/api/v1/reflections/template-for-me/",
+        {"language": "es"},
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["language"] == "es"
+    assert body["schema"]["fields"][0]["prompts"] == {"es": "Español"}
+
+
+@pytest.mark.django_db
+def test_wellness_team_readonly_enforced(
+    api,
+    org_a,
+    program_a,
+    counselor_template,
+    counselor_user,
+):
+    tpl_well = ReflectionTemplate.all_objects.create(
+        organization=org_a,
+        name="Care check-in",
+        slug="care-in",
+        cadence="weekly",
+        role="camper_care",
+        program_type="summer_camp",
+        schema=_tpl_schema_bilingual("w"),
+        languages=["en", "es"],
+    )
+    user_c, person_c = counselor_user
+    nurse = User.objects.create_user(email="nurse@example.com", password="pw")
+    person_n = Person.all_objects.create(organization=org_a, first_name="N", last_name="C", user=nurse)
+    Membership.all_objects.create(program=program_a, person=person_n, role="health_center", is_active=True)
+
+    api.force_authenticate(user=nurse)
+    wellness_other = Reflection.all_objects.create(
+        organization=org_a,
+        program=program_a,
+        person=person_c,
+        template=tpl_well,
+        period_start=date(2026, 6, 1),
+        period_end=date(2026, 6, 7),
+        answers={"w": "well"},
+        language="en",
+    )
+    g = api.get(f"/api/v1/reflections/{wellness_other.id}/", **_hdr_org(org_a.slug))
+    assert g.status_code == 200
+
+    bad = api.patch(
+        f"/api/v1/reflections/{wellness_other.id}/",
+        {"answers": {"w": "hacked"}},
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert bad.status_code == 403
+
+
+@pytest.mark.django_db
+def test_membership_role_filter(api, org_a, program_a, counselor_template, counselor_user, other_counselor):
+    user_a, person_a = counselor_user
+    user_b, person_b = other_counselor
+    Membership.all_objects.filter(person=person_b, program=program_a).update(role="specialist")
+
+    tpl_sp = ReflectionTemplate.all_objects.create(
+        organization=org_a,
+        name="Spec",
+        slug="spec-w",
+        cadence="weekly",
+        role="specialist",
+        program_type="summer_camp",
+        schema=_tpl_schema_bilingual("s"),
+        languages=["en"],
+    )
+
+    api.force_authenticate(user=user_a)
+    api.post(
+        "/api/v1/reflections/",
+        {
+            "program_slug": program_a.slug,
+            "template": counselor_template.id,
+            "period_start": "2026-06-01",
+            "period_end": "2026-06-07",
+            "answers": {"note": "a"},
+            "language": "en",
+        },
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    api.force_authenticate(user=user_b)
+    api.post(
+        "/api/v1/reflections/",
+        {
+            "program_slug": program_a.slug,
+            "template": tpl_sp.id,
+            "period_start": "2026-06-02",
+            "period_end": "2026-06-08",
+            "answers": {"s": "b"},
+            "language": "en",
+        },
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+
+    api.force_authenticate(user=user_a)
+    r = api.get(
+        "/api/v1/reflections/",
+        {"membership_role": "specialist"},
+        **_hdr_org(org_a.slug),
+    )
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+@pytest.mark.django_db
+def test_incomplete_reflection_can_patch(api, org_a, program_a, counselor_template, counselor_user):
+    user, person = counselor_user
+    ref = Reflection.all_objects.create(
+        organization=org_a,
+        program=program_a,
+        person=person,
+        template=counselor_template,
+        period_start=date(2026, 6, 1),
+        period_end=date(2026, 6, 7),
+        answers={"note": "draft"},
+        language="en",
+        is_complete=False,
+    )
+    api.force_authenticate(user=user)
+    resp = api.patch(
+        f"/api/v1/reflections/{ref.id}/",
+        {"answers": {"note": "updated"}},
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["answers"]["note"] == "updated"

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -4,6 +4,7 @@ from rest_framework.routers import DefaultRouter
 
 from bunk_logs.users.api.views import UserViewSet
 
+from . import reflections
 from . import views
 
 router = DefaultRouter()
@@ -19,6 +20,8 @@ router.register(r"campers", views.CamperViewSet, basename="camper")
 router.register(r"camper-bunk-assignments", views.CamperBunkAssignmentViewSet, basename="camper-bunk-assignment")
 router.register(r"bunklogs", views.BunkLogViewSet, basename="bunklog")
 router.register(r"counselorlogs", views.CounselorLogViewSet, basename="counselorlog")
+
+router.register(r"reflections", reflections.ReflectionViewSet, basename="reflection")
 
 # Ordering system
 router.register(r"orders", views.OrderViewSet, basename="order")


### PR DESCRIPTION
Implements migration step 3_4: DRF endpoints under /api/v1/reflections/ with serializers, template-for-me, tenant-scoped permissions (self, admin, leadership unit metadata, wellness read-only), query filters, and pytest coverage.

Made with [Cursor](https://cursor.com)