### PR TITLE
feat(reflection): org admin auth and /reflect submission UI

### DIFF
--- a/backend/bunk_logs/api/reflections.py
+++ b/backend/bunk_logs/api/reflections.py
@@ -43,6 +43,44 @@ def _has_wellness_membership(person: Person) -> bool:
     ).exists()
 
 
+def _privileged_reflection_actor(request) -> bool:
+    return bool(getattr(request.user, "is_superuser", False))
+
+
+def _template_matches_program(template: ReflectionTemplate, program: Program) -> bool:
+    if template.organization_id and template.organization_id != program.organization_id:
+        return False
+    return not (template.program_type and template.program_type != program.program_type)
+
+
+def _may_use_template(request, viewer: Person, program: Program, template: ReflectionTemplate) -> None:
+    """Raise ValidationError if viewer may not submit using this template on this program."""
+    if program.organization_id != viewer.organization_id:
+        raise serializers.ValidationError({"program_slug": "Program is not in your organization."})
+    if not _template_matches_program(template, program):
+        raise serializers.ValidationError({"template": "Template does not apply to this program."})
+
+    if _privileged_reflection_actor(request) or _has_tenant_admin(viewer):
+        return
+
+    if template.role:
+        allowed = Membership.objects.filter(
+            person=viewer,
+            program=program,
+            role=template.role,
+            is_active=True,
+        ).exists()
+        if not allowed:
+            raise serializers.ValidationError(
+                {"template": "Your membership role does not match this template."},
+            )
+        return
+
+    allowed = Membership.objects.filter(person=viewer, program=program, is_active=True).exists()
+    if not allowed:
+        raise serializers.ValidationError({"program_slug": "No active membership in this program."})
+
+
 def _validate_language_coverage(schema: dict, lang: str) -> None:
     fields = schema.get("fields")
     if not isinstance(fields, list):
@@ -227,23 +265,7 @@ class ReflectionSerializer(serializers.ModelSerializer):
         except Program.DoesNotExist as e:
             raise serializers.ValidationError({"program_slug": "Program not found."}) from e
         template = validated_data["template"]
-        if template.program_type and template.program_type != program.program_type:
-            raise serializers.ValidationError({"template": "Template does not match program type."})
-        if template.role:
-            allowed = Membership.objects.filter(
-                person=viewer,
-                program=program,
-                role=template.role,
-                is_active=True,
-            ).exists()
-            if not allowed:
-                raise serializers.ValidationError(
-                    {"template": "Your membership role does not match this template."},
-                )
-        else:
-            allowed = Membership.objects.filter(person=viewer, program=program, is_active=True).exists()
-            if not allowed:
-                raise serializers.ValidationError({"program_slug": "No active membership in this program."})
+        _may_use_template(request, viewer, program, template)
 
         validated_data["organization"] = org
         validated_data["program"] = program
@@ -340,6 +362,18 @@ class ReflectionViewSet(viewsets.ModelViewSet):
             )
         return qs
 
+    def _template_for_me_payload(self, tpl: ReflectionTemplate, language: str, program: Program) -> Response:
+        try:
+            _validate_language_coverage(tpl.schema, language)
+        except serializers.ValidationError as e:
+            detail = getattr(e, "detail", str(e))
+            return Response(detail, status=status.HTTP_400_BAD_REQUEST)
+        payload = ReflectionTemplateSummarySerializer(tpl).data
+        payload["schema"] = _localize_schema(tpl.schema, language)
+        payload["language"] = language
+        payload["program_slug"] = program.slug
+        return Response(payload)
+
     @action(detail=False, methods=["get"], url_path="template-for-me")
     def template_for_me(self, request):
         viewer = _person_for_request(request)
@@ -347,6 +381,43 @@ class ReflectionViewSet(viewsets.ModelViewSet):
             return Response({"detail": "Person profile required."}, status=status.HTTP_403_FORBIDDEN)
         program_slug = (request.query_params.get("program") or "").strip()
         language = (request.query_params.get("language") or "en").strip()
+        elevated = _has_tenant_admin(viewer) or _privileged_reflection_actor(request)
+
+        if elevated and program_slug:
+            try:
+                prog = Program.objects.get(slug=program_slug)
+            except Program.DoesNotExist:
+                return Response({"detail": "Program not found."}, status=status.HTTP_404_NOT_FOUND)
+            if prog.organization_id != viewer.organization_id:
+                return Response({"detail": "Program is not in your organization."}, status=status.HTTP_403_FORBIDDEN)
+            role_for_tpl = (request.query_params.get("role") or "").strip()
+            if not role_for_tpl:
+                m_on_prog = (
+                    Membership.objects.filter(person=viewer, program=prog, is_active=True)
+                    .order_by("-created_at")
+                    .first()
+                )
+                if m_on_prog:
+                    role_for_tpl = m_on_prog.role
+                else:
+                    return Response(
+                        {
+                            "detail": (
+                                "role query parameter is required when you have no active membership on this program."
+                            ),
+                        },
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+            tpl = (
+                ReflectionTemplate.objects.filter(role=role_for_tpl, is_active=True)
+                .filter(Q(program_type=prog.program_type) | Q(program_type__isnull=True))
+                .order_by("-version")
+                .first()
+            )
+            if tpl is None:
+                return Response({"detail": "No template for this role."}, status=status.HTTP_404_NOT_FOUND)
+            return self._template_for_me_payload(tpl, language, prog)
+
         memberships = Membership.objects.filter(person=viewer, is_active=True).select_related("program")
         if program_slug:
             memberships = memberships.filter(program__slug=program_slug)
@@ -362,12 +433,4 @@ class ReflectionViewSet(viewsets.ModelViewSet):
         )
         if tpl is None:
             return Response({"detail": "No template for this role."}, status=status.HTTP_404_NOT_FOUND)
-        try:
-            _validate_language_coverage(tpl.schema, language)
-        except serializers.ValidationError as e:
-            detail = getattr(e, "detail", str(e))
-            return Response(detail, status=status.HTTP_400_BAD_REQUEST)
-        payload = ReflectionTemplateSummarySerializer(tpl).data
-        payload["schema"] = _localize_schema(tpl.schema, language)
-        payload["language"] = language
-        return Response(payload)
+        return self._template_for_me_payload(tpl, language, prog)

--- a/backend/bunk_logs/api/tests/test_reflection_api.py
+++ b/backend/bunk_logs/api/tests/test_reflection_api.py
@@ -72,6 +72,40 @@ def counselor_template(org_a):
 
 
 @pytest.fixture
+def program_second_session(org_a):
+    return Program.all_objects.create(
+        organization=org_a,
+        name="Alpha Ref Session B",
+        slug="prog-ref-session-b",
+        program_type="summer_camp",
+        start_date=date(2026, 7, 1),
+        end_date=date(2026, 8, 15),
+    )
+
+
+@pytest.fixture
+def kitchen_template(org_a):
+    return ReflectionTemplate.all_objects.create(
+        organization=org_a,
+        name="Kitchen weekly",
+        slug="kit-weekly",
+        cadence="weekly",
+        role="kitchen_staff",
+        program_type="summer_camp",
+        schema=_tpl_schema_bilingual("k"),
+        languages=["en", "es"],
+    )
+
+
+@pytest.fixture
+def org_admin_user(org_a, program_a):
+    u = User.objects.create_user(email="adm@example.com", password="pw")
+    p = Person.all_objects.create(organization=org_a, first_name="A", last_name="D", user=u)
+    Membership.all_objects.create(program=program_a, person=p, role="admin", is_active=True)
+    return u, p
+
+
+@pytest.fixture
 def counselor_user(org_a, program_a):
     u = User.objects.create_user(email="cns@example.com", password="pw")
     p = Person.all_objects.create(organization=org_a, first_name="C", last_name="One", user=u)
@@ -255,6 +289,7 @@ def test_template_for_me_language_parameter(api, org_a, program_a, counselor_tem
     assert resp.status_code == 200
     body = resp.json()
     assert body["language"] == "es"
+    assert body["program_slug"] == program_a.slug
     assert body["schema"]["fields"][0]["prompts"] == {"es": "Español"}
 
 
@@ -383,3 +418,164 @@ def test_incomplete_reflection_can_patch(api, org_a, program_a, counselor_templa
     )
     assert resp.status_code == 200
     assert resp.json()["answers"]["note"] == "updated"
+
+
+@pytest.mark.django_db
+def test_org_admin_can_submit_reflection_without_membership_on_target_program(
+    api,
+    org_a,
+    program_second_session,
+    kitchen_template,
+    org_admin_user,
+):
+    """Org admin on any program in the org may submit using any template on another program in the same org."""
+    user, _person = org_admin_user
+    api.force_authenticate(user=user)
+    resp = api.post(
+        "/api/v1/reflections/",
+        {
+            "program_slug": program_second_session.slug,
+            "template": kitchen_template.id,
+            "period_start": "2026-07-01",
+            "period_end": "2026-07-07",
+            "answers": {"k": "prep lists"},
+            "language": "en",
+        },
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 201, resp.content
+    assert resp.json()["answers"] == {"k": "prep lists"}
+
+
+@pytest.mark.django_db
+def test_counselor_rejected_for_mismatched_template_role(
+    api,
+    org_a,
+    program_a,
+    kitchen_template,
+    counselor_user,
+):
+    user, _ = counselor_user
+    api.force_authenticate(user=user)
+    resp = api.post(
+        "/api/v1/reflections/",
+        {
+            "program_slug": program_a.slug,
+            "template": kitchen_template.id,
+            "period_start": "2026-06-01",
+            "period_end": "2026-06-07",
+            "answers": {"k": "nope"},
+            "language": "en",
+        },
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert "template" in body
+
+
+@pytest.mark.django_db
+def test_superuser_can_submit_without_program_membership(
+    api,
+    org_a,
+    program_second_session,
+    kitchen_template,
+):
+    u = User.objects.create_superuser(email="su@example.com", password="pw")
+    Person.all_objects.create(organization=org_a, first_name="S", last_name="U", user=u)
+    api.force_authenticate(user=u)
+    resp = api.post(
+        "/api/v1/reflections/",
+        {
+            "program_slug": program_second_session.slug,
+            "template": kitchen_template.id,
+            "period_start": "2026-07-01",
+            "period_end": "2026-07-07",
+            "answers": {"k": "su note"},
+            "language": "en",
+        },
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 201, resp.content
+
+
+@pytest.mark.django_db
+def test_template_for_me_org_admin_with_program_and_role(
+    api,
+    org_a,
+    program_second_session,
+    kitchen_template,
+    org_admin_user,
+):
+    user, _ = org_admin_user
+    api.force_authenticate(user=user)
+    resp = api.get(
+        "/api/v1/reflections/template-for-me/",
+        {"program": program_second_session.slug, "role": "kitchen_staff", "language": "en"},
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == kitchen_template.id
+    assert body["program_slug"] == program_second_session.slug
+    assert body["schema"]["fields"][0]["prompts"] == {"en": "English"}
+
+
+@pytest.mark.django_db
+def test_template_for_me_org_admin_requires_role_when_not_on_program(
+    api,
+    org_a,
+    program_second_session,
+    org_admin_user,
+):
+    user, _ = org_admin_user
+    api.force_authenticate(user=user)
+    resp = api.get(
+        "/api/v1/reflections/template-for-me/",
+        {"program": program_second_session.slug},
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 400
+    assert "role" in resp.json()["detail"].lower()
+
+
+@pytest.mark.django_db
+def test_rejects_template_from_other_organization(
+    api,
+    org_a,
+    org_b,
+    program_a,
+    program_b,
+    counselor_user,
+):
+    """Even privileged users cannot attach another org's template to a program."""
+    tpl_other = ReflectionTemplate.all_objects.create(
+        organization=org_b,
+        name="Other org tpl",
+        slug="other-org-tpl",
+        cadence="weekly",
+        role="counselor",
+        program_type="summer_camp",
+        schema=_tpl_schema_bilingual("z"),
+        languages=["en"],
+    )
+    user, _ = counselor_user
+    api.force_authenticate(user=user)
+    resp = api.post(
+        "/api/v1/reflections/",
+        {
+            "program_slug": program_a.slug,
+            "template": tpl_other.id,
+            "period_start": "2026-06-01",
+            "period_end": "2026-06-07",
+            "answers": {"z": "x"},
+            "language": "en",
+        },
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 400
+    assert "template" in resp.json()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,10 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.0.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "^4.3.4",
         "jsdom": "^25.0.1",
         "postcss": "^8.5.1",
@@ -40,6 +44,13 @@
         "vite": "^6.3.5",
         "vitest": "^2.1.9"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -2662,6 +2673,102 @@
         "tailwindcss": "4.1.6"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2885,6 +2992,29 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2901,6 +3031,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/assertion-error": {
@@ -3119,6 +3259,13 @@
       "integrity": "sha512-/RC5F4l1SCqD/jazwUF6+t34Cd8zTSAGZ7rvvZu1whZUhD2a5MOGKjSGowoGcpj/cbVZk1ZODIooJEQQq3nNAA==",
       "license": "MIT"
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssstyle": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.4.0.tgz",
@@ -3295,6 +3442,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -3318,6 +3475,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-helpers": {
@@ -3793,6 +3957,16 @@
         "module-details-from-path": "^1.0.3"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -4247,6 +4421,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -4285,6 +4469,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mini-svg-data-uri": {
@@ -4528,6 +4722,28 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.1.0.tgz",
       "integrity": "sha512-0+G5bHH0RNr8E5hoZo/zJYsL92MhkZjwrHp3O2IxmY8RJL9ooKeuZ8Tm0ZNBw5sGZ9TiM71sthTjWoR2Vf5/xw==",
+      "license": "MIT"
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prop-types": {
@@ -4800,6 +5016,20 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -4966,6 +5196,19 @@
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/stylis": {
       "version": "4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,10 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.0.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.3.4",
     "jsdom": "^25.0.1",
     "postcss": "^8.5.1",

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -22,6 +22,8 @@ import OrderEdit from './pages/OrderEdit';
 import AdminBunkLogs from './pages/AdminBunkLogs';
 import StaffMemberHistory from './pages/StaffMemberHistory';
 import MigrationDashboard from './pages/MigrationDashboard';
+import ReflectionFormPage from './pages/ReflectionFormPage';
+import ReflectionSummaryPage from './pages/ReflectionSummaryPage';
 import { useBunk } from './contexts/BunkContext';
 
 // Protected route component
@@ -254,6 +256,23 @@ function Router() {
           element={
             <ProtectedRoute>
               <MigrationDashboard />
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/reflect"
+          element={
+            <ProtectedRoute>
+              <ReflectionFormPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/reflect/summary"
+          element={
+            <ProtectedRoute>
+              <ReflectionSummaryPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/pages/ReflectionFormPage.jsx
+++ b/frontend/src/pages/ReflectionFormPage.jsx
@@ -1,0 +1,481 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import api from '../api';
+import {
+  validateReflectionAnswers,
+  buildDefaultAnswers,
+  ratingScaleValues,
+  localizedOptionLabel,
+} from '../utils/reflection/reflectionFormValidation';
+import {
+  reflectionDraftKey,
+  loadReflectionDraft,
+  saveReflectionDraft,
+  clearReflectionDraft,
+} from '../utils/reflection/reflectionDraftStorage';
+
+function promptText(field) {
+  if (!field.prompts || typeof field.prompts !== 'object') return '';
+  const v = Object.values(field.prompts)[0];
+  return typeof v === 'string' ? v : '';
+}
+
+function categoryLabel(cat) {
+  if (!cat.labels || typeof cat.labels !== 'object') return cat.key || '';
+  const v = Object.values(cat.labels)[0];
+  return typeof v === 'string' ? v : cat.key || '';
+}
+
+function scaleLabelsList(field) {
+  if (!field.scale_labels || typeof field.scale_labels !== 'object') return [];
+  const row = Object.values(field.scale_labels)[0];
+  return Array.isArray(row) ? row : [];
+}
+
+function mergeAnswers(defaults, draftAnswers) {
+  if (!draftAnswers || typeof draftAnswers !== 'object') return defaults;
+  return { ...defaults, ...draftAnswers };
+}
+
+export default function ReflectionFormPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const programParam = searchParams.get('program') || '';
+  const roleParam = searchParams.get('role') || '';
+
+  const [language, setLanguage] = useState('en');
+  const [meta, setMeta] = useState(null);
+  const [schema, setSchema] = useState(null);
+  const [programSlug, setProgramSlug] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
+  const [answers, setAnswers] = useState({});
+  const [periodStart, setPeriodStart] = useState('');
+  const [periodEnd, setPeriodEnd] = useState('');
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [submitError, setSubmitError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const draftKey = useMemo(() => {
+    if (!meta?.id || !periodStart || !periodEnd) return null;
+    return reflectionDraftKey(meta.id, periodStart, periodEnd);
+  }, [meta?.id, periodStart, periodEnd]);
+
+  const fetchTemplate = useCallback(async () => {
+    setLoading(true);
+    setLoadError('');
+    try {
+      const params = { language };
+      if (programParam) params.program = programParam;
+      if (roleParam) params.role = roleParam;
+      const { data } = await api.get('/api/v1/reflections/template-for-me/', { params });
+      setMeta({
+        id: data.id,
+        name: data.name,
+        cadence: data.cadence,
+        languages: data.languages || [],
+      });
+      setSchema(data.schema);
+      setProgramSlug(data.program_slug || '');
+      setAnswers(buildDefaultAnswers(data.schema));
+    } catch (err) {
+      const status = err.response?.status;
+      const detail = err.response?.data?.detail;
+      const msg =
+        typeof detail === 'string'
+          ? detail
+          : status === 403
+            ? 'You do not have access to reflections for this organization.'
+            : status === 404
+              ? 'No reflection template is available for your role or program.'
+              : 'Could not load reflection template.';
+      setLoadError(msg);
+      setMeta(null);
+      setSchema(null);
+      setProgramSlug('');
+      setAnswers({});
+    } finally {
+      setLoading(false);
+    }
+  }, [language, programParam, roleParam]);
+
+  useEffect(() => {
+    fetchTemplate();
+  }, [fetchTemplate]);
+
+  useEffect(() => {
+    if (!meta?.id || !schema || !periodStart || !periodEnd) return;
+    const key = reflectionDraftKey(meta.id, periodStart, periodEnd);
+    const draft = loadReflectionDraft(key);
+    const defaults = buildDefaultAnswers(schema);
+    setAnswers((prev) => {
+      if (draft?.answers && typeof draft.answers === 'object') {
+        return mergeAnswers(defaults, draft.answers);
+      }
+      return mergeAnswers(defaults, prev);
+    });
+  }, [meta?.id, schema, periodStart, periodEnd]);
+
+  useEffect(() => {
+    if (!draftKey || !schema) return;
+    const t = setTimeout(() => {
+      saveReflectionDraft(draftKey, { answers, updatedAt: Date.now() });
+    }, 300);
+    return () => clearTimeout(t);
+  }, [answers, draftKey, schema]);
+
+  const updateAnswer = (key, value) => {
+    setAnswers((prev) => ({ ...prev, [key]: value }));
+    setFieldErrors((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  };
+
+  const renderField = (field) => {
+    const err = fieldErrors[field.key];
+    const commonLabel = (
+      <label className="block text-sm font-medium text-gray-800 dark:text-gray-200 mb-1">
+        {field.type === 'rating_group' ? null : promptText(field)}
+      </label>
+    );
+
+    if (field.type === 'text') {
+      return (
+        <div key={field.key} className="mb-5">
+          {commonLabel}
+          <input
+            type="text"
+            data-testid={`reflect-input-${field.key}`}
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+            value={answers[field.key] ?? ''}
+            onChange={(e) => updateAnswer(field.key, e.target.value)}
+          />
+          {err ? <p className="text-red-600 text-xs mt-1">{err}</p> : null}
+        </div>
+      );
+    }
+
+    if (field.type === 'textarea') {
+      const v = answers[field.key] ?? '';
+      const max = field.max_length;
+      return (
+        <div key={field.key} className="mb-5">
+          {commonLabel}
+          <textarea
+            rows={4}
+            data-testid={`reflect-input-${field.key}`}
+            maxLength={typeof max === 'number' ? max : undefined}
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+            value={v}
+            onChange={(e) => updateAnswer(field.key, e.target.value)}
+          />
+          <div className="flex justify-between text-xs text-gray-500 mt-1">
+            <span>{err || ''}</span>
+            {typeof max === 'number' ? (
+              <span>
+                {v.length}/{max}
+              </span>
+            ) : (
+              <span>{v.length} characters</span>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    if (field.type === 'text_list') {
+      const items = Array.isArray(answers[field.key]) ? [...answers[field.key]] : [];
+      const maxItems = typeof field.max_items === 'number' ? field.max_items : 12;
+      const minItems = typeof field.min_items === 'number' ? field.min_items : 1;
+      return (
+        <div key={field.key} className="mb-5">
+          {commonLabel}
+          <div className="space-y-2">
+            {items.map((line, idx) => (
+              <input
+                key={idx}
+                type="text"
+                className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm"
+                value={line}
+                onChange={(e) => {
+                  const next = [...items];
+                  next[idx] = e.target.value;
+                  updateAnswer(field.key, next);
+                }}
+              />
+            ))}
+          </div>
+          <div className="flex flex-wrap gap-2 mt-2">
+            {items.length < maxItems ? (
+              <button
+                type="button"
+                className="text-sm text-blue-600 dark:text-blue-400"
+                onClick={() => updateAnswer(field.key, [...items, ''])}
+              >
+                + Add line
+              </button>
+            ) : null}
+            {items.length > minItems ? (
+              <button
+                type="button"
+                className="text-sm text-gray-600 dark:text-gray-400"
+                onClick={() => updateAnswer(field.key, items.slice(0, -1))}
+              >
+                Remove last
+              </button>
+            ) : null}
+          </div>
+          {err ? <p className="text-red-600 text-xs mt-1">{err}</p> : null}
+        </div>
+      );
+    }
+
+    if (field.type === 'rating_group') {
+      const scale = ratingScaleValues(field);
+      const labels = scaleLabelsList(field);
+      const val = answers[field.key] && typeof answers[field.key] === 'object' ? answers[field.key] : {};
+      const heading = promptText(field) || 'Ratings';
+      return (
+        <div key={field.key} className="mb-6">
+          <p className="text-sm font-medium text-gray-800 dark:text-gray-200 mb-2">{heading}</p>
+          <div className="space-y-3">
+            {(field.categories || []).map((cat) => (
+              <div key={cat.key}>
+                <p className="text-xs text-gray-600 dark:text-gray-400 mb-2">{categoryLabel(cat)}</p>
+                <div className="flex flex-wrap gap-2">
+                  {scale.map((n, idx) => {
+                    const label = labels[idx] ?? String(n);
+                    const selected = val[cat.key] === n || val[cat.key] === String(n);
+                    return (
+                      <button
+                        key={String(n)}
+                        type="button"
+                        title={label}
+                        onClick={() =>
+                          updateAnswer(field.key, {
+                            ...val,
+                            [cat.key]: n,
+                          })
+                        }
+                        className={`min-h-[44px] min-w-[44px] px-3 rounded-lg border text-sm font-medium transition-colors ${
+                          selected
+                            ? 'border-blue-600 bg-blue-600 text-white'
+                            : 'border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100'
+                        }`}
+                      >
+                        {label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+          {err ? <p className="text-red-600 text-xs mt-1">{err}</p> : null}
+        </div>
+      );
+    }
+
+    const options = Array.isArray(field.options) ? field.options : [];
+
+    if (field.type === 'single_choice') {
+      const v = answers[field.key] ?? '';
+      return (
+        <div key={field.key} className="mb-5">
+          {commonLabel}
+          <div className="space-y-2">
+            {options.map((opt) => (
+              <label key={opt.key} className="flex items-center gap-2 text-sm cursor-pointer">
+                <input
+                  type="radio"
+                  name={`choice_${field.key}`}
+                  checked={v === opt.key}
+                  onChange={() => updateAnswer(field.key, opt.key)}
+                />
+                <span>{localizedOptionLabel(opt, opt.key)}</span>
+              </label>
+            ))}
+          </div>
+          {err ? <p className="text-red-600 text-xs mt-1">{err}</p> : null}
+        </div>
+      );
+    }
+
+    if (field.type === 'multiple_choice') {
+      const v = Array.isArray(answers[field.key]) ? answers[field.key] : [];
+      const toggle = (key) => {
+        if (v.includes(key)) updateAnswer(field.key, v.filter((x) => x !== key));
+        else updateAnswer(field.key, [...v, key]);
+      };
+      return (
+        <div key={field.key} className="mb-5">
+          {commonLabel}
+          <div className="space-y-2">
+            {options.map((opt) => (
+              <label key={opt.key} className="flex items-center gap-2 text-sm cursor-pointer">
+                <input type="checkbox" checked={v.includes(opt.key)} onChange={() => toggle(opt.key)} />
+                <span>{localizedOptionLabel(opt, opt.key)}</span>
+              </label>
+            ))}
+          </div>
+          {err ? <p className="text-red-600 text-xs mt-1">{err}</p> : null}
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitError('');
+    if (!schema || !meta?.id || !programSlug) {
+      setSubmitError('Template not loaded.');
+      return;
+    }
+    if (!periodStart || !periodEnd) {
+      setSubmitError('Choose a period start and end date.');
+      return;
+    }
+    if (periodEnd < periodStart) {
+      setSubmitError('Period end must be on or after period start.');
+      return;
+    }
+
+    const { ok, errors } = validateReflectionAnswers(schema, answers);
+    setFieldErrors(errors);
+    if (!ok) return;
+
+    setSubmitting(true);
+    try {
+      const { data } = await api.post('/api/v1/reflections/', {
+        program_slug: programSlug,
+        template: meta.id,
+        period_start: periodStart,
+        period_end: periodEnd,
+        answers,
+        language,
+      });
+      if (draftKey) clearReflectionDraft(draftKey);
+      navigate('/reflect/summary', {
+        replace: true,
+        state: {
+          reflectionId: data.id,
+          templateName: meta.name,
+          periodStart,
+          periodEnd,
+          language,
+          schema,
+          answers: data.answers || answers,
+        },
+      });
+    } catch (err) {
+      const body = err.response?.data;
+      const detail =
+        typeof body?.detail === 'string'
+          ? body.detail
+          : body && typeof body === 'object'
+            ? JSON.stringify(body)
+            : err.message;
+      setSubmitError(detail || 'Submit failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const langChoices = meta?.languages?.length ? meta.languages : ['en', 'es'];
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 px-4 py-6 pb-24">
+      <div className="max-w-lg mx-auto">
+        <header className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <h1 className="text-xl font-semibold text-gray-900 dark:text-white">Reflection</h1>
+            {meta ? (
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">{meta.name}</p>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <span className="text-xs text-gray-500 uppercase tracking-wide">Language</span>
+            <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden">
+              {langChoices.map((code) => (
+                <button
+                  key={code}
+                  type="button"
+                  onClick={() => setLanguage(code)}
+                  className={`px-3 py-1.5 text-sm font-medium min-h-[44px] ${
+                    language === code
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200'
+                  }`}
+                >
+                  {code === 'es' ? 'Español' : code === 'en' ? 'English' : code}
+                </button>
+              ))}
+            </div>
+          </div>
+        </header>
+
+        {loading ? (
+          <p className="text-gray-600 dark:text-gray-400">Loading form…</p>
+        ) : loadError ? (
+          <div
+            className="rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/40 dark:border-amber-800 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+            role="alert"
+          >
+            {loadError}
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-2">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
+              <div>
+                <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                  Period start
+                </label>
+                <input
+                  type="date"
+                  data-testid="reflect-period-start"
+                  required
+                  className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm"
+                  value={periodStart}
+                  onChange={(e) => setPeriodStart(e.target.value)}
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                  Period end
+                </label>
+                <input
+                  type="date"
+                  data-testid="reflect-period-end"
+                  required
+                  className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm"
+                  value={periodEnd}
+                  onChange={(e) => setPeriodEnd(e.target.value)}
+                />
+              </div>
+            </div>
+
+            {(schema?.fields || []).map((field) => renderField(field))}
+
+            {submitError ? (
+              <p className="text-red-600 text-sm" role="alert">
+                {submitError}
+              </p>
+            ) : null}
+
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full sm:w-auto mt-4 min-h-[48px] px-6 rounded-lg bg-blue-600 text-white font-medium text-sm disabled:opacity-50"
+            >
+              {submitting ? 'Submitting…' : 'Submit reflection'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ReflectionFormPage.test.jsx
+++ b/frontend/src/pages/ReflectionFormPage.test.jsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import ReflectionFormPage from './ReflectionFormPage';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+
+vi.mock('../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: (...args) => postMock(...args),
+  },
+}));
+
+const templatePayload = {
+  id: 9,
+  name: 'Test weekly',
+  cadence: 'weekly',
+  languages: ['en', 'es'],
+  program_slug: 'prog-a',
+  schema: {
+    fields: [
+      { key: 'note', type: 'text', prompts: { en: 'Note?' } },
+      {
+        key: 'r',
+        type: 'rating_group',
+        scale_labels: { en: ['1', '2', '3', '4'] },
+        categories: [{ key: 'effort', labels: { en: 'Effort' } }],
+      },
+    ],
+  },
+  language: 'en',
+};
+
+function renderPage(search = '') {
+  return render(
+    <MemoryRouter initialEntries={[`/reflect${search}`]}>
+      <Routes>
+        <Route path="/reflect" element={<ReflectionFormPage />} />
+        <Route path="/reflect/summary" element={<div data-testid="summary">Summary</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ReflectionFormPage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    postMock.mockReset();
+    getMock.mockResolvedValue({ data: { ...templatePayload } });
+  });
+
+  it('renders dynamic fields from schema', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Test weekly')).toBeInTheDocument());
+    expect(screen.getByText('Note?')).toBeInTheDocument();
+    expect(screen.getByText('Effort')).toBeInTheDocument();
+  });
+
+  it('language switch re-fetches template', async () => {
+    const user = userEvent.setup();
+    getMock.mockResolvedValueOnce({ data: { ...templatePayload, language: 'en' } });
+    getMock.mockResolvedValueOnce({
+      data: {
+        ...templatePayload,
+        language: 'es',
+        schema: {
+          fields: [{ key: 'note', type: 'text', prompts: { es: 'Nota?' } }],
+        },
+      },
+    });
+    renderPage();
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(1));
+    const es = screen.getByRole('button', { name: 'Español' });
+    await user.click(es);
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2));
+    const lastCall = getMock.mock.calls.at(-1);
+    expect(lastCall[0]).toBe('/api/v1/reflections/template-for-me/');
+    expect(lastCall[1].params.language).toBe('es');
+  });
+
+  it('validation prevents submit when required fields empty', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Note?')).toBeInTheDocument());
+    await user.type(screen.getByTestId('reflect-period-start'), '2026-06-01');
+    await user.type(screen.getByTestId('reflect-period-end'), '2026-06-07');
+    await user.type(screen.getByTestId('reflect-input-note'), 'filled note');
+    await user.click(screen.getByRole('button', { name: /Submit reflection/i }));
+    expect(postMock).not.toHaveBeenCalled();
+    expect(screen.getByText(/Rate every category/i)).toBeInTheDocument();
+  });
+
+  it('successful submit posts correct payload and navigates', async () => {
+    const user = userEvent.setup();
+    postMock.mockResolvedValue({
+      data: { id: 100, answers: { note: 'ok', r: { effort: 2 } } },
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Note?')).toBeInTheDocument());
+    await user.type(screen.getByTestId('reflect-input-note'), 'ok');
+    await user.type(screen.getByTestId('reflect-period-start'), '2026-06-01');
+    await user.type(screen.getByTestId('reflect-period-end'), '2026-06-07');
+    const effortButtons = screen.getAllByRole('button', { name: '2' });
+    await user.click(effortButtons[0]);
+    await user.click(screen.getByRole('button', { name: /Submit reflection/i }));
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    const body = postMock.mock.calls[0][1];
+    expect(body.program_slug).toBe('prog-a');
+    expect(body.template).toBe(9);
+    expect(body.answers.note).toBe('ok');
+    await waitFor(() => expect(screen.getByTestId('summary')).toBeInTheDocument());
+  });
+
+  it('passes program and role query params to template endpoint', async () => {
+    renderPage('?program=prog-b&role=kitchen_staff');
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    expect(getMock.mock.calls[0][1].params).toMatchObject({
+      program: 'prog-b',
+      role: 'kitchen_staff',
+    });
+  });
+});

--- a/frontend/src/pages/ReflectionSummaryPage.jsx
+++ b/frontend/src/pages/ReflectionSummaryPage.jsx
@@ -1,0 +1,85 @@
+import { Link, useLocation } from 'react-router-dom';
+
+function promptText(field) {
+  if (!field.prompts || typeof field.prompts !== 'object') return '';
+  const v = Object.values(field.prompts)[0];
+  return typeof v === 'string' ? v : '';
+}
+
+function categoryLabel(cat) {
+  if (!cat.labels || typeof cat.labels !== 'object') return cat.key || '';
+  const v = Object.values(cat.labels)[0];
+  return typeof v === 'string' ? v : cat.key || '';
+}
+
+function formatAnswer(field, value) {
+  if (value === undefined || value === null) return '—';
+  if (field.type === 'rating_group' && value && typeof value === 'object') {
+    return Object.entries(value)
+      .map(([k, v]) => {
+        const cat = (field.categories || []).find((c) => c.key === k);
+        const label = cat ? categoryLabel(cat) : k;
+        return `${label}: ${v}`;
+      })
+      .join('; ');
+  }
+  if (Array.isArray(value)) return value.join(', ') || '—';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+export default function ReflectionSummaryPage() {
+  const location = useLocation();
+  const data = location.state;
+
+  if (!data?.reflectionId) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 px-4 py-8">
+        <div className="max-w-lg mx-auto rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-sm">
+          <p className="text-gray-700 dark:text-gray-300 mb-4">
+            No reflection summary to show. Submit a reflection from the form first.
+          </p>
+          <Link
+            to="/reflect"
+            className="text-blue-600 dark:text-blue-400 underline font-medium"
+          >
+            Open reflection form
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const { reflectionId, templateName, periodStart, periodEnd, language, schema, answers } = data;
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 px-4 py-8">
+      <div className="max-w-xl mx-auto rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-sm">
+        <h1 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+          Reflection submitted
+        </h1>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+          Reference #{reflectionId} · {templateName} · {periodStart} → {periodEnd} · {language}
+        </p>
+        <ul className="space-y-4">
+          {(schema?.fields || []).map((field) => (
+            <li key={field.key} className="border-b border-gray-100 dark:border-gray-700 pb-3 last:border-0">
+              <p className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                {field.type === 'rating_group' ? 'Ratings' : promptText(field)}
+              </p>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 whitespace-pre-wrap">
+                {formatAnswer(field, answers[field.key])}
+              </p>
+            </li>
+          ))}
+        </ul>
+        <Link
+          to="/reflect"
+          className="inline-block mt-8 text-blue-600 dark:text-blue-400 underline font-medium"
+        >
+          Submit another
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,4 +1,5 @@
-// Basic test setup for Vitest
+import '@testing-library/jest-dom/vitest';
+
 // Mock environment variables for tests
-process.env.VITE_GOOGLE_CLIENT_ID = 'test-google-client-id'
-process.env.VITE_API_BASE_URL = 'http://localhost:8000'
+process.env.VITE_GOOGLE_CLIENT_ID = 'test-google-client-id';
+process.env.VITE_API_BASE_URL = 'http://localhost:8000';

--- a/frontend/src/utils/reflection/reflectionDraftStorage.js
+++ b/frontend/src/utils/reflection/reflectionDraftStorage.js
@@ -1,0 +1,31 @@
+export function reflectionDraftKey(templateId, periodStart, periodEnd) {
+  return `reflectionDraft:${templateId}:${periodStart}:${periodEnd}`;
+}
+
+export function loadReflectionDraft(key) {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    const data = JSON.parse(raw);
+    if (!data || typeof data !== 'object') return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+export function saveReflectionDraft(key, payload) {
+  try {
+    localStorage.setItem(key, JSON.stringify(payload));
+  } catch {
+    /* quota / private mode */
+  }
+}
+
+export function clearReflectionDraft(key) {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    /* ignore */
+  }
+}

--- a/frontend/src/utils/reflection/reflectionDraftStorage.test.js
+++ b/frontend/src/utils/reflection/reflectionDraftStorage.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  reflectionDraftKey,
+  loadReflectionDraft,
+  saveReflectionDraft,
+  clearReflectionDraft,
+} from './reflectionDraftStorage';
+
+describe('reflectionDraftStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('save and resume round-trip', () => {
+    const key = reflectionDraftKey(42, '2026-06-01', '2026-06-07');
+    expect(key).toContain('42');
+    saveReflectionDraft(key, { answers: { note: 'draft' } });
+    const loaded = loadReflectionDraft(key);
+    expect(loaded.answers.note).toBe('draft');
+    clearReflectionDraft(key);
+    expect(loadReflectionDraft(key)).toBeNull();
+  });
+});

--- a/frontend/src/utils/reflection/reflectionFormValidation.js
+++ b/frontend/src/utils/reflection/reflectionFormValidation.js
@@ -1,0 +1,171 @@
+const FIELD_TYPES = new Set([
+  'text',
+  'textarea',
+  'text_list',
+  'rating_group',
+  'multiple_choice',
+  'single_choice',
+]);
+
+/**
+ * Client-side validation aligned with backend validate_reflection_answers.
+ * @returns {{ ok: boolean, errors: Record<string, string> }}
+ */
+export function validateReflectionAnswers(schema, answers) {
+  const errors = {};
+  if (!answers || typeof answers !== 'object' || Array.isArray(answers)) {
+    return { ok: false, errors: { form: 'Answers must be an object.' } };
+  }
+  const fields = schema?.fields;
+  if (!Array.isArray(fields)) {
+    return { ok: false, errors: { form: 'Invalid template schema.' } };
+  }
+
+  for (let i = 0; i < fields.length; i++) {
+    const field = fields[i];
+    if (!field || typeof field !== 'object') {
+      errors[`field_${i}`] = 'Invalid field definition.';
+      continue;
+    }
+    const key = field.key;
+    const ftype = field.type;
+    const required = field.required !== false;
+
+    if (typeof key !== 'string' || !key.trim()) {
+      errors[`field_${i}`] = 'Invalid field key.';
+      continue;
+    }
+    if (!FIELD_TYPES.has(ftype)) {
+      errors[key] = 'Unknown field type.';
+      continue;
+    }
+
+    if (!(key in answers)) {
+      if (!required) continue;
+      errors[key] = 'This field is required.';
+      continue;
+    }
+
+    const value = answers[key];
+    if (ftype === 'text' || ftype === 'textarea' || ftype === 'single_choice') {
+      if (typeof value !== 'string') {
+        errors[key] = 'Must be text.';
+        continue;
+      }
+      if (required && !value.trim()) {
+        errors[key] = 'This field is required.';
+        continue;
+      }
+      const max = field.max_length;
+      if (typeof max === 'number' && value.length > max) {
+        errors[key] = `Max ${max} characters.`;
+      }
+    } else if (ftype === 'text_list') {
+      if (!Array.isArray(value) || !value.every((x) => typeof x === 'string')) {
+        errors[key] = 'Must be a list of text lines.';
+        continue;
+      }
+      const nonEmpty = value.filter((x) => x.trim()).length;
+      const minItems = field.min_items;
+      const maxItems = field.max_items;
+      if (typeof minItems === 'number' && nonEmpty < minItems) {
+        errors[key] = `Enter at least ${minItems} items.`;
+      }
+      if (typeof maxItems === 'number' && value.length > maxItems) {
+        errors[key] = `At most ${maxItems} items.`;
+      }
+      if (required && nonEmpty === 0) {
+        errors[key] = 'This field is required.';
+      }
+    } else if (ftype === 'multiple_choice') {
+      if (!Array.isArray(value)) {
+        errors[key] = 'Select one or more options.';
+        continue;
+      }
+      if (required && value.length === 0) {
+        errors[key] = 'Select at least one option.';
+      }
+    } else if (ftype === 'rating_group') {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        errors[key] = 'Ratings must be provided for each category.';
+        continue;
+      }
+      const cats = field.categories;
+      if (!Array.isArray(cats)) {
+        errors[key] = 'Invalid template categories.';
+        continue;
+      }
+      const catKeys = new Set(
+        cats.filter((c) => c && typeof c === 'object' && typeof c.key === 'string').map((c) => c.key),
+      );
+      for (const ck of Object.keys(value)) {
+        if (!catKeys.has(ck)) {
+          errors[key] = `Unknown category: ${ck}`;
+          break;
+        }
+        const r = value[ck];
+        if (typeof r === 'boolean' || (typeof r !== 'number' && typeof r !== 'string')) {
+          errors[key] = 'Each rating must be a number.';
+          break;
+        }
+        const num = typeof r === 'string' ? Number(r) : r;
+        if (!Number.isFinite(num)) {
+          errors[key] = 'Each rating must be a number.';
+          break;
+        }
+      }
+      if (errors[key]) continue;
+      if (required) {
+        for (const ck of catKeys) {
+          if (!(ck in value)) {
+            errors[key] = 'Rate every category.';
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  return { ok: Object.keys(errors).length === 0, errors };
+}
+
+export function buildDefaultAnswers(schema) {
+  const out = {};
+  const fields = schema?.fields;
+  if (!Array.isArray(fields)) return out;
+  for (const field of fields) {
+    if (!field?.key) continue;
+    const { key, type: ftype } = field;
+    if (ftype === 'text' || ftype === 'textarea' || ftype === 'single_choice') {
+      out[key] = '';
+    } else if (ftype === 'text_list') {
+      const n = Math.max(1, field.min_items || 1);
+      const cap = typeof field.max_items === 'number' ? field.max_items : n;
+      out[key] = Array.from({ length: Math.min(n, cap) }, () => '');
+    } else if (ftype === 'multiple_choice') {
+      out[key] = [];
+    } else if (ftype === 'rating_group') {
+      out[key] = {};
+    }
+  }
+  return out;
+}
+
+export function ratingScaleValues(field) {
+  if (Array.isArray(field.scale) && field.scale.length > 0) {
+    return field.scale.map((x) => Number(x));
+  }
+  const labels = field.scale_labels && typeof field.scale_labels === 'object'
+    ? Object.values(field.scale_labels)[0]
+    : null;
+  if (Array.isArray(labels) && labels.length > 0) {
+    return labels.map((_, i) => i + 1);
+  }
+  return [1, 2, 3, 4];
+}
+
+export function localizedOptionLabel(option, fallback = '') {
+  if (!option?.labels || typeof option.labels !== 'object') return fallback;
+  const first = Object.values(option.labels)[0];
+  return typeof first === 'string' ? first : fallback;
+}

--- a/frontend/src/utils/reflection/reflectionFormValidation.test.js
+++ b/frontend/src/utils/reflection/reflectionFormValidation.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateReflectionAnswers,
+  buildDefaultAnswers,
+  ratingScaleValues,
+  localizedOptionLabel,
+} from './reflectionFormValidation';
+
+describe('validateReflectionAnswers', () => {
+  const schema = {
+    fields: [
+      { key: 'a', type: 'text', prompts: { en: 'A' } },
+      { key: 'b', type: 'textarea', required: false, prompts: { en: 'B' } },
+      {
+        key: 'r',
+        type: 'rating_group',
+        scale_labels: { en: ['L', 'M', 'H'] },
+        categories: [{ key: 'x', labels: { en: 'X' } }],
+      },
+    ],
+  };
+
+  it('requires present keys', () => {
+    const r = validateReflectionAnswers(schema, { r: { x: 2 } });
+    expect(r.ok).toBe(false);
+    expect(r.errors.a).toBeDefined();
+  });
+
+  it('allows optional empty textarea', () => {
+    const r = validateReflectionAnswers(schema, { a: 'hi', r: { x: 1 } });
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects incomplete rating_group', () => {
+    const r = validateReflectionAnswers(schema, { a: 'hi', r: {} });
+    expect(r.ok).toBe(false);
+    expect(r.errors.r).toBeDefined();
+  });
+});
+
+describe('buildDefaultAnswers', () => {
+  it('builds shapes per type', () => {
+    const schema = {
+      fields: [
+        { key: 't', type: 'text', prompts: { en: 't' } },
+        { key: 'tl', type: 'text_list', min_items: 2, prompts: { en: 'tl' } },
+        { key: 'mc', type: 'multiple_choice', prompts: { en: 'm' } },
+        {
+          key: 'rg',
+          type: 'rating_group',
+          scale_labels: { en: ['a'] },
+          categories: [{ key: 'c', labels: { en: 'c' } }],
+        },
+      ],
+    };
+    const a = buildDefaultAnswers(schema);
+    expect(a.t).toBe('');
+    expect(a.tl).toEqual(['', '']);
+    expect(a.mc).toEqual([]);
+    expect(a.rg).toEqual({});
+  });
+});
+
+describe('ratingScaleValues', () => {
+  it('uses explicit scale', () => {
+    expect(ratingScaleValues({ scale: [1, 4] })).toEqual([1, 4]);
+  });
+
+  it('derives from scale_labels row length', () => {
+    expect(ratingScaleValues({ scale_labels: { en: ['a', 'b', 'c'] } })).toEqual([1, 2, 3]);
+  });
+});
+
+describe('localizedOptionLabel', () => {
+  it('reads first label value', () => {
+    expect(localizedOptionLabel({ key: 'k', labels: { en: 'Hello' } }, 'k')).toBe('Hello');
+  });
+});


### PR DESCRIPTION
Backend: org-wide tenant admin and Django superuser can use reflection templates across programs in the same organization; staff path unchanged. template-for-me gains elevated program/role query handling and returns program_slug.

Frontend: protected /reflect and /reflect/summary routes, dynamic multilingual form, localStorage drafts, Vitest + Testing Library. Helpers live in frontend/src/utils/reflection (avoid repo-root lib/ gitignore).

Tests: expanded reflection API pytest; frontend vitest for validation, storage, and form flows.

Made with [Cursor](https://cursor.com)