### PR TITLE
fix: admin Membership form ignores org-scope on FK fields

### DIFF
--- a/backend/bunk_logs/core/admin.py
+++ b/backend/bunk_logs/core/admin.py
@@ -332,6 +332,23 @@ class MembershipAdmin(admin.ModelAdmin):
     autocomplete_fields = ["program", "person"]
     readonly_fields = ["created_at"]
 
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        # The admin is privileged staff territory; bypass OrgScopedManager so the
+        # form's FK validation works even when the logged-in user has no Person
+        # record (i.e. request.organization is None). The admin changelist itself
+        # already uses all_objects via get_queryset.
+        if db_field.name == "program":
+            kwargs.setdefault(
+                "queryset",
+                Program.all_objects.select_related("organization"),
+            )
+        elif db_field.name == "person":
+            kwargs.setdefault(
+                "queryset",
+                Person.all_objects.select_related("organization"),
+            )
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
     @admin.action(description="Edit tags on selected memberships")
     def bulk_edit_tags(self, request, queryset):
         if "apply" in request.POST:

--- a/backend/bunk_logs/core/test_admin_membership.py
+++ b/backend/bunk_logs/core/test_admin_membership.py
@@ -1,0 +1,93 @@
+"""Regression: Membership admin must let a superuser without a Person edit FK fields.
+
+When the logged-in admin user has no Person record, OrganizationMiddleware can't
+infer an org, so request.organization is None and OrgScopedManager.objects.none()
+returns nothing. Admin form FK validation must bypass that scope (the admin is
+privileged staff territory) or saving an existing Membership fails with
+"Select a valid choice" on Program/Person.
+"""
+
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+
+User = get_user_model()
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="Admin Form Org", slug="admin-form-org")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="Admin Form Org Summer",
+        slug="admin-form-prog",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def person(org):
+    return Person.all_objects.create(organization=org, first_name="A", last_name="P")
+
+
+@pytest.fixture
+def superuser_without_person(db):
+    return User.objects.create_superuser(email="orphan-su@example.test", password="pw")
+
+
+@pytest.mark.django_db
+def test_change_membership_works_for_superuser_without_person(
+    superuser_without_person,
+    org,
+    program,
+    person,
+):
+    membership = Membership.all_objects.create(
+        program=program,
+        person=person,
+        role="counselor",
+        is_active=True,
+        tags=[],
+    )
+
+    client = Client()
+    client.force_login(superuser_without_person)
+    url = f"/admin/core/membership/{membership.id}/change/"
+
+    get_resp = client.get(url)
+    assert get_resp.status_code == 200, get_resp.content
+
+    post_resp = client.post(
+        url,
+        {
+            "program": str(program.id),
+            "person": str(person.id),
+            "role": "counselor",
+            "grade_level": "",
+            "tags": "international, waterfront",
+            "start_date": "",
+            "end_date": "",
+            "is_active": "on",
+            "metadata": "{}",
+            "_save": "Save",
+        },
+    )
+    # Admin redirects to the changelist on success (302); on a validation error it
+    # re-renders the change form with status 200 and a "Please correct" banner.
+    assert post_resp.status_code == 302, post_resp.content
+
+    membership.refresh_from_db()
+    assert membership.tags == ["international", "waterfront"]


### PR DESCRIPTION
## Summary

Follow-up to PR #38 (`3_8_membership_tagging_ui`). The Membership change form in Django admin was rejecting **Save** with "Select a valid choice" on the **Program** and **Person** fields whenever the logged-in admin user had no `Person` record (i.e. a fresh Django superuser).

Root cause: `OrganizationMiddleware` couldn't infer an org for that user, so `request.organization` was `None`, `Program.objects` / `Person.objects` (both `OrgScopedManager`) fail-closed to `.none()`, and the FK fields' validation queryset was empty. The changelist itself was already fine because `MembershipAdmin.get_queryset` uses `Membership.all_objects`.

The admin is privileged staff territory, so this PR mirrors that pattern for the FK formfields by overriding `formfield_for_foreignkey` on `MembershipAdmin` to use `Program.all_objects` / `Person.all_objects`.

## Changes

- `backend/bunk_logs/core/admin.py` — adds `formfield_for_foreignkey` override on `MembershipAdmin`.
- `backend/bunk_logs/core/test_admin_membership.py` — regression test that drives the change form as a superuser without a Person and asserts a successful save (302 redirect + tags persisted).

## Test plan

- [x] `pytest bunk_logs/core/ bunk_logs/api/tests/` (158 passed)
- [x] `ruff check` on touched files
- [ ] Manual smoke: log into `/admin/core/membership/<id>/change/` as a superuser without a Person, edit tags, save — should succeed without "Select a valid choice."

## Notes

`PersonAdmin`, `ProgramAdmin`, `ReflectionTemplateAdmin`, and `ReflectionAdmin` have the same theoretical issue on their org-scoped FK fields (e.g. `parent_template`, `program`, `person`, `template`). Not patching them in this PR to keep scope tight; happy to follow up if anyone hits it.

Made with [Cursor](https://cursor.com)