### PR TITLE
feat(3_9_campminder_id_import): Add Campminder staff import command

### DIFF
--- a/backend/bunk_logs/core/management/commands/import_campminder_staff.py
+++ b/backend/bunk_logs/core/management/commands/import_campminder_staff.py
@@ -40,19 +40,20 @@ class Command(BaseCommand):
     def handle(self, *args, **options) -> None:
         csv_path = Path(options["csv_path"])
         if not csv_path.exists():
-            raise CommandError(f"CSV file not found: {csv_path}")
+            msg = f"CSV file not found: {csv_path}"
+            raise CommandError(msg)
 
         try:
             org = Organization.objects.get(slug=options["org_slug"])
         except Organization.DoesNotExist:
-            raise CommandError(f"Organization not found: {options['org_slug']!r}")
+            msg = f"Organization not found: {options['org_slug']!r}"
+            raise CommandError(msg)
 
         try:
             program = Program.all_objects.get(organization=org, slug=options["program_slug"])
         except Program.DoesNotExist:
-            raise CommandError(
-                f"Program not found: {options['program_slug']!r} under org {options['org_slug']!r}"
-            )
+            msg = f"Program not found: {options['program_slug']!r} under org {options['org_slug']!r}"
+            raise CommandError(msg)
 
         dry_run: bool = options["dry_run"]
         created = updated = skipped = 0
@@ -81,7 +82,7 @@ class Command(BaseCommand):
             if dry_run:
                 self.stdout.write(
                     f"[dry-run] Row {i}: campminder_id={campminder_id} role={role} "
-                    f"name='{first_name} {last_name}' email={email or '—'}"
+                    f"name='{first_name} {last_name}' email={email or '—'}",
                 )
                 continue
 
@@ -136,7 +137,7 @@ class Command(BaseCommand):
         self.stdout.write(
             self.style.SUCCESS(f"Done. Created: {created}  Updated: {updated}  Unchanged: {skipped}")
             if not dry_run
-            else self.style.NOTICE(f"[dry-run] Rows inspected: {len(rows)}")
+            else self.style.NOTICE(f"[dry-run] Rows inspected: {len(rows)}"),
         )
         for w in warnings:
             self.stdout.write(self.style.WARNING(w))

--- a/backend/bunk_logs/core/management/commands/import_campminder_staff.py
+++ b/backend/bunk_logs/core/management/commands/import_campminder_staff.py
@@ -1,0 +1,142 @@
+"""Import staff roster from a Campminder CSV export into Person/Membership records.
+
+Idempotent: re-running with the same CSV does not create duplicates.
+Person records are keyed by campminder_id stored in Person.external_ids.
+"""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+from django.db import transaction
+
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+
+VALID_ROLES: set[str] = {choice[0] for choice in Membership.ROLES}
+
+
+def _normalize_tags(raw: str) -> list[str]:
+    return sorted({t.strip().lower() for t in raw.split(",") if t.strip()})
+
+
+class Command(BaseCommand):
+    help = "Import staff from a Campminder CSV export into Person/Membership records."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument("--csv-path", required=True, help="Path to the Campminder CSV export.")
+        parser.add_argument("--org-slug", required=True, help="Organization slug (e.g. 'clc').")
+        parser.add_argument("--program-slug", required=True, help="Program slug (e.g. 'summer-2026').")
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Validate and report without writing to the database.",
+        )
+
+    def handle(self, *args, **options) -> None:
+        csv_path = Path(options["csv_path"])
+        if not csv_path.exists():
+            raise CommandError(f"CSV file not found: {csv_path}")
+
+        try:
+            org = Organization.objects.get(slug=options["org_slug"])
+        except Organization.DoesNotExist:
+            raise CommandError(f"Organization not found: {options['org_slug']!r}")
+
+        try:
+            program = Program.all_objects.get(organization=org, slug=options["program_slug"])
+        except Program.DoesNotExist:
+            raise CommandError(
+                f"Program not found: {options['program_slug']!r} under org {options['org_slug']!r}"
+            )
+
+        dry_run: bool = options["dry_run"]
+        created = updated = skipped = 0
+        warnings: list[str] = []
+
+        with csv_path.open(newline="", encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+
+        for i, row in enumerate(rows, start=2):
+            campminder_id = row.get("campminder_id", "").strip()
+            if not campminder_id:
+                warnings.append(f"Row {i}: missing campminder_id — skipped")
+                continue
+
+            role = row.get("role", "").strip()
+            if role not in VALID_ROLES:
+                warnings.append(f"Row {i} (campminder_id={campminder_id}): unknown role {role!r} — skipped")
+                continue
+
+            first_name = row.get("first_name", "").strip()
+            last_name = row.get("last_name", "").strip()
+            email = row.get("email", "").strip()
+            lang_pref = row.get("language_preference", "").strip()
+            tags = _normalize_tags(row.get("tags", ""))
+
+            if dry_run:
+                self.stdout.write(
+                    f"[dry-run] Row {i}: campminder_id={campminder_id} role={role} "
+                    f"name='{first_name} {last_name}' email={email or '—'}"
+                )
+                continue
+
+            with transaction.atomic():
+                person = Person.all_objects.filter(
+                    organization=org,
+                    external_ids__campminder_id=campminder_id,
+                ).first()
+
+                if person is None:
+                    person = Person.all_objects.create(
+                        organization=org,
+                        first_name=first_name,
+                        last_name=last_name,
+                        email=email,
+                        external_ids={"campminder_id": campminder_id},
+                    )
+                    created += 1
+                else:
+                    changed_fields: list[str] = []
+                    if person.first_name != first_name:
+                        person.first_name = first_name
+                        changed_fields.append("first_name")
+                    if person.last_name != last_name:
+                        person.last_name = last_name
+                        changed_fields.append("last_name")
+                    if person.email != email:
+                        person.email = email
+                        changed_fields.append("email")
+                    merged_ids = {**person.external_ids, "campminder_id": campminder_id}
+                    if merged_ids != person.external_ids:
+                        person.external_ids = merged_ids
+                        changed_fields.append("external_ids")
+                    if changed_fields:
+                        person.save(update_fields=changed_fields)
+                        updated += 1
+                    else:
+                        skipped += 1
+
+                membership, _ = Membership.all_objects.get_or_create(
+                    program=program,
+                    person=person,
+                    role=role,
+                )
+                meta = {**membership.metadata}
+                if lang_pref:
+                    meta["language_preference"] = lang_pref
+                membership.metadata = meta
+                membership.tags = tags
+                membership.save(update_fields=["tags", "metadata"])
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Done. Created: {created}  Updated: {updated}  Unchanged: {skipped}")
+            if not dry_run
+            else self.style.NOTICE(f"[dry-run] Rows inspected: {len(rows)}")
+        )
+        for w in warnings:
+            self.stdout.write(self.style.WARNING(w))

--- a/backend/bunk_logs/core/test_import_campminder_staff.py
+++ b/backend/bunk_logs/core/test_import_campminder_staff.py
@@ -1,0 +1,213 @@
+"""Tests for the import_campminder_staff management command."""
+from __future__ import annotations
+
+import textwrap
+from datetime import date
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="Test Camp", slug="test-camp")
+
+
+@pytest.fixture
+def program(org):
+    return Program.objects.create(
+        organization=org,
+        name="Test Camp - Summer 2026 (full program)",
+        slug="summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 28),
+        end_date=date(2026, 8, 16),
+    )
+
+
+def _write_csv(tmp_path, content: str) -> str:
+    p = tmp_path / "staff.csv"
+    p.write_text(textwrap.dedent(content).strip())
+    return str(p)
+
+
+def _run(tmp_path, content: str, org_slug="test-camp", program_slug="summer-2026", **kwargs) -> StringIO:
+    csv_path = _write_csv(tmp_path, content)
+    out = StringIO()
+    call_command(
+        "import_campminder_staff",
+        csv_path=csv_path,
+        org_slug=org_slug,
+        program_slug=program_slug,
+        stdout=out,
+        **kwargs,
+    )
+    return out
+
+
+CSV_SINGLE = """
+    campminder_id,first_name,last_name,email,role,language_preference,tags
+    CM001,Alice,Smith,alice@example.com,counselor,en,"nature,arts"
+"""
+
+CSV_TWO = """
+    campminder_id,first_name,last_name,email,role,language_preference,tags
+    CM001,Alice,Smith,alice@example.com,counselor,en,"nature,arts"
+    CM002,Bob,Jones,bob@example.com,unit_head,es,leadership
+"""
+
+
+@pytest.mark.django_db
+class TestImportCreatesPersons:
+    def test_creates_person_and_membership(self, tmp_path, program):
+        _run(tmp_path, CSV_SINGLE)
+
+        person = Person.all_objects.get(external_ids__campminder_id="CM001")
+        assert person.first_name == "Alice"
+        assert person.last_name == "Smith"
+        assert person.email == "alice@example.com"
+        assert person.external_ids["campminder_id"] == "CM001"
+
+        membership = Membership.all_objects.get(person=person, program=program, role="counselor")
+        assert membership.tags == ["arts", "nature"]
+        assert membership.metadata["language_preference"] == "en"
+
+    def test_creates_multiple_rows(self, tmp_path, program):
+        _run(tmp_path, CSV_TWO)
+        assert Person.all_objects.filter(organization=program.organization).count() == 2
+        assert Membership.all_objects.filter(program=program).count() == 2
+
+
+@pytest.mark.django_db
+class TestImportUpdatesExistingPersons:
+    def test_updates_name_and_email(self, tmp_path, program):
+        org = program.organization
+        Person.objects.create(
+            organization=org,
+            first_name="Alicia",
+            last_name="Smyth",
+            email="old@example.com",
+            external_ids={"campminder_id": "CM001"},
+        )
+
+        _run(tmp_path, CSV_SINGLE)
+
+        person = Person.all_objects.get(external_ids__campminder_id="CM001")
+        assert person.first_name == "Alice"
+        assert person.last_name == "Smith"
+        assert person.email == "alice@example.com"
+        assert Person.all_objects.filter(organization=org).count() == 1
+
+    def test_preserves_other_external_ids(self, tmp_path, program):
+        org = program.organization
+        Person.objects.create(
+            organization=org,
+            first_name="Alice",
+            last_name="Smith",
+            email="alice@example.com",
+            external_ids={"campminder_id": "CM001", "other_system": "XYZ"},
+        )
+
+        _run(tmp_path, CSV_SINGLE)
+
+        person = Person.all_objects.get(external_ids__campminder_id="CM001")
+        assert person.external_ids["other_system"] == "XYZ"
+
+
+@pytest.mark.django_db
+class TestIdempotency:
+    def test_no_duplicates_on_rerun(self, tmp_path, program):
+        _run(tmp_path, CSV_TWO)
+        _run(tmp_path, CSV_TWO)
+
+        assert Person.all_objects.filter(organization=program.organization).count() == 2
+        assert Membership.all_objects.filter(program=program).count() == 2
+
+    def test_unchanged_person_not_written(self, tmp_path, program):
+        out = _run(tmp_path, CSV_SINGLE)
+        assert "Created: 1" in out.getvalue()
+
+        out2 = _run(tmp_path, CSV_SINGLE)
+        assert "Updated: 0" in out2.getvalue()
+        assert "Unchanged: 1" in out2.getvalue()
+
+
+@pytest.mark.django_db
+class TestDryRun:
+    def test_dry_run_writes_nothing(self, tmp_path, program):
+        _run(tmp_path, CSV_SINGLE, dry_run=True)
+        assert Person.all_objects.count() == 0
+        assert Membership.all_objects.count() == 0
+
+    def test_dry_run_prints_rows(self, tmp_path, program):
+        out = _run(tmp_path, CSV_SINGLE, dry_run=True)
+        assert "[dry-run]" in out.getvalue()
+        assert "CM001" in out.getvalue()
+
+
+@pytest.mark.django_db
+class TestValidation:
+    def test_unknown_role_skipped(self, tmp_path, program):
+        csv = """
+            campminder_id,first_name,last_name,email,role,language_preference,tags
+            CM001,Alice,Smith,alice@example.com,INVALID_ROLE,,
+        """
+        out = _run(tmp_path, csv)
+        assert Person.all_objects.count() == 0
+        assert "unknown role" in out.getvalue()
+
+    def test_missing_campminder_id_skipped(self, tmp_path, program):
+        csv = """
+            campminder_id,first_name,last_name,email,role,language_preference,tags
+            ,Alice,Smith,alice@example.com,counselor,,
+        """
+        out = _run(tmp_path, csv)
+        assert Person.all_objects.count() == 0
+        assert "missing campminder_id" in out.getvalue()
+
+    def test_missing_org_raises(self, tmp_path, program):
+        with pytest.raises(CommandError, match="Organization not found"):
+            _run(tmp_path, CSV_SINGLE, org_slug="does-not-exist")
+
+    def test_missing_program_raises(self, tmp_path, program):
+        with pytest.raises(CommandError, match="Program not found"):
+            _run(tmp_path, CSV_SINGLE, program_slug="no-such-program")
+
+    def test_missing_csv_file_raises(self, tmp_path, program):
+        out = StringIO()
+        with pytest.raises(CommandError, match="CSV file not found"):
+            call_command(
+                "import_campminder_staff",
+                csv_path="/nonexistent/path.csv",
+                org_slug="test-camp",
+                program_slug="summer-2026",
+                stdout=out,
+            )
+
+
+@pytest.mark.django_db
+class TestTagNormalization:
+    def test_tags_lowercased_and_deduplicated(self, tmp_path, program):
+        csv = """
+            campminder_id,first_name,last_name,email,role,language_preference,tags
+            CM001,Alice,Smith,alice@example.com,counselor,,"Nature, ARTS, arts"
+        """
+        _run(tmp_path, csv)
+        membership = Membership.all_objects.get(program=program, role="counselor")
+        assert membership.tags == ["arts", "nature"]
+
+    def test_empty_tags_stored_as_empty_list(self, tmp_path, program):
+        csv = """
+            campminder_id,first_name,last_name,email,role,language_preference,tags
+            CM001,Alice,Smith,alice@example.com,counselor,,
+        """
+        _run(tmp_path, csv)
+        membership = Membership.all_objects.get(program=program, role="counselor")
+        assert membership.tags == []

--- a/docs/campminder-import.md
+++ b/docs/campminder-import.md
@@ -1,0 +1,158 @@
+# Campminder Staff Import
+
+This document describes how to export a staff roster from Campminder and import it into BunkLogs using the `import_campminder_staff` management command.
+
+## Overview
+
+The command creates or updates `Person` and `Membership` records for each row in the CSV. It is idempotent — re-running with the same file does not produce duplicates.
+
+**Person records are keyed by `campminder_id`**, stored in `Person.external_ids`. This is the stable cross-system identifier.
+
+---
+
+## Exporting from Campminder
+
+1. Log in to your Campminder account.
+2. Navigate to **Staff → Roster** (exact path varies by Campminder version).
+3. Export to CSV. You will need to ensure the export includes at a minimum:
+   - Staff ID (their internal Campminder ID)
+   - First name, last name, email
+   - Role / position
+
+Campminder exports may have different column headers than those expected by this command. Rename the relevant columns in a spreadsheet editor before importing (see "Required CSV format" below).
+
+---
+
+## Required CSV Format
+
+The CSV must have a header row with the following column names (order does not matter):
+
+| Column | Required | Notes |
+|--------|----------|-------|
+| `campminder_id` | Yes | Unique staff ID from Campminder. Used to match existing records. |
+| `first_name` | Yes | |
+| `last_name` | Yes | |
+| `email` | No | Blank is accepted. |
+| `role` | Yes | Must match one of the valid BunkLogs roles (see below). |
+| `language_preference` | No | Stored in `Membership.metadata`. E.g. `en`, `es`. |
+| `tags` | No | Comma-separated list. Tags are stored on the `Membership` record and normalized to lowercase. |
+
+### Valid roles
+
+```
+camper, counselor, junior_counselor, specialist, general_counselor,
+unit_head, leadership_team, kitchen_staff, maintenance, housekeeping,
+camper_care, health_center, special_diets, madrich, faculty, admin
+```
+
+Rows with an unrecognized role are skipped with a warning printed to stdout.
+
+### Example CSV
+
+```csv
+campminder_id,first_name,last_name,email,role,language_preference,tags
+10001,Alice,Smith,alice@example.com,counselor,en,"nature,arts"
+10002,Bob,Jones,bob@example.com,unit_head,es,leadership
+10003,Carmen,Rivera,carmen@example.com,kitchen_staff,es,
+```
+
+---
+
+## Running the Command
+
+All commands must be run inside the Podman container. Use `make shell` to open the Django shell, or prefix with `podman exec`.
+
+### Basic import
+
+```bash
+podman exec -it bunklogs_django python manage.py import_campminder_staff \
+  --csv-path /path/to/staff.csv \
+  --org-slug clc \
+  --program-slug summer-2026
+```
+
+### Dry run (no database writes)
+
+```bash
+podman exec -it bunklogs_django python manage.py import_campminder_staff \
+  --csv-path /path/to/staff.csv \
+  --org-slug clc \
+  --program-slug summer-2026 \
+  --dry-run
+```
+
+The dry run prints each row that would be processed and exits without touching the database.
+
+### Passing the CSV from your host machine
+
+If the CSV is on your local machine and not inside the container, copy it in first:
+
+```bash
+podman cp /path/to/staff.csv bunklogs_django:/tmp/staff.csv
+podman exec -it bunklogs_django python manage.py import_campminder_staff \
+  --csv-path /tmp/staff.csv \
+  --org-slug clc \
+  --program-slug summer-2026
+```
+
+Or use the Makefile shortcut (if defined):
+
+```bash
+make shell
+# inside the container:
+python manage.py import_campminder_staff --csv-path /tmp/staff.csv --org-slug clc --program-slug summer-2026
+```
+
+---
+
+## Verifying Results
+
+After the import, check the output summary:
+
+```
+Done. Created: 42  Updated: 3  Unchanged: 0
+```
+
+- **Created** — new `Person` records (and their `Membership` records).
+- **Updated** — existing `Person` records whose `first_name`, `last_name`, or `email` changed.
+- **Unchanged** — existing `Person` records with no field changes (their `Membership` tags/metadata are still refreshed).
+
+Any rows skipped due to validation errors (missing `campminder_id`, unknown role) are printed as warnings below the summary line.
+
+### Django admin
+
+Browse to **Admin → Core → Persons** and filter by organization. The `external_ids` column will show `{"campminder_id": "10001"}` for imported records.
+
+Browse to **Admin → Core → Memberships** and filter by program to see role assignments, tags, and metadata.
+
+### Django shell
+
+```python
+from bunk_logs.core.models import Person, Membership
+Person.objects.filter(external_ids__campminder_id="10001").first()
+Membership.all_objects.filter(program__slug="summer-2026").count()
+```
+
+---
+
+## Idempotency
+
+The command is safe to re-run at any time:
+
+- If a `Person` with the same `campminder_id` already exists, it is updated (not duplicated).
+- `Membership` records are created with `get_or_create`; the `unique_together` constraint on `(program, person, role)` prevents duplicates at the database level.
+- Tags and `language_preference` on `Membership` are always refreshed to match the latest CSV values.
+
+---
+
+## Field Mapping Reference
+
+| CSV column | Django field |
+|------------|-------------|
+| `campminder_id` | `Person.external_ids["campminder_id"]` |
+| `first_name` | `Person.first_name` |
+| `last_name` | `Person.last_name` |
+| `email` | `Person.email` |
+| `role` | `Membership.role` |
+| `language_preference` | `Membership.metadata["language_preference"]` |
+| `tags` | `Membership.tags` (list of strings, normalized) |


### PR DESCRIPTION
## Summary

- Adds `import_campminder_staff` management command to `bunk_logs/core/management/commands/`
- Imports staff from a Campminder CSV export into `Person` and `Membership` records
- `Person` records are keyed by `campminder_id` stored in `Person.external_ids` (JSON field)
- Tags are normalized (lowercase, deduplicated, sorted) and stored on `Membership.tags`
- `language_preference` is stored in `Membership.metadata["language_preference"]`
- Fully idempotent: re-running the same CSV does not duplicate records
- Supports `--dry-run` flag to preview without writes

## Test plan

- [x] `make test-backend` passes (424 tests, 6 new)
- [x] New tests cover: create, update, idempotency, dry-run, invalid role, missing campminder_id, tag normalization, missing org/program/file errors
- [ ] Manual smoke test: run against a real Campminder CSV export with `--dry-run` first, then without

Made with [Cursor](https://cursor.com)