### PR TITLE
fix(dashboard): detect 3_12 completion via artifact on main

### DIFF
--- a/backend/config/migration_views.py
+++ b/backend/config/migration_views.py
@@ -29,6 +29,7 @@ SKIP_FILES = {"prefix.md", "0_0_context_prompt.md"}
 # git log main will not mention the earlier step id — treat as done if these paths exist on main.
 STEP_COMPLETION_ARTIFACTS: dict[str, tuple[str, ...]] = {
     "1_5": ("docs/api-consolidation-plan.md",),
+    "3_12": ("backend/bunk_logs/core/management/commands/onboard_clc_summer_2026.py",),
 }
 
 


### PR DESCRIPTION
The commit that delivered 3.12 did not include the step number in its title, so the git-log scan misses it. Adding an artifact entry in `STEP_COMPLETION_ARTIFACTS` so the dashboard checks for the onboard command file's presence on `main` instead.

Made with [Cursor](https://cursor.com)