### PR TITLE
3_16_dashboard_role_rendering: template-aware dashboard with role-to-widget mapping

### DIFF
--- a/backend/bunk_logs/api/template_dashboard.py
+++ b/backend/bunk_logs/api/template_dashboard.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+import csv
+import io
+from collections import Counter
+from collections import defaultdict
+from datetime import date
+from datetime import timedelta
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from django.http import HttpResponse
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+
+User = get_user_model()
+
+TREND_EPS = 0.02
+MAX_TEXT_ITEMS = 50
+META_FIELD_TYPES = frozenset({"section_header", "instructions"})
+
+# viewer roles that may access templates by template role
+_LT_ACCESS = frozenset({"leadership_team", "admin"})
+_WELLNESS_ACCESS = frozenset({"camper_care", "health_center", "special_diets", "admin"})
+_ADMIN_ONLY = frozenset({"admin"})
+
+TEMPLATE_ROLE_VIEWER_ROLES: dict[str, frozenset[str]] = {
+    "leadership_team": _LT_ACCESS,
+    "camper_care": _WELLNESS_ACCESS,
+    "health_center": _WELLNESS_ACCESS,
+    "special_diets": _WELLNESS_ACCESS,
+    "wellness": _WELLNESS_ACCESS,
+}
+
+
+def _parse_period(request) -> tuple[date, date, date, date]:
+    start_s = (request.query_params.get("period_start") or "").strip()
+    end_s = (request.query_params.get("period_end") or "").strip()
+    days_s = (request.query_params.get("period_days") or "14").strip()
+    try:
+        days = max(1, min(90, int(days_s)))
+    except ValueError:
+        days = 14
+    cur_end = date.today()
+    if end_s:
+        try:
+            cur_end = date.fromisoformat(end_s)
+        except ValueError:
+            pass
+    if start_s:
+        try:
+            cur_start = date.fromisoformat(start_s)
+        except ValueError:
+            cur_start = cur_end - timedelta(days=days - 1)
+    else:
+        cur_start = cur_end - timedelta(days=days - 1)
+    prev_end = cur_start - timedelta(days=1)
+    prev_start = prev_end - timedelta(days=days - 1)
+    return cur_start, cur_end, prev_start, prev_end
+
+
+def _trend_label(current: float | None, prior: float | None) -> str:
+    if current is None or prior is None:
+        return "flat"
+    delta = current - prior
+    if delta > TREND_EPS:
+        return "up"
+    if delta < -TREND_EPS:
+        return "down"
+    return "flat"
+
+
+def _viewer_can_access_template(viewer: Person, user, template: ReflectionTemplate) -> bool:
+    user_role = getattr(user, "role", "") or ""
+    if user.is_superuser or user_role == User.ADMIN:
+        return True
+    allowed_viewer_roles = TEMPLATE_ROLE_VIEWER_ROLES.get(template.role or "", _ADMIN_ONLY)
+    return Membership.objects.filter(
+        person=viewer,
+        role__in=allowed_viewer_roles,
+        is_active=True,
+        program__organization_id=viewer.organization_id,
+    ).exists()
+
+
+def _get_reflections(
+    template: ReflectionTemplate,
+    org_id: int,
+    start: date,
+    end: date,
+) -> list[Reflection]:
+    return list(
+        Reflection.objects.filter(
+            template=template,
+            organization_id=org_id,
+            period_end__gte=start,
+            period_end__lte=end,
+            is_complete=True,
+        ).select_related("person"),
+    )
+
+
+def _eligible_person_count(template: ReflectionTemplate, org_id: int) -> int:
+    qs = Membership.objects.filter(
+        program__organization_id=org_id,
+        is_active=True,
+    )
+    if template.role:
+        qs = qs.filter(role=template.role)
+    if template.program_type:
+        qs = qs.filter(program__program_type=template.program_type)
+    return qs.values("person_id").distinct().count()
+
+
+# ── per-field aggregators ─────────────────────────────────────────────────────
+
+
+def _agg_single_rating(
+    field: dict,
+    refs: list[Reflection],
+    prev_refs: list[Reflection],
+) -> dict[str, Any]:
+    key = field["key"]
+    scale = field.get("scale", [1, 5])
+    scale_min, scale_max = int(scale[0]), int(scale[-1])
+
+    def _vals(rlist: list[Reflection]) -> list[float]:
+        out = []
+        for r in rlist:
+            v = r.answers.get(key)
+            if isinstance(v, (int, float)) and not isinstance(v, bool):
+                out.append(float(v))
+        return out
+
+    cur_vals = _vals(refs)
+    prev_vals = _vals(prev_refs)
+    cur_mean = sum(cur_vals) / len(cur_vals) if cur_vals else None
+    prev_mean = sum(prev_vals) / len(prev_vals) if prev_vals else None
+    dist = {str(i): 0 for i in range(scale_min, scale_max + 1)}
+    for v in cur_vals:
+        k = str(int(round(v)))
+        if k in dist:
+            dist[k] += 1
+    return {
+        "mean": round(cur_mean, 3) if cur_mean is not None else None,
+        "prior_mean": round(prev_mean, 3) if prev_mean is not None else None,
+        "trend": _trend_label(cur_mean, prev_mean),
+        "response_count": len(cur_vals),
+        "distribution": dist,
+    }
+
+
+def _agg_rating_group(
+    field: dict,
+    refs: list[Reflection],
+    prev_refs: list[Reflection],
+) -> dict[str, Any]:
+    key = field["key"]
+    categories = field.get("categories") or []
+    scale = field.get("scale", [1, 5])
+    scale_min, scale_max = int(scale[0]), int(scale[-1])
+
+    def _collect(rlist: list[Reflection]):
+        sums: dict[str, float] = defaultdict(float)
+        counts: dict[str, int] = defaultdict(int)
+        dists: dict[str, dict[str, int]] = {
+            cat["key"]: {str(i): 0 for i in range(scale_min, scale_max + 1)}
+            for cat in categories
+        }
+        for r in rlist:
+            block = r.answers.get(key)
+            if not isinstance(block, dict):
+                continue
+            for cat in categories:
+                ck = cat["key"]
+                v = block.get(ck)
+                if isinstance(v, (int, float)) and not isinstance(v, bool):
+                    sums[ck] += float(v)
+                    counts[ck] += 1
+                    sk = str(int(round(float(v))))
+                    if sk in dists.get(ck, {}):
+                        dists[ck][sk] += 1
+        return sums, counts, dists
+
+    cur_sums, cur_counts, cur_dists = _collect(refs)
+    prev_sums, prev_counts, _ = _collect(prev_refs)
+
+    cat_data = []
+    for cat in categories:
+        ck = cat["key"]
+        cur_mean = cur_sums[ck] / cur_counts[ck] if cur_counts[ck] else None
+        prev_mean = prev_sums[ck] / prev_counts[ck] if prev_counts[ck] else None
+        cat_data.append(
+            {
+                "key": ck,
+                "mean": round(cur_mean, 3) if cur_mean is not None else None,
+                "prior_mean": round(prev_mean, 3) if prev_mean is not None else None,
+                "trend": _trend_label(cur_mean, prev_mean),
+                "response_count": cur_counts[ck],
+                "distribution": cur_dists.get(ck, {}),
+            },
+        )
+    return {"categories": cat_data}
+
+
+def _agg_text_list(field: dict, refs: list[Reflection]) -> dict[str, Any]:
+    key = field["key"]
+    counter: Counter[str] = Counter()
+    for r in refs:
+        v = r.answers.get(key)
+        if isinstance(v, list):
+            for item in v:
+                if isinstance(item, str) and item.strip():
+                    counter[item.strip()] += 1
+    items = [{"text": t, "count": c} for t, c in counter.most_common(MAX_TEXT_ITEMS)]
+    return {"items": items, "total_mentions": sum(counter.values())}
+
+
+def _agg_text(field: dict, refs: list[Reflection]) -> dict[str, Any]:
+    key = field["key"]
+    items = []
+    for r in refs:
+        v = r.answers.get(key)
+        if isinstance(v, str) and v.strip():
+            items.append(
+                {
+                    "reflection_id": r.id,
+                    "person_id": r.person_id,
+                    "period_end": r.period_end.isoformat(),
+                    "text": v.strip()[:2000],
+                    "is_read": False,
+                },
+            )
+    items.sort(key=lambda x: x["period_end"], reverse=True)
+    return {"items": items[:MAX_TEXT_ITEMS], "total": len(items)}
+
+
+def _agg_yes_no(field: dict, refs: list[Reflection]) -> dict[str, Any]:
+    key = field["key"]
+    yes = no = 0
+    for r in refs:
+        v = r.answers.get(key)
+        if v is True or v in ("true", "yes", 1):
+            yes += 1
+        elif v is False or v in ("false", "no", 0):
+            no += 1
+    total = yes + no
+    return {
+        "yes_count": yes,
+        "no_count": no,
+        "yes_pct": round(yes / total, 4) if total else None,
+    }
+
+
+def _agg_choice(field: dict, refs: list[Reflection]) -> dict[str, Any]:
+    key = field["key"]
+    counter: Counter[str] = Counter()
+    for r in refs:
+        v = r.answers.get(key)
+        if isinstance(v, str) and v.strip():
+            counter[v.strip()] += 1
+        elif isinstance(v, list):
+            for item in v:
+                if isinstance(item, str) and item.strip():
+                    counter[item.strip()] += 1
+    raw_options = field.get("options") or []
+    option_keys = []
+    for o in raw_options:
+        ok = o.get("key") if isinstance(o, dict) else str(o)
+        if ok:
+            option_keys.append(ok)
+    bars: list[dict[str, Any]] = []
+    seen = set()
+    for ok in option_keys:
+        bars.append({"option": ok, "count": counter.get(ok, 0)})
+        seen.add(ok)
+    for k, v in counter.most_common():
+        if k not in seen:
+            bars.append({"option": k, "count": v})
+    bars.sort(key=lambda x: -x["count"])
+    return {"choices": bars, "response_count": sum(counter.values())}
+
+
+def _agg_number(field: dict, refs: list[Reflection]) -> dict[str, Any]:
+    key = field["key"]
+    vals: list[float] = []
+    for r in refs:
+        v = r.answers.get(key)
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            vals.append(float(v))
+    if not vals:
+        return {"mean": None, "min": None, "max": None, "response_count": 0}
+    return {
+        "mean": round(sum(vals) / len(vals), 3),
+        "min": min(vals),
+        "max": max(vals),
+        "response_count": len(vals),
+    }
+
+
+def _agg_date_field(field: dict, refs: list[Reflection]) -> dict[str, Any]:
+    key = field["key"]
+    values: list[str] = []
+    for r in refs:
+        v = r.answers.get(key)
+        if isinstance(v, str) and v.strip():
+            values.append(v.strip())
+    values.sort()
+    return {"values": values[:MAX_TEXT_ITEMS], "response_count": len(values)}
+
+
+def _aggregate_field(
+    field: dict,
+    refs: list[Reflection],
+    prev_refs: list[Reflection],
+) -> dict[str, Any] | None:
+    ftype = field.get("type", "")
+    if ftype in META_FIELD_TYPES:
+        return None
+    if ftype == "single_rating":
+        return _agg_single_rating(field, refs, prev_refs)
+    if ftype == "rating_group":
+        return _agg_rating_group(field, refs, prev_refs)
+    if ftype == "text_list":
+        return _agg_text_list(field, refs)
+    if ftype in ("text", "textarea"):
+        return _agg_text(field, refs)
+    if ftype == "yes_no":
+        return _agg_yes_no(field, refs)
+    if ftype in ("single_choice", "multiple_choice"):
+        return _agg_choice(field, refs)
+    if ftype == "number":
+        return _agg_number(field, refs)
+    if ftype == "date":
+        return _agg_date_field(field, refs)
+    return None
+
+
+# ── CSV export ────────────────────────────────────────────────────────────────
+
+
+def _build_csv(template: ReflectionTemplate, refs: list[Reflection]) -> str:
+    schema_fields = [
+        f
+        for f in (template.schema.get("fields") or [])
+        if isinstance(f, dict) and f.get("type") not in META_FIELD_TYPES
+    ]
+    out = io.StringIO()
+    writer = csv.writer(out)
+    headers = ["person_name", "person_id", "period_end", "language"]
+    for field in schema_fields:
+        ftype = field.get("type", "")
+        fkey = field.get("key", "")
+        if ftype == "rating_group":
+            for cat in field.get("categories") or []:
+                headers.append(f"{fkey}__{cat['key']}")
+        else:
+            headers.append(fkey)
+    writer.writerow(headers)
+    for r in sorted(refs, key=lambda x: (x.period_end, x.person_id)):
+        person_name = ""
+        if r.person:
+            person_name = f"{r.person.first_name} {r.person.last_name}".strip()
+        row: list[Any] = [person_name, r.person_id, r.period_end.isoformat(), r.language]
+        for field in schema_fields:
+            ftype = field.get("type", "")
+            fkey = field.get("key", "")
+            v = r.answers.get(fkey)
+            if ftype == "rating_group":
+                block = v if isinstance(v, dict) else {}
+                for cat in field.get("categories") or []:
+                    row.append(block.get(cat["key"], ""))
+            elif ftype == "text_list":
+                row.append("; ".join(str(x) for x in v if x) if isinstance(v, list) else (v or ""))
+            else:
+                row.append("" if v is None else v)
+        writer.writerow(row)
+    return out.getvalue()
+
+
+# ── Views ─────────────────────────────────────────────────────────────────────
+
+
+class TemplateDashboardView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def _get_template_or_error(self, org, template_id: int):
+        tmpl = ReflectionTemplate.objects.filter(id=template_id, organization=org).first()
+        if tmpl is None:
+            tmpl = ReflectionTemplate.objects.filter(
+                id=template_id,
+                organization__isnull=True,
+            ).first()
+        return tmpl
+
+    def get(self, request, template_id: int, *args, **kwargs):
+        org = getattr(request, "organization", None)
+        viewer = Person.objects.filter(user=request.user).first()
+        if org is None or viewer is None:
+            return Response(
+                {"detail": "Organization context and person profile required."},
+                status=403,
+            )
+
+        template = self._get_template_or_error(org, template_id)
+        if template is None:
+            return Response({"detail": "Template not found."}, status=404)
+
+        if not _viewer_can_access_template(viewer, request.user, template):
+            return Response({"detail": "Access denied for this template."}, status=403)
+
+        cur_start, cur_end, prev_start, prev_end = _parse_period(request)
+        cur_refs = _get_reflections(template, org.id, cur_start, cur_end)
+        prev_refs = _get_reflections(template, org.id, prev_start, prev_end)
+
+        person_ids = {r.person_id for r in cur_refs}
+        eligible = _eligible_person_count(template, org.id)
+
+        fields_out = []
+        for field in template.schema.get("fields") or []:
+            if not isinstance(field, dict):
+                continue
+            ftype = field.get("type", "")
+            if ftype in META_FIELD_TYPES:
+                continue
+            agg = _aggregate_field(field, cur_refs, prev_refs)
+            fields_out.append(
+                {
+                    "key": field.get("key", ""),
+                    "type": ftype,
+                    "dashboard_role": field.get("dashboard_role"),
+                    "data": agg,
+                },
+            )
+
+        payload: dict[str, Any] = {
+            "template": {
+                "id": template.id,
+                "name": template.name,
+                "slug": template.slug,
+                "role": template.role,
+                "schema": template.schema,
+            },
+            "period": {
+                "current_start": cur_start.isoformat(),
+                "current_end": cur_end.isoformat(),
+                "prior_start": prev_start.isoformat(),
+                "prior_end": prev_end.isoformat(),
+            },
+            "summary": {
+                "person_count": len(person_ids),
+                "response_count": len(cur_refs),
+                "eligible_count": eligible,
+                "completion_rate": round(len(person_ids) / eligible, 4) if eligible else 0.0,
+            },
+            "fields": fields_out,
+        }
+        return Response(payload)
+
+
+class TemplateDashboardExportView(TemplateDashboardView):
+    def get(self, request, template_id: int, *args, **kwargs):
+        org = getattr(request, "organization", None)
+        viewer = Person.objects.filter(user=request.user).first()
+        if org is None or viewer is None:
+            return Response(
+                {"detail": "Organization context and person profile required."},
+                status=403,
+            )
+
+        template = self._get_template_or_error(org, template_id)
+        if template is None:
+            return Response({"detail": "Template not found."}, status=404)
+
+        if not _viewer_can_access_template(viewer, request.user, template):
+            return Response({"detail": "Access denied for this template."}, status=403)
+
+        cur_start, cur_end, _, __ = _parse_period(request)
+        cur_refs = _get_reflections(template, org.id, cur_start, cur_end)
+        csv_text = _build_csv(template, cur_refs)
+        filename = f"{template.slug}_{cur_start}_{cur_end}.csv"
+        response = HttpResponse(csv_text, content_type="text/csv")
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
+        return response

--- a/backend/bunk_logs/api/tests/test_template_dashboard.py
+++ b/backend/bunk_logs/api/tests/test_template_dashboard.py
@@ -1,0 +1,600 @@
+from __future__ import annotations
+
+import csv
+import io
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+
+User = get_user_model()
+
+
+def _hdr(org_slug: str) -> dict:
+    return {"HTTP_X_ORGANIZATION_SLUG": org_slug}
+
+
+# ── Shared schema fixtures ─────────────────────────────────────────────────────
+
+
+def _full_schema() -> dict:
+    return {
+        "fields": [
+            {
+                "key": "overall",
+                "type": "single_rating",
+                "dashboard_role": "primary_rating",
+                "scale": [1, 5],
+                "scale_labels": {"en": ["1", "2", "3", "4", "5"]},
+                "required": True,
+            },
+            {
+                "key": "pulse",
+                "type": "rating_group",
+                "dashboard_role": "category_ratings",
+                "scale": [1, 4],
+                "scale_labels": {"en": ["1", "2", "3", "4"]},
+                "categories": [
+                    {"key": "morale", "labels": {"en": "Morale"}},
+                    {"key": "energy", "labels": {"en": "Energy"}},
+                ],
+                "required": True,
+            },
+            {
+                "key": "win_items",
+                "type": "text_list",
+                "dashboard_role": "wins",
+                "prompts": {"en": "What went well?"},
+                "min_items": 1,
+                "max_items": 3,
+            },
+            {
+                "key": "growth_items",
+                "type": "text_list",
+                "dashboard_role": "improvements",
+                "prompts": {"en": "What to improve?"},
+                "min_items": 1,
+                "max_items": 3,
+            },
+            {
+                "key": "concerns",
+                "type": "textarea",
+                "dashboard_role": "open_concern",
+                "prompts": {"en": "Any concerns?"},
+                "max_length": 1000,
+            },
+            {
+                "key": "yn_question",
+                "type": "yes_no",
+                "prompts": {"en": "All good?"},
+            },
+            {
+                "key": "notes",
+                "type": "text",
+                "prompts": {"en": "Extra notes"},
+                "max_length": 500,
+            },
+            {
+                "key": "header_section",
+                "type": "section_header",
+                "prompts": {"en": "Section"},
+            },
+        ],
+    }
+
+
+def _wellness_schema() -> dict:
+    return {
+        "fields": [
+            {
+                "key": "pulse",
+                "type": "rating_group",
+                "dashboard_role": "category_ratings",
+                "scale": [1, 4],
+                "scale_labels": {"en": ["1", "2", "3", "4"]},
+                "categories": [
+                    {"key": "workload", "labels": {"en": "Workload"}},
+                ],
+            },
+            {
+                "key": "concern_text",
+                "type": "textarea",
+                "dashboard_role": "open_concern",
+                "prompts": {"en": "Concerns?"},
+                "max_length": 1000,
+            },
+        ],
+    }
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="TDash Org", slug="tdash-org")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="TDash Org Summer",
+        slug="tdash-org-summer",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def lt_template(org):
+    return ReflectionTemplate.all_objects.create(
+        organization=org,
+        name="LT Weekly",
+        slug="lt-weekly",
+        cadence="weekly",
+        role="leadership_team",
+        program_type="summer_camp",
+        schema=_full_schema(),
+        languages=["en"],
+    )
+
+
+@pytest.fixture
+def wellness_template(org):
+    return ReflectionTemplate.all_objects.create(
+        organization=org,
+        name="Wellness Daily",
+        slug="wellness-daily",
+        cadence="daily",
+        role="camper_care",
+        program_type="summer_camp",
+        schema=_wellness_schema(),
+        languages=["en"],
+    )
+
+
+def _make_person(org, program, role: str, unit_slug: str | None = None, email_suffix: str = ""):
+    u = User.objects.create_user(email=f"td-{role}-{email_suffix}@example.com", password="pw")
+    p = Person.all_objects.create(organization=org, first_name="F", last_name="L", user=u)
+    meta = {"unit_slug": unit_slug} if unit_slug else {}
+    Membership.all_objects.create(
+        program=program,
+        person=p,
+        role=role,
+        is_active=True,
+        metadata=meta,
+    )
+    return u, p
+
+
+@pytest.fixture
+def lt_user(org, program):
+    return _make_person(org, program, "leadership_team", email_suffix="lt")
+
+
+@pytest.fixture
+def wellness_user(org, program):
+    return _make_person(org, program, "camper_care", email_suffix="wl")
+
+
+@pytest.fixture
+def admin_user(org, program):
+    return _make_person(org, program, "admin", email_suffix="adm")
+
+
+@pytest.fixture
+def counselor_user(org, program):
+    return _make_person(org, program, "counselor", "alef", email_suffix="c1")
+
+
+def _make_reflection(
+    org,
+    program,
+    person,
+    template,
+    period_end: date,
+    answers: dict,
+) -> Reflection:
+    return Reflection.all_objects.create(
+        organization=org,
+        program=program,
+        person=person,
+        template=template,
+        period_start=period_end,
+        period_end=period_end,
+        answers=answers,
+        language="en",
+    )
+
+
+# ── Permission tests ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_unauthenticated_returns_401(api_client, org, lt_template):
+    r = api_client.get(f"/api/v1/dashboards/template/{lt_template.id}/", **_hdr(org.slug))
+    assert r.status_code == 401
+
+
+@pytest.mark.django_db
+def test_counselor_cannot_access_lt_dashboard(api_client, org, lt_template, counselor_user):
+    u, _ = counselor_user
+    api_client.force_authenticate(user=u)
+    r = api_client.get(f"/api/v1/dashboards/template/{lt_template.id}/", **_hdr(org.slug))
+    assert r.status_code == 403
+
+
+@pytest.mark.django_db
+def test_wellness_user_cannot_access_lt_dashboard(api_client, org, lt_template, wellness_user):
+    u, _ = wellness_user
+    api_client.force_authenticate(user=u)
+    r = api_client.get(f"/api/v1/dashboards/template/{lt_template.id}/", **_hdr(org.slug))
+    assert r.status_code == 403
+
+
+@pytest.mark.django_db
+def test_lt_user_can_access_lt_dashboard(api_client, org, lt_template, lt_user):
+    u, _ = lt_user
+    api_client.force_authenticate(user=u)
+    r = api_client.get(f"/api/v1/dashboards/template/{lt_template.id}/", **_hdr(org.slug))
+    assert r.status_code == 200
+
+
+@pytest.mark.django_db
+def test_admin_user_can_access_lt_dashboard(api_client, org, lt_template, admin_user):
+    u, _ = admin_user
+    api_client.force_authenticate(user=u)
+    r = api_client.get(f"/api/v1/dashboards/template/{lt_template.id}/", **_hdr(org.slug))
+    assert r.status_code == 200
+
+
+@pytest.mark.django_db
+def test_wellness_user_can_access_wellness_dashboard(api_client, org, wellness_template, wellness_user):
+    u, _ = wellness_user
+    api_client.force_authenticate(user=u)
+    r = api_client.get(f"/api/v1/dashboards/template/{wellness_template.id}/", **_hdr(org.slug))
+    assert r.status_code == 200
+
+
+@pytest.mark.django_db
+def test_lt_user_cannot_access_wellness_dashboard(api_client, org, wellness_template, lt_user):
+    u, _ = lt_user
+    api_client.force_authenticate(user=u)
+    r = api_client.get(f"/api/v1/dashboards/template/{wellness_template.id}/", **_hdr(org.slug))
+    assert r.status_code == 403
+
+
+@pytest.mark.django_db
+def test_superuser_can_access_any_template(api_client, org, lt_template):
+    su = User.objects.create_superuser(email="super@example.com", password="pw")
+    p = Person.all_objects.create(organization=org, first_name="S", last_name="U", user=su)  # noqa: F841
+    api_client.force_authenticate(user=su)
+    r = api_client.get(f"/api/v1/dashboards/template/{lt_template.id}/", **_hdr(org.slug))
+    assert r.status_code == 200
+
+
+@pytest.mark.django_db
+def test_template_not_found_returns_404(api_client, org, lt_user):
+    u, _ = lt_user
+    api_client.force_authenticate(user=u)
+    r = api_client.get("/api/v1/dashboards/template/99999/", **_hdr(org.slug))
+    assert r.status_code == 404
+
+
+# ── Aggregation correctness tests ──────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_summary_counts(api_client, org, program, lt_template, lt_user, counselor_user):
+    u_lt, _ = lt_user
+    _, p_c = counselor_user
+    period_end = date(2026, 6, 14)
+    _make_reflection(
+        org,
+        program,
+        p_c,
+        lt_template,
+        period_end,
+        {"overall": 4, "pulse": {"morale": 3, "energy": 4}},
+    )
+    api_client.force_authenticate(user=u_lt)
+    r = api_client.get(
+        f"/api/v1/dashboards/template/{lt_template.id}/",
+        {"period_end": str(period_end), "period_days": "14"},
+        **_hdr(org.slug),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["summary"]["response_count"] == 1
+    assert body["summary"]["person_count"] == 1
+
+
+@pytest.mark.django_db
+def test_single_rating_aggregation(api_client, org, program, lt_template, lt_user, counselor_user):
+    u_lt, _ = lt_user
+    _, p_c = counselor_user
+    u2 = User.objects.create_user(email="c2@example.com", password="pw")
+    p2 = Person.all_objects.create(organization=org, first_name="C", last_name="2", user=u2)
+    Membership.all_objects.create(
+        program=program, person=p2, role="counselor", is_active=True
+    )
+    period_end = date(2026, 6, 14)
+    _make_reflection(org, program, p_c, lt_template, period_end, {"overall": 4})
+    _make_reflection(org, program, p2, lt_template, period_end, {"overall": 2})
+    api_client.force_authenticate(user=u_lt)
+    r = api_client.get(
+        f"/api/v1/dashboards/template/{lt_template.id}/",
+        {"period_end": str(period_end), "period_days": "14"},
+        **_hdr(org.slug),
+    )
+    body = r.json()
+    overall_field = next(f for f in body["fields"] if f["key"] == "overall")
+    assert overall_field["dashboard_role"] == "primary_rating"
+    assert overall_field["data"]["mean"] == 3.0
+    assert overall_field["data"]["response_count"] == 2
+    assert overall_field["data"]["distribution"]["4"] == 1
+    assert overall_field["data"]["distribution"]["2"] == 1
+
+
+@pytest.mark.django_db
+def test_rating_group_aggregation(api_client, org, program, lt_template, lt_user, counselor_user):
+    u_lt, _ = lt_user
+    _, p_c = counselor_user
+    period_end = date(2026, 6, 14)
+    _make_reflection(
+        org,
+        program,
+        p_c,
+        lt_template,
+        period_end,
+        {"pulse": {"morale": 4, "energy": 3}},
+    )
+    api_client.force_authenticate(user=u_lt)
+    r = api_client.get(
+        f"/api/v1/dashboards/template/{lt_template.id}/",
+        {"period_end": str(period_end), "period_days": "14"},
+        **_hdr(org.slug),
+    )
+    body = r.json()
+    pulse_field = next(f for f in body["fields"] if f["key"] == "pulse")
+    assert pulse_field["dashboard_role"] == "category_ratings"
+    cats = {c["key"]: c for c in pulse_field["data"]["categories"]}
+    assert cats["morale"]["mean"] == 4.0
+    assert cats["energy"]["mean"] == 3.0
+
+
+@pytest.mark.django_db
+def test_text_list_aggregation(api_client, org, program, lt_template, lt_user, counselor_user):
+    u_lt, _ = lt_user
+    _, p_c = counselor_user
+    u2 = User.objects.create_user(email="c3@example.com", password="pw")
+    p2 = Person.all_objects.create(organization=org, first_name="C", last_name="3", user=u2)
+    Membership.all_objects.create(program=program, person=p2, role="counselor", is_active=True)
+    period_end = date(2026, 6, 14)
+    _make_reflection(
+        org, program, p_c, lt_template, period_end,
+        {"win_items": ["teamwork", "communication"]},
+    )
+    _make_reflection(
+        org, program, p2, lt_template, period_end,
+        {"win_items": ["teamwork", "punctuality"]},
+    )
+    api_client.force_authenticate(user=u_lt)
+    r = api_client.get(
+        f"/api/v1/dashboards/template/{lt_template.id}/",
+        {"period_end": str(period_end)},
+        **_hdr(org.slug),
+    )
+    body = r.json()
+    wins_field = next(f for f in body["fields"] if f["key"] == "win_items")
+    items_by_text = {i["text"]: i["count"] for i in wins_field["data"]["items"]}
+    assert items_by_text["teamwork"] == 2
+    assert items_by_text["communication"] == 1
+    assert items_by_text["punctuality"] == 1
+    assert wins_field["data"]["total_mentions"] == 4
+
+
+@pytest.mark.django_db
+def test_yes_no_aggregation(api_client, org, program, lt_template, lt_user, counselor_user):
+    u_lt, _ = lt_user
+    _, p_c = counselor_user
+    u2 = User.objects.create_user(email="c4@example.com", password="pw")
+    p2 = Person.all_objects.create(organization=org, first_name="C", last_name="4", user=u2)
+    Membership.all_objects.create(program=program, person=p2, role="counselor", is_active=True)
+    u3 = User.objects.create_user(email="c5@example.com", password="pw")
+    p3 = Person.all_objects.create(organization=org, first_name="C", last_name="5", user=u3)
+    Membership.all_objects.create(program=program, person=p3, role="counselor", is_active=True)
+    period_end = date(2026, 6, 14)
+    _make_reflection(org, program, p_c, lt_template, period_end, {"yn_question": True})
+    _make_reflection(org, program, p2, lt_template, period_end, {"yn_question": True})
+    _make_reflection(org, program, p3, lt_template, period_end, {"yn_question": False})
+    api_client.force_authenticate(user=u_lt)
+    r = api_client.get(
+        f"/api/v1/dashboards/template/{lt_template.id}/",
+        {"period_end": str(period_end)},
+        **_hdr(org.slug),
+    )
+    body = r.json()
+    yn_field = next(f for f in body["fields"] if f["key"] == "yn_question")
+    assert yn_field["data"]["yes_count"] == 2
+    assert yn_field["data"]["no_count"] == 1
+    assert abs(yn_field["data"]["yes_pct"] - 2 / 3) < 0.001
+
+
+@pytest.mark.django_db
+def test_meta_fields_not_in_output(api_client, org, program, lt_template, lt_user):
+    u_lt, _ = lt_user
+    api_client.force_authenticate(user=u_lt)
+    r = api_client.get(
+        f"/api/v1/dashboards/template/{lt_template.id}/",
+        {"period_end": str(date(2026, 6, 14))},
+        **_hdr(org.slug),
+    )
+    body = r.json()
+    field_keys = [f["key"] for f in body["fields"]]
+    assert "header_section" not in field_keys
+
+
+@pytest.mark.django_db
+def test_trend_vs_prior_period(api_client, org, program, lt_template, lt_user, counselor_user):
+    u_lt, _ = lt_user
+    _, p_c = counselor_user
+    # Prior period: low rating
+    prior_end = date(2026, 6, 7)
+    _make_reflection(org, program, p_c, lt_template, prior_end, {"overall": 2})
+    # Current period: high rating
+    cur_end = date(2026, 6, 14)
+    _make_reflection(org, program, p_c, lt_template, cur_end, {"overall": 4})
+    api_client.force_authenticate(user=u_lt)
+    r = api_client.get(
+        f"/api/v1/dashboards/template/{lt_template.id}/",
+        {"period_end": str(cur_end), "period_days": "7"},
+        **_hdr(org.slug),
+    )
+    body = r.json()
+    overall_field = next(f for f in body["fields"] if f["key"] == "overall")
+    assert overall_field["data"]["mean"] == 4.0
+    assert overall_field["data"]["prior_mean"] == 2.0
+    assert overall_field["data"]["trend"] == "up"
+
+
+# ── CSV export tests ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_csv_export_returns_parseable_csv(api_client, org, program, lt_template, lt_user, counselor_user):
+    u_lt, _ = lt_user
+    _, p_c = counselor_user
+    period_end = date(2026, 6, 14)
+    _make_reflection(
+        org,
+        program,
+        p_c,
+        lt_template,
+        period_end,
+        {
+            "overall": 3,
+            "pulse": {"morale": 4, "energy": 3},
+            "win_items": ["collaboration", "initiative"],
+            "concerns": "Some concern here",
+        },
+    )
+    api_client.force_authenticate(user=u_lt)
+    r = api_client.get(
+        f"/api/v1/dashboards/template/{lt_template.id}/export/",
+        {"period_end": str(period_end)},
+        **_hdr(org.slug),
+    )
+    assert r.status_code == 200
+    assert "text/csv" in r["Content-Type"]
+    assert "attachment" in r["Content-Disposition"]
+    content = r.content.decode("utf-8")
+    reader = csv.reader(io.StringIO(content))
+    rows = list(reader)
+    assert len(rows) >= 2  # header + at least one data row
+    header = rows[0]
+    assert "person_name" in header
+    assert "period_end" in header
+    assert "overall" in header
+    assert "pulse__morale" in header
+    assert "pulse__energy" in header
+    assert "win_items" in header
+    assert "concerns" in header
+    # section_header should not appear
+    assert "header_section" not in header
+    # Data row
+    data_row = dict(zip(header, rows[1]))
+    assert data_row["overall"] == "3"
+    assert data_row["pulse__morale"] == "4"
+    assert "collaboration" in data_row["win_items"]
+
+
+@pytest.mark.django_db
+def test_csv_export_permission_denied(api_client, org, wellness_template, lt_user):
+    u_lt, _ = lt_user
+    api_client.force_authenticate(user=u_lt)
+    r = api_client.get(
+        f"/api/v1/dashboards/template/{wellness_template.id}/export/",
+        **_hdr(org.slug),
+    )
+    assert r.status_code == 403
+
+
+@pytest.mark.django_db
+def test_csv_export_filename_includes_slug_and_period(
+    api_client, org, lt_template, lt_user
+):
+    u_lt, _ = lt_user
+    api_client.force_authenticate(user=u_lt)
+    period_end = date(2026, 6, 14)
+    r = api_client.get(
+        f"/api/v1/dashboards/template/{lt_template.id}/export/",
+        {"period_end": str(period_end)},
+        **_hdr(org.slug),
+    )
+    assert r.status_code == 200
+    assert "lt-weekly" in r["Content-Disposition"]
+    assert "2026-06-14" in r["Content-Disposition"]
+
+
+# ── Response structure tests ───────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_response_includes_template_info(api_client, org, lt_template, lt_user):
+    u_lt, _ = lt_user
+    api_client.force_authenticate(user=u_lt)
+    r = api_client.get(
+        f"/api/v1/dashboards/template/{lt_template.id}/",
+        **_hdr(org.slug),
+    )
+    body = r.json()
+    assert body["template"]["id"] == lt_template.id
+    assert body["template"]["slug"] == "lt-weekly"
+    assert body["template"]["role"] == "leadership_team"
+    assert "schema" in body["template"]
+
+
+@pytest.mark.django_db
+def test_response_includes_period(api_client, org, lt_template, lt_user):
+    u_lt, _ = lt_user
+    api_client.force_authenticate(user=u_lt)
+    r = api_client.get(
+        f"/api/v1/dashboards/template/{lt_template.id}/",
+        {"period_end": "2026-06-14", "period_days": "7"},
+        **_hdr(org.slug),
+    )
+    body = r.json()
+    assert body["period"]["current_end"] == "2026-06-14"
+    assert body["period"]["current_start"] == "2026-06-08"
+    assert "prior_start" in body["period"]
+    assert "prior_end" in body["period"]
+
+
+@pytest.mark.django_db
+def test_empty_period_returns_zeros(api_client, org, lt_template, lt_user):
+    u_lt, _ = lt_user
+    api_client.force_authenticate(user=u_lt)
+    r = api_client.get(
+        f"/api/v1/dashboards/template/{lt_template.id}/",
+        {"period_end": "2020-01-01"},
+        **_hdr(org.slug),
+    )
+    body = r.json()
+    assert body["summary"]["response_count"] == 0
+    assert body["summary"]["person_count"] == 0

--- a/backend/bunk_logs/api/tests/test_template_dashboard.py
+++ b/backend/bunk_logs/api/tests/test_template_dashboard.py
@@ -331,7 +331,7 @@ def test_single_rating_aggregation(api_client, org, program, lt_template, lt_use
     u2 = User.objects.create_user(email="c2@example.com", password="pw")
     p2 = Person.all_objects.create(organization=org, first_name="C", last_name="2", user=u2)
     Membership.all_objects.create(
-        program=program, person=p2, role="counselor", is_active=True
+        program=program, person=p2, role="counselor", is_active=True,
     )
     period_end = date(2026, 6, 14)
     _make_reflection(org, program, p_c, lt_template, period_end, {"overall": 4})
@@ -518,7 +518,7 @@ def test_csv_export_returns_parseable_csv(api_client, org, program, lt_template,
     # section_header should not appear
     assert "header_section" not in header
     # Data row
-    data_row = dict(zip(header, rows[1]))
+    data_row = dict(zip(header, rows[1], strict=False))
     assert data_row["overall"] == "3"
     assert data_row["pulse__morale"] == "4"
     assert "collaboration" in data_row["win_items"]
@@ -537,7 +537,7 @@ def test_csv_export_permission_denied(api_client, org, wellness_template, lt_use
 
 @pytest.mark.django_db
 def test_csv_export_filename_includes_slug_and_period(
-    api_client, org, lt_template, lt_user
+    api_client, org, lt_template, lt_user,
 ):
     u_lt, _ = lt_user
     api_client.force_authenticate(user=u_lt)

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -8,6 +8,7 @@ from . import field_keys as field_keys_api
 from . import memberships
 from . import reflections
 from . import team_dashboard
+from . import template_dashboard
 from . import templates as templates_api
 from . import views
 from . import wellness_dashboard
@@ -72,6 +73,18 @@ urlpatterns = [
         "dashboards/wellness/",
         wellness_dashboard.WellnessDashboardView.as_view(),
         name="wellness-dashboard",
+    ),
+
+    # Template-scoped aggregation dashboard and CSV export
+    path(
+        "dashboards/template/<int:template_id>/",
+        template_dashboard.TemplateDashboardView.as_view(),
+        name="template-dashboard",
+    ),
+    path(
+        "dashboards/template/<int:template_id>/export/",
+        template_dashboard.TemplateDashboardExportView.as_view(),
+        name="template-dashboard-export",
     ),
 
     # Unit head and camper care dashboard endpoints

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -1,0 +1,214 @@
+# Dashboard Role-to-Widget Contract
+
+This document describes how the BunkLogs template-driven dashboard system
+works and how to extend it with new `dashboard_role` + widget pairs.
+
+---
+
+## Overview
+
+Every `ReflectionTemplate` has a JSON `schema` containing `fields`. Each field
+can carry an optional `dashboard_role` string. When reflection data is
+aggregated, the frontend reads these tags to select the right visualization
+widget.
+
+```
+ReflectionTemplate.schema.fields[n].dashboard_role → widget component
+```
+
+---
+
+## The Five `dashboard_role` Values
+
+| `dashboard_role`    | Allowed field types          | Widget component         | Description |
+|---------------------|------------------------------|--------------------------|-------------|
+| `primary_rating`    | `single_rating`              | `RatingHeadlineWidget`   | Large number with trend arrow vs prior period |
+| `category_ratings`  | `rating_group`               | `CategoryRadarWidget`    | Bar per category with mean and trend |
+| `wins`              | `text_list`                  | `HighlightFeedWidget`    | Frequency-weighted list of wins, green accent |
+| `improvements`      | `text_list`                  | `ImprovementFeedWidget`  | Frequency-weighted list of growth areas, amber accent |
+| `open_concern`      | `text`, `textarea`           | `ConcernQueueWidget`     | Expandable queue with unread counter |
+
+Each template should use at most one field per role (the validator enforces
+this). Role-tagged fields render **before** untagged fields in the dashboard.
+
+---
+
+## Generic Widgets (untagged fields)
+
+Fields without a `dashboard_role` get a widget based on `type`:
+
+| Field type                    | Widget component             |
+|-------------------------------|------------------------------|
+| `text`, `textarea`            | `TextResponseListWidget`     |
+| `text_list`                   | `ItemCloudWidget`            |
+| `single_rating`               | `RatingDistributionWidget`   |
+| `rating_group`                | `RatingTableWidget`          |
+| `single_choice`, `multiple_choice` | `ChoiceBarChartWidget`  |
+| `yes_no`                      | `YesNoBreakdownWidget`       |
+| `number`                      | `NumberSparklineWidget`      |
+| `date`                        | `DateHistogramWidget`        |
+| `section_header`, `instructions` | *(not rendered)*          |
+
+Generic widgets appear in a collapsible "More fields" disclosure below the
+role-tagged widgets.
+
+---
+
+## API: Aggregation Endpoint
+
+```
+GET /api/v1/dashboards/template/{id}/?period_end=YYYY-MM-DD&period_days=N
+```
+
+**Query params:**
+
+| Param          | Default   | Description                        |
+|----------------|-----------|------------------------------------|
+| `period_end`   | today     | End of the current window (ISO)    |
+| `period_start` | —         | Explicit start (overrides `period_days`) |
+| `period_days`  | 14        | Window length in days (1–90)       |
+
+**Response shape:**
+
+```json
+{
+  "template": { "id": 1, "name": "...", "slug": "...", "role": "...", "schema": {...} },
+  "period": { "current_start": "...", "current_end": "...", "prior_start": "...", "prior_end": "..." },
+  "summary": { "person_count": 8, "response_count": 6, "eligible_count": 10, "completion_rate": 0.6 },
+  "fields": [
+    {
+      "key": "overall",
+      "type": "single_rating",
+      "dashboard_role": "primary_rating",
+      "data": {
+        "mean": 3.8, "prior_mean": 3.2, "trend": "up",
+        "response_count": 6,
+        "distribution": { "1": 0, "2": 0, "3": 1, "4": 4, "5": 1 }
+      }
+    },
+    {
+      "key": "pulse",
+      "type": "rating_group",
+      "dashboard_role": "category_ratings",
+      "data": {
+        "categories": [
+          { "key": "morale", "mean": 3.5, "prior_mean": 3.1, "trend": "up",
+            "response_count": 6, "distribution": { "1": 0, ... } }
+        ]
+      }
+    }
+  ]
+}
+```
+
+**Permissions:**  
+Access is controlled by the template's `role` field:
+
+| Template `role`                             | Required viewer membership |
+|---------------------------------------------|---------------------------|
+| `leadership_team`                           | `leadership_team` or `admin` |
+| `camper_care`, `health_center`, `special_diets`, `wellness` | Those roles or `admin` |
+| All other roles                             | `admin` only |
+| (Legacy) User.role == `Admin` / superuser   | Always allowed |
+
+---
+
+## API: CSV Export
+
+```
+GET /api/v1/dashboards/template/{id}/export/?period_end=YYYY-MM-DD&period_days=N
+```
+
+Same parameters and permissions as the aggregation endpoint. Returns
+`Content-Type: text/csv` with `Content-Disposition: attachment`.
+
+**CSV columns:**
+
+- `person_name`, `person_id`, `period_end`, `language`
+- One column per non-meta field
+- `rating_group` fields expand to one column per category, e.g.
+  `pulse__morale`, `pulse__energy`
+- `text_list` fields are serialized as semicolon-joined strings
+
+---
+
+## Frontend: `TemplateDashboard` Component
+
+```jsx
+import TemplateDashboard from '../dashboards/TemplateDashboard';
+
+<TemplateDashboard
+  templateId={12}
+  language="en"           // optional, default 'en'
+  title="Custom Title"    // optional
+  subtitle="..."          // optional
+  accentColor="teal"      // optional Tailwind color prefix for Refresh button
+/>
+```
+
+The component:
+1. Fetches template data from `GET /api/v1/dashboards/template/{id}/`
+2. Renders a `SummaryBar` (completion, responses, respondents, period dates)
+3. Renders role-tagged widgets first (in schema field order)
+4. Renders generic widgets in a collapsible "More fields" section
+5. Renders a CSV export link when there are responses
+
+---
+
+## Frontend: `DashboardPreviewModal`
+
+The template editor includes a **"Dashboard"** button in the header that opens
+a preview modal. The modal generates synthetic sample data for each field in
+the current schema and renders the appropriate widgets, so admins can see what
+the dashboard will look like before any real reflections are submitted.
+
+```jsx
+import DashboardPreviewModal from '../dashboards/DashboardPreviewModal';
+
+<DashboardPreviewModal
+  schemaFields={fields}      // from the editor's draft state (with _id keys)
+  language={language}        // currently selected editor language
+  onClose={() => setShow(false)}
+/>
+```
+
+---
+
+## Adding a New `dashboard_role` + Widget
+
+1. **Backend validator** — Add the new role to `DASHBOARD_ROLES` and
+   `DASHBOARD_ROLE_ALLOWED_TYPES` in
+   `backend/bunk_logs/core/validators/template_schema.py`.
+
+2. **Frontend validator mirror** — Update `DASHBOARD_ROLES` and
+   `DASHBOARD_ROLE_ALLOWED_TYPES` in
+   `frontend/src/components/templates/FieldInspector.jsx`.
+
+3. **Widget component** — Create
+   `frontend/src/dashboards/widgets/MyNewWidget.jsx`.  
+   Export it from `frontend/src/dashboards/widgets/index.js`.
+
+4. **widgetMap** — Add the role→widget entry to `ROLE_WIDGET_MAP` in
+   `frontend/src/dashboards/widgetMap.js`.
+
+5. **Aggregation** — If the new role requires a new aggregation shape, add a
+   new aggregator function in
+   `backend/bunk_logs/api/template_dashboard.py` and wire it in
+   `_aggregate_field`.
+
+6. **Tests** — Add tests to `widgetMap.test.js`, `widgets.test.jsx`, and
+   `test_template_dashboard.py`.
+
+7. **Docs** — Update the tables in this file.
+
+---
+
+## Permission Model Summary
+
+- LT users see data for `leadership_team`-role templates only.
+- Wellness users see data for wellness-type templates only.
+- Admin users (membership role `admin` or legacy `User.role == Admin`) see
+  all templates.
+- Superusers always have full access.
+- The counselor self-tracking dashboard (Prompt 3.11) is a separate flow and
+  is not affected by this system.

--- a/frontend/src/dashboards/DashboardPreviewModal.jsx
+++ b/frontend/src/dashboards/DashboardPreviewModal.jsx
@@ -1,0 +1,251 @@
+import { X } from 'lucide-react';
+import { useMemo } from 'react';
+import { partitionFields, resolveWidgetName } from './widgetMap';
+import * as Widgets from './widgets/index';
+
+/**
+ * Generate synthetic sample data for a single field so the dashboard preview
+ * shows realistic widget output even before any real reflections exist.
+ */
+function syntheticData(field) {
+  const ftype = field.type;
+  const scale = field.scale ?? [1, 5];
+  const scaleMin = Number(scale[0]);
+  const scaleMax = Number(scale[scale.length - 1]);
+  const midHigh = scaleMin + Math.round((scaleMax - scaleMin) * 0.7);
+  const midLow = scaleMin + Math.round((scaleMax - scaleMin) * 0.4);
+
+  if (ftype === 'single_rating') {
+    const dist = {};
+    for (let i = scaleMin; i <= scaleMax; i++) dist[String(i)] = 0;
+    dist[String(midHigh)] = 4;
+    dist[String(midHigh - 1)] = 2;
+    dist[String(midLow)] = 1;
+    return {
+      mean: midHigh - 0.3,
+      prior_mean: midHigh - 0.8,
+      trend: 'up',
+      response_count: 7,
+      distribution: dist,
+    };
+  }
+
+  if (ftype === 'rating_group') {
+    const categories = (field.categories ?? []).map((cat) => {
+      const dist = {};
+      for (let i = scaleMin; i <= scaleMax; i++) dist[String(i)] = 0;
+      dist[String(midHigh)] = 3;
+      dist[String(midHigh - 1)] = 2;
+      return {
+        key: cat.key,
+        mean: midHigh - 0.4,
+        prior_mean: midHigh - 0.9,
+        trend: 'up',
+        response_count: 5,
+        distribution: dist,
+      };
+    });
+    return { categories };
+  }
+
+  if (ftype === 'text_list') {
+    return {
+      items: [
+        { text: 'Teamwork', count: 5 },
+        { text: 'Communication', count: 3 },
+        { text: 'Creativity', count: 2 },
+        { text: 'Punctuality', count: 1 },
+      ],
+      total_mentions: 11,
+    };
+  }
+
+  if (ftype === 'text' || ftype === 'textarea') {
+    return {
+      items: [
+        {
+          reflection_id: 1,
+          person_id: 1,
+          period_end: '2026-06-14',
+          text: 'Sample response text for dashboard preview.',
+          is_read: false,
+        },
+        {
+          reflection_id: 2,
+          person_id: 2,
+          period_end: '2026-06-13',
+          text: 'Another example response shown in the preview.',
+          is_read: false,
+        },
+      ],
+      total: 2,
+    };
+  }
+
+  if (ftype === 'yes_no') {
+    return { yes_count: 6, no_count: 2, yes_pct: 0.75 };
+  }
+
+  if (ftype === 'single_choice' || ftype === 'multiple_choice') {
+    const opts = (field.options ?? []).slice(0, 4);
+    const choices =
+      opts.length > 0
+        ? opts.map((o, i) => ({
+            option: typeof o === 'string' ? o : (o.key ?? o.label ?? `Option ${i + 1}`),
+            count: Math.max(1, 5 - i),
+          }))
+        : [
+            { option: 'Option A', count: 5 },
+            { option: 'Option B', count: 3 },
+            { option: 'Option C', count: 1 },
+          ];
+    return { choices, response_count: choices.reduce((s, c) => s + c.count, 0) };
+  }
+
+  if (ftype === 'number') {
+    return { mean: 42.5, min: 30, max: 60, response_count: 8 };
+  }
+
+  if (ftype === 'date') {
+    return { values: ['2026-06-10', '2026-06-11', '2026-06-12'], response_count: 3 };
+  }
+
+  return null;
+}
+
+/**
+ * Build synthetic aggregated fields from a raw schema (as used in the editor,
+ * with _id keys present).
+ */
+function buildSyntheticFields(schemaFields) {
+  return (schemaFields ?? [])
+    .filter((f) => f.type && f.type !== 'section_header' && f.type !== 'instructions')
+    .map((f) => ({
+      key: f.key || '(unnamed)',
+      type: f.type,
+      dashboard_role: f.dashboard_role ?? null,
+      data: syntheticData(f),
+    }));
+}
+
+function Widget({ widgetName, field, schemaField, schemaFields, language }) {
+  const Component = Widgets[widgetName];
+  if (!Component) return null;
+  const prompts = schemaField?.prompts;
+  const label = (prompts && (prompts[language] || prompts.en)) || field.key;
+  const enriched = {
+    ...field,
+    scale: schemaField?.scale ?? field?.scale,
+    categories: schemaField?.categories ?? field?.categories,
+  };
+  return <Component field={enriched} label={label} />;
+}
+
+/**
+ * DashboardPreviewModal — shows what the dashboard would look like for the
+ * current template schema, using synthetic sample data.
+ *
+ * Props:
+ *   schemaFields  {Array}   raw fields from the editor (with _id, type, key, etc.)
+ *   language      {string}  currently selected preview language
+ *   onClose       {fn}
+ */
+export default function DashboardPreviewModal({ schemaFields, language = 'en', onClose }) {
+  const syntheticFields = useMemo(
+    () => buildSyntheticFields(schemaFields),
+    [schemaFields],
+  );
+
+  const { tagged, generic } = useMemo(
+    () => partitionFields(syntheticFields),
+    [syntheticFields],
+  );
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Dashboard preview"
+    >
+      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl w-full max-w-4xl max-h-[90vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+          <div>
+            <h2 className="text-base font-semibold text-gray-900 dark:text-white">Dashboard preview</h2>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              Synthetic sample data — shows how widgets will appear with real responses.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+            aria-label="Close preview"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="overflow-y-auto p-6 space-y-6">
+          {tagged.length > 0 && (
+            <section>
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
+                Role-tagged widgets
+              </p>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {tagged.map((field) => {
+                  const widgetName = resolveWidgetName(field);
+                  if (!widgetName) return null;
+                  const schemaField = schemaFields.find((f) => f.key === field.key);
+                  return (
+                    <Widget
+                      key={field.key}
+                      widgetName={widgetName}
+                      field={field}
+                      schemaField={schemaField}
+                      schemaFields={schemaFields}
+                      language={language}
+                    />
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+          {generic.length > 0 && (
+            <section>
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
+                Generic widgets (untagged fields)
+              </p>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {generic.map((field) => {
+                  const widgetName = resolveWidgetName(field);
+                  if (!widgetName) return null;
+                  const schemaField = schemaFields.find((f) => f.key === field.key);
+                  return (
+                    <Widget
+                      key={field.key}
+                      widgetName={widgetName}
+                      field={field}
+                      schemaField={schemaField}
+                      schemaFields={schemaFields}
+                      language={language}
+                    />
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+          {tagged.length === 0 && generic.length === 0 && (
+            <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-8">
+              Add fields to your template to see a dashboard preview.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/dashboards/TemplateDashboard.jsx
+++ b/frontend/src/dashboards/TemplateDashboard.jsx
@@ -1,0 +1,267 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ChevronDown, ChevronUp, Download } from 'lucide-react';
+import api from '../api';
+import { partitionFields, resolveWidgetName } from './widgetMap';
+import * as Widgets from './widgets/index';
+
+function pct(n) {
+  if (n == null || Number.isNaN(n)) return '—';
+  return `${Math.round(n * 1000) / 10}%`;
+}
+
+function todayIso() {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+/**
+ * Resolve a field's human-readable label from the schema.
+ * Tries en prompt, then field key.
+ */
+function fieldLabel(fieldKey, schemaFields, language = 'en') {
+  const schemaField = (schemaFields ?? []).find((f) => f.key === fieldKey);
+  if (!schemaField) return fieldKey;
+  const prompts = schemaField.prompts;
+  if (prompts) {
+    return prompts[language] || prompts.en || fieldKey;
+  }
+  return schemaField.name || fieldKey;
+}
+
+/** Render a single widget by name. */
+function Widget({ widgetName, field, schemaField, schemaFields, language }) {
+  const Component = Widgets[widgetName];
+  if (!Component) return null;
+  const label = fieldLabel(field.key, schemaFields, language);
+
+  // Pass scale info from schema if available (needed by rating widgets)
+  const enriched = {
+    ...field,
+    scale: schemaField?.scale ?? field?.scale,
+    categories: schemaField?.categories ?? field?.categories,
+  };
+  return <Component field={enriched} label={label} />;
+}
+
+/**
+ * SummaryBar — top header stats: completion, responses, persons.
+ */
+function SummaryBar({ summary, period }) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+      <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 px-4 py-3">
+        <p className="text-xs uppercase text-gray-500 dark:text-gray-400">Completion</p>
+        <p className="text-xl font-semibold text-gray-900 dark:text-white">
+          {pct(summary?.completion_rate)}
+        </p>
+      </div>
+      <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 px-4 py-3">
+        <p className="text-xs uppercase text-gray-500 dark:text-gray-400">Responses</p>
+        <p className="text-xl font-semibold text-gray-900 dark:text-white">{summary?.response_count ?? '—'}</p>
+      </div>
+      <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 px-4 py-3">
+        <p className="text-xs uppercase text-gray-500 dark:text-gray-400">Respondents</p>
+        <p className="text-xl font-semibold text-gray-900 dark:text-white">{summary?.person_count ?? '—'}</p>
+      </div>
+      <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 px-4 py-3">
+        <p className="text-xs uppercase text-gray-500 dark:text-gray-400">Period</p>
+        <p className="text-sm font-medium text-gray-700 dark:text-gray-300 truncate">
+          {period?.current_start} → {period?.current_end}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * TemplateDashboard — renders aggregated data for a single template.
+ *
+ * Props:
+ *   templateId  {number}  - the template to display
+ *   language    {string}  - language code for labels (default 'en')
+ *   title       {string}  - optional header title override
+ *   subtitle    {string}  - optional subtitle
+ *   accentColor {string}  - Tailwind color prefix for the export button, e.g. 'indigo' (default)
+ */
+export default function TemplateDashboard({
+  templateId,
+  language = 'en',
+  title,
+  subtitle,
+  accentColor = 'indigo',
+}) {
+  const [periodEnd, setPeriodEnd] = useState(todayIso);
+  const [periodDays, setPeriodDays] = useState(14);
+  const [payload, setPayload] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [showGeneric, setShowGeneric] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!templateId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await api.get(`/api/v1/dashboards/template/${templateId}/`, {
+        params: { period_end: periodEnd, period_days: periodDays },
+      });
+      setPayload(data);
+    } catch (e) {
+      const status = e.response?.status;
+      if (status === 403) setError('access');
+      else setError(e.response?.data?.detail || e.message || 'Failed to load dashboard');
+      setPayload(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [templateId, periodEnd, periodDays]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const exportUrl = templateId
+    ? `/api/v1/dashboards/template/${templateId}/export/?period_end=${periodEnd}&period_days=${periodDays}`
+    : null;
+
+  const schemaFields = payload?.template?.schema?.fields ?? [];
+  const { tagged, generic } = partitionFields(payload?.fields ?? []);
+
+  return (
+    <div>
+      {/* Controls row */}
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        {(title || payload?.template?.name) && (
+          <div>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+              {title ?? payload?.template?.name}
+            </h2>
+            {subtitle && (
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{subtitle}</p>
+            )}
+          </div>
+        )}
+        <div className="flex flex-wrap items-center gap-3">
+          <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+            <span>Period ends</span>
+            <input
+              type="date"
+              value={periodEnd}
+              onChange={(e) => setPeriodEnd(e.target.value)}
+              className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
+            />
+          </label>
+          <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+            <span>Days</span>
+            <select
+              value={periodDays}
+              onChange={(e) => setPeriodDays(Number(e.target.value))}
+              className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
+            >
+              {[7, 14, 30, 60, 90].map((d) => (
+                <option key={d} value={d}>{d}</option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={load}
+            className={`rounded-md bg-${accentColor}-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-${accentColor}-500`}
+          >
+            Refresh
+          </button>
+          {exportUrl && payload?.summary?.response_count > 0 && (
+            <a
+              href={exportUrl}
+              download
+              className="flex items-center gap-1.5 rounded-md border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
+            >
+              <Download size={14} />
+              CSV
+            </a>
+          )}
+        </div>
+      </div>
+
+      {loading && <p className="text-gray-500 dark:text-gray-400 text-sm">Loading…</p>}
+
+      {!loading && error === 'access' && (
+        <div className="rounded-lg border border-amber-200 dark:border-amber-900/40 bg-amber-50 dark:bg-amber-900/20 p-4 text-amber-900 dark:text-amber-100 text-sm">
+          <p className="font-medium">Access restricted</p>
+          <p className="mt-1">You do not have permission to view this dashboard.</p>
+        </div>
+      )}
+
+      {!loading && error && error !== 'access' && (
+        <p className="text-rose-600 dark:text-rose-400 text-sm">{error}</p>
+      )}
+
+      {!loading && payload && (
+        <>
+          <SummaryBar summary={payload.summary} period={payload.period} />
+
+          {/* Role-tagged widgets */}
+          {tagged.length > 0 && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 mb-6">
+              {tagged.map((field) => {
+                const widgetName = resolveWidgetName(field);
+                if (!widgetName) return null;
+                const schemaField = schemaFields.find((f) => f.key === field.key);
+                return (
+                  <Widget
+                    key={field.key}
+                    widgetName={widgetName}
+                    field={field}
+                    schemaField={schemaField}
+                    schemaFields={schemaFields}
+                    language={language}
+                  />
+                );
+              })}
+            </div>
+          )}
+
+          {/* Generic widgets in disclosure */}
+          {generic.length > 0 && (
+            <div className="mt-4">
+              <button
+                type="button"
+                className="flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white mb-3"
+                onClick={() => setShowGeneric((v) => !v)}
+                aria-expanded={showGeneric}
+              >
+                {showGeneric ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                {showGeneric ? 'Hide' : 'Show'} additional fields ({generic.length})
+              </button>
+              {showGeneric && (
+                <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+                  {generic.map((field) => {
+                    const widgetName = resolveWidgetName(field);
+                    if (!widgetName) return null;
+                    const schemaField = schemaFields.find((f) => f.key === field.key);
+                    return (
+                      <Widget
+                        key={field.key}
+                        widgetName={widgetName}
+                        field={field}
+                        schemaField={schemaField}
+                        schemaFields={schemaFields}
+                        language={language}
+                      />
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+
+          {tagged.length === 0 && generic.length === 0 && (
+            <p className="text-sm text-gray-400 dark:text-gray-500">
+              No field data to display for this period.
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/dashboards/__tests__/TemplateDashboard.test.jsx
+++ b/frontend/src/dashboards/__tests__/TemplateDashboard.test.jsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import TemplateDashboard from '../TemplateDashboard';
+
+const getMock = vi.fn();
+
+vi.mock('../../api', () => ({
+  default: { get: (...args) => getMock(...args) },
+}));
+
+vi.mock('../../auth/AuthContext', () => ({
+  useAuth: () => ({ user: null }),
+}));
+
+const samplePayload = {
+  template: {
+    id: 1,
+    name: 'LT Weekly',
+    slug: 'lt-weekly',
+    role: 'leadership_team',
+    schema: {
+      fields: [
+        {
+          key: 'overall',
+          type: 'single_rating',
+          dashboard_role: 'primary_rating',
+          scale: [1, 5],
+          prompts: { en: 'How are you overall?' },
+        },
+        {
+          key: 'pulse',
+          type: 'rating_group',
+          dashboard_role: 'category_ratings',
+          scale: [1, 4],
+          categories: [{ key: 'morale', labels: { en: 'Morale' } }],
+        },
+        {
+          key: 'notes',
+          type: 'text',
+          dashboard_role: null,
+          prompts: { en: 'Extra notes' },
+        },
+      ],
+    },
+  },
+  period: {
+    current_start: '2026-06-01',
+    current_end: '2026-06-14',
+    prior_start: '2026-05-18',
+    prior_end: '2026-05-31',
+  },
+  summary: { person_count: 5, response_count: 4, eligible_count: 6, completion_rate: 0.667 },
+  fields: [
+    {
+      key: 'overall',
+      type: 'single_rating',
+      dashboard_role: 'primary_rating',
+      data: {
+        mean: 3.5,
+        prior_mean: 3.0,
+        trend: 'up',
+        response_count: 4,
+        distribution: { '1': 0, '2': 0, '3': 1, '4': 3, '5': 0 },
+      },
+    },
+    {
+      key: 'pulse',
+      type: 'rating_group',
+      dashboard_role: 'category_ratings',
+      data: {
+        categories: [
+          { key: 'morale', mean: 3.8, prior_mean: 3.2, trend: 'up', response_count: 4, distribution: {} },
+        ],
+      },
+    },
+    {
+      key: 'notes',
+      type: 'text',
+      dashboard_role: null,
+      data: { items: [{ reflection_id: 1, person_id: 1, period_end: '2026-06-14', text: 'Sample note', is_read: false }], total: 1 },
+    },
+  ],
+};
+
+function renderDashboard(props = {}) {
+  return render(
+    <MemoryRouter>
+      <TemplateDashboard templateId={1} {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe('TemplateDashboard', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    getMock.mockResolvedValue({ data: samplePayload });
+  });
+
+  it('shows loading state initially', () => {
+    getMock.mockReturnValue(new Promise(() => {}));
+    renderDashboard();
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it('renders summary bar after load', async () => {
+    renderDashboard();
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByText('66.7%')).toBeInTheDocument());
+    expect(screen.getByText('4')).toBeInTheDocument(); // response count
+  });
+
+  it('renders role-tagged widgets', async () => {
+    renderDashboard();
+    await waitFor(() => expect(screen.getByText('3.5')).toBeInTheDocument());
+    expect(screen.getByText(/3\.8/)).toBeInTheDocument();
+  });
+
+  it('generic fields hidden until expanded', async () => {
+    renderDashboard();
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByText(/additional fields/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText('Sample note')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText(/additional fields/i));
+    await waitFor(() =>
+      expect(screen.getByText('Sample note')).toBeInTheDocument(),
+    );
+  });
+
+  it('shows access denied message on 403', async () => {
+    getMock.mockRejectedValueOnce({ response: { status: 403 } });
+    renderDashboard();
+    await waitFor(() =>
+      expect(screen.getByText(/access restricted/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('shows error message on other failure', async () => {
+    getMock.mockRejectedValueOnce({ response: { status: 500, data: { detail: 'Server error' } } });
+    renderDashboard();
+    await waitFor(() => expect(screen.getByText('Server error')).toBeInTheDocument());
+  });
+
+  it('calls API with template id', async () => {
+    renderDashboard({ templateId: 42 });
+    await waitFor(() => expect(getMock).toHaveBeenCalledWith(
+      '/api/v1/dashboards/template/42/',
+      expect.any(Object),
+    ));
+  });
+
+  it('renders title prop', async () => {
+    renderDashboard({ title: 'Custom Title' });
+    await waitFor(() => expect(screen.getByText('Custom Title')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/dashboards/__tests__/widgetMap.test.js
+++ b/frontend/src/dashboards/__tests__/widgetMap.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveWidgetName,
+  partitionFields,
+  ROLE_WIDGET_MAP,
+  TYPE_WIDGET_MAP,
+} from '../widgetMap';
+
+describe('resolveWidgetName', () => {
+  it('returns correct widget for primary_rating role', () => {
+    expect(resolveWidgetName({ type: 'single_rating', dashboard_role: 'primary_rating' }))
+      .toBe('RatingHeadlineWidget');
+  });
+
+  it('returns correct widget for category_ratings role', () => {
+    expect(resolveWidgetName({ type: 'rating_group', dashboard_role: 'category_ratings' }))
+      .toBe('CategoryRadarWidget');
+  });
+
+  it('returns correct widget for wins role', () => {
+    expect(resolveWidgetName({ type: 'text_list', dashboard_role: 'wins' }))
+      .toBe('HighlightFeedWidget');
+  });
+
+  it('returns correct widget for improvements role', () => {
+    expect(resolveWidgetName({ type: 'text_list', dashboard_role: 'improvements' }))
+      .toBe('ImprovementFeedWidget');
+  });
+
+  it('returns correct widget for open_concern role', () => {
+    expect(resolveWidgetName({ type: 'textarea', dashboard_role: 'open_concern' }))
+      .toBe('ConcernQueueWidget');
+  });
+
+  it('returns generic widget for untagged text field', () => {
+    expect(resolveWidgetName({ type: 'text', dashboard_role: null }))
+      .toBe('TextResponseListWidget');
+  });
+
+  it('returns generic widget for untagged textarea field', () => {
+    expect(resolveWidgetName({ type: 'textarea', dashboard_role: null }))
+      .toBe('TextResponseListWidget');
+  });
+
+  it('returns ItemCloudWidget for untagged text_list', () => {
+    expect(resolveWidgetName({ type: 'text_list', dashboard_role: null }))
+      .toBe('ItemCloudWidget');
+  });
+
+  it('returns RatingDistributionWidget for untagged single_rating', () => {
+    expect(resolveWidgetName({ type: 'single_rating', dashboard_role: null }))
+      .toBe('RatingDistributionWidget');
+  });
+
+  it('returns RatingTableWidget for untagged rating_group', () => {
+    expect(resolveWidgetName({ type: 'rating_group', dashboard_role: null }))
+      .toBe('RatingTableWidget');
+  });
+
+  it('returns ChoiceBarChartWidget for single_choice', () => {
+    expect(resolveWidgetName({ type: 'single_choice' })).toBe('ChoiceBarChartWidget');
+  });
+
+  it('returns ChoiceBarChartWidget for multiple_choice', () => {
+    expect(resolveWidgetName({ type: 'multiple_choice' })).toBe('ChoiceBarChartWidget');
+  });
+
+  it('returns YesNoBreakdownWidget for yes_no', () => {
+    expect(resolveWidgetName({ type: 'yes_no' })).toBe('YesNoBreakdownWidget');
+  });
+
+  it('returns null for section_header', () => {
+    expect(resolveWidgetName({ type: 'section_header' })).toBeNull();
+  });
+
+  it('returns null for instructions', () => {
+    expect(resolveWidgetName({ type: 'instructions' })).toBeNull();
+  });
+
+  it('returns null for null field', () => {
+    expect(resolveWidgetName(null)).toBeNull();
+  });
+
+  it('role-tagged field uses role widget over type widget', () => {
+    const result = resolveWidgetName({ type: 'single_rating', dashboard_role: 'primary_rating' });
+    expect(result).toBe(ROLE_WIDGET_MAP.primary_rating);
+    expect(result).not.toBe(TYPE_WIDGET_MAP.single_rating);
+  });
+});
+
+describe('partitionFields', () => {
+  const fields = [
+    { key: 'overall', type: 'single_rating', dashboard_role: 'primary_rating' },
+    { key: 'pulse', type: 'rating_group', dashboard_role: 'category_ratings' },
+    { key: 'wins', type: 'text_list', dashboard_role: 'wins' },
+    { key: 'extra_text', type: 'text', dashboard_role: null },
+    { key: 'a_header', type: 'section_header', dashboard_role: null },
+    { key: 'yn', type: 'yes_no', dashboard_role: null },
+  ];
+
+  it('puts role-tagged fields in tagged array', () => {
+    const { tagged } = partitionFields(fields);
+    expect(tagged.map((f) => f.key)).toEqual(['overall', 'pulse', 'wins']);
+  });
+
+  it('puts untagged non-meta fields in generic array', () => {
+    const { generic } = partitionFields(fields);
+    const keys = generic.map((f) => f.key);
+    expect(keys).toContain('extra_text');
+    expect(keys).toContain('yn');
+  });
+
+  it('excludes meta field types', () => {
+    const { tagged, generic } = partitionFields(fields);
+    const all = [...tagged, ...generic].map((f) => f.key);
+    expect(all).not.toContain('a_header');
+  });
+
+  it('handles empty/null input', () => {
+    expect(partitionFields(null)).toEqual({ tagged: [], generic: [] });
+    expect(partitionFields([])).toEqual({ tagged: [], generic: [] });
+  });
+});

--- a/frontend/src/dashboards/__tests__/widgets.test.jsx
+++ b/frontend/src/dashboards/__tests__/widgets.test.jsx
@@ -1,0 +1,276 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RatingHeadlineWidget from '../widgets/RatingHeadlineWidget';
+import CategoryRadarWidget from '../widgets/CategoryRadarWidget';
+import HighlightFeedWidget from '../widgets/HighlightFeedWidget';
+import ImprovementFeedWidget from '../widgets/ImprovementFeedWidget';
+import ConcernQueueWidget from '../widgets/ConcernQueueWidget';
+import TextResponseListWidget from '../widgets/TextResponseListWidget';
+import ItemCloudWidget from '../widgets/ItemCloudWidget';
+import RatingDistributionWidget from '../widgets/RatingDistributionWidget';
+import RatingTableWidget from '../widgets/RatingTableWidget';
+import ChoiceBarChartWidget from '../widgets/ChoiceBarChartWidget';
+import YesNoBreakdownWidget from '../widgets/YesNoBreakdownWidget';
+
+// ── RatingHeadlineWidget ───────────────────────────────────────────────────────
+
+describe('RatingHeadlineWidget', () => {
+  const field = {
+    key: 'overall',
+    scale: [1, 5],
+    data: { mean: 3.7, prior_mean: 3.2, trend: 'up', response_count: 6, distribution: {} },
+  };
+
+  it('shows mean value', () => {
+    render(<RatingHeadlineWidget field={field} label="Overall" />);
+    expect(screen.getByText('3.7')).toBeInTheDocument();
+  });
+
+  it('shows prior period mean', () => {
+    render(<RatingHeadlineWidget field={field} label="Overall" />);
+    expect(screen.getByText(/prior period/i)).toBeInTheDocument();
+    expect(screen.getByText(/3\.2/)).toBeInTheDocument();
+  });
+
+  it('shows response count', () => {
+    render(<RatingHeadlineWidget field={field} label="Overall" />);
+    expect(screen.getByText(/6 responses/i)).toBeInTheDocument();
+  });
+
+  it('shows dash when no data', () => {
+    render(<RatingHeadlineWidget field={{ key: 'x', scale: [1, 5], data: { mean: null } }} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+});
+
+// ── CategoryRadarWidget ───────────────────────────────────────────────────────
+
+describe('CategoryRadarWidget', () => {
+  const field = {
+    key: 'pulse',
+    scale: [1, 4],
+    data: {
+      categories: [
+        { key: 'morale', mean: 3.5, prior_mean: 3.0, trend: 'up', response_count: 5, distribution: {} },
+        { key: 'energy', mean: 2.8, prior_mean: 3.1, trend: 'down', response_count: 5, distribution: {} },
+      ],
+    },
+  };
+
+  it('renders all categories', () => {
+    render(<CategoryRadarWidget field={field} />);
+    expect(screen.getByText('morale')).toBeInTheDocument();
+    expect(screen.getByText('energy')).toBeInTheDocument();
+  });
+
+  it('shows mean values', () => {
+    render(<CategoryRadarWidget field={field} />);
+    expect(screen.getByText('3.5')).toBeInTheDocument();
+    expect(screen.getByText('2.8')).toBeInTheDocument();
+  });
+
+  it('shows empty state', () => {
+    render(<CategoryRadarWidget field={{ key: 'x', data: { categories: [] } }} />);
+    expect(screen.getByText(/no data/i)).toBeInTheDocument();
+  });
+});
+
+// ── HighlightFeedWidget ───────────────────────────────────────────────────────
+
+describe('HighlightFeedWidget', () => {
+  const field = {
+    key: 'wins',
+    data: {
+      items: [
+        { text: 'Teamwork', count: 4 },
+        { text: 'Communication', count: 2 },
+      ],
+      total_mentions: 6,
+    },
+  };
+
+  it('renders items', () => {
+    render(<HighlightFeedWidget field={field} />);
+    expect(screen.getByText('Teamwork')).toBeInTheDocument();
+    expect(screen.getByText('Communication')).toBeInTheDocument();
+  });
+
+  it('shows total mentions', () => {
+    render(<HighlightFeedWidget field={field} />);
+    expect(screen.getByText(/6 mentions/i)).toBeInTheDocument();
+  });
+
+  it('shows empty state', () => {
+    render(<HighlightFeedWidget field={{ key: 'x', data: { items: [], total_mentions: 0 } }} />);
+    expect(screen.getByText(/none submitted/i)).toBeInTheDocument();
+  });
+});
+
+// ── ImprovementFeedWidget ─────────────────────────────────────────────────────
+
+describe('ImprovementFeedWidget', () => {
+  it('renders items with growth framing', () => {
+    const field = {
+      key: 'growth',
+      data: { items: [{ text: 'Time management', count: 3 }], total_mentions: 3 },
+    };
+    render(<ImprovementFeedWidget field={field} />);
+    expect(screen.getByText('Time management')).toBeInTheDocument();
+  });
+});
+
+// ── ConcernQueueWidget ────────────────────────────────────────────────────────
+
+describe('ConcernQueueWidget', () => {
+  const field = {
+    key: 'concerns',
+    data: {
+      items: [
+        { reflection_id: 1, person_id: 5, period_end: '2026-06-14', text: 'Concern text here', is_read: false },
+      ],
+      total: 1,
+    },
+  };
+
+  it('shows unread badge', () => {
+    render(<ConcernQueueWidget field={field} />);
+    expect(screen.getByText(/1 new/i)).toBeInTheDocument();
+  });
+
+  it('expands to show text on click', () => {
+    render(<ConcernQueueWidget field={field} />);
+    expect(screen.queryByText('Concern text here')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText(/Person 5/i));
+    expect(screen.getByText('Concern text here')).toBeInTheDocument();
+  });
+
+  it('shows empty state', () => {
+    render(<ConcernQueueWidget field={{ key: 'x', data: { items: [], total: 0 } }} />);
+    expect(screen.getByText(/no concerns/i)).toBeInTheDocument();
+  });
+});
+
+// ── TextResponseListWidget ────────────────────────────────────────────────────
+
+describe('TextResponseListWidget', () => {
+  const field = {
+    key: 'notes',
+    data: {
+      items: [
+        { reflection_id: 1, person_id: 1, period_end: '2026-06-14', text: 'Short note', is_read: false },
+      ],
+      total: 1,
+    },
+  };
+
+  it('renders text items', () => {
+    render(<TextResponseListWidget field={field} />);
+    expect(screen.getByText('Short note')).toBeInTheDocument();
+  });
+
+  it('shows response count', () => {
+    render(<TextResponseListWidget field={field} />);
+    expect(screen.getByText(/1 response/i)).toBeInTheDocument();
+  });
+});
+
+// ── ItemCloudWidget ───────────────────────────────────────────────────────────
+
+describe('ItemCloudWidget', () => {
+  const field = {
+    key: 'items',
+    data: {
+      items: [{ text: 'Creativity', count: 5 }, { text: 'Initiative', count: 2 }],
+      total_mentions: 7,
+    },
+  };
+
+  it('renders items as tags', () => {
+    render(<ItemCloudWidget field={field} />);
+    expect(screen.getByText(/creativity/i)).toBeInTheDocument();
+    expect(screen.getByText(/initiative/i)).toBeInTheDocument();
+  });
+});
+
+// ── RatingDistributionWidget ──────────────────────────────────────────────────
+
+describe('RatingDistributionWidget', () => {
+  const field = {
+    key: 'single',
+    data: {
+      mean: 3.5,
+      prior_mean: 3.0,
+      trend: 'up',
+      response_count: 4,
+      distribution: { '1': 0, '2': 0, '3': 2, '4': 2, '5': 0 },
+    },
+  };
+
+  it('shows mean', () => {
+    render(<RatingDistributionWidget field={field} />);
+    expect(screen.getByText('3.5')).toBeInTheDocument();
+  });
+});
+
+// ── RatingTableWidget ─────────────────────────────────────────────────────────
+
+describe('RatingTableWidget', () => {
+  const field = {
+    key: 'group',
+    data: {
+      categories: [
+        { key: 'morale', mean: 3.5, response_count: 5, distribution: {} },
+        { key: 'energy', mean: 2.8, response_count: 4, distribution: {} },
+      ],
+    },
+  };
+
+  it('renders category rows', () => {
+    render(<RatingTableWidget field={field} />);
+    expect(screen.getByText('morale')).toBeInTheDocument();
+    expect(screen.getByText('energy')).toBeInTheDocument();
+    expect(screen.getByText('3.50')).toBeInTheDocument();
+  });
+});
+
+// ── ChoiceBarChartWidget ──────────────────────────────────────────────────────
+
+describe('ChoiceBarChartWidget', () => {
+  const field = {
+    key: 'pick',
+    data: {
+      choices: [
+        { option: 'Option A', count: 5 },
+        { option: 'Option B', count: 3 },
+      ],
+      response_count: 8,
+    },
+  };
+
+  it('renders choices', () => {
+    render(<ChoiceBarChartWidget field={field} />);
+    expect(screen.getByText('Option A')).toBeInTheDocument();
+    expect(screen.getByText('Option B')).toBeInTheDocument();
+  });
+});
+
+// ── YesNoBreakdownWidget ──────────────────────────────────────────────────────
+
+describe('YesNoBreakdownWidget', () => {
+  const field = {
+    key: 'yn',
+    data: { yes_count: 6, no_count: 2, yes_pct: 0.75 },
+  };
+
+  it('shows yes and no counts', () => {
+    render(<YesNoBreakdownWidget field={field} />);
+    expect(screen.getByText(/Yes/)).toBeInTheDocument();
+    expect(screen.getByText(/No/)).toBeInTheDocument();
+    expect(screen.getByText(/75%/)).toBeInTheDocument();
+  });
+
+  it('shows empty state', () => {
+    render(<YesNoBreakdownWidget field={{ key: 'x', data: { yes_count: 0, no_count: 0, yes_pct: null } }} />);
+    expect(screen.getByText(/no responses/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/dashboards/widgetMap.js
+++ b/frontend/src/dashboards/widgetMap.js
@@ -1,0 +1,70 @@
+/**
+ * Maps dashboard_role values and generic field types to widget component names.
+ *
+ * Role-tagged fields get polished widgets; untagged fields get generic widgets.
+ * The widget components themselves live alongside this file.
+ *
+ * dashboard_role → widget name
+ * field type (no role) → widget name
+ */
+
+export const ROLE_WIDGET_MAP = {
+  primary_rating: 'RatingHeadlineWidget',
+  category_ratings: 'CategoryRadarWidget',
+  wins: 'HighlightFeedWidget',
+  improvements: 'ImprovementFeedWidget',
+  open_concern: 'ConcernQueueWidget',
+};
+
+export const TYPE_WIDGET_MAP = {
+  text: 'TextResponseListWidget',
+  textarea: 'TextResponseListWidget',
+  text_list: 'ItemCloudWidget',
+  single_rating: 'RatingDistributionWidget',
+  rating_group: 'RatingTableWidget',
+  single_choice: 'ChoiceBarChartWidget',
+  multiple_choice: 'ChoiceBarChartWidget',
+  yes_no: 'YesNoBreakdownWidget',
+  number: 'NumberSparklineWidget',
+  date: 'DateHistogramWidget',
+};
+
+/** Fields that should never be rendered in dashboards. */
+export const META_FIELD_TYPES = new Set(['section_header', 'instructions']);
+
+/**
+ * Given a field descriptor from the aggregation response, return the widget
+ * name to use. Returns null for meta fields.
+ *
+ * @param {{ type: string, dashboard_role?: string|null }} field
+ * @returns {string|null}
+ */
+export function resolveWidgetName(field) {
+  if (!field) return null;
+  if (META_FIELD_TYPES.has(field.type)) return null;
+  if (field.dashboard_role && ROLE_WIDGET_MAP[field.dashboard_role]) {
+    return ROLE_WIDGET_MAP[field.dashboard_role];
+  }
+  return TYPE_WIDGET_MAP[field.type] ?? 'TextResponseListWidget';
+}
+
+/**
+ * Partition fields into role-tagged (to show first) and generic (to show in
+ * a "More fields" disclosure).
+ *
+ * @param {Array} fields - array of { key, type, dashboard_role, data }
+ * @returns {{ tagged: Array, generic: Array }}
+ */
+export function partitionFields(fields) {
+  const tagged = [];
+  const generic = [];
+  for (const field of fields ?? []) {
+    if (META_FIELD_TYPES.has(field.type)) continue;
+    if (field.dashboard_role && ROLE_WIDGET_MAP[field.dashboard_role]) {
+      tagged.push(field);
+    } else {
+      generic.push(field);
+    }
+  }
+  return { tagged, generic };
+}

--- a/frontend/src/dashboards/widgets/CategoryRadarWidget.jsx
+++ b/frontend/src/dashboards/widgets/CategoryRadarWidget.jsx
@@ -1,0 +1,51 @@
+import { Minus, TrendingDown, TrendingUp } from 'lucide-react';
+
+function TrendIcon({ label }) {
+  if (label === 'up') return <TrendingUp className="inline h-3.5 w-3.5 text-emerald-500" aria-hidden />;
+  if (label === 'down') return <TrendingDown className="inline h-3.5 w-3.5 text-rose-500" aria-hidden />;
+  return <Minus className="inline h-3.5 w-3.5 text-gray-400" aria-hidden />;
+}
+
+/**
+ * CategoryRadarWidget — for dashboard_role: category_ratings (rating_group fields).
+ * Shows one row per category with mean, trend, and a mini bar.
+ */
+export default function CategoryRadarWidget({ field, label }) {
+  const categories = field?.data?.categories ?? [];
+  const scale = field?.scale ?? [1, 5];
+  const scaleMax = Array.isArray(scale) ? scale[scale.length - 1] : 5;
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-5">
+      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-4">
+        {label ?? field?.key}
+      </p>
+      {categories.length === 0 ? (
+        <p className="text-sm text-gray-400 dark:text-gray-500">No data yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {categories.map((cat) => {
+            const pct = cat.mean != null ? (cat.mean / scaleMax) * 100 : 0;
+            return (
+              <li key={cat.key} className="flex items-center gap-3">
+                <span className="w-28 shrink-0 text-sm text-gray-700 dark:text-gray-300 capitalize truncate">
+                  {cat.key}
+                </span>
+                <div className="flex-1 h-2.5 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
+                  <div
+                    className="h-full rounded-full bg-indigo-500"
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+                <span className="w-10 shrink-0 text-right text-sm font-semibold tabular-nums text-gray-800 dark:text-gray-200">
+                  {cat.mean != null ? cat.mean.toFixed(1) : '—'}
+                </span>
+                <TrendIcon label={cat.trend} />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/dashboards/widgets/ChoiceBarChartWidget.jsx
+++ b/frontend/src/dashboards/widgets/ChoiceBarChartWidget.jsx
@@ -1,0 +1,45 @@
+/**
+ * ChoiceBarChartWidget — generic widget for single_choice/multiple_choice fields.
+ */
+export default function ChoiceBarChartWidget({ field, label }) {
+  const choices = field?.data?.choices ?? [];
+  const total = field?.data?.response_count ?? 0;
+  const maxCount = choices.length > 0 ? choices[0].count : 1;
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-5">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          {label ?? field?.key}
+        </p>
+        <span className="text-xs text-gray-400 dark:text-gray-500">{total} response{total !== 1 ? 's' : ''}</span>
+      </div>
+      {choices.length === 0 ? (
+        <p className="text-sm text-gray-400 dark:text-gray-500">No data yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {choices.map((choice) => {
+            const pct = maxCount > 0 ? (choice.count / maxCount) * 100 : 0;
+            const pctOfTotal = total > 0 ? Math.round((choice.count / total) * 100) : 0;
+            return (
+              <li key={choice.option} className="flex items-center gap-2">
+                <span className="w-32 shrink-0 text-sm text-gray-700 dark:text-gray-300 truncate">
+                  {choice.option}
+                </span>
+                <div className="flex-1 h-2 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
+                  <div
+                    className="h-full rounded-full bg-violet-500"
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+                <span className="w-10 shrink-0 text-right text-xs tabular-nums text-gray-500 dark:text-gray-400">
+                  {pctOfTotal}%
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/dashboards/widgets/ConcernQueueWidget.jsx
+++ b/frontend/src/dashboards/widgets/ConcernQueueWidget.jsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+
+/**
+ * ConcernQueueWidget — for dashboard_role: open_concern (text/textarea fields).
+ * Shows unread concern queue; supervisors can expand to read full text.
+ */
+export default function ConcernQueueWidget({ field, label }) {
+  const items = field?.data?.items ?? [];
+  const [expanded, setExpanded] = useState(null);
+
+  const unread = items.filter((i) => !i.is_read).length;
+
+  return (
+    <div className="rounded-xl border border-rose-200 dark:border-rose-900/50 bg-rose-50/40 dark:bg-rose-950/20 p-5">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-rose-600 dark:text-rose-400">
+          {label ?? field?.key}
+        </p>
+        {unread > 0 && (
+          <span className="px-2 py-0.5 rounded-full bg-rose-100 dark:bg-rose-900/50 text-xs font-medium text-rose-700 dark:text-rose-300">
+            {unread} new
+          </span>
+        )}
+      </div>
+      {items.length === 0 ? (
+        <p className="text-sm text-gray-400 dark:text-gray-500">No concerns this period.</p>
+      ) : (
+        <ul className="space-y-2">
+          {items.map((item) => {
+            const isExpanded = expanded === item.reflection_id;
+            return (
+              <li
+                key={`${item.reflection_id}-${item.period_end}`}
+                className="rounded-lg border border-rose-200 dark:border-rose-900/40 bg-white dark:bg-gray-900/60 overflow-hidden"
+              >
+                <button
+                  type="button"
+                  className="w-full text-left px-3 py-2 flex items-center justify-between gap-2"
+                  onClick={() => setExpanded(isExpanded ? null : item.reflection_id)}
+                >
+                  <span className="text-xs text-gray-500 dark:text-gray-400">
+                    Person {item.person_id} · {item.period_end}
+                  </span>
+                  {isExpanded ? (
+                    <ChevronUp size={14} className="shrink-0 text-gray-400" />
+                  ) : (
+                    <ChevronDown size={14} className="shrink-0 text-gray-400" />
+                  )}
+                </button>
+                {isExpanded && (
+                  <div className="px-3 pb-3">
+                    <p className="text-sm text-gray-800 dark:text-gray-200 whitespace-pre-wrap">
+                      {item.text}
+                    </p>
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/dashboards/widgets/DateHistogramWidget.jsx
+++ b/frontend/src/dashboards/widgets/DateHistogramWidget.jsx
@@ -1,0 +1,28 @@
+/**
+ * DateHistogramWidget — generic widget for untagged date fields.
+ */
+export default function DateHistogramWidget({ field, label }) {
+  const data = field?.data ?? {};
+  const values = data.values ?? [];
+  const count = data.response_count ?? 0;
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-5">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          {label ?? field?.key}
+        </p>
+        <span className="text-xs text-gray-400 dark:text-gray-500">{count} response{count !== 1 ? 's' : ''}</span>
+      </div>
+      {values.length === 0 ? (
+        <p className="text-sm text-gray-400 dark:text-gray-500">No dates submitted yet.</p>
+      ) : (
+        <ul className="space-y-1 max-h-40 overflow-y-auto">
+          {values.slice(0, 20).map((v, i) => (
+            <li key={`${v}-${i}`} className="text-sm text-gray-700 dark:text-gray-300 tabular-nums">{v}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/dashboards/widgets/HighlightFeedWidget.jsx
+++ b/frontend/src/dashboards/widgets/HighlightFeedWidget.jsx
@@ -1,0 +1,47 @@
+/**
+ * HighlightFeedWidget — for dashboard_role: wins (text_list fields).
+ * Shows a frequency-weighted list of wins/highlights.
+ */
+export default function HighlightFeedWidget({ field, label }) {
+  const items = field?.data?.items ?? [];
+  const totalMentions = field?.data?.total_mentions ?? 0;
+  const maxCount = items.length > 0 ? items[0].count : 1;
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-5">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          {label ?? field?.key}
+        </p>
+        <span className="text-xs text-gray-400 dark:text-gray-500">{totalMentions} mentions</span>
+      </div>
+      {items.length === 0 ? (
+        <p className="text-sm text-gray-400 dark:text-gray-500">None submitted yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {items.slice(0, 10).map((item) => {
+            const pct = maxCount > 0 ? (item.count / maxCount) * 100 : 0;
+            return (
+              <li key={item.text} className="flex items-center gap-2">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between mb-0.5">
+                    <span className="text-sm text-gray-800 dark:text-gray-200 truncate">{item.text}</span>
+                    <span className="ml-2 shrink-0 text-xs text-emerald-600 dark:text-emerald-400 font-medium">
+                      ×{item.count}
+                    </span>
+                  </div>
+                  <div className="h-1 w-full rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-emerald-500"
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/dashboards/widgets/ImprovementFeedWidget.jsx
+++ b/frontend/src/dashboards/widgets/ImprovementFeedWidget.jsx
@@ -1,0 +1,47 @@
+/**
+ * ImprovementFeedWidget — for dashboard_role: improvements (text_list fields).
+ * Similar to HighlightFeedWidget but framed as growth areas.
+ */
+export default function ImprovementFeedWidget({ field, label }) {
+  const items = field?.data?.items ?? [];
+  const totalMentions = field?.data?.total_mentions ?? 0;
+  const maxCount = items.length > 0 ? items[0].count : 1;
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-5">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          {label ?? field?.key}
+        </p>
+        <span className="text-xs text-gray-400 dark:text-gray-500">{totalMentions} mentions</span>
+      </div>
+      {items.length === 0 ? (
+        <p className="text-sm text-gray-400 dark:text-gray-500">None submitted yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {items.slice(0, 10).map((item) => {
+            const pct = maxCount > 0 ? (item.count / maxCount) * 100 : 0;
+            return (
+              <li key={item.text} className="flex items-center gap-2">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between mb-0.5">
+                    <span className="text-sm text-gray-800 dark:text-gray-200 truncate">{item.text}</span>
+                    <span className="ml-2 shrink-0 text-xs text-amber-600 dark:text-amber-400 font-medium">
+                      ×{item.count}
+                    </span>
+                  </div>
+                  <div className="h-1 w-full rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-amber-500"
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/dashboards/widgets/ItemCloudWidget.jsx
+++ b/frontend/src/dashboards/widgets/ItemCloudWidget.jsx
@@ -1,0 +1,43 @@
+/**
+ * ItemCloudWidget — generic widget for untagged text_list fields.
+ * Shows frequency-weighted item cloud/list.
+ */
+export default function ItemCloudWidget({ field, label }) {
+  const items = field?.data?.items ?? [];
+  const total = field?.data?.total_mentions ?? 0;
+  const maxCount = items.length > 0 ? items[0].count : 1;
+
+  function fontSize(count) {
+    const pct = count / maxCount;
+    if (pct > 0.8) return 'text-base font-semibold';
+    if (pct > 0.5) return 'text-sm font-medium';
+    return 'text-xs';
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-5">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          {label ?? field?.key}
+        </p>
+        <span className="text-xs text-gray-400 dark:text-gray-500">{total} mentions</span>
+      </div>
+      {items.length === 0 ? (
+        <p className="text-sm text-gray-400 dark:text-gray-500">No items submitted yet.</p>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {items.map((item) => (
+            <span
+              key={item.text}
+              className={`px-2 py-1 rounded-full bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 ${fontSize(item.count)}`}
+              title={`${item.count} mention${item.count !== 1 ? 's' : ''}`}
+            >
+              {item.text}
+              <span className="ml-1 opacity-60">×{item.count}</span>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/dashboards/widgets/NumberSparklineWidget.jsx
+++ b/frontend/src/dashboards/widgets/NumberSparklineWidget.jsx
@@ -1,0 +1,43 @@
+/**
+ * NumberSparklineWidget — generic widget for untagged number fields.
+ */
+export default function NumberSparklineWidget({ field, label }) {
+  const data = field?.data ?? {};
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-5">
+      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3">
+        {label ?? field?.key}
+      </p>
+      {data.response_count === 0 ? (
+        <p className="text-sm text-gray-400 dark:text-gray-500">No responses yet.</p>
+      ) : (
+        <div className="flex gap-6 flex-wrap">
+          <div>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Mean</p>
+            <p className="text-2xl font-bold tabular-nums text-gray-900 dark:text-white">
+              {data.mean?.toFixed(1) ?? '—'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Min</p>
+            <p className="text-2xl font-bold tabular-nums text-gray-900 dark:text-white">
+              {data.min ?? '—'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Max</p>
+            <p className="text-2xl font-bold tabular-nums text-gray-900 dark:text-white">
+              {data.max ?? '—'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Responses</p>
+            <p className="text-2xl font-bold tabular-nums text-gray-900 dark:text-white">
+              {data.response_count}
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/dashboards/widgets/RatingDistributionWidget.jsx
+++ b/frontend/src/dashboards/widgets/RatingDistributionWidget.jsx
@@ -1,0 +1,48 @@
+import { Minus, TrendingDown, TrendingUp } from 'lucide-react';
+
+function TrendIcon({ label }) {
+  if (label === 'up') return <TrendingUp className="inline h-3.5 w-3.5 text-emerald-500" aria-hidden />;
+  if (label === 'down') return <TrendingDown className="inline h-3.5 w-3.5 text-rose-500" aria-hidden />;
+  return <Minus className="inline h-3.5 w-3.5 text-gray-400" aria-hidden />;
+}
+
+/**
+ * RatingDistributionWidget — generic widget for untagged single_rating fields.
+ * Shows a small bar chart of rating distribution.
+ */
+export default function RatingDistributionWidget({ field, label }) {
+  const data = field?.data ?? {};
+  const dist = data.distribution ?? {};
+  const entries = Object.entries(dist).sort((a, b) => Number(a[0]) - Number(b[0]));
+  const maxVal = Math.max(...entries.map(([, v]) => v), 1);
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-5">
+      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3">
+        {label ?? field?.key}
+      </p>
+      <div className="flex items-end gap-2 mb-3">
+        <span className="text-3xl font-bold tabular-nums text-gray-900 dark:text-white">
+          {data.mean != null ? data.mean.toFixed(1) : '—'}
+        </span>
+        <TrendIcon label={data.trend} />
+        <span className="text-xs text-gray-400 ml-auto">{data.response_count ?? 0} responses</span>
+      </div>
+      <div className="flex items-end gap-1 h-14">
+        {entries.map(([val, count]) => {
+          const pct = (count / maxVal) * 100;
+          return (
+            <div key={val} className="flex-1 flex flex-col items-center gap-0.5">
+              <div
+                className="w-full rounded-t bg-indigo-400 dark:bg-indigo-500 transition-all"
+                style={{ height: `${pct}%`, minHeight: count > 0 ? '4px' : '0' }}
+                title={`${val}: ${count}`}
+              />
+              <span className="text-xs text-gray-500 dark:text-gray-400">{val}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/dashboards/widgets/RatingHeadlineWidget.jsx
+++ b/frontend/src/dashboards/widgets/RatingHeadlineWidget.jsx
@@ -1,0 +1,45 @@
+import { Minus, TrendingDown, TrendingUp } from 'lucide-react';
+
+function TrendIcon({ label }) {
+  if (label === 'up') return <TrendingUp className="inline h-5 w-5 text-emerald-500" aria-hidden />;
+  if (label === 'down') return <TrendingDown className="inline h-5 w-5 text-rose-500" aria-hidden />;
+  return <Minus className="inline h-5 w-5 text-gray-400" aria-hidden />;
+}
+
+/**
+ * RatingHeadlineWidget — for dashboard_role: primary_rating (single_rating fields).
+ * Displays a large number with trend arrow vs prior period.
+ */
+export default function RatingHeadlineWidget({ field, label }) {
+  const data = field?.data ?? {};
+  const mean = data.mean;
+  const priorMean = data.prior_mean;
+  const trend = data.trend ?? 'flat';
+  const scale = field?.scale ?? [1, 5];
+  const scaleMax = Array.isArray(scale) ? scale[scale.length - 1] : 5;
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-5">
+      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3">
+        {label ?? field?.key}
+      </p>
+      <div className="flex items-end gap-3">
+        <span className="text-5xl font-bold text-gray-900 dark:text-white tabular-nums">
+          {mean != null ? mean.toFixed(1) : '—'}
+        </span>
+        <span className="text-lg text-gray-400 dark:text-gray-500 mb-1">/ {scaleMax}</span>
+        <span className="mb-1">
+          <TrendIcon label={trend} />
+        </span>
+      </div>
+      {priorMean != null && (
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+          Prior period: {priorMean.toFixed(1)}
+        </p>
+      )}
+      <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+        {data.response_count ?? 0} response{data.response_count !== 1 ? 's' : ''}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/dashboards/widgets/RatingTableWidget.jsx
+++ b/frontend/src/dashboards/widgets/RatingTableWidget.jsx
@@ -1,0 +1,43 @@
+/**
+ * RatingTableWidget — generic widget for untagged rating_group fields.
+ * Rows = categories, summary of mean per category.
+ */
+export default function RatingTableWidget({ field, label }) {
+  const categories = field?.data?.categories ?? [];
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-5">
+      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3">
+        {label ?? field?.key}
+      </p>
+      {categories.length === 0 ? (
+        <p className="text-sm text-gray-400 dark:text-gray-500">No data yet.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="text-xs text-gray-500 dark:text-gray-400">
+                <th className="text-left pb-2 font-medium">Category</th>
+                <th className="text-right pb-2 font-medium">Mean</th>
+                <th className="text-right pb-2 font-medium">Responses</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+              {categories.map((cat) => (
+                <tr key={cat.key}>
+                  <td className="py-1.5 text-gray-700 dark:text-gray-300 capitalize">{cat.key}</td>
+                  <td className="py-1.5 text-right font-medium tabular-nums text-gray-900 dark:text-white">
+                    {cat.mean != null ? cat.mean.toFixed(2) : '—'}
+                  </td>
+                  <td className="py-1.5 text-right tabular-nums text-gray-500 dark:text-gray-400">
+                    {cat.response_count}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/dashboards/widgets/TextResponseListWidget.jsx
+++ b/frontend/src/dashboards/widgets/TextResponseListWidget.jsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+
+/**
+ * TextResponseListWidget — generic widget for untagged text/textarea fields.
+ * Shows recent responses, truncated, click to expand.
+ */
+export default function TextResponseListWidget({ field, label }) {
+  const items = field?.data?.items ?? [];
+  const total = field?.data?.total ?? 0;
+  const [expanded, setExpanded] = useState(null);
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-5">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          {label ?? field?.key}
+        </p>
+        <span className="text-xs text-gray-400 dark:text-gray-500">{total} response{total !== 1 ? 's' : ''}</span>
+      </div>
+      {items.length === 0 ? (
+        <p className="text-sm text-gray-400 dark:text-gray-500">No responses this period.</p>
+      ) : (
+        <ul className="space-y-2">
+          {items.map((item, i) => {
+            const key = `${item.reflection_id ?? i}-${item.period_end}`;
+            const isExpanded = expanded === key;
+            const preview = item.text.length > 120 ? `${item.text.slice(0, 120)}…` : item.text;
+            return (
+              <li
+                key={key}
+                className="rounded-lg border border-gray-100 dark:border-gray-800 px-3 py-2"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-sm text-gray-800 dark:text-gray-200 flex-1 whitespace-pre-wrap">
+                    {isExpanded ? item.text : preview}
+                  </p>
+                  {item.text.length > 120 && (
+                    <button
+                      type="button"
+                      onClick={() => setExpanded(isExpanded ? null : key)}
+                      className="shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 mt-0.5"
+                      aria-label={isExpanded ? 'Collapse' : 'Expand'}
+                    >
+                      {isExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                    </button>
+                  )}
+                </div>
+                <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">{item.period_end}</p>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/dashboards/widgets/YesNoBreakdownWidget.jsx
+++ b/frontend/src/dashboards/widgets/YesNoBreakdownWidget.jsx
@@ -1,0 +1,52 @@
+/**
+ * YesNoBreakdownWidget — generic widget for yes_no fields.
+ * Shows donut-style count + yes/no breakdown.
+ */
+export default function YesNoBreakdownWidget({ field, label }) {
+  const data = field?.data ?? {};
+  const yes = data.yes_count ?? 0;
+  const no = data.no_count ?? 0;
+  const total = yes + no;
+  const yesPct = total > 0 ? Math.round((yes / total) * 100) : null;
+  const noPct = total > 0 ? 100 - yesPct : null;
+
+  const yesDeg = total > 0 ? (yes / total) * 360 : 0;
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-5">
+      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-4">
+        {label ?? field?.key}
+      </p>
+      {total === 0 ? (
+        <p className="text-sm text-gray-400 dark:text-gray-500">No responses yet.</p>
+      ) : (
+        <div className="flex items-center gap-6">
+          {/* Simple donut via conic-gradient */}
+          <div
+            className="shrink-0 w-16 h-16 rounded-full"
+            style={{
+              background: `conic-gradient(#10b981 0deg ${yesDeg}deg, #f43f5e ${yesDeg}deg 360deg)`,
+            }}
+            aria-label={`${yesPct}% Yes, ${noPct}% No`}
+          />
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded-full bg-emerald-500 shrink-0" />
+              <span className="text-sm text-gray-700 dark:text-gray-300">
+                Yes — <strong className="tabular-nums">{yes}</strong>
+                {yesPct != null && <span className="text-gray-400 ml-1">({yesPct}%)</span>}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded-full bg-rose-500 shrink-0" />
+              <span className="text-sm text-gray-700 dark:text-gray-300">
+                No — <strong className="tabular-nums">{no}</strong>
+                {noPct != null && <span className="text-gray-400 ml-1">({noPct}%)</span>}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/dashboards/widgets/index.js
+++ b/frontend/src/dashboards/widgets/index.js
@@ -1,0 +1,13 @@
+export { default as RatingHeadlineWidget } from './RatingHeadlineWidget';
+export { default as CategoryRadarWidget } from './CategoryRadarWidget';
+export { default as HighlightFeedWidget } from './HighlightFeedWidget';
+export { default as ImprovementFeedWidget } from './ImprovementFeedWidget';
+export { default as ConcernQueueWidget } from './ConcernQueueWidget';
+export { default as TextResponseListWidget } from './TextResponseListWidget';
+export { default as ItemCloudWidget } from './ItemCloudWidget';
+export { default as RatingDistributionWidget } from './RatingDistributionWidget';
+export { default as RatingTableWidget } from './RatingTableWidget';
+export { default as ChoiceBarChartWidget } from './ChoiceBarChartWidget';
+export { default as YesNoBreakdownWidget } from './YesNoBreakdownWidget';
+export { default as NumberSparklineWidget } from './NumberSparklineWidget';
+export { default as DateHistogramWidget } from './DateHistogramWidget';

--- a/frontend/src/pages/TeamDashboardPage.jsx
+++ b/frontend/src/pages/TeamDashboardPage.jsx
@@ -1,68 +1,48 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Minus, TrendingDown, TrendingUp } from 'lucide-react';
-
+import api from '../api';
 import Header from '../partials/Header';
 import Sidebar from '../partials/Sidebar';
-import api from '../api';
+import TemplateDashboard from '../dashboards/TemplateDashboard';
 
-function trendIcon(label) {
-  if (label === 'up') {
-    return <TrendingUp className="inline h-4 w-4 text-emerald-600 dark:text-emerald-400" aria-hidden />;
-  }
-  if (label === 'down') {
-    return <TrendingDown className="inline h-4 w-4 text-rose-600 dark:text-rose-400" aria-hidden />;
-  }
-  return <Minus className="inline h-4 w-4 text-gray-400" aria-hidden />;
-}
-
-function pct(n) {
-  if (n == null || Number.isNaN(n)) return '—';
-  return `${Math.round(n * 1000) / 10}%`;
-}
-
+/**
+ * TeamDashboardPage — Leadership Team dashboard.
+ *
+ * Fetches all active templates with role=leadership_team for the current org,
+ * lets the user pick one, then renders TemplateDashboard for that template.
+ */
 export default function TeamDashboardPage() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [payload, setPayload] = useState(null);
-  const [yearRoundOnly, setYearRoundOnly] = useState(false);
-  const [periodEnd, setPeriodEnd] = useState(() => {
-    const d = new Date();
-    const y = d.getFullYear();
-    const m = String(d.getMonth() + 1).padStart(2, '0');
-    const day = String(d.getDate()).padStart(2, '0');
-    return `${y}-${m}-${day}`;
-  });
+  const [templates, setTemplates] = useState([]);
+  const [selectedId, setSelectedId] = useState(null);
+  const [loadingTemplates, setLoadingTemplates] = useState(true);
+  const [templatesError, setTemplatesError] = useState(null);
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
+  const loadTemplates = useCallback(async () => {
+    setLoadingTemplates(true);
+    setTemplatesError(null);
     try {
-      const { data } = await api.get('/api/v1/dashboards/team/', {
-        params: {
-          period_end: periodEnd,
-          period_days: 14,
-          year_round_only: yearRoundOnly ? 'true' : 'false',
-        },
+      const { data } = await api.get('/api/v1/templates/', {
+        params: { is_active: 'true' },
       });
-      setPayload(data);
+      const list = Array.isArray(data) ? data : (data.results ?? []);
+      const ltTemplates = list.filter((t) => t.role === 'leadership_team');
+      setTemplates(ltTemplates);
+      if (ltTemplates.length > 0) setSelectedId(ltTemplates[0].id);
     } catch (e) {
       const status = e.response?.status;
-      if (status === 403) {
-        setError('access');
-      } else {
-        setError(e.response?.data?.detail || e.message || 'Failed to load dashboard');
-      }
-      setPayload(null);
+      if (status === 403) setTemplatesError('access');
+      else setTemplatesError(e.response?.data?.detail || 'Failed to load templates');
     } finally {
-      setLoading(false);
+      setLoadingTemplates(false);
     }
-  }, [periodEnd, yearRoundOnly]);
+  }, []);
 
   useEffect(() => {
-    load();
-  }, [load]);
+    loadTemplates();
+  }, [loadTemplates]);
+
+  const selected = templates.find((t) => t.id === selectedId);
 
   return (
     <div className="flex h-screen overflow-hidden">
@@ -70,53 +50,24 @@ export default function TeamDashboardPage() {
       <div className="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
         <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
         <main className="grow px-4 sm:px-6 lg:px-8 py-8 w-full max-w-9xl mx-auto">
-          <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-            <div>
-              <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Unit health</h1>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-                Leadership view of reflection completion and themes (multi-tenant programs).
-              </p>
-            </div>
-            <div className="flex flex-wrap items-center gap-4">
-              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-                <span>Period ends</span>
-                <input
-                  type="date"
-                  value={periodEnd}
-                  onChange={(ev) => setPeriodEnd(ev.target.value)}
-                  className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
-                />
-              </label>
-              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={yearRoundOnly}
-                  onChange={(ev) => setYearRoundOnly(ev.target.checked)}
-                  className="rounded border-gray-300 dark:border-gray-600"
-                />
-                Year-round staff only
-              </label>
-              <button
-                type="button"
-                onClick={load}
-                className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500"
-              >
-                Refresh
-              </button>
-            </div>
+          <div className="mb-6">
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Unit health</h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              Leadership team reflection dashboard. Select a template to view aggregated data.
+            </p>
           </div>
 
-          {loading && (
-            <p className="text-gray-600 dark:text-gray-400">Loading…</p>
+          {loadingTemplates && (
+            <p className="text-gray-500 dark:text-gray-400 text-sm">Loading templates…</p>
           )}
 
-          {!loading && error === 'access' && (
+          {!loadingTemplates && templatesError === 'access' && (
             <div className="rounded-lg border border-amber-200 dark:border-amber-900/40 bg-amber-50 dark:bg-amber-900/20 p-4 text-amber-900 dark:text-amber-100">
               <p className="font-medium">Access restricted</p>
               <p className="text-sm mt-1">
-                This dashboard requires a multi-tenant <strong>admin</strong> or <strong>leadership_team</strong>{' '}
-                program membership, or an account with the <strong>Admin</strong> staff role. If you need access,
-                ask an administrator to adjust memberships in Django admin.
+                This dashboard requires a multi-tenant <strong>admin</strong> or{' '}
+                <strong>leadership_team</strong> program membership, or an account with the{' '}
+                <strong>Admin</strong> staff role.
               </p>
               <Link to="/dashboard" className="text-sm underline mt-2 inline-block">
                 Back to dashboard
@@ -124,111 +75,43 @@ export default function TeamDashboardPage() {
             </div>
           )}
 
-          {!loading && error && error !== 'access' && (
-            <p className="text-rose-600 dark:text-rose-400">{error}</p>
+          {!loadingTemplates && templatesError && templatesError !== 'access' && (
+            <p className="text-rose-600 dark:text-rose-400 text-sm">{templatesError}</p>
           )}
 
-          {!loading && payload && (
+          {!loadingTemplates && !templatesError && templates.length === 0 && (
+            <p className="text-gray-500 dark:text-gray-400 text-sm">
+              No active leadership team templates found.
+            </p>
+          )}
+
+          {!loadingTemplates && templates.length > 0 && (
             <>
-              <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
-                Window: {payload.period?.current_start} → {payload.period?.current_end} (prior:{' '}
-                {payload.period?.prior_start} → {payload.period?.prior_end})
-              </p>
-
-              <section className="mb-10">
-                <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-3">Unit overview</h2>
-                <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
-                  <table className="min-w-full text-sm">
-                    <thead className="bg-gray-50 dark:bg-gray-800/80">
-                      <tr>
-                        <th className="text-left px-3 py-2 font-medium">Unit</th>
-                        <th className="text-left px-3 py-2 font-medium">Program</th>
-                        <th className="text-right px-3 py-2 font-medium">Staff</th>
-                        <th className="text-right px-3 py-2 font-medium">Submitted</th>
-                        <th className="text-right px-3 py-2 font-medium">Completion</th>
-                        <th className="text-center px-3 py-2 font-medium">Comp. trend</th>
-                        <th className="text-left px-3 py-2 font-medium">Category averages</th>
-                        <th className="text-center px-3 py-2 font-medium">Rating trend</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
-                      {(payload.units || []).map((u) => (
-                        <tr key={`${u.program_slug}-${u.unit_slug}`} className="bg-white dark:bg-gray-900/40">
-                          <td className="px-3 py-2 font-medium text-gray-900 dark:text-white">{u.unit_slug}</td>
-                          <td className="px-3 py-2 text-gray-600 dark:text-gray-300">{u.program_slug}</td>
-                          <td className="px-3 py-2 text-right">{u.total_staff}</td>
-                          <td className="px-3 py-2 text-right">{u.reflections_submitted}</td>
-                          <td className="px-3 py-2 text-right">{pct(u.completion_rate)}</td>
-                          <td className="px-3 py-2 text-center">
-                            {trendIcon(u.completion_trend)}
-                            <span className="sr-only">{u.completion_trend}</span>
-                          </td>
-                          <td className="px-3 py-2 text-gray-600 dark:text-gray-300 text-xs">
-                            {Object.keys(u.category_averages || {}).length === 0
-                              ? '—'
-                              : Object.entries(u.category_averages)
-                                  .map(([k, v]) => `${k}: ${v}`)
-                                  .join(', ')}
-                          </td>
-                          <td className="px-3 py-2 text-center">
-                            {trendIcon(u.rating_trend)}
-                            <span className="sr-only">{u.rating_trend}</span>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                  {(payload.units || []).length === 0 && (
-                    <p className="p-4 text-gray-500 dark:text-gray-400 text-sm">
-                      No units with staff assignments in scope for this filter.
-                    </p>
-                  )}
+              {templates.length > 1 && (
+                <div className="mb-6 flex items-center gap-3">
+                  <label className="text-sm text-gray-700 dark:text-gray-300">Template</label>
+                  <select
+                    value={selectedId ?? ''}
+                    onChange={(e) => setSelectedId(Number(e.target.value))}
+                    className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm"
+                    aria-label="Select template"
+                  >
+                    {templates.map((t) => (
+                      <option key={t.id} value={t.id}>{t.name}</option>
+                    ))}
+                  </select>
                 </div>
-              </section>
+              )}
 
-              <section className="mb-10">
-                <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
-                  Concerning ratings (≤2)
-                </h2>
-                <ul className="space-y-2 text-sm">
-                  {(payload.concerning || []).map((c, i) => (
-                    <li
-                      key={`${c.reflection_id}-${c.field_key}-${c.category}-${i}`}
-                      className="rounded-md border border-rose-200 dark:border-rose-900/50 bg-rose-50/50 dark:bg-rose-950/30 px-3 py-2"
-                    >
-                      <span className="font-medium text-rose-800 dark:text-rose-200">
-                        {c.unit_slug} · {c.category} = {c.value}
-                      </span>
-                      <span className="text-gray-600 dark:text-gray-400 ml-2">
-                        person {c.person_id} · {c.period_end}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-                {(payload.concerning || []).length === 0 && (
-                  <p className="text-gray-500 dark:text-gray-400 text-sm">None in this period.</p>
-                )}
-              </section>
-
-              <section>
-                <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-3">Open questions / concerns</h2>
-                <ul className="space-y-2 text-sm">
-                  {(payload.open_questions || []).map((q) => (
-                    <li
-                      key={`${q.reflection_id}-${q.field_key}`}
-                      className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 px-3 py-2"
-                    >
-                      <p className="text-gray-500 dark:text-gray-400 text-xs mb-1">
-                        {q.unit_slug} · {q.field_key} · {q.period_end}
-                      </p>
-                      <p className="text-gray-800 dark:text-gray-200 whitespace-pre-wrap">{q.text}</p>
-                    </li>
-                  ))}
-                </ul>
-                {(payload.open_questions || []).length === 0 && (
-                  <p className="text-gray-500 dark:text-gray-400 text-sm">None captured in this period.</p>
-                )}
-              </section>
+              {selectedId && (
+                <TemplateDashboard
+                  key={selectedId}
+                  templateId={selectedId}
+                  title={selected?.name}
+                  subtitle="Leadership team aggregated reflections"
+                  accentColor="indigo"
+                />
+              )}
             </>
           )}
         </main>

--- a/frontend/src/pages/TeamDashboardPage.test.jsx
+++ b/frontend/src/pages/TeamDashboardPage.test.jsx
@@ -6,66 +6,74 @@ import TeamDashboardPage from './TeamDashboardPage';
 const getMock = vi.fn();
 
 vi.mock('../api', () => ({
-  default: {
-    get: (...args) => getMock(...args),
-  },
+  default: { get: (...args) => getMock(...args) },
 }));
 
 vi.mock('../auth/AuthContext', () => ({
   useAuth: () => ({ user: null }),
 }));
 
-const samplePayload = {
-  period: {
-    current_start: '2026-06-01',
-    current_end: '2026-06-14',
-    prior_start: '2026-05-18',
-    prior_end: '2026-05-31',
-  },
-  year_round_only: false,
-  units: [
-    {
-      unit_slug: 'alef',
-      program_slug: 'summer',
-      total_staff: 2,
-      reflections_submitted: 1,
-      completion_rate: 0.5,
-      prior_completion_rate: 0.25,
-      completion_trend: 'up',
-      category_averages: { morale: 3 },
-      prior_category_averages: { morale: 2 },
-      rating_trend: 'up',
-    },
-  ],
-  concerning: [],
-  open_questions: [],
-};
+// Stub TemplateDashboard to avoid deep mock chains
+vi.mock('../dashboards/TemplateDashboard', () => ({
+  default: ({ templateId }) => (
+    <div data-testid="template-dashboard">template-{templateId}</div>
+  ),
+}));
+
+const ltTemplate = { id: 7, name: 'LT Weekly', slug: 'lt-weekly', role: 'leadership_team', is_active: true };
 
 describe('TeamDashboardPage', () => {
   beforeEach(() => {
     getMock.mockReset();
-    getMock.mockResolvedValue({ data: samplePayload });
   });
 
-  it('loads dashboard and shows unit row', async () => {
+  it('loads templates and renders TemplateDashboard', async () => {
+    getMock.mockResolvedValueOnce({ data: [ltTemplate] });
     render(
       <MemoryRouter>
         <TeamDashboardPage />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(getMock).toHaveBeenCalled());
-    expect(screen.getByText('Unit health')).toBeInTheDocument();
-    await waitFor(() => expect(screen.getByText('alef')).toBeInTheDocument());
-    expect(screen.getByText('summer')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('template-dashboard')).toBeInTheDocument());
+    expect(screen.getByText('template-7')).toBeInTheDocument();
   });
 
-  it('shows access message on 403', async () => {
+  it('shows access restricted on 403', async () => {
     getMock.mockRejectedValueOnce({ response: { status: 403 } });
     render(
       <MemoryRouter>
         <TeamDashboardPage />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(screen.getByText(/Access restricted/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/access restricted/i)).toBeInTheDocument());
+  });
+
+  it('shows message when no LT templates exist', async () => {
+    getMock.mockResolvedValueOnce({ data: [] });
+    render(
+      <MemoryRouter>
+        <TeamDashboardPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/no active leadership team templates/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('filters to leadership_team role only', async () => {
+    getMock.mockResolvedValueOnce({
+      data: [
+        ltTemplate,
+        { id: 99, name: 'Wellness Daily', slug: 'wl', role: 'camper_care', is_active: true },
+      ],
+    });
+    render(
+      <MemoryRouter>
+        <TeamDashboardPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByTestId('template-dashboard')).toBeInTheDocument());
+    expect(screen.getByText('template-7')).toBeInTheDocument();
+    expect(screen.queryByText('template-99')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/WellnessDashboardPage.jsx
+++ b/frontend/src/pages/WellnessDashboardPage.jsx
@@ -1,77 +1,50 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Minus, TrendingDown, TrendingUp } from 'lucide-react';
-
+import api from '../api';
 import Header from '../partials/Header';
 import Sidebar from '../partials/Sidebar';
-import api from '../api';
+import TemplateDashboard from '../dashboards/TemplateDashboard';
 
-const SUB_ROLE_LABELS = {
-  camper_care: 'Camper Care',
-  health_center: 'Health Center',
-  special_diets: 'Special Diets',
-};
+const WELLNESS_ROLES = new Set(['camper_care', 'health_center', 'special_diets', 'wellness']);
 
-function trendIcon(label) {
-  if (label === 'up') {
-    return <TrendingUp className="inline h-4 w-4 text-emerald-600 dark:text-emerald-400" aria-hidden />;
-  }
-  if (label === 'down') {
-    return <TrendingDown className="inline h-4 w-4 text-rose-600 dark:text-rose-400" aria-hidden />;
-  }
-  return <Minus className="inline h-4 w-4 text-gray-400" aria-hidden />;
-}
-
-function pct(n) {
-  if (n == null || Number.isNaN(n)) return '—';
-  return `${Math.round(n * 1000) / 10}%`;
-}
-
-function todayIso() {
-  const d = new Date();
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
-}
-
+/**
+ * WellnessDashboardPage — Wellness team dashboard.
+ *
+ * Fetches all active templates with a wellness-type role for the current org,
+ * lets the user pick one, then renders TemplateDashboard for that template.
+ */
 export default function WellnessDashboardPage() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [payload, setPayload] = useState(null);
-  const [subRole, setSubRole] = useState('');
-  const [periodEnd, setPeriodEnd] = useState(todayIso);
+  const [templates, setTemplates] = useState([]);
+  const [selectedId, setSelectedId] = useState(null);
+  const [loadingTemplates, setLoadingTemplates] = useState(true);
+  const [templatesError, setTemplatesError] = useState(null);
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
+  const loadTemplates = useCallback(async () => {
+    setLoadingTemplates(true);
+    setTemplatesError(null);
     try {
-      const params = {
-        period_end: periodEnd,
-        period_days: 14,
-      };
-      if (subRole) params.sub_role = subRole;
-      const { data } = await api.get('/api/v1/dashboards/wellness/', { params });
-      setPayload(data);
+      const { data } = await api.get('/api/v1/templates/', {
+        params: { is_active: 'true' },
+      });
+      const list = Array.isArray(data) ? data : (data.results ?? []);
+      const wellnessTemplates = list.filter((t) => WELLNESS_ROLES.has(t.role));
+      setTemplates(wellnessTemplates);
+      if (wellnessTemplates.length > 0) setSelectedId(wellnessTemplates[0].id);
     } catch (e) {
       const status = e.response?.status;
-      if (status === 403) {
-        setError('access');
-      } else {
-        setError(e.response?.data?.detail || e.message || 'Failed to load wellness dashboard');
-      }
-      setPayload(null);
+      if (status === 403) setTemplatesError('access');
+      else setTemplatesError(e.response?.data?.detail || 'Failed to load templates');
     } finally {
-      setLoading(false);
+      setLoadingTemplates(false);
     }
-  }, [periodEnd, subRole]);
+  }, []);
 
   useEffect(() => {
-    load();
-  }, [load]);
+    loadTemplates();
+  }, [loadTemplates]);
 
-  const totals = useMemo(() => payload?.completion ?? null, [payload]);
+  const selected = templates.find((t) => t.id === selectedId);
 
   return (
     <div className="flex h-screen overflow-hidden">
@@ -79,53 +52,18 @@ export default function WellnessDashboardPage() {
       <div className="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
         <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
         <main className="grow px-4 sm:px-6 lg:px-8 py-8 w-full max-w-9xl mx-auto">
-          <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-            <div>
-              <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Wellness team</h1>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-                Camper Care, Health Center, and Special Diets reflections, with cross-team patterns
-                surfaced from other staff feedback.
-              </p>
-            </div>
-            <div className="flex flex-wrap items-center gap-4">
-              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-                <span>Sub-role</span>
-                <select
-                  value={subRole}
-                  onChange={(ev) => setSubRole(ev.target.value)}
-                  className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
-                  aria-label="Filter by wellness sub-role"
-                >
-                  <option value="">All wellness roles</option>
-                  <option value="camper_care">Camper Care</option>
-                  <option value="health_center">Health Center</option>
-                  <option value="special_diets">Special Diets</option>
-                </select>
-              </label>
-              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-                <span>Period ends</span>
-                <input
-                  type="date"
-                  value={periodEnd}
-                  onChange={(ev) => setPeriodEnd(ev.target.value)}
-                  className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
-                />
-              </label>
-              <button
-                type="button"
-                onClick={load}
-                className="rounded-md bg-teal-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-teal-500"
-              >
-                Refresh
-              </button>
-            </div>
+          <div className="mb-6">
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Wellness team</h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              Camper Care, Health Center, and Special Diets reflection dashboard.
+            </p>
           </div>
 
-          {loading && (
-            <p className="text-gray-600 dark:text-gray-400">Loading…</p>
+          {loadingTemplates && (
+            <p className="text-gray-500 dark:text-gray-400 text-sm">Loading templates…</p>
           )}
 
-          {!loading && error === 'access' && (
+          {!loadingTemplates && templatesError === 'access' && (
             <div className="rounded-lg border border-amber-200 dark:border-amber-900/40 bg-amber-50 dark:bg-amber-900/20 p-4 text-amber-900 dark:text-amber-100">
               <p className="font-medium">Access restricted</p>
               <p className="text-sm mt-1">
@@ -140,179 +78,43 @@ export default function WellnessDashboardPage() {
             </div>
           )}
 
-          {!loading && error && error !== 'access' && (
-            <p className="text-rose-600 dark:text-rose-400">{error}</p>
+          {!loadingTemplates && templatesError && templatesError !== 'access' && (
+            <p className="text-rose-600 dark:text-rose-400 text-sm">{templatesError}</p>
           )}
 
-          {!loading && payload && (
-            <>
-              <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
-                Window: {payload.period?.current_start} → {payload.period?.current_end} (prior:{' '}
-                {payload.period?.prior_start} → {payload.period?.prior_end})
-              </p>
+          {!loadingTemplates && !templatesError && templates.length === 0 && (
+            <p className="text-gray-500 dark:text-gray-400 text-sm">
+              No active wellness team templates found.
+            </p>
+          )}
 
-              {totals && (
-                <section className="mb-8 grid grid-cols-1 sm:grid-cols-3 gap-4">
-                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-4">
-                    <p className="text-xs uppercase text-gray-500 dark:text-gray-400">Wellness staff</p>
-                    <p className="text-2xl font-semibold text-gray-900 dark:text-white">
-                      {totals.total_staff}
-                    </p>
-                  </div>
-                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-4">
-                    <p className="text-xs uppercase text-gray-500 dark:text-gray-400">Reflections submitted</p>
-                    <p className="text-2xl font-semibold text-gray-900 dark:text-white">
-                      {totals.reflections_submitted}
-                    </p>
-                  </div>
-                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-4">
-                    <p className="text-xs uppercase text-gray-500 dark:text-gray-400">Completion rate</p>
-                    <p className="text-2xl font-semibold text-gray-900 dark:text-white">
-                      {pct(totals.completion_rate)}
-                    </p>
-                  </div>
-                </section>
+          {!loadingTemplates && templates.length > 0 && (
+            <>
+              {templates.length > 1 && (
+                <div className="mb-6 flex items-center gap-3">
+                  <label className="text-sm text-gray-700 dark:text-gray-300">Template</label>
+                  <select
+                    value={selectedId ?? ''}
+                    onChange={(e) => setSelectedId(Number(e.target.value))}
+                    className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm"
+                    aria-label="Select template"
+                  >
+                    {templates.map((t) => (
+                      <option key={t.id} value={t.id}>{t.name}</option>
+                    ))}
+                  </select>
+                </div>
               )}
 
-              <section className="mb-10">
-                <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
-                  Reflections by sub-role
-                </h2>
-                <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
-                  <table className="min-w-full text-sm">
-                    <thead className="bg-gray-50 dark:bg-gray-800/80">
-                      <tr>
-                        <th className="text-left px-3 py-2 font-medium">Sub-role</th>
-                        <th className="text-left px-3 py-2 font-medium">Program</th>
-                        <th className="text-right px-3 py-2 font-medium">Staff</th>
-                        <th className="text-right px-3 py-2 font-medium">Submitted</th>
-                        <th className="text-right px-3 py-2 font-medium">Completion</th>
-                        <th className="text-center px-3 py-2 font-medium">Comp. trend</th>
-                        <th className="text-left px-3 py-2 font-medium">Category averages</th>
-                        <th className="text-center px-3 py-2 font-medium">Rating trend</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
-                      {(payload.by_sub_role || []).map((row) => (
-                        <tr
-                          key={`${row.program_slug}-${row.role}`}
-                          className="bg-white dark:bg-gray-900/40"
-                        >
-                          <td className="px-3 py-2 font-medium text-gray-900 dark:text-white">
-                            {SUB_ROLE_LABELS[row.role] || row.role}
-                          </td>
-                          <td className="px-3 py-2 text-gray-600 dark:text-gray-300">{row.program_slug}</td>
-                          <td className="px-3 py-2 text-right">{row.total_staff}</td>
-                          <td className="px-3 py-2 text-right">{row.reflections_submitted}</td>
-                          <td className="px-3 py-2 text-right">{pct(row.completion_rate)}</td>
-                          <td className="px-3 py-2 text-center">
-                            {trendIcon(row.completion_trend)}
-                            <span className="sr-only">{row.completion_trend}</span>
-                          </td>
-                          <td className="px-3 py-2 text-gray-600 dark:text-gray-300 text-xs">
-                            {Object.keys(row.category_averages || {}).length === 0
-                              ? '—'
-                              : Object.entries(row.category_averages)
-                                  .map(([k, v]) => `${k}: ${v}`)
-                                  .join(', ')}
-                          </td>
-                          <td className="px-3 py-2 text-center">
-                            {trendIcon(row.rating_trend)}
-                            <span className="sr-only">{row.rating_trend}</span>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                  {(payload.by_sub_role || []).length === 0 && (
-                    <p className="p-4 text-gray-500 dark:text-gray-400 text-sm">
-                      No wellness staff in scope for this filter.
-                    </p>
-                  )}
-                </div>
-              </section>
-
-              <section className="mb-10">
-                <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
-                  Concerning ratings (≤2)
-                </h2>
-                <ul className="space-y-2 text-sm">
-                  {(payload.by_sub_role || [])
-                    .flatMap((row) =>
-                      (row.concerning || []).map((c) => ({ ...c, role: row.role })),
-                    )
-                    .map((c, i) => (
-                      <li
-                        key={`${c.reflection_id}-${c.field_key}-${c.category}-${i}`}
-                        className="rounded-md border border-rose-200 dark:border-rose-900/50 bg-rose-50/50 dark:bg-rose-950/30 px-3 py-2"
-                      >
-                        <span className="font-medium text-rose-800 dark:text-rose-200">
-                          {SUB_ROLE_LABELS[c.role] || c.role} · {c.category} = {c.value}
-                        </span>
-                        <span className="text-gray-600 dark:text-gray-400 ml-2">
-                          person {c.person_id} · {c.period_end}
-                        </span>
-                      </li>
-                    ))}
-                </ul>
-                {((payload.by_sub_role || []).flatMap((r) => r.concerning || []).length === 0) && (
-                  <p className="text-gray-500 dark:text-gray-400 text-sm">None in this period.</p>
-                )}
-              </section>
-
-              <section className="mb-10">
-                <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
-                  Cross-team patterns
-                </h2>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
-                  Concerns flagged in non-wellness reflections that mention wellness, camper care,
-                  health center, or special diets.
-                </p>
-                <ul className="space-y-2 text-sm">
-                  {(payload.cross_team_patterns || []).map((p, i) => (
-                    <li
-                      key={`${p.reflection_id}-${p.field_key}-${i}`}
-                      className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 px-3 py-2"
-                    >
-                      <p className="text-gray-500 dark:text-gray-400 text-xs mb-1">
-                        {p.template_role || p.template_slug} · {p.field_key} · {p.period_end}
-                      </p>
-                      <p className="text-gray-800 dark:text-gray-200 whitespace-pre-wrap">{p.text}</p>
-                    </li>
-                  ))}
-                </ul>
-                {(payload.cross_team_patterns || []).length === 0 && (
-                  <p className="text-gray-500 dark:text-gray-400 text-sm">
-                    No wellness mentions surfaced in other teams' reflections this period.
-                  </p>
-                )}
-              </section>
-
-              <section>
-                <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
-                  Open questions / concerns
-                </h2>
-                <ul className="space-y-2 text-sm">
-                  {(payload.by_sub_role || [])
-                    .flatMap((row) =>
-                      (row.open_questions || []).map((oq) => ({ ...oq, role: row.role })),
-                    )
-                    .map((q) => (
-                      <li
-                        key={`${q.reflection_id}-${q.field_key}`}
-                        className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 px-3 py-2"
-                      >
-                        <p className="text-gray-500 dark:text-gray-400 text-xs mb-1">
-                          {SUB_ROLE_LABELS[q.role] || q.role} · {q.field_key} · {q.period_end}
-                        </p>
-                        <p className="text-gray-800 dark:text-gray-200 whitespace-pre-wrap">{q.text}</p>
-                      </li>
-                    ))}
-                </ul>
-                {((payload.by_sub_role || []).flatMap((r) => r.open_questions || []).length === 0) && (
-                  <p className="text-gray-500 dark:text-gray-400 text-sm">None captured in this period.</p>
-                )}
-              </section>
+              {selectedId && (
+                <TemplateDashboard
+                  key={selectedId}
+                  templateId={selectedId}
+                  title={selected?.name}
+                  subtitle="Wellness team aggregated reflections"
+                  accentColor="teal"
+                />
+              )}
             </>
           )}
         </main>

--- a/frontend/src/pages/WellnessDashboardPage.test.jsx
+++ b/frontend/src/pages/WellnessDashboardPage.test.jsx
@@ -1,158 +1,78 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import userEvent from '@testing-library/user-event';
 import WellnessDashboardPage from './WellnessDashboardPage';
 
 const getMock = vi.fn();
 
 vi.mock('../api', () => ({
-  default: {
-    get: (...args) => getMock(...args),
-  },
+  default: { get: (...args) => getMock(...args) },
 }));
 
 vi.mock('../auth/AuthContext', () => ({
   useAuth: () => ({ user: null }),
 }));
 
-const samplePayload = {
-  period: {
-    current_start: '2026-06-01',
-    current_end: '2026-06-14',
-    prior_start: '2026-05-18',
-    prior_end: '2026-05-31',
-  },
-  sub_role_filter: null,
-  by_sub_role: [
-    {
-      role: 'camper_care',
-      program_slug: 'summer',
-      total_staff: 2,
-      reflections_submitted: 1,
-      completion_rate: 0.5,
-      prior_completion_rate: 0.25,
-      completion_trend: 'up',
-      category_averages: { workload: 3, morale: 4 },
-      prior_category_averages: { workload: 2, morale: 3 },
-      rating_trend: 'up',
-      concerning: [
-        {
-          reflection_id: 7,
-          person_id: 11,
-          field_key: 'pulse',
-          category: 'workload',
-          value: 1,
-          period_end: '2026-06-14',
-        },
-      ],
-      open_questions: [
-        {
-          reflection_id: 7,
-          person_id: 11,
-          field_key: 'primary_concern',
-          period_end: '2026-06-14',
-          text: 'Need backup at meds line',
-        },
-      ],
-    },
-    {
-      role: 'health_center',
-      program_slug: 'summer',
-      total_staff: 1,
-      reflections_submitted: 0,
-      completion_rate: 0,
-      prior_completion_rate: 0,
-      completion_trend: 'flat',
-      category_averages: {},
-      prior_category_averages: {},
-      rating_trend: 'flat',
-      concerning: [],
-      open_questions: [],
-    },
-    {
-      role: 'special_diets',
-      program_slug: 'summer',
-      total_staff: 0,
-      reflections_submitted: 0,
-      completion_rate: 0,
-      prior_completion_rate: 0,
-      completion_trend: 'flat',
-      category_averages: {},
-      prior_category_averages: {},
-      rating_trend: 'flat',
-      concerning: [],
-      open_questions: [],
-    },
-  ],
-  cross_team_patterns: [
-    {
-      reflection_id: 33,
-      person_id: 99,
-      program_slug: 'summer',
-      field_key: 'primary_concern',
-      template_slug: 'counselor-pulse',
-      template_role: 'counselor',
-      period_end: '2026-06-12',
-      text: 'Camper Aviva needs Camper Care follow-up.',
-    },
-  ],
-  completion: {
-    total_staff: 3,
-    reflections_submitted: 1,
-    completion_rate: 0.3333,
-    by_sub_role: [
-      { role: 'camper_care', program_slug: 'summer', total_staff: 2, reflections_submitted: 1, completion_rate: 0.5 },
-      { role: 'health_center', program_slug: 'summer', total_staff: 1, reflections_submitted: 0, completion_rate: 0 },
-      { role: 'special_diets', program_slug: 'summer', total_staff: 0, reflections_submitted: 0, completion_rate: 0 },
-    ],
-  },
-};
+vi.mock('../dashboards/TemplateDashboard', () => ({
+  default: ({ templateId }) => (
+    <div data-testid="template-dashboard">template-{templateId}</div>
+  ),
+}));
+
+const wellnessTemplate = { id: 12, name: 'Wellness Daily', slug: 'wellness-daily', role: 'camper_care', is_active: true };
 
 describe('WellnessDashboardPage', () => {
   beforeEach(() => {
     getMock.mockReset();
-    getMock.mockResolvedValue({ data: samplePayload });
   });
 
-  it('loads dashboard and shows sub-role rows and cross-team patterns', async () => {
+  it('loads templates and renders TemplateDashboard for wellness role', async () => {
+    getMock.mockResolvedValueOnce({ data: [wellnessTemplate] });
     render(
       <MemoryRouter>
         <WellnessDashboardPage />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(getMock).toHaveBeenCalled());
-    expect(screen.getByRole('heading', { name: /Wellness team/i, level: 1 })).toBeInTheDocument();
-    // Each sub-role appears at least twice (dropdown option + table row)
-    await waitFor(() => expect(screen.getAllByText('Camper Care').length).toBeGreaterThanOrEqual(2));
-    expect(screen.getAllByText('Health Center').length).toBeGreaterThanOrEqual(2);
-    expect(screen.getAllByText('Special Diets').length).toBeGreaterThanOrEqual(2);
-    expect(screen.getByText(/Camper Aviva needs Camper Care follow-up/i)).toBeInTheDocument();
-    expect(screen.getByText(/Need backup at meds line/i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('template-dashboard')).toBeInTheDocument());
+    expect(screen.getByText('template-12')).toBeInTheDocument();
   });
 
-  it('passes sub_role param when filter is set', async () => {
-    const user = userEvent.setup();
-    render(
-      <MemoryRouter>
-        <WellnessDashboardPage />
-      </MemoryRouter>,
-    );
-    await waitFor(() => expect(getMock).toHaveBeenCalled());
-    getMock.mockClear();
-    await user.selectOptions(screen.getByLabelText(/Filter by wellness sub-role/i), 'health_center');
-    await waitFor(() => expect(getMock).toHaveBeenCalled());
-    const lastCall = getMock.mock.calls.at(-1);
-    expect(lastCall?.[1]?.params?.sub_role).toBe('health_center');
-  });
-
-  it('shows access message on 403', async () => {
+  it('shows access restricted on 403', async () => {
     getMock.mockRejectedValueOnce({ response: { status: 403 } });
     render(
       <MemoryRouter>
         <WellnessDashboardPage />
       </MemoryRouter>,
     );
-    await waitFor(() => expect(screen.getByText(/Access restricted/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/access restricted/i)).toBeInTheDocument());
+  });
+
+  it('shows message when no wellness templates found', async () => {
+    getMock.mockResolvedValueOnce({ data: [] });
+    render(
+      <MemoryRouter>
+        <WellnessDashboardPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/no active wellness team templates/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('filters to wellness roles only', async () => {
+    getMock.mockResolvedValueOnce({
+      data: [
+        wellnessTemplate,
+        { id: 5, name: 'LT Weekly', slug: 'lt-weekly', role: 'leadership_team', is_active: true },
+      ],
+    });
+    render(
+      <MemoryRouter>
+        <WellnessDashboardPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByTestId('template-dashboard')).toBeInTheDocument());
+    expect(screen.getByText('template-12')).toBeInTheDocument();
+    expect(screen.queryByText('template-5')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/admin/templates/TemplateEditorPage.jsx
+++ b/frontend/src/pages/admin/templates/TemplateEditorPage.jsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { ArrowLeft, ChevronDown, Plus, X, AlertTriangle } from 'lucide-react';
+import { ArrowLeft, BarChart2, ChevronDown, Plus, X, AlertTriangle } from 'lucide-react';
 import api from '../../../api';
 import FieldList from '../../../components/templates/FieldList';
 import FieldInspector from '../../../components/templates/FieldInspector';
 import FieldTypePicker from '../../../components/templates/FieldTypePicker';
 import LivePreview from '../../../components/templates/LivePreview';
+import DashboardPreviewModal from '../../../dashboards/DashboardPreviewModal';
 
 /* ── helpers ─────────────────────────────────────────────────── */
 
@@ -171,6 +172,7 @@ export default function TemplateEditorPage() {
   const [selectedFieldId, setSelectedFieldId] = useState(null);
   const [showTypePicker, setShowTypePicker] = useState(false);
   const [showAddLang, setShowAddLang] = useState(false);
+  const [showDashPreview, setShowDashPreview] = useState(false);
   const [saving, setSaving] = useState(false);
   const [validationErrors, setValidationErrors] = useState([]);
   const [toast, setToast] = useState('');
@@ -388,6 +390,17 @@ export default function TemplateEditorPage() {
 
             <button
               type="button"
+              onClick={() => setShowDashPreview(true)}
+              className="px-3 py-1.5 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-sm font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 flex items-center gap-1.5 transition-colors"
+              aria-label="Preview dashboard"
+              data-testid="dash-preview-btn"
+            >
+              <BarChart2 size={14} />
+              Dashboard
+            </button>
+
+            <button
+              type="button"
               onClick={() => handleSave(false)}
               disabled={!dirty || saving}
               className="px-4 py-1.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
@@ -484,6 +497,14 @@ export default function TemplateEditorPage() {
           existing={languages}
           onAdd={addLanguage}
           onClose={() => setShowAddLang(false)}
+        />
+      )}
+
+      {showDashPreview && (
+        <DashboardPreviewModal
+          schemaFields={fields}
+          language={language}
+          onClose={() => setShowDashPreview(false)}
         />
       )}
 

--- a/frontend/src/pages/admin/templates/__tests__/TemplateEditorPage.test.jsx
+++ b/frontend/src/pages/admin/templates/__tests__/TemplateEditorPage.test.jsx
@@ -259,6 +259,25 @@ describe('TemplateEditorPage', () => {
     });
   });
 
+  it('dashboard preview button opens preview modal with synthetic data', async () => {
+    renderEditor();
+    await waitFor(() => screen.getByTestId('dash-preview-btn'));
+    await userEvent.click(screen.getByTestId('dash-preview-btn'));
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: /dashboard preview/i })).toBeInTheDocument();
+    });
+    expect(screen.getByText(/synthetic sample data/i)).toBeInTheDocument();
+  });
+
+  it('dashboard preview modal can be closed', async () => {
+    renderEditor();
+    await waitFor(() => screen.getByTestId('dash-preview-btn'));
+    await userEvent.click(screen.getByTestId('dash-preview-btn'));
+    await waitFor(() => screen.getByRole('dialog', { name: /dashboard preview/i }));
+    await userEvent.click(screen.getByRole('button', { name: /close preview/i }));
+    expect(screen.queryByRole('dialog', { name: /dashboard preview/i })).not.toBeInTheDocument();
+  });
+
   it('field deletion removes field from list', async () => {
     renderEditor();
     await waitFor(() => screen.getAllByRole('option'));


### PR DESCRIPTION
## Summary

- Backend: new aggregation endpoint GET /api/v1/dashboards/template/{id}/ and CSV export GET .../export/; per-field aggregators for all schema types with prior-period trends; permission-scoped by template role
- Frontend: new frontend/src/dashboards/ package — widgetMap.js, 5 role-tagged widgets (RatingHeadlineWidget, CategoryRadarWidget, HighlightFeedWidget, ImprovementFeedWidget, ConcernQueueWidget), 8 generic fallback widgets, TemplateDashboard component
- Refactored TeamDashboardPage and WellnessDashboardPage to use TemplateDashboard (template-API-driven) instead of heuristic aggregation
- Dashboard preview modal in TemplateEditorPage with synthetic sample data
- docs/dashboards.md documents role-to-widget contract and extension guide
- 409 backend + 123 frontend tests passing; build succeeds

## Test plan

- [ ] All tests pass
- [ ] /team/dashboard and /wellness/dashboard load and render widgets
- [ ] Template editor Dashboard button opens preview modal
- [ ] Permission scoping works (403 for wrong role, 404 for missing)
- [ ] CSV export downloads correctly

Made with [Cursor](https://cursor.com)