### PR TITLE
3_8_membership_tagging_ui: Membership tagging UI for admins

### DIFF
--- a/backend/bunk_logs/api/memberships.py
+++ b/backend/bunk_logs/api/memberships.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from rest_framework import permissions
+from rest_framework import serializers
+from rest_framework import status
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Person
+
+
+def _normalize_tags(values) -> list[str]:
+    """Lowercase, strip, dedupe (preserving order). Reused from admin helper conventions."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for v in values or []:
+        if v is None:
+            continue
+        t = str(v).strip().lower()
+        if not t or t in seen:
+            continue
+        seen.add(t)
+        result.append(t)
+    return result
+
+
+def _person_for_request(request) -> Person | None:
+    if not getattr(request, "organization", None) or not request.user.is_authenticated:
+        return None
+    return Person.objects.filter(user=request.user).first()
+
+
+def _is_org_admin(person: Person | None) -> bool:
+    if person is None:
+        return False
+    return Membership.objects.filter(person=person, role="admin", is_active=True).exists()
+
+
+class MembershipPermission(permissions.BasePermission):
+    """Reads + writes restricted to org admins (and Django superusers) inside an org context."""
+
+    message = "Organization admin membership required."
+
+    def has_permission(self, request, view):
+        if not (request.user and request.user.is_authenticated and getattr(request, "organization", None)):
+            return False
+        if request.user.is_superuser:
+            return True
+        return _is_org_admin(_person_for_request(request))
+
+    def has_object_permission(self, request, view, obj):
+        return self.has_permission(request, view)
+
+
+class MembershipSerializer(serializers.ModelSerializer):
+    tags = serializers.JSONField(required=False)
+    person_name = serializers.CharField(source="person.full_name", read_only=True)
+    person_email = serializers.EmailField(source="person.email", read_only=True)
+    program_slug = serializers.SlugField(source="program.slug", read_only=True)
+    program_name = serializers.CharField(source="program.name", read_only=True)
+
+    class Meta:
+        model = Membership
+        fields = [
+            "id",
+            "program",
+            "program_slug",
+            "program_name",
+            "person",
+            "person_name",
+            "person_email",
+            "role",
+            "grade_level",
+            "tags",
+            "start_date",
+            "end_date",
+            "is_active",
+            "metadata",
+            "created_at",
+        ]
+        read_only_fields = [
+            "id",
+            "program",
+            "program_slug",
+            "program_name",
+            "person",
+            "person_name",
+            "person_email",
+            "role",
+            "created_at",
+        ]
+
+    def validate_tags(self, value):
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            msg = "tags must be a JSON array of strings."
+            raise serializers.ValidationError(msg)
+        if not all(isinstance(t, str) for t in value):
+            msg = "Every tag must be a string."
+            raise serializers.ValidationError(msg)
+        return _normalize_tags(value)
+
+
+class MembershipViewSet(viewsets.ModelViewSet):
+    serializer_class = MembershipSerializer
+    permission_classes = [MembershipPermission]
+    http_method_names = ["get", "patch", "post", "head", "options"]
+
+    def create(self, request, *args, **kwargs):
+        from rest_framework.exceptions import MethodNotAllowed
+
+        method = "POST"
+        raise MethodNotAllowed(method)
+
+    def get_queryset(self):
+        qs = Membership.objects.select_related("program", "program__organization", "person")
+        params = self.request.query_params
+
+        program_slug = (params.get("program") or "").strip()
+        if program_slug:
+            qs = qs.filter(program__slug=program_slug)
+
+        role = (params.get("role") or "").strip()
+        if role:
+            qs = qs.filter(role=role)
+
+        is_active = (params.get("is_active") or "").strip().lower()
+        if is_active in ("true", "1", "yes"):
+            qs = qs.filter(is_active=True)
+        elif is_active in ("false", "0", "no"):
+            qs = qs.filter(is_active=False)
+
+        tag_filter = params.getlist("tag") or []
+        for t in tag_filter:
+            t_norm = t.strip().lower()
+            if t_norm:
+                qs = qs.filter(tags__contains=[t_norm])
+
+        search = (params.get("search") or "").strip()
+        if search:
+            qs = qs.filter(person__last_name__icontains=search) | qs.filter(
+                person__first_name__icontains=search,
+            ) | qs.filter(person__preferred_name__icontains=search)
+            qs = qs.distinct()
+
+        return qs.order_by("person__last_name", "person__first_name")
+
+    @action(detail=False, methods=["post"], url_path="bulk-tag")
+    def bulk_tag(self, request):
+        """Add or remove a set of tags on a list of membership ids.
+
+        POST body: {
+          "operation": "add" | "remove" | "set",
+          "membership_ids": [1, 2, 3],
+          "tags": ["international", "waterfront"]
+        }
+        Returns: { updated: int }
+        """
+        op = (request.data.get("operation") or "").strip().lower()
+        if op not in {"add", "remove", "set"}:
+            return Response(
+                {"operation": 'Must be one of "add", "remove", "set".'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        ids = request.data.get("membership_ids") or []
+        if not isinstance(ids, list) or not all(isinstance(i, int) for i in ids):
+            return Response(
+                {"membership_ids": "Must be a list of integers."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if not ids:
+            return Response({"updated": 0})
+
+        raw_tags = request.data.get("tags") or []
+        if not isinstance(raw_tags, list) or not all(isinstance(t, str) for t in raw_tags):
+            return Response(
+                {"tags": "Must be a list of strings."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        new_tags = _normalize_tags(raw_tags)
+        if op != "set" and not new_tags:
+            return Response({"tags": "Provide at least one tag."}, status=status.HTTP_400_BAD_REQUEST)
+
+        qs = self.get_queryset().filter(id__in=ids)
+        updated = 0
+        for membership in qs:
+            current = list(membership.tags or [])
+            if op == "add":
+                merged = _normalize_tags([*current, *new_tags])
+            elif op == "remove":
+                remove = set(new_tags)
+                merged = [t for t in _normalize_tags(current) if t not in remove]
+            else:
+                merged = new_tags
+            if merged != current:
+                membership.tags = merged
+                membership.save(update_fields=["tags"])
+                updated += 1
+
+        return Response({"updated": updated})

--- a/backend/bunk_logs/api/tests/test_memberships_api.py
+++ b/backend/bunk_logs/api/tests/test_memberships_api.py
@@ -1,0 +1,367 @@
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+
+User = get_user_model()
+
+
+def _hdr_org(slug: str):
+    return {"HTTP_X_ORGANIZATION_SLUG": slug}
+
+
+@pytest.fixture
+def api():
+    return APIClient()
+
+
+@pytest.fixture
+def org_a(db):
+    return Organization.objects.create(name="Mem Org A", slug="mem-org-a")
+
+
+@pytest.fixture
+def org_b(db):
+    return Organization.objects.create(name="Mem Org B", slug="mem-org-b")
+
+
+@pytest.fixture
+def program_a(org_a):
+    return Program.all_objects.create(
+        organization=org_a,
+        name="Mem Org A Summer",
+        slug="prog-mem-a",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def program_b(org_b):
+    return Program.all_objects.create(
+        organization=org_b,
+        name="Mem Org B Summer",
+        slug="prog-mem-b",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def admin_user(org_a, program_a):
+    u = User.objects.create_user(email="memadmin@example.com", password="pw")
+    p = Person.all_objects.create(organization=org_a, first_name="Ada", last_name="Min", user=u)
+    Membership.all_objects.create(program=program_a, person=p, role="admin", is_active=True)
+    return u, p
+
+
+@pytest.fixture
+def counselor_user(org_a, program_a):
+    u = User.objects.create_user(email="memcns@example.com", password="pw")
+    p = Person.all_objects.create(organization=org_a, first_name="Cas", last_name="Cee", user=u)
+    Membership.all_objects.create(program=program_a, person=p, role="counselor", is_active=True)
+    return u, p
+
+
+def _make_member(org, program, *, first="Mem", last="Ber", role="counselor", tags=None):
+    p = Person.all_objects.create(organization=org, first_name=first, last_name=last)
+    m = Membership.all_objects.create(
+        program=program,
+        person=p,
+        role=role,
+        is_active=True,
+        tags=tags or [],
+    )
+    return p, m
+
+
+@pytest.mark.django_db
+def test_admin_can_list_memberships_in_program(api, org_a, program_a, admin_user):
+    user, _ = admin_user
+    _make_member(org_a, program_a, last="Alpha")
+    _make_member(org_a, program_a, last="Beta")
+    api.force_authenticate(user=user)
+    resp = api.get(
+        "/api/v1/memberships/",
+        {"program": program_a.slug},
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 200, resp.content
+    body = resp.json()
+    items = body if isinstance(body, list) else body.get("results", body)
+    assert len(items) >= 3
+
+
+@pytest.mark.django_db
+def test_non_admin_cannot_list(api, org_a, counselor_user):
+    user, _ = counselor_user
+    api.force_authenticate(user=user)
+    resp = api.get("/api/v1/memberships/", **_hdr_org(org_a.slug))
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_admin_can_patch_tags(api, org_a, program_a, admin_user):
+    user, _ = admin_user
+    _, m = _make_member(org_a, program_a)
+    api.force_authenticate(user=user)
+    resp = api.patch(
+        f"/api/v1/memberships/{m.id}/",
+        {"tags": ["International", "Waterfront"]},
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 200, resp.content
+    m.refresh_from_db()
+    assert m.tags == ["international", "waterfront"]
+
+
+@pytest.mark.django_db
+def test_patch_rejects_non_string_tag(api, org_a, program_a, admin_user):
+    user, _ = admin_user
+    _, m = _make_member(org_a, program_a)
+    api.force_authenticate(user=user)
+    resp = api.patch(
+        f"/api/v1/memberships/{m.id}/",
+        {"tags": ["ok", 42]},
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 400
+    assert "tags" in resp.json()
+
+
+@pytest.mark.django_db
+def test_patch_dedupes_and_lowercases_tags(api, org_a, program_a, admin_user):
+    user, _ = admin_user
+    _, m = _make_member(org_a, program_a)
+    api.force_authenticate(user=user)
+    resp = api.patch(
+        f"/api/v1/memberships/{m.id}/",
+        {"tags": ["Arts", "arts", "  Sports  ", "ARTS"]},
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 200
+    m.refresh_from_db()
+    assert m.tags == ["arts", "sports"]
+
+
+@pytest.mark.django_db
+def test_role_field_is_read_only(api, org_a, program_a, admin_user):
+    """Role should not be mutable via this endpoint to avoid privilege escalation surface."""
+    user, _ = admin_user
+    _, m = _make_member(org_a, program_a, role="counselor")
+    api.force_authenticate(user=user)
+    resp = api.patch(
+        f"/api/v1/memberships/{m.id}/",
+        {"role": "admin", "tags": ["x"]},
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 200
+    m.refresh_from_db()
+    assert m.role == "counselor"
+    assert m.tags == ["x"]
+
+
+@pytest.mark.django_db
+def test_filter_by_role(api, org_a, program_a, admin_user):
+    user, _ = admin_user
+    _make_member(org_a, program_a, role="counselor", last="Cn1")
+    _make_member(org_a, program_a, role="specialist", last="Sp1")
+    _make_member(org_a, program_a, role="specialist", last="Sp2")
+    api.force_authenticate(user=user)
+    resp = api.get(
+        "/api/v1/memberships/",
+        {"program": program_a.slug, "role": "specialist"},
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 200
+    items = resp.json()
+    items = items if isinstance(items, list) else items.get("results", items)
+    assert {m["role"] for m in items} == {"specialist"}
+    assert len(items) == 2
+
+
+@pytest.mark.django_db
+def test_filter_by_tag_returns_only_matching(api, org_a, program_a, admin_user):
+    user, _ = admin_user
+    _make_member(org_a, program_a, last="A1", tags=["international", "waterfront"])
+    _make_member(org_a, program_a, last="A2", tags=["domestic"])
+    _make_member(org_a, program_a, last="A3", tags=["israeli", "waterfront"])
+    api.force_authenticate(user=user)
+    resp = api.get(
+        "/api/v1/memberships/",
+        {"program": program_a.slug, "tag": "waterfront"},
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 200
+    items = resp.json()
+    items = items if isinstance(items, list) else items.get("results", items)
+    last_names = {m["person_name"].split(" ")[-1] for m in items}
+    assert last_names == {"A1", "A3"}
+
+
+@pytest.mark.django_db
+def test_filter_by_multiple_tags_is_intersection(api, org_a, program_a, admin_user):
+    user, _ = admin_user
+    _make_member(org_a, program_a, last="X1", tags=["international", "waterfront"])
+    _make_member(org_a, program_a, last="X2", tags=["international"])
+    _make_member(org_a, program_a, last="X3", tags=["waterfront"])
+    api.force_authenticate(user=user)
+    resp = api.get(
+        f"/api/v1/memberships/?program={program_a.slug}&tag=international&tag=waterfront",
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 200
+    items = resp.json()
+    items = items if isinstance(items, list) else items.get("results", items)
+    last_names = {m["person_name"].split(" ")[-1] for m in items}
+    assert last_names == {"X1"}
+
+
+@pytest.mark.django_db
+def test_bulk_tag_add_and_remove(api, org_a, program_a, admin_user):
+    user, _ = admin_user
+    _, m1 = _make_member(org_a, program_a, last="B1", tags=["existing"])
+    _, m2 = _make_member(org_a, program_a, last="B2")
+    _, m3 = _make_member(org_a, program_a, last="B3", tags=["other"])
+    api.force_authenticate(user=user)
+
+    add = api.post(
+        "/api/v1/memberships/bulk-tag/",
+        {
+            "operation": "add",
+            "membership_ids": [m1.id, m2.id, m3.id],
+            "tags": ["International", "Waterfront"],
+        },
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert add.status_code == 200, add.content
+    assert add.json()["updated"] == 3
+    m1.refresh_from_db()
+    m2.refresh_from_db()
+    m3.refresh_from_db()
+    assert m1.tags == ["existing", "international", "waterfront"]
+    assert m2.tags == ["international", "waterfront"]
+    assert m3.tags == ["other", "international", "waterfront"]
+
+    remove = api.post(
+        "/api/v1/memberships/bulk-tag/",
+        {
+            "operation": "remove",
+            "membership_ids": [m1.id, m3.id],
+            "tags": ["waterfront"],
+        },
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert remove.status_code == 200
+    assert remove.json()["updated"] == 2
+    m1.refresh_from_db()
+    m3.refresh_from_db()
+    assert "waterfront" not in m1.tags
+    assert "waterfront" not in m3.tags
+
+
+@pytest.mark.django_db
+def test_bulk_tag_set_overwrites(api, org_a, program_a, admin_user):
+    user, _ = admin_user
+    _, m1 = _make_member(org_a, program_a, last="S1", tags=["one", "two"])
+    api.force_authenticate(user=user)
+    resp = api.post(
+        "/api/v1/memberships/bulk-tag/",
+        {
+            "operation": "set",
+            "membership_ids": [m1.id],
+            "tags": ["fresh"],
+        },
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 200
+    m1.refresh_from_db()
+    assert m1.tags == ["fresh"]
+
+
+@pytest.mark.django_db
+def test_bulk_tag_rejects_non_admin(api, org_a, program_a, counselor_user):
+    user, _ = counselor_user
+    api.force_authenticate(user=user)
+    resp = api.post(
+        "/api/v1/memberships/bulk-tag/",
+        {"operation": "add", "membership_ids": [1], "tags": ["x"]},
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_bulk_tag_validates_payload(api, org_a, program_a, admin_user):
+    user, _ = admin_user
+    api.force_authenticate(user=user)
+    bad_op = api.post(
+        "/api/v1/memberships/bulk-tag/",
+        {"operation": "destroy", "membership_ids": [1], "tags": ["x"]},
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert bad_op.status_code == 400
+
+    bad_ids = api.post(
+        "/api/v1/memberships/bulk-tag/",
+        {"operation": "add", "membership_ids": "not-a-list", "tags": ["x"]},
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert bad_ids.status_code == 400
+
+    bad_tags = api.post(
+        "/api/v1/memberships/bulk-tag/",
+        {"operation": "add", "membership_ids": [1], "tags": [1, 2]},
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert bad_tags.status_code == 400
+
+
+@pytest.mark.django_db
+def test_cross_org_isolation_on_list(api, org_a, org_b, program_a, program_b, admin_user):
+    """An admin scoped to org_a must not see memberships in org_b."""
+    user, _ = admin_user
+    _make_member(org_a, program_a, last="Mine")
+    _make_member(org_b, program_b, last="Theirs")
+    api.force_authenticate(user=user)
+    resp = api.get("/api/v1/memberships/", **_hdr_org(org_a.slug))
+    assert resp.status_code == 200
+    items = resp.json()
+    items = items if isinstance(items, list) else items.get("results", items)
+    last_names = {m["person_name"].split(" ")[-1] for m in items}
+    assert "Theirs" not in last_names
+
+
+@pytest.mark.django_db
+def test_cross_org_isolation_on_patch(api, org_a, org_b, program_a, program_b, admin_user):
+    user, _ = admin_user
+    _, other = _make_member(org_b, program_b, last="OtherOrg")
+    api.force_authenticate(user=user)
+    resp = api.patch(
+        f"/api/v1/memberships/{other.id}/",
+        {"tags": ["snooped"]},
+        format="json",
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code in (403, 404)
+    other.refresh_from_db()
+    assert other.tags == []

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -4,6 +4,7 @@ from rest_framework.routers import DefaultRouter
 
 from bunk_logs.users.api.views import UserViewSet
 
+from . import memberships
 from . import reflections
 from . import team_dashboard
 from . import views
@@ -24,6 +25,7 @@ router.register(r"bunklogs", views.BunkLogViewSet, basename="bunklog")
 router.register(r"counselorlogs", views.CounselorLogViewSet, basename="counselorlog")
 
 router.register(r"reflections", reflections.ReflectionViewSet, basename="reflection")
+router.register(r"memberships", memberships.MembershipViewSet, basename="membership")
 
 # Ordering system
 router.register(r"orders", views.OrderViewSet, basename="order")

--- a/backend/bunk_logs/core/admin.py
+++ b/backend/bunk_logs/core/admin.py
@@ -1,7 +1,9 @@
 from django import forms
 from django.contrib import admin
+from django.contrib import messages
 from django.contrib.admin.widgets import AdminTextareaWidget
 from django.db import models
+from django.shortcuts import render
 
 from .models import Membership
 from .models import Organization
@@ -192,8 +194,107 @@ class ReflectionAdmin(admin.ModelAdmin):
     date_hierarchy = "period_end"
 
 
+def _normalize_tags(values) -> list[str]:
+    """Lowercase, strip, dedupe (preserving order)."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for v in values:
+        if v is None:
+            continue
+        t = str(v).strip().lower()
+        if not t or t in seen:
+            continue
+        seen.add(t)
+        result.append(t)
+    return result
+
+
+def _parse_tag_input(text: str) -> list[str]:
+    """Accept comma- or newline-separated text and return a normalized tag list."""
+    if not text:
+        return []
+    parts = [p.strip() for chunk in text.replace("\n", ",").split(",") for p in [chunk]]
+    return _normalize_tags(parts)
+
+
+class MembershipTagsWidget(forms.Textarea):
+    """Render the JSON list of tags as comma-separated text for editing in admin."""
+
+    def format_value(self, value):
+        if isinstance(value, list):
+            return ", ".join(str(t) for t in value)
+        if isinstance(value, str) and value.startswith("["):
+            try:
+                import json
+
+                parsed = json.loads(value)
+                if isinstance(parsed, list):
+                    return ", ".join(str(t) for t in parsed)
+            except (ValueError, TypeError):
+                pass
+        return super().format_value(value)
+
+
+class MembershipTagsField(forms.Field):
+    widget = MembershipTagsWidget(attrs={"rows": 2, "cols": 60})
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("required", False)
+        kwargs.setdefault(
+            "help_text",
+            "Comma- or newline-separated tags (e.g. international, waterfront).",
+        )
+        super().__init__(*args, **kwargs)
+
+    def to_python(self, value):
+        if value is None or value == "":
+            return []
+        if isinstance(value, list):
+            return _normalize_tags(value)
+        return _parse_tag_input(str(value))
+
+    def prepare_value(self, value):
+        if isinstance(value, list):
+            return ", ".join(str(t) for t in value)
+        return value
+
+
+class MembershipAdminForm(forms.ModelForm):
+    tags = MembershipTagsField()
+
+    class Meta:
+        model = Membership
+        fields = (
+            "program",
+            "person",
+            "role",
+            "grade_level",
+            "tags",
+            "start_date",
+            "end_date",
+            "is_active",
+            "metadata",
+        )
+
+
+class BulkTagForm(forms.Form):
+    OP_CHOICES = (
+        ("add", "Add tag(s) to selected"),
+        ("remove", "Remove tag(s) from selected"),
+    )
+    operation = forms.ChoiceField(choices=OP_CHOICES)
+    tags_text = forms.CharField(
+        label="Tags",
+        widget=forms.Textarea(attrs={"rows": 2, "cols": 60}),
+        help_text="Comma- or newline-separated tags.",
+    )
+
+
 @admin.register(Membership)
 class MembershipAdmin(admin.ModelAdmin):
+    form = MembershipAdminForm
+    actions = ["bulk_edit_tags"]
+
     def get_queryset(self, request):
         return Membership.all_objects.select_related("program__organization", "person")
 
@@ -201,11 +302,18 @@ class MembershipAdmin(admin.ModelAdmin):
     def program_organization_name(self, obj):
         return obj.program.organization.name
 
+    @admin.display(description="Tags")
+    def tags_display(self, obj):
+        if not obj.tags:
+            return "—"
+        return ", ".join(str(t) for t in obj.tags)
+
     list_display = [
         "person",
         "program_organization_name",
         "program",
         "role",
+        "tags_display",
         "grade_level",
         "is_active",
         "start_date",
@@ -219,6 +327,45 @@ class MembershipAdmin(admin.ModelAdmin):
         "person__preferred_name",
         "person__email",
         "program__name",
+        "tags",
     ]
     autocomplete_fields = ["program", "person"]
     readonly_fields = ["created_at"]
+
+    @admin.action(description="Edit tags on selected memberships")
+    def bulk_edit_tags(self, request, queryset):
+        if "apply" in request.POST:
+            form = BulkTagForm(request.POST)
+            if form.is_valid():
+                tags = _parse_tag_input(form.cleaned_data["tags_text"])
+                op = form.cleaned_data["operation"]
+                updated = 0
+                for membership in queryset:
+                    current = list(membership.tags or [])
+                    if op == "add":
+                        new = _normalize_tags([*current, *tags])
+                    else:
+                        remove = set(tags)
+                        new = [t for t in _normalize_tags(current) if t not in remove]
+                    if new != current:
+                        membership.tags = new
+                        membership.save(update_fields=["tags"])
+                        updated += 1
+                self.message_user(
+                    request,
+                    f"Updated tags on {updated} membership(s).",
+                    messages.SUCCESS,
+                )
+                return None
+        else:
+            form = BulkTagForm()
+
+        return render(
+            request,
+            "admin/core/membership/bulk_tag_action.html",
+            context={
+                "form": form,
+                "memberships": queryset,
+                "action_name": "bulk_edit_tags",
+            },
+        )

--- a/backend/bunk_logs/core/templates/admin/core/membership/bulk_tag_action.html
+++ b/backend/bunk_logs/core/templates/admin/core/membership/bulk_tag_action.html
@@ -1,0 +1,47 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+    &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+    &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+    &rsaquo; {% trans 'Bulk edit tags' %}
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+    <h1>{% trans 'Bulk edit tags on selected memberships' %}</h1>
+    <p>{{ memberships|length }} membership{{ memberships|length|pluralize }} selected.</p>
+
+    <form method="post">
+        {% csrf_token %}
+        <fieldset class="module aligned">
+            {% for field in form %}
+            <div class="form-row{% if field.errors %} errors{% endif %}">
+                <div>
+                    {{ field.errors }}
+                    {{ field.label_tag }}
+                    {{ field }}
+                    {% if field.help_text %}
+                    <p class="help">{{ field.help_text|safe }}</p>
+                    {% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        </fieldset>
+
+        {% for membership in memberships %}
+        <input type="hidden" name="_selected_action" value="{{ membership.pk }}" />
+        {% endfor %}
+        <input type="hidden" name="action" value="{{ action_name }}" />
+        <input type="hidden" name="apply" value="1" />
+
+        <div class="submit-row">
+            <input type="submit" value="{% trans 'Apply' %}" class="default" />
+            <a href="{% url opts|admin_urlname:'changelist' %}">{% trans 'Cancel' %}</a>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -26,6 +26,7 @@ import ReflectionFormPage from './pages/ReflectionFormPage';
 import ReflectionSummaryPage from './pages/ReflectionSummaryPage';
 import TeamDashboardPage from './pages/TeamDashboardPage';
 import WellnessDashboardPage from './pages/WellnessDashboardPage';
+import MembershipManagementPage from './pages/MembershipManagementPage';
 import { useBunk } from './contexts/BunkContext';
 
 // Protected route component
@@ -300,6 +301,15 @@ function Router() {
           element={
             <ProtectedRoute>
               <WellnessDashboardPage />
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/admin/memberships"
+          element={
+            <ProtectedRoute>
+              <MembershipManagementPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/pages/MembershipManagementPage.jsx
+++ b/frontend/src/pages/MembershipManagementPage.jsx
@@ -1,0 +1,453 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import Header from '../partials/Header';
+import Sidebar from '../partials/Sidebar';
+import api from '../api';
+
+const ROLE_OPTIONS = [
+  { value: '', label: 'All roles' },
+  { value: 'camper', label: 'Camper' },
+  { value: 'counselor', label: 'Counselor' },
+  { value: 'junior_counselor', label: 'Junior Counselor' },
+  { value: 'specialist', label: 'Specialist' },
+  { value: 'general_counselor', label: 'General Counselor' },
+  { value: 'unit_head', label: 'Unit Head' },
+  { value: 'leadership_team', label: 'Leadership Team' },
+  { value: 'kitchen_staff', label: 'Kitchen Staff' },
+  { value: 'maintenance', label: 'Maintenance' },
+  { value: 'housekeeping', label: 'Housekeeping' },
+  { value: 'camper_care', label: 'Camper Care' },
+  { value: 'health_center', label: 'Health Center' },
+  { value: 'special_diets', label: 'Special Diets' },
+  { value: 'madrich', label: 'Madrich' },
+  { value: 'faculty', label: 'Faculty' },
+  { value: 'admin', label: 'Admin' },
+];
+
+function parseTagsInput(text) {
+  if (!text) return [];
+  const parts = text
+    .split(/[,\n]/)
+    .map((p) => p.trim().toLowerCase())
+    .filter(Boolean);
+  const seen = new Set();
+  const out = [];
+  for (const p of parts) {
+    if (!seen.has(p)) {
+      seen.add(p);
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+function tagsToInput(tags) {
+  return Array.isArray(tags) ? tags.join(', ') : '';
+}
+
+function MembershipRow({ membership, onSave, isSelected, onToggleSelect }) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(tagsToInput(membership.tags));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const reset = () => {
+    setDraft(tagsToInput(membership.tags));
+    setError(null);
+    setEditing(false);
+  };
+
+  const submit = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const tags = parseTagsInput(draft);
+      await onSave(membership.id, tags);
+      setEditing(false);
+    } catch (e) {
+      setError(e.response?.data?.tags?.[0] || e.message || 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <tr className="bg-white dark:bg-gray-900/40">
+      <td className="px-3 py-2">
+        <input
+          type="checkbox"
+          checked={isSelected}
+          onChange={(ev) => onToggleSelect(membership.id, ev.target.checked)}
+          aria-label={`Select ${membership.person_name}`}
+        />
+      </td>
+      <td className="px-3 py-2 font-medium text-gray-900 dark:text-white">
+        {membership.person_name}
+        {membership.person_email && (
+          <p className="text-xs text-gray-500 dark:text-gray-400">{membership.person_email}</p>
+        )}
+      </td>
+      <td className="px-3 py-2 text-gray-600 dark:text-gray-300">{membership.role}</td>
+      <td className="px-3 py-2 text-gray-600 dark:text-gray-300 text-xs">{membership.program_slug}</td>
+      <td className="px-3 py-2">
+        {!editing && (
+          <div className="flex flex-wrap gap-1">
+            {(membership.tags || []).length === 0 ? (
+              <span className="text-gray-400 italic text-sm">no tags</span>
+            ) : (
+              (membership.tags || []).map((t) => (
+                <span
+                  key={t}
+                  className="inline-flex items-center rounded-full bg-indigo-100 dark:bg-indigo-900/40 px-2 py-0.5 text-xs font-medium text-indigo-800 dark:text-indigo-200"
+                >
+                  {t}
+                </span>
+              ))
+            )}
+          </div>
+        )}
+        {editing && (
+          <div className="flex flex-col gap-1">
+            <input
+              type="text"
+              value={draft}
+              onChange={(ev) => setDraft(ev.target.value)}
+              placeholder="comma-separated tags"
+              className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
+              autoFocus
+            />
+            {error && <p className="text-xs text-rose-600 dark:text-rose-400">{error}</p>}
+          </div>
+        )}
+      </td>
+      <td className="px-3 py-2 text-right whitespace-nowrap">
+        {!editing ? (
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="text-indigo-600 dark:text-indigo-400 text-sm hover:underline"
+          >
+            Edit
+          </button>
+        ) : (
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={submit}
+              disabled={saving}
+              className="rounded-md bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+            <button
+              type="button"
+              onClick={reset}
+              disabled={saving}
+              className="rounded-md border border-gray-300 dark:border-gray-600 px-2 py-1 text-xs"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+export default function MembershipManagementPage() {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [memberships, setMemberships] = useState([]);
+  const [program, setProgram] = useState('');
+  const [role, setRole] = useState('');
+  const [tagFilter, setTagFilter] = useState('');
+  const [search, setSearch] = useState('');
+  const [selectedIds, setSelectedIds] = useState(new Set());
+  const [bulkOp, setBulkOp] = useState('add');
+  const [bulkTags, setBulkTags] = useState('');
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const [bulkMessage, setBulkMessage] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (program) params.set('program', program);
+      if (role) params.set('role', role);
+      if (search) params.set('search', search);
+      for (const t of parseTagsInput(tagFilter)) {
+        params.append('tag', t);
+      }
+      const { data } = await api.get(`/api/v1/memberships/?${params.toString()}`);
+      const items = Array.isArray(data) ? data : data?.results || [];
+      setMemberships(items);
+      setSelectedIds((prev) => {
+        const visible = new Set(items.map((m) => m.id));
+        const next = new Set();
+        for (const id of prev) if (visible.has(id)) next.add(id);
+        return next;
+      });
+    } catch (e) {
+      const status = e.response?.status;
+      if (status === 403) {
+        setError('access');
+      } else {
+        setError(e.response?.data?.detail || e.message || 'Failed to load memberships');
+      }
+      setMemberships([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [program, role, search, tagFilter]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const saveTags = useCallback(async (membershipId, tags) => {
+    const { data } = await api.patch(`/api/v1/memberships/${membershipId}/`, { tags });
+    setMemberships((prev) => prev.map((m) => (m.id === membershipId ? { ...m, ...data } : m)));
+  }, []);
+
+  const toggleSelect = useCallback((id, checked) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (checked) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  }, []);
+
+  const toggleSelectAll = useCallback(
+    (checked) => {
+      if (!checked) {
+        setSelectedIds(new Set());
+        return;
+      }
+      setSelectedIds(new Set(memberships.map((m) => m.id)));
+    },
+    [memberships],
+  );
+
+  const allSelected = useMemo(
+    () => memberships.length > 0 && memberships.every((m) => selectedIds.has(m.id)),
+    [memberships, selectedIds],
+  );
+
+  const submitBulk = useCallback(async () => {
+    setBulkBusy(true);
+    setBulkMessage(null);
+    try {
+      const tags = parseTagsInput(bulkTags);
+      const ids = Array.from(selectedIds);
+      if (ids.length === 0) {
+        setBulkMessage({ type: 'error', text: 'Select at least one membership.' });
+        return;
+      }
+      if (bulkOp !== 'set' && tags.length === 0) {
+        setBulkMessage({ type: 'error', text: 'Provide at least one tag.' });
+        return;
+      }
+      const { data } = await api.post('/api/v1/memberships/bulk-tag/', {
+        operation: bulkOp,
+        membership_ids: ids,
+        tags,
+      });
+      setBulkMessage({
+        type: 'success',
+        text: `Updated ${data.updated} membership${data.updated === 1 ? '' : 's'}.`,
+      });
+      setBulkTags('');
+      await load();
+    } catch (e) {
+      setBulkMessage({
+        type: 'error',
+        text: e.response?.data?.detail || e.message || 'Bulk update failed',
+      });
+    } finally {
+      setBulkBusy(false);
+    }
+  }, [bulkOp, bulkTags, selectedIds, load]);
+
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+      <div className="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
+        <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+        <main className="grow px-4 sm:px-6 lg:px-8 py-8 w-full max-w-9xl mx-auto">
+          <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Memberships</h1>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                Tag memberships with demographic and grouping labels (e.g. international,
+                domestic, israeli, waterfront, arts, sports).
+              </p>
+            </div>
+          </div>
+
+          <section className="mb-6 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-4">
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+              <label className="flex flex-col gap-1 text-sm text-gray-700 dark:text-gray-300">
+                <span>Program slug</span>
+                <input
+                  type="text"
+                  value={program}
+                  onChange={(ev) => setProgram(ev.target.value.trim())}
+                  placeholder="e.g. crane-lake-summer-2026"
+                  className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm text-gray-700 dark:text-gray-300">
+                <span>Role</span>
+                <select
+                  value={role}
+                  onChange={(ev) => setRole(ev.target.value)}
+                  className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
+                >
+                  {ROLE_OPTIONS.map((o) => (
+                    <option key={o.value} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-sm text-gray-700 dark:text-gray-300">
+                <span>Tag filter</span>
+                <input
+                  type="text"
+                  value={tagFilter}
+                  onChange={(ev) => setTagFilter(ev.target.value)}
+                  placeholder="comma-separated; ALL must match"
+                  className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm text-gray-700 dark:text-gray-300">
+                <span>Name search</span>
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(ev) => setSearch(ev.target.value)}
+                  placeholder="first / last / preferred"
+                  className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
+                />
+              </label>
+            </div>
+          </section>
+
+          {selectedIds.size > 0 && (
+            <section className="mb-6 rounded-lg border border-indigo-200 dark:border-indigo-900/50 bg-indigo-50 dark:bg-indigo-950/30 p-4">
+              <div className="flex flex-col md:flex-row md:items-end gap-3">
+                <div className="text-sm text-indigo-900 dark:text-indigo-100">
+                  <p className="font-medium">{selectedIds.size} selected</p>
+                  <p className="text-xs">Bulk update tags on the selected memberships.</p>
+                </div>
+                <label className="flex flex-col gap-1 text-sm text-indigo-900 dark:text-indigo-100">
+                  <span>Operation</span>
+                  <select
+                    value={bulkOp}
+                    onChange={(ev) => setBulkOp(ev.target.value)}
+                    className="rounded-md border border-indigo-300 dark:border-indigo-700 bg-white dark:bg-gray-900 px-2 py-1 text-sm"
+                  >
+                    <option value="add">Add tag(s)</option>
+                    <option value="remove">Remove tag(s)</option>
+                    <option value="set">Set tag(s) (replace)</option>
+                  </select>
+                </label>
+                <label className="flex flex-col gap-1 text-sm text-indigo-900 dark:text-indigo-100 flex-1">
+                  <span>Tags</span>
+                  <input
+                    type="text"
+                    value={bulkTags}
+                    onChange={(ev) => setBulkTags(ev.target.value)}
+                    placeholder="comma-separated"
+                    className="rounded-md border border-indigo-300 dark:border-indigo-700 bg-white dark:bg-gray-900 px-2 py-1 text-sm"
+                  />
+                </label>
+                <button
+                  type="button"
+                  onClick={submitBulk}
+                  disabled={bulkBusy}
+                  className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+                >
+                  {bulkBusy ? 'Applying…' : 'Apply'}
+                </button>
+              </div>
+              {bulkMessage && (
+                <p
+                  className={`mt-2 text-sm ${
+                    bulkMessage.type === 'success'
+                      ? 'text-emerald-700 dark:text-emerald-300'
+                      : 'text-rose-700 dark:text-rose-300'
+                  }`}
+                >
+                  {bulkMessage.text}
+                </p>
+              )}
+            </section>
+          )}
+
+          {loading && <p className="text-gray-600 dark:text-gray-400">Loading…</p>}
+
+          {!loading && error === 'access' && (
+            <div className="rounded-lg border border-amber-200 dark:border-amber-900/40 bg-amber-50 dark:bg-amber-900/20 p-4 text-amber-900 dark:text-amber-100">
+              <p className="font-medium">Access restricted</p>
+              <p className="text-sm mt-1">
+                Membership management requires an organization <strong>admin</strong> membership.
+              </p>
+              <Link to="/dashboard" className="text-sm underline mt-2 inline-block">
+                Back to dashboard
+              </Link>
+            </div>
+          )}
+
+          {!loading && error && error !== 'access' && (
+            <p className="text-rose-600 dark:text-rose-400">{error}</p>
+          )}
+
+          {!loading && !error && (
+            <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+              <table className="min-w-full text-sm">
+                <thead className="bg-gray-50 dark:bg-gray-800/80">
+                  <tr>
+                    <th className="px-3 py-2">
+                      <input
+                        type="checkbox"
+                        checked={allSelected}
+                        onChange={(ev) => toggleSelectAll(ev.target.checked)}
+                        aria-label="Select all visible"
+                      />
+                    </th>
+                    <th className="text-left px-3 py-2 font-medium">Person</th>
+                    <th className="text-left px-3 py-2 font-medium">Role</th>
+                    <th className="text-left px-3 py-2 font-medium">Program</th>
+                    <th className="text-left px-3 py-2 font-medium">Tags</th>
+                    <th className="text-right px-3 py-2 font-medium">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                  {memberships.map((m) => (
+                    <MembershipRow
+                      key={m.id}
+                      membership={m}
+                      onSave={saveTags}
+                      isSelected={selectedIds.has(m.id)}
+                      onToggleSelect={toggleSelect}
+                    />
+                  ))}
+                </tbody>
+              </table>
+              {memberships.length === 0 && (
+                <p className="p-4 text-gray-500 dark:text-gray-400 text-sm">
+                  No memberships match these filters.
+                </p>
+              )}
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/partials/Sidebar.jsx
+++ b/frontend/src/partials/Sidebar.jsx
@@ -226,6 +226,28 @@ function Sidebar({
                   </NavLink>
                 </li>
               )}
+              {user && user.role === 'Admin' && (
+                <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
+                  <NavLink
+                    to="/admin/memberships"
+                    className={({ isActive }) =>
+                      `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
+                        isActive ? 'text-indigo-600 dark:text-indigo-400' : 'hover:text-gray-900 dark:hover:text-white'
+                      }`
+                    }
+                  >
+                    <div className="flex items-center">
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z" />
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 6h.008v.008H6V6z" />
+                      </svg>
+                      <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
+                        Memberships
+                      </span>
+                    </div>
+                  </NavLink>
+                </li>
+              )}
               {user && REFLECTION_FORM_ROLES.includes(user.role) && (
                 <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
                   <NavLink

--- a/migration_prompts/3_8_membership_tagging_ui.md
+++ b/migration_prompts/3_8_membership_tagging_ui.md
@@ -1,0 +1,22 @@
+Allow admin to tag Memberships with demographic and grouping tags (International/Domestic/Israeli, specialist sub-types like waterfront/arts/sports).
+
+Tasks:
+1. In Django admin: add a tag editing widget for Membership.tags (JSON list field).
+2. In the admin user-facing app: add a Membership management view where admins can:
+   - View all memberships in current program
+   - Filter by role, tags
+   - Edit tags on individual memberships (text input that adds to tags list)
+   - Bulk tag operations (add tag X to selected memberships)
+
+3. API endpoint: PATCH /api/v1/memberships/{id}/ to update tags.
+
+4. Tests:
+   - Tag CRUD via API
+   - Bulk tagging
+   - Tag-based filtering returns correct memberships
+
+Acceptance criteria:
+- Admin can manage tags via UI
+- Tag changes persist
+- Tests pass
+- Commit with message: "Add Membership tagging UI for admin"


### PR DESCRIPTION
## Summary

Implements step `3_8_membership_tagging_ui` from the multi-tenant migration roadmap.

- **Django admin**: `Membership.tags` is now editable as comma-separated text via a custom `MembershipTagsField`. Added a bulk action ("Edit tags on selected memberships") that supports add or remove operations across selected rows. Tags column is shown on the changelist and is searchable.
- **REST API**: New `MembershipViewSet` at `/api/v1/memberships/` (org-admin only) with:
  - `GET` list with filters: `program=<slug>`, `role`, `tag` (repeatable, intersection), `is_active`, `search`.
  - `PATCH /api/v1/memberships/{id}/` to update `tags` (role / person / program kept read-only here to avoid privilege escalation).
  - `POST /api/v1/memberships/bulk-tag/` with `{ operation: "add"|"remove"|"set", membership_ids, tags }`.
  - Tags are normalized server-side (trim, lowercase, dedupe).
- **Frontend**: New `/admin/memberships` page with role/tag/program/name filters, inline per-row tag editing, multi-select with sticky bulk-tag bar, and tenant-aware error messaging. Sidebar entry surfaced for users with the legacy `Admin` role.
- **Tests**: 15 new backend tests for tag CRUD, bulk add/remove/set, multi-tag intersection filtering, role read-only enforcement, non-admin denial, and cross-org isolation.

Multi-tenant invariants:
- All queries go through `Membership.objects` (org-scoped manager) — admins only ever see memberships in their own org.
- `MembershipPermission` requires both `request.organization` and an active `admin` membership (or superuser).
- Old single-tenant models are untouched.

## Test plan

- [x] `make test-backend` (277 passed)
- [x] `make test-frontend` (25 passed)
- [x] `npm run build` (clean)
- [x] `ruff check` on touched files
- [ ] Manual smoke: log in as a CLC admin → `/admin/memberships`, filter by role, edit tags inline, bulk-tag a few rows.
- [ ] Manual smoke: Django admin `/admin/core/membership/` → edit tags via comma-separated field, run "Edit tags on selected memberships" action.


Made with [Cursor](https://cursor.com)