### PR TITLE
3_7_wellness_team_dashboard: Add Wellness team dashboard

### DIFF
--- a/backend/bunk_logs/api/tests/test_wellness_dashboard.py
+++ b/backend/bunk_logs/api/tests/test_wellness_dashboard.py
@@ -1,0 +1,428 @@
+from datetime import date
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+
+User = get_user_model()
+
+
+def _hdr_org(slug: str):
+    return {"HTTP_X_ORGANIZATION_SLUG": slug}
+
+
+def _wellness_schema():
+    return {
+        "fields": [
+            {
+                "key": "pulse",
+                "type": "rating_group",
+                "scale": [1, 4],
+                "scale_labels": {"en": ["1", "2", "3", "4"]},
+                "categories": [
+                    {"key": "workload", "labels": {"en": "Workload"}},
+                    {"key": "morale", "labels": {"en": "Morale"}},
+                ],
+            },
+            {
+                "key": "primary_concern",
+                "type": "textarea",
+                "required": False,
+                "prompts": {"en": "One concern?"},
+            },
+        ],
+    }
+
+
+def _counselor_schema():
+    return {
+        "fields": [
+            {
+                "key": "pulse",
+                "type": "rating_group",
+                "scale": [1, 4],
+                "scale_labels": {"en": ["1", "2", "3", "4"]},
+                "categories": [{"key": "morale", "labels": {"en": "Morale"}}],
+            },
+            {
+                "key": "primary_concern",
+                "type": "textarea",
+                "required": False,
+                "prompts": {"en": "One concern?"},
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def api():
+    return APIClient()
+
+
+@pytest.fixture
+def org_w(db):
+    return Organization.objects.create(name="Wellness Org", slug="wellness-org")
+
+
+@pytest.fixture
+def program_w(org_w):
+    return Program.all_objects.create(
+        organization=org_w,
+        name="Wellness Org Summer",
+        slug="wellness-prog",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def wellness_template(org_w):
+    return ReflectionTemplate.all_objects.create(
+        organization=org_w,
+        name="Wellness pulse",
+        slug="wellness-pulse",
+        cadence="weekly",
+        role="camper_care",
+        program_type="summer_camp",
+        schema=_wellness_schema(),
+        languages=["en"],
+    )
+
+
+@pytest.fixture
+def counselor_template(org_w):
+    return ReflectionTemplate.all_objects.create(
+        organization=org_w,
+        name="Counselor pulse",
+        slug="counselor-pulse",
+        cadence="weekly",
+        role="counselor",
+        program_type="summer_camp",
+        schema=_counselor_schema(),
+        languages=["en"],
+    )
+
+
+def _make_membership_user(org, program, role, *, email_prefix, metadata=None, tags=None):
+    u = User.objects.create_user(email=f"{email_prefix}@example.com", password="pw")
+    p = Person.all_objects.create(
+        organization=org,
+        first_name=email_prefix.upper(),
+        last_name="Test",
+        user=u,
+    )
+    Membership.all_objects.create(
+        program=program,
+        person=p,
+        role=role,
+        is_active=True,
+        metadata=metadata or {},
+        tags=tags or [],
+    )
+    return u, p
+
+
+@pytest.fixture
+def camper_care_user(org_w, program_w):
+    return _make_membership_user(org_w, program_w, "camper_care", email_prefix="cc")
+
+
+@pytest.fixture
+def health_center_user(org_w, program_w):
+    return _make_membership_user(org_w, program_w, "health_center", email_prefix="hc")
+
+
+@pytest.fixture
+def special_diets_user(org_w, program_w):
+    return _make_membership_user(org_w, program_w, "special_diets", email_prefix="sd")
+
+
+@pytest.fixture
+def admin_membership_user(org_w, program_w):
+    return _make_membership_user(org_w, program_w, "admin", email_prefix="adm")
+
+
+@pytest.fixture
+def counselor_user(org_w, program_w):
+    return _make_membership_user(
+        org_w,
+        program_w,
+        "counselor",
+        email_prefix="cn",
+        metadata={"unit_slug": "alef"},
+    )
+
+
+@pytest.mark.django_db
+def test_counselor_forbidden(api, org_w, program_w, counselor_user):
+    user, _ = counselor_user
+    api.force_authenticate(user=user)
+    r = api.get("/api/v1/dashboards/wellness/", **_hdr_org(org_w.slug))
+    assert r.status_code == 403
+
+
+@pytest.mark.django_db
+def test_camper_care_user_can_access(
+    api,
+    org_w,
+    program_w,
+    wellness_template,
+    camper_care_user,
+):
+    user, person = camper_care_user
+    period_end = date(2026, 6, 14)
+    period_start = date(2026, 6, 8)
+    Reflection.all_objects.create(
+        organization=org_w,
+        program=program_w,
+        person=person,
+        template=wellness_template,
+        period_start=period_start,
+        period_end=period_end,
+        answers={"pulse": {"workload": 3, "morale": 4}, "primary_concern": "Need more breaks"},
+        language="en",
+    )
+    api.force_authenticate(user=user)
+    r = api.get(
+        "/api/v1/dashboards/wellness/",
+        {"period_end": str(period_end), "period_days": "14"},
+        **_hdr_org(org_w.slug),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    roles = {row["role"] for row in body["by_sub_role"]}
+    assert roles == {"camper_care", "health_center", "special_diets"}
+    cc_row = next(row for row in body["by_sub_role"] if row["role"] == "camper_care")
+    assert cc_row["total_staff"] == 1
+    assert cc_row["reflections_submitted"] == 1
+    assert cc_row["completion_rate"] == 1.0
+    assert cc_row["category_averages"]["morale"] == 4.0
+    assert cc_row["category_averages"]["workload"] == 3.0
+    assert any(oq["text"] == "Need more breaks" for oq in cc_row["open_questions"])
+
+
+@pytest.mark.django_db
+def test_health_center_and_special_diets_can_access(
+    api,
+    org_w,
+    program_w,
+    health_center_user,
+    special_diets_user,
+):
+    user_hc, _ = health_center_user
+    api.force_authenticate(user=user_hc)
+    r = api.get("/api/v1/dashboards/wellness/", **_hdr_org(org_w.slug))
+    assert r.status_code == 200
+
+    user_sd, _ = special_diets_user
+    api.force_authenticate(user=user_sd)
+    r2 = api.get("/api/v1/dashboards/wellness/", **_hdr_org(org_w.slug))
+    assert r2.status_code == 200
+
+
+@pytest.mark.django_db
+def test_admin_membership_user_can_access(
+    api,
+    org_w,
+    program_w,
+    admin_membership_user,
+):
+    user, _ = admin_membership_user
+    api.force_authenticate(user=user)
+    r = api.get("/api/v1/dashboards/wellness/", **_hdr_org(org_w.slug))
+    assert r.status_code == 200
+
+
+@pytest.mark.django_db
+def test_legacy_django_admin_user_role_allowed_without_membership_admin(
+    api,
+    org_w,
+    program_w,
+    counselor_user,
+):
+    """Users with the legacy User.ADMIN role can open the wellness dashboard."""
+    user, _ = counselor_user
+    user.role = User.ADMIN
+    user.save(update_fields=["role"])
+    api.force_authenticate(user=user)
+    r = api.get("/api/v1/dashboards/wellness/", **_hdr_org(org_w.slug))
+    assert r.status_code == 200
+
+
+@pytest.mark.django_db
+def test_sub_role_filter_returns_only_requested(
+    api,
+    org_w,
+    program_w,
+    wellness_template,
+    camper_care_user,
+    health_center_user,
+):
+    user, _ = camper_care_user
+    api.force_authenticate(user=user)
+    r = api.get(
+        "/api/v1/dashboards/wellness/",
+        {"sub_role": "health_center"},
+        **_hdr_org(org_w.slug),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["sub_role_filter"] == "health_center"
+    assert {row["role"] for row in body["by_sub_role"]} == {"health_center"}
+
+
+@pytest.mark.django_db
+def test_invalid_sub_role_rejected(api, org_w, camper_care_user):
+    user, _ = camper_care_user
+    api.force_authenticate(user=user)
+    r = api.get(
+        "/api/v1/dashboards/wellness/",
+        {"sub_role": "counselor"},
+        **_hdr_org(org_w.slug),
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.django_db
+def test_low_ratings_flagged_as_concerning(
+    api,
+    org_w,
+    program_w,
+    wellness_template,
+    camper_care_user,
+):
+    user, person = camper_care_user
+    period_end = date(2026, 6, 14)
+    period_start = date(2026, 6, 8)
+    Reflection.all_objects.create(
+        organization=org_w,
+        program=program_w,
+        person=person,
+        template=wellness_template,
+        period_start=period_start,
+        period_end=period_end,
+        answers={"pulse": {"workload": 1, "morale": 2}},
+        language="en",
+    )
+    api.force_authenticate(user=user)
+    r = api.get(
+        "/api/v1/dashboards/wellness/",
+        {"period_end": str(period_end), "period_days": "14"},
+        **_hdr_org(org_w.slug),
+    )
+    assert r.status_code == 200
+    cc_row = next(row for row in r.json()["by_sub_role"] if row["role"] == "camper_care")
+    flagged = {(c["category"], c["value"]) for c in cc_row["concerning"]}
+    assert flagged == {("workload", 1.0), ("morale", 2.0)}
+
+
+@pytest.mark.django_db
+def test_cross_team_patterns_surface_wellness_mentions(
+    api,
+    org_w,
+    program_w,
+    counselor_template,
+    camper_care_user,
+    counselor_user,
+):
+    user_cc, _ = camper_care_user
+    _u_cn, person_cn = counselor_user
+    period_end = date(2026, 6, 14)
+    period_start = date(2026, 6, 8)
+    Reflection.all_objects.create(
+        organization=org_w,
+        program=program_w,
+        person=person_cn,
+        template=counselor_template,
+        period_start=period_start,
+        period_end=period_end,
+        answers={
+            "pulse": {"morale": 3},
+            "primary_concern": "Camper Aviva needs Camper Care follow-up after rough night.",
+        },
+        language="en",
+    )
+    Reflection.all_objects.create(
+        organization=org_w,
+        program=program_w,
+        person=person_cn,
+        template=counselor_template,
+        period_start=period_start,
+        period_end=period_end - timedelta(days=1),
+        answers={"pulse": {"morale": 4}, "primary_concern": "All good this week."},
+        language="en",
+    )
+
+    api.force_authenticate(user=user_cc)
+    r = api.get(
+        "/api/v1/dashboards/wellness/",
+        {"period_end": str(period_end), "period_days": "14"},
+        **_hdr_org(org_w.slug),
+    )
+    assert r.status_code == 200
+    patterns = r.json()["cross_team_patterns"]
+    assert len(patterns) == 1
+    assert "camper care" in patterns[0]["text"].lower()
+    assert patterns[0]["template_role"] == "counselor"
+
+
+@pytest.mark.django_db
+def test_completion_aggregation(
+    api,
+    org_w,
+    program_w,
+    wellness_template,
+    camper_care_user,
+    health_center_user,
+):
+    _u_cc, person_cc = camper_care_user
+    period_end = date(2026, 6, 14)
+    period_start = date(2026, 6, 8)
+    Reflection.all_objects.create(
+        organization=org_w,
+        program=program_w,
+        person=person_cc,
+        template=wellness_template,
+        period_start=period_start,
+        period_end=period_end,
+        answers={"pulse": {"workload": 3, "morale": 3}},
+        language="en",
+    )
+
+    user_hc, _ = health_center_user
+    api.force_authenticate(user=user_hc)
+    r = api.get(
+        "/api/v1/dashboards/wellness/",
+        {"period_end": str(period_end), "period_days": "14"},
+        **_hdr_org(org_w.slug),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["completion"]["total_staff"] == 2
+    assert body["completion"]["reflections_submitted"] == 1
+    assert body["completion"]["completion_rate"] == 0.5
+    by_role = {b["role"]: b for b in body["completion"]["by_sub_role"]}
+    assert by_role["camper_care"]["completion_rate"] == 1.0
+    assert by_role["health_center"]["completion_rate"] == 0.0
+    assert by_role["special_diets"]["total_staff"] == 0
+
+
+@pytest.mark.django_db
+def test_program_filter_unknown_returns_404(api, org_w, camper_care_user):
+    user, _ = camper_care_user
+    api.force_authenticate(user=user)
+    r = api.get(
+        "/api/v1/dashboards/wellness/",
+        {"program": "no-such-program"},
+        **_hdr_org(org_w.slug),
+    )
+    assert r.status_code == 404

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -7,6 +7,7 @@ from bunk_logs.users.api.views import UserViewSet
 from . import reflections
 from . import team_dashboard
 from . import views
+from . import wellness_dashboard
 
 router = DefaultRouter()
 
@@ -59,6 +60,13 @@ urlpatterns = [
 
     # Leadership Team unit health (multi-tenant reflections)
     path("dashboards/team/", team_dashboard.TeamDashboardView.as_view(), name="team-dashboard"),
+
+    # Wellness team dashboard (Camper Care, Health Center, Special Diets)
+    path(
+        "dashboards/wellness/",
+        wellness_dashboard.WellnessDashboardView.as_view(),
+        name="wellness-dashboard",
+    ),
 
     # Unit head and camper care dashboard endpoints
     path("unithead/<str:unithead_id>/<str:date>/", views.get_unit_head_bunks, name="unit-head-bunks"),

--- a/backend/bunk_logs/api/wellness_dashboard.py
+++ b/backend/bunk_logs/api/wellness_dashboard.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date
+from datetime import timedelta
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+
+User = get_user_model()
+
+WELLNESS_SUB_ROLES = ("camper_care", "health_center", "special_diets")
+WELLNESS_ACCESS_ROLES = frozenset(set(WELLNESS_SUB_ROLES) | {"admin"})
+NON_WELLNESS_EXCLUDED_ROLES = WELLNESS_ACCESS_ROLES | {"camper"}
+WELLNESS_KEYWORDS = (
+    "wellness",
+    "health center",
+    "camper care",
+    "special diet",
+    "infirmary",
+    "nurse",
+)
+LOW_RATING_MAX = 2
+TREND_EPS = 0.02
+MAX_TEXT_LEN = 2000
+
+
+def _viewer_program_scope(viewer: Person, user) -> list[int]:
+    """Return program ids the viewer can see for the wellness dashboard."""
+    program_ids: set[int] = set(
+        Membership.objects.filter(
+            person=viewer,
+            role__in=WELLNESS_ACCESS_ROLES,
+            is_active=True,
+        ).values_list("program_id", flat=True),
+    )
+    if program_ids:
+        return list(program_ids)
+    role = getattr(user, "role", "") or ""
+    if user.is_superuser or role == User.ADMIN:
+        return list(
+            Program.objects.filter(
+                organization_id=viewer.organization_id,
+                is_active=True,
+            ).values_list("id", flat=True),
+        )
+    return []
+
+
+def _parse_period(request) -> tuple[date, date, date, date]:
+    end_s = (request.query_params.get("period_end") or "").strip()
+    days_s = (request.query_params.get("period_days") or "14").strip()
+    try:
+        days = max(1, min(90, int(days_s)))
+    except ValueError:
+        days = 14
+    if end_s:
+        try:
+            period_end = date.fromisoformat(end_s)
+        except ValueError:
+            period_end = date.today()
+    else:
+        period_end = date.today()
+    cur_start = period_end - timedelta(days=days - 1)
+    prev_end = cur_start - timedelta(days=1)
+    prev_start = prev_end - timedelta(days=days - 1)
+    return cur_start, period_end, prev_start, prev_end
+
+
+def _collect_rating_pairs(schema: dict, answers: dict) -> list[tuple[str, float]]:
+    out: list[tuple[str, float]] = []
+    for field in schema.get("fields") or []:
+        if not isinstance(field, dict) or field.get("type") != "rating_group":
+            continue
+        key = field.get("key")
+        if not key:
+            continue
+        block = answers.get(key)
+        if not isinstance(block, dict):
+            continue
+        for cat, val in block.items():
+            if isinstance(val, bool) or not isinstance(val, (int, float)):
+                continue
+            out.append((str(cat), float(val)))
+    return out
+
+
+def _open_question_field_keys(schema: dict) -> list[str]:
+    keys: list[str] = []
+    for field in schema.get("fields") or []:
+        if not isinstance(field, dict) or field.get("type") != "textarea":
+            continue
+        k = field.get("key") or ""
+        kl = k.lower()
+        if "concern" in kl or "question" in kl:
+            keys.append(k)
+    if keys:
+        return keys
+    for field in schema.get("fields") or []:
+        if isinstance(field, dict) and field.get("type") == "textarea":
+            fk = field.get("key")
+            if fk:
+                return [fk]
+    return []
+
+
+def _all_textarea_keys(schema: dict) -> list[str]:
+    out: list[str] = []
+    for field in schema.get("fields") or []:
+        if isinstance(field, dict) and field.get("type") == "textarea":
+            fk = field.get("key")
+            if fk:
+                out.append(fk)
+    return out
+
+
+def _avg_ratings(reflections: list[Reflection]) -> dict[str, float]:
+    sums: dict[str, float] = defaultdict(float)
+    counts: dict[str, int] = defaultdict(int)
+    for ref in reflections:
+        for cat, val in _collect_rating_pairs(ref.template.schema, ref.answers):
+            sums[cat] += val
+            counts[cat] += 1
+    return {c: sums[c] / counts[c] for c in counts if counts[c]}
+
+
+def _mean_of_values(d: dict[str, float]) -> float | None:
+    if not d:
+        return None
+    return sum(d.values()) / len(d)
+
+
+def _trend_label(current: float | None, prior: float | None) -> str:
+    if current is None or prior is None:
+        return "flat"
+    delta = current - prior
+    if delta > TREND_EPS:
+        return "up"
+    if delta < -TREND_EPS:
+        return "down"
+    return "flat"
+
+
+def _completion_rate(person_ids: set[int], reflections: list[Reflection]) -> float:
+    if not person_ids:
+        return 0.0
+    submitted = {r.person_id for r in reflections}
+    return len(submitted & person_ids) / len(person_ids)
+
+
+def _person_ids_for_role(program_id: int, role: str) -> set[int]:
+    return set(
+        Membership.objects.filter(
+            program_id=program_id,
+            role=role,
+            is_active=True,
+        ).values_list("person_id", flat=True),
+    )
+
+
+def _looks_like_wellness(text: Any) -> bool:
+    if not isinstance(text, str):
+        return False
+    lowered = text.lower()
+    return any(kw in lowered for kw in WELLNESS_KEYWORDS)
+
+
+class WellnessDashboardView(APIView):
+    """Wellness team dashboard: reflections by sub-role, cross-team patterns, completion."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        org = getattr(request, "organization", None)
+        viewer = Person.objects.filter(user=request.user).first()
+        if org is None or viewer is None:
+            return Response(
+                {"detail": "Organization context and person profile required."},
+                status=403,
+            )
+
+        program_ids = _viewer_program_scope(viewer, request.user)
+        if not program_ids:
+            return Response(
+                {"detail": "Wellness team or admin membership required."},
+                status=403,
+            )
+
+        sub_role_filter = (request.query_params.get("sub_role") or "").strip()
+        if sub_role_filter and sub_role_filter not in WELLNESS_SUB_ROLES:
+            return Response(
+                {
+                    "detail": (
+                        "Invalid sub_role. Allowed: " + ", ".join(WELLNESS_SUB_ROLES)
+                    ),
+                },
+                status=400,
+            )
+
+        program_slug = (request.query_params.get("program") or "").strip()
+        if program_slug:
+            prog = Program.objects.filter(organization=org, slug=program_slug).first()
+            if prog is None:
+                return Response({"detail": "Program not found."}, status=404)
+            if prog.id not in set(program_ids):
+                return Response({"detail": "No access to this program."}, status=403)
+            program_ids = [prog.id]
+
+        cur_start, cur_end, prev_start, prev_end = _parse_period(request)
+        sub_roles_to_show: tuple[str, ...] = (
+            (sub_role_filter,) if sub_role_filter else WELLNESS_SUB_ROLES
+        )
+
+        by_sub_role: list[dict[str, Any]] = []
+        cross_team_patterns: list[dict[str, Any]] = []
+        completion_buckets: list[dict[str, Any]] = []
+        total_staff_overall = 0
+        total_submitted_overall = 0
+
+        for program_id in program_ids:
+            prog = Program.objects.filter(id=program_id).first()
+            if prog is None:
+                continue
+
+            for role in sub_roles_to_show:
+                role_pids = _person_ids_for_role(program_id, role)
+                cur_refs = list(
+                    Reflection.objects.filter(
+                        program_id=program_id,
+                        person_id__in=role_pids,
+                        period_end__gte=cur_start,
+                        period_end__lte=cur_end,
+                        is_complete=True,
+                    ).select_related("template", "person", "program"),
+                )
+                prev_refs = list(
+                    Reflection.objects.filter(
+                        program_id=program_id,
+                        person_id__in=role_pids,
+                        period_end__gte=prev_start,
+                        period_end__lte=prev_end,
+                        is_complete=True,
+                    ).select_related("template"),
+                )
+
+                cur_rate = _completion_rate(role_pids, cur_refs)
+                prev_rate = _completion_rate(role_pids, prev_refs)
+                cur_avgs = _avg_ratings(cur_refs)
+                prev_avgs = _avg_ratings(prev_refs)
+                cur_mean = _mean_of_values(cur_avgs)
+                prev_mean = _mean_of_values(prev_avgs)
+
+                concerning: list[dict[str, Any]] = []
+                open_questions: list[dict[str, Any]] = []
+                for ref in cur_refs:
+                    schema = ref.template.schema
+                    for field in schema.get("fields") or []:
+                        if not isinstance(field, dict) or field.get("type") != "rating_group":
+                            continue
+                        fkey = field.get("key")
+                        block = ref.answers.get(fkey) if fkey else None
+                        if not isinstance(block, dict):
+                            continue
+                        for cat, val in block.items():
+                            if isinstance(val, bool) or not isinstance(val, (int, float)):
+                                continue
+                            if float(val) <= LOW_RATING_MAX:
+                                concerning.append(
+                                    {
+                                        "reflection_id": ref.id,
+                                        "person_id": ref.person_id,
+                                        "field_key": fkey,
+                                        "category": cat,
+                                        "value": float(val),
+                                        "period_end": ref.period_end.isoformat(),
+                                    },
+                                )
+                    for oq_key in _open_question_field_keys(schema):
+                        text = ref.answers.get(oq_key)
+                        if isinstance(text, str) and text.strip():
+                            open_questions.append(
+                                {
+                                    "reflection_id": ref.id,
+                                    "person_id": ref.person_id,
+                                    "field_key": oq_key,
+                                    "period_end": ref.period_end.isoformat(),
+                                    "text": text.strip()[:MAX_TEXT_LEN],
+                                },
+                            )
+
+                submitted_count = len({r.person_id for r in cur_refs})
+                total_staff_overall += len(role_pids)
+                total_submitted_overall += submitted_count
+
+                row = {
+                    "role": role,
+                    "program_slug": prog.slug,
+                    "total_staff": len(role_pids),
+                    "reflections_submitted": submitted_count,
+                    "completion_rate": round(cur_rate, 4),
+                    "prior_completion_rate": round(prev_rate, 4),
+                    "completion_trend": _trend_label(cur_rate, prev_rate),
+                    "category_averages": {
+                        k: round(v, 3) for k, v in sorted(cur_avgs.items())
+                    },
+                    "prior_category_averages": {
+                        k: round(v, 3) for k, v in sorted(prev_avgs.items())
+                    },
+                    "rating_trend": _trend_label(cur_mean, prev_mean),
+                    "concerning": concerning,
+                    "open_questions": open_questions,
+                }
+                by_sub_role.append(row)
+                completion_buckets.append(
+                    {
+                        "role": role,
+                        "program_slug": prog.slug,
+                        "total_staff": len(role_pids),
+                        "reflections_submitted": submitted_count,
+                        "completion_rate": round(cur_rate, 4),
+                    },
+                )
+
+            # Cross-team patterns: scan reflections from non-wellness staff
+            # for textarea answers that mention wellness keywords.
+            non_wellness_pids = set(
+                Membership.objects.filter(
+                    program_id=program_id,
+                    is_active=True,
+                )
+                .exclude(role__in=NON_WELLNESS_EXCLUDED_ROLES)
+                .values_list("person_id", flat=True),
+            )
+            if non_wellness_pids:
+                other_refs = Reflection.objects.filter(
+                    program_id=program_id,
+                    person_id__in=non_wellness_pids,
+                    period_end__gte=cur_start,
+                    period_end__lte=cur_end,
+                    is_complete=True,
+                ).select_related("template")
+                for ref in other_refs:
+                    schema = ref.template.schema
+                    for fkey in _all_textarea_keys(schema):
+                        text = ref.answers.get(fkey)
+                        if _looks_like_wellness(text):
+                            cross_team_patterns.append(
+                                {
+                                    "reflection_id": ref.id,
+                                    "person_id": ref.person_id,
+                                    "program_slug": prog.slug,
+                                    "field_key": fkey,
+                                    "template_slug": ref.template.slug,
+                                    "template_role": ref.template.role,
+                                    "period_end": ref.period_end.isoformat(),
+                                    "text": text.strip()[:MAX_TEXT_LEN],
+                                },
+                            )
+
+        completion_rate_overall = (
+            total_submitted_overall / total_staff_overall if total_staff_overall else 0.0
+        )
+
+        payload = {
+            "period": {
+                "current_start": cur_start.isoformat(),
+                "current_end": cur_end.isoformat(),
+                "prior_start": prev_start.isoformat(),
+                "prior_end": prev_end.isoformat(),
+            },
+            "sub_role_filter": sub_role_filter or None,
+            "by_sub_role": by_sub_role,
+            "cross_team_patterns": cross_team_patterns,
+            "completion": {
+                "total_staff": total_staff_overall,
+                "reflections_submitted": total_submitted_overall,
+                "completion_rate": round(completion_rate_overall, 4),
+                "by_sub_role": completion_buckets,
+            },
+        }
+        return Response(payload)

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -25,6 +25,7 @@ import MigrationDashboard from './pages/MigrationDashboard';
 import ReflectionFormPage from './pages/ReflectionFormPage';
 import ReflectionSummaryPage from './pages/ReflectionSummaryPage';
 import TeamDashboardPage from './pages/TeamDashboardPage';
+import WellnessDashboardPage from './pages/WellnessDashboardPage';
 import { useBunk } from './contexts/BunkContext';
 
 // Protected route component
@@ -290,6 +291,15 @@ function Router() {
           element={
             <ProtectedRoute>
               <TeamDashboardPage />
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/wellness/dashboard"
+          element={
+            <ProtectedRoute>
+              <WellnessDashboardPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/pages/WellnessDashboardPage.jsx
+++ b/frontend/src/pages/WellnessDashboardPage.jsx
@@ -1,0 +1,322 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Minus, TrendingDown, TrendingUp } from 'lucide-react';
+
+import Header from '../partials/Header';
+import Sidebar from '../partials/Sidebar';
+import api from '../api';
+
+const SUB_ROLE_LABELS = {
+  camper_care: 'Camper Care',
+  health_center: 'Health Center',
+  special_diets: 'Special Diets',
+};
+
+function trendIcon(label) {
+  if (label === 'up') {
+    return <TrendingUp className="inline h-4 w-4 text-emerald-600 dark:text-emerald-400" aria-hidden />;
+  }
+  if (label === 'down') {
+    return <TrendingDown className="inline h-4 w-4 text-rose-600 dark:text-rose-400" aria-hidden />;
+  }
+  return <Minus className="inline h-4 w-4 text-gray-400" aria-hidden />;
+}
+
+function pct(n) {
+  if (n == null || Number.isNaN(n)) return '—';
+  return `${Math.round(n * 1000) / 10}%`;
+}
+
+function todayIso() {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export default function WellnessDashboardPage() {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [payload, setPayload] = useState(null);
+  const [subRole, setSubRole] = useState('');
+  const [periodEnd, setPeriodEnd] = useState(todayIso);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = {
+        period_end: periodEnd,
+        period_days: 14,
+      };
+      if (subRole) params.sub_role = subRole;
+      const { data } = await api.get('/api/v1/dashboards/wellness/', { params });
+      setPayload(data);
+    } catch (e) {
+      const status = e.response?.status;
+      if (status === 403) {
+        setError('access');
+      } else {
+        setError(e.response?.data?.detail || e.message || 'Failed to load wellness dashboard');
+      }
+      setPayload(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [periodEnd, subRole]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const totals = useMemo(() => payload?.completion ?? null, [payload]);
+
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+      <div className="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
+        <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+        <main className="grow px-4 sm:px-6 lg:px-8 py-8 w-full max-w-9xl mx-auto">
+          <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Wellness team</h1>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                Camper Care, Health Center, and Special Diets reflections, with cross-team patterns
+                surfaced from other staff feedback.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-4">
+              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                <span>Sub-role</span>
+                <select
+                  value={subRole}
+                  onChange={(ev) => setSubRole(ev.target.value)}
+                  className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
+                  aria-label="Filter by wellness sub-role"
+                >
+                  <option value="">All wellness roles</option>
+                  <option value="camper_care">Camper Care</option>
+                  <option value="health_center">Health Center</option>
+                  <option value="special_diets">Special Diets</option>
+                </select>
+              </label>
+              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                <span>Period ends</span>
+                <input
+                  type="date"
+                  value={periodEnd}
+                  onChange={(ev) => setPeriodEnd(ev.target.value)}
+                  className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
+                />
+              </label>
+              <button
+                type="button"
+                onClick={load}
+                className="rounded-md bg-teal-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-teal-500"
+              >
+                Refresh
+              </button>
+            </div>
+          </div>
+
+          {loading && (
+            <p className="text-gray-600 dark:text-gray-400">Loading…</p>
+          )}
+
+          {!loading && error === 'access' && (
+            <div className="rounded-lg border border-amber-200 dark:border-amber-900/40 bg-amber-50 dark:bg-amber-900/20 p-4 text-amber-900 dark:text-amber-100">
+              <p className="font-medium">Access restricted</p>
+              <p className="text-sm mt-1">
+                The wellness dashboard requires a multi-tenant <strong>camper_care</strong>,{' '}
+                <strong>health_center</strong>, <strong>special_diets</strong>, or{' '}
+                <strong>admin</strong> program membership, or an account with the legacy{' '}
+                <strong>Admin</strong> staff role.
+              </p>
+              <Link to="/dashboard" className="text-sm underline mt-2 inline-block">
+                Back to dashboard
+              </Link>
+            </div>
+          )}
+
+          {!loading && error && error !== 'access' && (
+            <p className="text-rose-600 dark:text-rose-400">{error}</p>
+          )}
+
+          {!loading && payload && (
+            <>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
+                Window: {payload.period?.current_start} → {payload.period?.current_end} (prior:{' '}
+                {payload.period?.prior_start} → {payload.period?.prior_end})
+              </p>
+
+              {totals && (
+                <section className="mb-8 grid grid-cols-1 sm:grid-cols-3 gap-4">
+                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-4">
+                    <p className="text-xs uppercase text-gray-500 dark:text-gray-400">Wellness staff</p>
+                    <p className="text-2xl font-semibold text-gray-900 dark:text-white">
+                      {totals.total_staff}
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-4">
+                    <p className="text-xs uppercase text-gray-500 dark:text-gray-400">Reflections submitted</p>
+                    <p className="text-2xl font-semibold text-gray-900 dark:text-white">
+                      {totals.reflections_submitted}
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-4">
+                    <p className="text-xs uppercase text-gray-500 dark:text-gray-400">Completion rate</p>
+                    <p className="text-2xl font-semibold text-gray-900 dark:text-white">
+                      {pct(totals.completion_rate)}
+                    </p>
+                  </div>
+                </section>
+              )}
+
+              <section className="mb-10">
+                <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
+                  Reflections by sub-role
+                </h2>
+                <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+                  <table className="min-w-full text-sm">
+                    <thead className="bg-gray-50 dark:bg-gray-800/80">
+                      <tr>
+                        <th className="text-left px-3 py-2 font-medium">Sub-role</th>
+                        <th className="text-left px-3 py-2 font-medium">Program</th>
+                        <th className="text-right px-3 py-2 font-medium">Staff</th>
+                        <th className="text-right px-3 py-2 font-medium">Submitted</th>
+                        <th className="text-right px-3 py-2 font-medium">Completion</th>
+                        <th className="text-center px-3 py-2 font-medium">Comp. trend</th>
+                        <th className="text-left px-3 py-2 font-medium">Category averages</th>
+                        <th className="text-center px-3 py-2 font-medium">Rating trend</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                      {(payload.by_sub_role || []).map((row) => (
+                        <tr
+                          key={`${row.program_slug}-${row.role}`}
+                          className="bg-white dark:bg-gray-900/40"
+                        >
+                          <td className="px-3 py-2 font-medium text-gray-900 dark:text-white">
+                            {SUB_ROLE_LABELS[row.role] || row.role}
+                          </td>
+                          <td className="px-3 py-2 text-gray-600 dark:text-gray-300">{row.program_slug}</td>
+                          <td className="px-3 py-2 text-right">{row.total_staff}</td>
+                          <td className="px-3 py-2 text-right">{row.reflections_submitted}</td>
+                          <td className="px-3 py-2 text-right">{pct(row.completion_rate)}</td>
+                          <td className="px-3 py-2 text-center">
+                            {trendIcon(row.completion_trend)}
+                            <span className="sr-only">{row.completion_trend}</span>
+                          </td>
+                          <td className="px-3 py-2 text-gray-600 dark:text-gray-300 text-xs">
+                            {Object.keys(row.category_averages || {}).length === 0
+                              ? '—'
+                              : Object.entries(row.category_averages)
+                                  .map(([k, v]) => `${k}: ${v}`)
+                                  .join(', ')}
+                          </td>
+                          <td className="px-3 py-2 text-center">
+                            {trendIcon(row.rating_trend)}
+                            <span className="sr-only">{row.rating_trend}</span>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  {(payload.by_sub_role || []).length === 0 && (
+                    <p className="p-4 text-gray-500 dark:text-gray-400 text-sm">
+                      No wellness staff in scope for this filter.
+                    </p>
+                  )}
+                </div>
+              </section>
+
+              <section className="mb-10">
+                <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
+                  Concerning ratings (≤2)
+                </h2>
+                <ul className="space-y-2 text-sm">
+                  {(payload.by_sub_role || [])
+                    .flatMap((row) =>
+                      (row.concerning || []).map((c) => ({ ...c, role: row.role })),
+                    )
+                    .map((c, i) => (
+                      <li
+                        key={`${c.reflection_id}-${c.field_key}-${c.category}-${i}`}
+                        className="rounded-md border border-rose-200 dark:border-rose-900/50 bg-rose-50/50 dark:bg-rose-950/30 px-3 py-2"
+                      >
+                        <span className="font-medium text-rose-800 dark:text-rose-200">
+                          {SUB_ROLE_LABELS[c.role] || c.role} · {c.category} = {c.value}
+                        </span>
+                        <span className="text-gray-600 dark:text-gray-400 ml-2">
+                          person {c.person_id} · {c.period_end}
+                        </span>
+                      </li>
+                    ))}
+                </ul>
+                {((payload.by_sub_role || []).flatMap((r) => r.concerning || []).length === 0) && (
+                  <p className="text-gray-500 dark:text-gray-400 text-sm">None in this period.</p>
+                )}
+              </section>
+
+              <section className="mb-10">
+                <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
+                  Cross-team patterns
+                </h2>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                  Concerns flagged in non-wellness reflections that mention wellness, camper care,
+                  health center, or special diets.
+                </p>
+                <ul className="space-y-2 text-sm">
+                  {(payload.cross_team_patterns || []).map((p, i) => (
+                    <li
+                      key={`${p.reflection_id}-${p.field_key}-${i}`}
+                      className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 px-3 py-2"
+                    >
+                      <p className="text-gray-500 dark:text-gray-400 text-xs mb-1">
+                        {p.template_role || p.template_slug} · {p.field_key} · {p.period_end}
+                      </p>
+                      <p className="text-gray-800 dark:text-gray-200 whitespace-pre-wrap">{p.text}</p>
+                    </li>
+                  ))}
+                </ul>
+                {(payload.cross_team_patterns || []).length === 0 && (
+                  <p className="text-gray-500 dark:text-gray-400 text-sm">
+                    No wellness mentions surfaced in other teams' reflections this period.
+                  </p>
+                )}
+              </section>
+
+              <section>
+                <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
+                  Open questions / concerns
+                </h2>
+                <ul className="space-y-2 text-sm">
+                  {(payload.by_sub_role || [])
+                    .flatMap((row) =>
+                      (row.open_questions || []).map((oq) => ({ ...oq, role: row.role })),
+                    )
+                    .map((q) => (
+                      <li
+                        key={`${q.reflection_id}-${q.field_key}`}
+                        className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 px-3 py-2"
+                      >
+                        <p className="text-gray-500 dark:text-gray-400 text-xs mb-1">
+                          {SUB_ROLE_LABELS[q.role] || q.role} · {q.field_key} · {q.period_end}
+                        </p>
+                        <p className="text-gray-800 dark:text-gray-200 whitespace-pre-wrap">{q.text}</p>
+                      </li>
+                    ))}
+                </ul>
+                {((payload.by_sub_role || []).flatMap((r) => r.open_questions || []).length === 0) && (
+                  <p className="text-gray-500 dark:text-gray-400 text-sm">None captured in this period.</p>
+                )}
+              </section>
+            </>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/WellnessDashboardPage.test.jsx
+++ b/frontend/src/pages/WellnessDashboardPage.test.jsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import WellnessDashboardPage from './WellnessDashboardPage';
+
+const getMock = vi.fn();
+
+vi.mock('../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+  },
+}));
+
+vi.mock('../auth/AuthContext', () => ({
+  useAuth: () => ({ user: null }),
+}));
+
+const samplePayload = {
+  period: {
+    current_start: '2026-06-01',
+    current_end: '2026-06-14',
+    prior_start: '2026-05-18',
+    prior_end: '2026-05-31',
+  },
+  sub_role_filter: null,
+  by_sub_role: [
+    {
+      role: 'camper_care',
+      program_slug: 'summer',
+      total_staff: 2,
+      reflections_submitted: 1,
+      completion_rate: 0.5,
+      prior_completion_rate: 0.25,
+      completion_trend: 'up',
+      category_averages: { workload: 3, morale: 4 },
+      prior_category_averages: { workload: 2, morale: 3 },
+      rating_trend: 'up',
+      concerning: [
+        {
+          reflection_id: 7,
+          person_id: 11,
+          field_key: 'pulse',
+          category: 'workload',
+          value: 1,
+          period_end: '2026-06-14',
+        },
+      ],
+      open_questions: [
+        {
+          reflection_id: 7,
+          person_id: 11,
+          field_key: 'primary_concern',
+          period_end: '2026-06-14',
+          text: 'Need backup at meds line',
+        },
+      ],
+    },
+    {
+      role: 'health_center',
+      program_slug: 'summer',
+      total_staff: 1,
+      reflections_submitted: 0,
+      completion_rate: 0,
+      prior_completion_rate: 0,
+      completion_trend: 'flat',
+      category_averages: {},
+      prior_category_averages: {},
+      rating_trend: 'flat',
+      concerning: [],
+      open_questions: [],
+    },
+    {
+      role: 'special_diets',
+      program_slug: 'summer',
+      total_staff: 0,
+      reflections_submitted: 0,
+      completion_rate: 0,
+      prior_completion_rate: 0,
+      completion_trend: 'flat',
+      category_averages: {},
+      prior_category_averages: {},
+      rating_trend: 'flat',
+      concerning: [],
+      open_questions: [],
+    },
+  ],
+  cross_team_patterns: [
+    {
+      reflection_id: 33,
+      person_id: 99,
+      program_slug: 'summer',
+      field_key: 'primary_concern',
+      template_slug: 'counselor-pulse',
+      template_role: 'counselor',
+      period_end: '2026-06-12',
+      text: 'Camper Aviva needs Camper Care follow-up.',
+    },
+  ],
+  completion: {
+    total_staff: 3,
+    reflections_submitted: 1,
+    completion_rate: 0.3333,
+    by_sub_role: [
+      { role: 'camper_care', program_slug: 'summer', total_staff: 2, reflections_submitted: 1, completion_rate: 0.5 },
+      { role: 'health_center', program_slug: 'summer', total_staff: 1, reflections_submitted: 0, completion_rate: 0 },
+      { role: 'special_diets', program_slug: 'summer', total_staff: 0, reflections_submitted: 0, completion_rate: 0 },
+    ],
+  },
+};
+
+describe('WellnessDashboardPage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    getMock.mockResolvedValue({ data: samplePayload });
+  });
+
+  it('loads dashboard and shows sub-role rows and cross-team patterns', async () => {
+    render(
+      <MemoryRouter>
+        <WellnessDashboardPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    expect(screen.getByRole('heading', { name: /Wellness team/i, level: 1 })).toBeInTheDocument();
+    // Each sub-role appears at least twice (dropdown option + table row)
+    await waitFor(() => expect(screen.getAllByText('Camper Care').length).toBeGreaterThanOrEqual(2));
+    expect(screen.getAllByText('Health Center').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText('Special Diets').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText(/Camper Aviva needs Camper Care follow-up/i)).toBeInTheDocument();
+    expect(screen.getByText(/Need backup at meds line/i)).toBeInTheDocument();
+  });
+
+  it('passes sub_role param when filter is set', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <WellnessDashboardPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    getMock.mockClear();
+    await user.selectOptions(screen.getByLabelText(/Filter by wellness sub-role/i), 'health_center');
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    const lastCall = getMock.mock.calls.at(-1);
+    expect(lastCall?.[1]?.params?.sub_role).toBe('health_center');
+  });
+
+  it('shows access message on 403', async () => {
+    getMock.mockRejectedValueOnce({ response: { status: 403 } });
+    render(
+      <MemoryRouter>
+        <WellnessDashboardPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText(/Access restricted/i)).toBeInTheDocument());
+  });
+});

--- a/frontend/src/partials/Sidebar.jsx
+++ b/frontend/src/partials/Sidebar.jsx
@@ -205,6 +205,27 @@ function Sidebar({
                   </NavLink>
                 </li>
               )}
+              {user && ['Admin', 'Camper Care'].includes(user.role) && (
+                <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
+                  <NavLink
+                    to="/wellness/dashboard"
+                    className={({ isActive }) =>
+                      `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
+                        isActive ? 'text-teal-600 dark:text-teal-400' : 'hover:text-gray-900 dark:hover:text-white'
+                      }`
+                    }
+                  >
+                    <div className="flex items-center">
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
+                      </svg>
+                      <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
+                        Wellness team
+                      </span>
+                    </div>
+                  </NavLink>
+                </li>
+              )}
               {user && REFLECTION_FORM_ROLES.includes(user.role) && (
                 <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
                   <NavLink

--- a/migration_prompts/3_7_wellness_team_dashboard.md
+++ b/migration_prompts/3_7_wellness_team_dashboard.md
@@ -1,0 +1,21 @@
+Build a separate dashboard for the Wellness team (Camper Care, Health Center, Special Diets). They have their own questions and need their own view.
+
+Tasks:
+1. Create route /wellness/dashboard.
+2. Permission: Memberships with role in ('camper_care', 'health_center', 'special_diets', 'admin').
+
+3. Sections:
+   - Wellness team reflections by sub-role
+   - Cross-team patterns (e.g., concerns flagged in counselor reflections that reference wellness)
+   - Wellness completion tracking
+
+4. API: /api/v1/dashboards/wellness/
+
+5. Tests for permissions, data correctness, sub-role filtering.
+
+Acceptance criteria:
+- Dashboard renders correctly
+- Wellness sub-roles get appropriate views
+- Permissions enforced
+- Tests pass
+- Commit with message: "Add Wellness team dashboard"


### PR DESCRIPTION
## Summary

Implements migration step **3_7_wellness_team_dashboard**: a separate dashboard for the Wellness team (Camper Care, Health Center, Special Diets) with their own questions and completion tracking.

- New backend endpoint `GET /api/v1/dashboards/wellness/` (in `backend/bunk_logs/api/wellness_dashboard.py`) that returns:
  - `by_sub_role`: per-sub-role rows with totals, completion rate vs prior period, average ratings per category, trend labels, low-rating concerns, and open-question text.
  - `cross_team_patterns`: textarea answers from non-wellness staff reflections that mention wellness/camper care/health center/special diets/infirmary/nurse keywords.
  - `completion`: org-wide completion rollup plus a per-sub-role completion bucket.
- Permission gate: any active `Membership` with role `camper_care`, `health_center`, `special_diets`, or `admin` grants access. Legacy `User.ADMIN` and superusers are scoped to their person's organization (mirrors the Leadership Team dashboard pattern).
- Query params: `period_end`, `period_days` (default 14), `sub_role` (optional filter), `program` (optional program slug).
- New React page `WellnessDashboardPage` mounted at `/wellness/dashboard`, with sub-role filter, period picker, summary cards, sub-role breakdown table, low-rating concern list, cross-team patterns, and open-question feed.
- Sidebar link surfaced for legacy `Admin` and `Camper Care` users.

## Test plan

- [x] `make test-backend` (262 passed, includes 11 new wellness tests covering counselor → 403, each wellness sub-role → 200, admin Membership → 200, legacy `User.ADMIN` → 200, sub-role filter, invalid sub-role 400, low-rating flagging, cross-team keyword surfacing, completion aggregation, missing program 404).
- [x] `make test-frontend` (25 passed, includes 3 new tests covering happy path render, sub-role filter API param, and 403 access message).
- [x] `npm run build` succeeds.
- [ ] Smoke test in dev with seeded data once deployed to a preview env.


Made with [Cursor](https://cursor.com)