### PR TITLE
3_24_filed_privately_chip: visible "Filed privately" indicator on reflection surfaces

### DIFF
--- a/backend/bunk_logs/api/dashboards/concerns.py
+++ b/backend/bunk_logs/api/dashboards/concerns.py
@@ -144,6 +144,7 @@ class ConcernsInboxView(APIView):
                     "subject_name": r.subject.full_name if r.subject else None,
                     "author_name": r.author.full_name if r.author else None,
                     "template_name": r.template.name,
+                    "team_visibility": r.team_visibility,
                     "assignment_group": (
                         {"id": r.assignment_group_id, "name": r.assignment_group.name}
                         if r.assignment_group_id else None

--- a/backend/bunk_logs/api/dashboards/subject.py
+++ b/backend/bunk_logs/api/dashboards/subject.py
@@ -80,13 +80,13 @@ def _detect_concerning_patterns(
 ) -> list[dict[str, Any]]:
     """Two-rule detection: any rating==1 in last 14d, or recent half lower than prior half.
 
-    series_by_label[label] is a list of (date, value, reflection_id, scale_max).
+    series_by_label[label] is a list of (date, value, reflection_id, scale_max, team_visibility).
     """
     patterns: list[dict[str, Any]] = []
     low_cutoff = today - timedelta(days=LOW_RATING_LOOKBACK_DAYS - 1)
     for label, points in series_by_label.items():
         # Any rating of 1 in last 14 days
-        for d, v, ref_id, _scale in points:
+        for d, v, ref_id, _scale, team_visibility in points:
             if d >= low_cutoff and v is not None and v <= 1.0:
                 patterns.append({
                     "kind": "low_rating",
@@ -94,13 +94,14 @@ def _detect_concerning_patterns(
                     "date": d.isoformat(),
                     "value": v,
                     "reflection_id": ref_id,
+                    "team_visibility": team_visibility,
                 })
         # Downward trend: split last 14 days in half, require >=3 each
         recent_cutoff = today - timedelta(days=TREND_LOOKBACK_DAYS - 1)
         midpoint = today - timedelta(days=(TREND_LOOKBACK_DAYS // 2) - 1)
-        recent_vals = [v for d, v, _, _ in points if d >= midpoint and v is not None]
+        recent_vals = [v for d, v, *_ in points if d >= midpoint and v is not None]
         prior_vals = [
-            v for d, v, _, _ in points
+            v for d, v, *_ in points
             if recent_cutoff <= d < midpoint and v is not None
         ]
         if (
@@ -166,7 +167,7 @@ class SubjectDetailView(APIView):
         # Group by template
         by_template: dict[int, dict[str, Any]] = {}
         # series_by_label across ALL templates: used for concerning-pattern detection
-        all_series: dict[str, list[tuple[date, float, int, int | None]]] = defaultdict(list)
+        all_series: dict[str, list[tuple[date, float, int, int | None, str]]] = defaultdict(list)
         recent_texts: list[dict[str, Any]] = []
 
         for r in refs:
@@ -202,6 +203,7 @@ class SubjectDetailView(APIView):
                                 "text": v.strip()[:1000],
                                 "date": r.period_end.isoformat(),
                                 "author_name": r.author.full_name if r.author else None,
+                                "team_visibility": r.team_visibility,
                             })
                     continue
                 ratings = _resolve_rating(field, r.answers)
@@ -216,13 +218,17 @@ class SubjectDetailView(APIView):
                         "value": value,
                         "reflection_id": r.id,
                         "scale_max": scale_max,
+                        "team_visibility": r.team_visibility,
                     })
                     if value is not None:
-                        all_series[label].append((r.period_end, value, r.id, scale_max))
+                        all_series[label].append(
+                            (r.period_end, value, r.id, scale_max, r.team_visibility),
+                        )
             tpl_entry["reflections"].append({
                 "id": r.id,
                 "date": r.period_end.isoformat(),
                 "author_name": r.author.full_name if r.author else None,
+                "team_visibility": r.team_visibility,
                 "assignment_group": (
                     {"id": r.assignment_group_id, "name": r.assignment_group.name}
                     if r.assignment_group_id else None

--- a/backend/bunk_logs/api/dashboards/template.py
+++ b/backend/bunk_logs/api/dashboards/template.py
@@ -269,6 +269,7 @@ def _agg_text(field: dict, refs: list[Reflection]) -> dict[str, Any]:
                     "person_id": r.subject_id,
                     "period_end": r.period_end.isoformat(),
                     "text": v.strip()[:2000],
+                    "team_visibility": r.team_visibility,
                     "is_read": False,
                 },
             )

--- a/backend/bunk_logs/api/dashboards/trends.py
+++ b/backend/bunk_logs/api/dashboards/trends.py
@@ -203,6 +203,7 @@ class SubjectTrendGridView(APIView):
                     "reflection_id": r.id,
                     "author_id": r.author_id,
                     "author_name": r.author.full_name if r.author else None,
+                    "team_visibility": r.team_visibility,
                     "submitted_at": r.submitted_at,
                 }
 
@@ -222,6 +223,7 @@ class SubjectTrendGridView(APIView):
                     "reflection_id": c["reflection_id"] if c is not None else None,
                     "author_id": c["author_id"] if c is not None else None,
                     "author_name": c["author_name"] if c is not None else None,
+                    "team_visibility": c["team_visibility"] if c is not None else None,
                 })
             out_subjects.append({
                 "person_id": s["person_id"],

--- a/backend/bunk_logs/api/reflections.py
+++ b/backend/bunk_logs/api/reflections.py
@@ -575,7 +575,10 @@ class ReflectionViewSet(viewsets.ModelViewSet):
                 template=tpl,
                 program=prog,
                 period_end__gte=cutoff,
-            ).values("id", "period_start", "period_end", "submitted_at", "is_complete"),
+            ).values(
+                "id", "period_start", "period_end", "submitted_at",
+                "is_complete", "team_visibility",
+            ),
         )
 
         history = []
@@ -590,6 +593,7 @@ class ReflectionViewSet(viewsets.ModelViewSet):
                 "submitted": bool(ref and ref["is_complete"]),
                 "submitted_at": ref["submitted_at"].isoformat() if ref and ref["submitted_at"] else None,
                 "reflection_id": ref["id"] if ref else None,
+                "team_visibility": ref["team_visibility"] if ref else None,
             })
 
         streak = 0

--- a/backend/bunk_logs/api/tests/test_dashboards_concerns.py
+++ b/backend/bunk_logs/api/tests/test_dashboards_concerns.py
@@ -104,16 +104,37 @@ def setup(org, program):
     return bunk, camper, counselor_user, counselor
 
 
-def _make_reflection(org, program, template, *, subject, author, group, day, answers):
+def _make_reflection(
+    org, program, template, *, subject, author, group, day, answers,
+    team_visibility=Reflection.TeamVisibility.TEAM,
+):
     return Reflection.all_objects.create(
         organization=org, program=program, template=template,
         subject=subject, author=author, assignment_group=group,
         period_start=day, period_end=day,
         answers=answers, language="en", is_complete=True,
+        team_visibility=team_visibility,
     )
 
 
 # ── Listing ──────────────────────────────────────────────────────────────────
+
+
+def test_concern_items_expose_team_visibility(api_client, org, program, setup):
+    """3.24: ConcernsInbox renders the PrivacyChip beside the KindBadge."""
+    bunk, camper, counselor_user, counselor = setup
+    tpl = _bunk_obs(org)
+    today = date.today()
+    _make_reflection(
+        org, program, tpl, subject=camper, author=counselor, group=bunk,
+        day=today, answers={"overall": 4, "concerns": "private worry"},
+        team_visibility=Reflection.TeamVisibility.SUPERVISORS_ONLY,
+    )
+    api_client.force_authenticate(user=counselor_user)
+    r = api_client.get("/api/v1/dashboards/concerns/", **_hdr(org.slug))
+    body = r.json()
+    private = next(i for i in body["items"] if i["value"] == "private worry")
+    assert private["team_visibility"] == "supervisors_only"
 
 
 def test_open_concern_text_appears(api_client, org, program, setup):

--- a/backend/bunk_logs/api/tests/test_dashboards_subject.py
+++ b/backend/bunk_logs/api/tests/test_dashboards_subject.py
@@ -104,12 +104,14 @@ def _wellness_template(org):
 
 def _make_reflection(
     org, program, template, *, subject, author, group=None, day, answers,
+    team_visibility=Reflection.TeamVisibility.TEAM,
 ):
     return Reflection.all_objects.create(
         organization=org, program=program, template=template,
         subject=subject, author=author, assignment_group=group,
         period_start=day, period_end=day,
         answers=answers, language="en", is_complete=True,
+        team_visibility=team_visibility,
     )
 
 
@@ -171,6 +173,41 @@ def test_supervisor_sees_cross_template_aggregation(api_client, org, program, se
     # Recent text response surfaced
     texts = body["recent_texts"]
     assert any(t["text"] == "missed mom" for t in texts)
+
+
+def test_subject_payload_exposes_team_visibility(api_client, org, program, setup):
+    """3.24: SubjectDetail renders PrivacyChip across patterns, recent_texts,
+    rating_series points, and per-template reflection rows -- so each surface
+    needs the flag in its payload."""
+    _, camper, counselor_user, counselor = setup
+    pulse = _bunk_pulse_template(org)
+    today = date.today()
+    _make_reflection(
+        org, program, pulse, subject=camper, author=counselor,
+        day=today, answers={"overall": 1, "concerns": "private worry"},
+        team_visibility=Reflection.TeamVisibility.SUPERVISORS_ONLY,
+    )
+    api_client.force_authenticate(user=counselor_user)
+    r = api_client.get(
+        f"/api/v1/dashboards/subject/{camper.id}/", **_hdr(org.slug),
+    )
+    body = r.json()
+    # patterns
+    low_rating = next(
+        p for p in body["concerning_patterns"] if p["kind"] == "low_rating"
+    )
+    assert low_rating["team_visibility"] == "supervisors_only"
+    # recent_texts
+    assert any(
+        t["text"] == "private worry" and t["team_visibility"] == "supervisors_only"
+        for t in body["recent_texts"]
+    )
+    # rating_series points
+    series = body["templates"][0]["rating_series"]
+    overall = next(s for s in series if s["label"] == "overall")
+    assert overall["points"][0]["team_visibility"] == "supervisors_only"
+    # per-template reflections list
+    assert body["templates"][0]["reflections"][0]["team_visibility"] == "supervisors_only"
 
 
 def test_low_rating_surfaces_concerning_pattern(api_client, org, program, setup):

--- a/backend/bunk_logs/api/tests/test_dashboards_trends.py
+++ b/backend/bunk_logs/api/tests/test_dashboards_trends.py
@@ -101,12 +101,16 @@ def _category_rating_template(org):
     )
 
 
-def _make_reflection(org, program, template, *, subject, author, group, day, answers):
+def _make_reflection(
+    org, program, template, *, subject, author, group, day, answers,
+    team_visibility=Reflection.TeamVisibility.TEAM,
+):
     return Reflection.all_objects.create(
         organization=org, program=program, template=template,
         subject=subject, author=author, assignment_group=group,
         period_start=day, period_end=day,
         answers=answers, language="en", is_complete=True,
+        team_visibility=team_visibility,
     )
 
 
@@ -316,3 +320,36 @@ def test_response_includes_author_for_each_filled_cell(api_client, org, program,
     assert c0_today["author_id"] == counselor.id
     assert c0_today["author_name"] == counselor.full_name
     assert c0_today["reflection_id"] is not None
+
+
+def test_cell_payload_exposes_team_visibility(api_client, org, program, setup_bunk):
+    """3.24: TrendCell needs the visibility flag to render the lock chip."""
+    bunk, campers, counselor_user, counselor = setup_bunk
+    tpl = _primary_rating_template(org)
+    today = date.today()
+    _make_reflection(
+        org, program, tpl, subject=campers[0], author=counselor, group=bunk,
+        day=today, answers={"overall": 3},
+        team_visibility=Reflection.TeamVisibility.SUPERVISORS_ONLY,
+    )
+    _make_reflection(
+        org, program, tpl, subject=campers[1], author=counselor, group=bunk,
+        day=today, answers={"overall": 4},
+    )
+    api_client.force_authenticate(user=counselor_user)
+    r = api_client.get(
+        f"/api/v1/dashboards/subject-trends/?assignment_group={bunk.id}&template={tpl.id}"
+        f"&date_start={today.isoformat()}&date_end={today.isoformat()}",
+        **_hdr(org.slug),
+    )
+    body = r.json()
+    by_id = {s["person_id"]: s for s in body["subjects"]}
+    c0 = next(c for c in by_id[campers[0].id]["cells"] if c["date"] == today.isoformat())
+    c1 = next(c for c in by_id[campers[1].id]["cells"] if c["date"] == today.isoformat())
+    assert c0["team_visibility"] == "supervisors_only"
+    assert c1["team_visibility"] == "team"
+    # No-data cells: the key is present and explicit null so the React
+    # side can lift a single helper.
+    c0_other_day = by_id[campers[0].id]["cells"][0]
+    if c0_other_day["reflection_id"] is None:
+        assert c0_other_day["team_visibility"] is None

--- a/backend/bunk_logs/api/tests/test_reflection_api.py
+++ b/backend/bunk_logs/api/tests/test_reflection_api.py
@@ -654,6 +654,44 @@ def test_template_for_me_org_admin_requires_role_when_not_on_program(
 
 
 @pytest.mark.django_db
+def test_my_summary_history_exposes_team_visibility(
+    api, org_a, program_a, counselor_template, counselor_user,
+):
+    """3.24: MyReflectionsPage shows a "Private" chip on history rows that
+    were filed supervisors-only."""
+    counselor_template.supports_privacy = True
+    counselor_template.save(update_fields=["supports_privacy"])
+    user, person = counselor_user
+    today = date.today()
+    Reflection.all_objects.create(
+        organization=org_a, program=program_a,
+        subject=person, author=person, template=counselor_template,
+        period_start=today, period_end=today,
+        answers={"note": "private"}, language="en",
+        team_visibility=Reflection.TeamVisibility.SUPERVISORS_ONLY,
+    )
+    api.force_authenticate(user=user)
+    resp = api.get(
+        "/api/v1/reflections/my-summary/",
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 200
+    history = resp.json()["history"]
+    # Find the entry whose period covers today.
+    today_entry = next(
+        h for h in history
+        if h["period_start"] <= today.isoformat() <= h["period_end"]
+        and h["submitted"]
+    )
+    assert today_entry["team_visibility"] == "supervisors_only"
+    # Empty-period entries don't have a submitted reflection -- their
+    # team_visibility is null.
+    unsubmitted = next((h for h in history if not h["submitted"]), None)
+    if unsubmitted is not None:
+        assert unsubmitted["team_visibility"] is None
+
+
+@pytest.mark.django_db
 def test_rejects_template_from_other_organization(
     api,
     org_a,

--- a/backend/bunk_logs/api/tests/test_template_dashboard.py
+++ b/backend/bunk_logs/api/tests/test_template_dashboard.py
@@ -209,6 +209,8 @@ def _make_reflection(
     template,
     period_end: date,
     answers: dict,
+    *,
+    team_visibility: str = Reflection.TeamVisibility.TEAM,
 ) -> Reflection:
     return Reflection.all_objects.create(
         organization=org,
@@ -219,6 +221,7 @@ def _make_reflection(
         period_end=period_end,
         answers=answers,
         language="en",
+        team_visibility=team_visibility,
     )
 
 
@@ -447,7 +450,36 @@ def test_text_list_aggregation(api_client, org, program, lt_template, lt_user, c
     assert items_by_text["teamwork"] == 2
     assert items_by_text["communication"] == 1
     assert items_by_text["punctuality"] == 1
-    assert wins_field["data"]["total_mentions"] == 4
+
+
+@pytest.mark.django_db
+def test_text_response_items_expose_team_visibility(
+    api_client, org, program, lt_template, lt_user, counselor_user,
+):
+    """3.24: TextResponseListWidget needs the visibility flag per item."""
+    u_lt, _ = lt_user
+    _, p_c = counselor_user
+    period_end = date(2026, 6, 14)
+    _make_reflection(
+        org, program, p_c, lt_template, period_end,
+        {"notes": "team-visible note"},
+    )
+    _make_reflection(
+        org, program, p_c, lt_template, period_end,
+        {"notes": "private note"},
+        team_visibility=Reflection.TeamVisibility.SUPERVISORS_ONLY,
+    )
+    api_client.force_authenticate(user=u_lt)
+    r = api_client.get(
+        f"/api/v1/dashboards/template/{lt_template.id}/",
+        {"period_end": str(period_end)},
+        **_hdr(org.slug),
+    )
+    body = r.json()
+    notes_field = next(f for f in body["fields"] if f["key"] == "notes")
+    by_text = {i["text"]: i for i in notes_field["data"]["items"]}
+    assert by_text["team-visible note"]["team_visibility"] == "team"
+    assert by_text["private note"]["team_visibility"] == "supervisors_only"
 
 
 @pytest.mark.django_db

--- a/docs/membership-role-vs-capability.md
+++ b/docs/membership-role-vs-capability.md
@@ -182,6 +182,35 @@ that sets `team_visibility="supervisors_only"` against that template:
   client that bypasses the editor can't sneak a private entry past the
   rule.
 
+### "Filed privately" chip surfaces (step 3.24)
+
+A reflection that's allowed through to a viewer despite being
+`supervisors_only` is still _flagged_ in the UI so the viewer treats it
+as sensitive. The shared component
+[`frontend/src/components/reflection/PrivacyChip.jsx`](../frontend/src/components/reflection/PrivacyChip.jsx)
+is the single source of truth for this glyph; anything that lists
+individual reflections renders it via `<PrivacyChip teamVisibility={…} />`.
+The chip returns `null` for `team` or missing values, so call sites can
+render it unconditionally.
+
+The chip currently appears on:
+
+- `TrendCell` (icon-only overlay) in the Subject Trend Grid.
+- `TextResponseListWidget` items on the Template Dashboard.
+- `ConcernsInbox` items.
+- `SubjectDetail` patterns, recent texts, rating-series rows, and the
+  per-template reflection list.
+- `MyReflectionsPage` history rows (author confirms their own toggle).
+- `ReflectionSummaryPage` immediately after the form is submitted.
+
+If you add a new surface that exposes a `reflection_id`, also add
+`team_visibility` to the matching dashboard payload (look at
+`backend/bunk_logs/api/dashboards/*.py` and
+`backend/bunk_logs/api/reflections.py::my_summary`) so the chip can
+render. The backend tests under `backend/bunk_logs/api/tests/` pin
+`team_visibility` presence on each of the existing surfaces; copy that
+pattern.
+
 ## When to revisit
 
 Revisit this design only if one of the following becomes true:

--- a/frontend/src/components/reflection/PrivacyChip.jsx
+++ b/frontend/src/components/reflection/PrivacyChip.jsx
@@ -1,0 +1,48 @@
+import { Lock } from 'lucide-react';
+
+const TOOLTIP =
+  'Filed privately. Only supervisors, admins, and (when subject_visible is on) the subject can read this entry.';
+
+/**
+ * PrivacyChip — shared indicator for ``Reflection.team_visibility === 'supervisors_only'``.
+ *
+ * Returns null for any other value (``'team'`` or missing) so callers can
+ * unconditionally render ``<PrivacyChip teamVisibility={x} />`` without
+ * branching at the call site.
+ *
+ * Sizes:
+ *   - "sm" (default): pill with lock glyph + "Filed privately" label.
+ *   - "icon": lock-only badge for very tight layouts (TrendCell uses this).
+ *
+ * The component is purely presentational. Visibility is enforced server-side
+ * (see ``reflections_visible_to`` in backend/bunk_logs/core/permissions/visibility.py);
+ * if a private reflection is in the payload at all, the viewer is allowed to see
+ * it -- the chip is communication, not access control.
+ */
+export default function PrivacyChip({ teamVisibility, size = 'sm' }) {
+  if (teamVisibility !== 'supervisors_only') return null;
+
+  if (size === 'icon') {
+    return (
+      <span
+        data-testid="privacy-chip"
+        aria-label="Filed privately"
+        title={TOOLTIP}
+        className="inline-flex items-center justify-center rounded-full bg-indigo-600 text-white w-4 h-4 shadow-sm"
+      >
+        <Lock size={10} aria-hidden="true" />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      data-testid="privacy-chip"
+      title={TOOLTIP}
+      className="inline-flex items-center gap-1 rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-200"
+    >
+      <Lock size={10} aria-hidden="true" />
+      <span>Filed privately</span>
+    </span>
+  );
+}

--- a/frontend/src/components/reflection/__tests__/PrivacyChip.test.jsx
+++ b/frontend/src/components/reflection/__tests__/PrivacyChip.test.jsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PrivacyChip from '../PrivacyChip';
+
+describe('PrivacyChip', () => {
+  it('returns null for team visibility', () => {
+    const { container } = render(<PrivacyChip teamVisibility="team" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('returns null for missing visibility', () => {
+    const { container } = render(<PrivacyChip />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a pill with "Filed privately" label on default size', () => {
+    render(<PrivacyChip teamVisibility="supervisors_only" />);
+    expect(screen.getByTestId('privacy-chip')).toBeInTheDocument();
+    expect(screen.getByText(/Filed privately/i)).toBeInTheDocument();
+  });
+
+  it('renders an icon-only badge when size="icon"', () => {
+    render(<PrivacyChip teamVisibility="supervisors_only" size="icon" />);
+    const chip = screen.getByTestId('privacy-chip');
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveAttribute('aria-label', 'Filed privately');
+    // No visible text -- aria-label carries the meaning
+    expect(screen.queryByText(/Filed privately/)).toBeNull();
+  });
+});

--- a/frontend/src/dashboards/__tests__/SubjectTrendGrid.test.jsx
+++ b/frontend/src/dashboards/__tests__/SubjectTrendGrid.test.jsx
@@ -125,6 +125,59 @@ describe('TrendCell', () => {
     );
     expect(screen.getByLabelText(/Sarah Levin.*no reflection/i)).toBeInTheDocument();
   });
+
+  it('renders the PrivacyChip lock overlay when the cell is filed privately', () => {
+    render(
+      withRouter(
+        <table>
+          <tbody>
+            <tr>
+              <TrendCell
+                cell={{
+                  date: '2026-06-14',
+                  rating: 2,
+                  reflection_id: 99,
+                  author_name: 'Mike',
+                  team_visibility: 'supervisors_only',
+                }}
+                scaleMax={4}
+                subjectName="Sarah Levin"
+              />
+            </tr>
+          </tbody>
+        </table>,
+      ),
+    );
+    expect(screen.getByTestId('privacy-chip')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/Sarah Levin.*filed privately/i),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the PrivacyChip when team_visibility is "team"', () => {
+    render(
+      withRouter(
+        <table>
+          <tbody>
+            <tr>
+              <TrendCell
+                cell={{
+                  date: '2026-06-14',
+                  rating: 4,
+                  reflection_id: 99,
+                  author_name: 'Mike',
+                  team_visibility: 'team',
+                }}
+                scaleMax={4}
+                subjectName="Sarah Levin"
+              />
+            </tr>
+          </tbody>
+        </table>,
+      ),
+    );
+    expect(screen.queryByTestId('privacy-chip')).toBeNull();
+  });
 });
 
 

--- a/frontend/src/dashboards/concerns/ConcernsInbox.jsx
+++ b/frontend/src/dashboards/concerns/ConcernsInbox.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import api from '../../api';
+import PrivacyChip from '../../components/reflection/PrivacyChip';
 
 function shortDate(iso) {
   const d = new Date(iso + 'T00:00:00');
@@ -83,6 +84,7 @@ export default function ConcernsInbox({ payload, onChanged }) {
                 <div className="min-w-0 flex-1">
                   <p className="text-xs text-gray-500 dark:text-gray-400 mb-1 flex flex-wrap items-center gap-2">
                     <KindBadge kind={it.kind} />
+                    <PrivacyChip teamVisibility={it.team_visibility} />
                     <span>{shortDate(it.date)}</span>
                     <span>·</span>
                     <span>{it.template_name}</span>

--- a/frontend/src/dashboards/subject/SubjectDetail.jsx
+++ b/frontend/src/dashboards/subject/SubjectDetail.jsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { ratingColor } from '../colors';
+import PrivacyChip from '../../components/reflection/PrivacyChip';
 
 function pad2(n) {
   return String(n).padStart(2, '0');
@@ -91,9 +92,12 @@ function ConcernsList({ concerns }) {
           const key = `${c.kind}-${c.field_label}-${i}`;
           if (c.kind === 'low_rating') {
             return (
-              <li key={key}>
-                <strong>{c.field_label}</strong>: rating of {c.value} on{' '}
-                {formatShortDate(c.date)}.{' '}
+              <li key={key} className="flex flex-wrap items-center gap-2">
+                <span>
+                  <strong>{c.field_label}</strong>: rating of {c.value} on{' '}
+                  {formatShortDate(c.date)}.
+                </span>
+                <PrivacyChip teamVisibility={c.team_visibility} />
                 {c.reflection_id && (
                   <Link
                     to={`/reflect/summary?reflection=${c.reflection_id}`}
@@ -177,10 +181,12 @@ export default function SubjectDetail({ payload }) {
                 </summary>
                 <ul className="text-xs text-gray-700 dark:text-gray-300 mt-2 space-y-1">
                   {t.reflections.map((r) => (
-                    <li key={r.id}>
-                      {r.date}
-                      {r.author_name ? ` · by ${r.author_name}` : ''}
-                      {' · '}
+                    <li key={r.id} className="flex flex-wrap items-center gap-2">
+                      <span>
+                        {r.date}
+                        {r.author_name ? ` · by ${r.author_name}` : ''}
+                      </span>
+                      <PrivacyChip teamVisibility={r.team_visibility} />
                       <Link
                         to={`/reflect/summary?reflection=${r.id}`}
                         className="underline"
@@ -207,9 +213,12 @@ export default function SubjectDetail({ payload }) {
                 key={`${t.reflection_id}-${t.field_key}-${i}`}
                 className="rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-3"
               >
-                <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
-                  {t.template_name} · {t.field_key} · {formatShortDate(t.date)}
-                  {t.author_name ? ` · ${t.author_name}` : ''}
+                <p className="text-xs text-gray-500 dark:text-gray-400 mb-1 flex flex-wrap items-center gap-2">
+                  <span>
+                    {t.template_name} · {t.field_key} · {formatShortDate(t.date)}
+                    {t.author_name ? ` · ${t.author_name}` : ''}
+                  </span>
+                  <PrivacyChip teamVisibility={t.team_visibility} />
                 </p>
                 <p className="text-sm text-gray-800 dark:text-gray-200 whitespace-pre-wrap">
                   {t.text}

--- a/frontend/src/dashboards/trends/TrendCell.jsx
+++ b/frontend/src/dashboards/trends/TrendCell.jsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { ratingColor, ratingTextColor, NO_DATA_FILL } from '../colors';
+import PrivacyChip from '../../components/reflection/PrivacyChip';
 
 function formatShortDate(iso) {
   const d = new Date(iso + 'T00:00:00');
@@ -23,21 +24,31 @@ export default function TrendCell({
   const fill = ratingColor(cell.rating, scaleMax);
   const color = ratingTextColor(cell.rating, scaleMax);
   const dateLabel = formatShortDate(cell.date);
+  const isPrivate = cell.team_visibility === 'supervisors_only';
+  const privateSuffix = isPrivate ? ', filed privately' : '';
 
   const aria = cell.rating == null
     ? `${subjectName}, ${dateLabel}, no reflection`
     : `${subjectName}, ${dateLabel}, rating ${Math.round(cell.rating)} of ${scaleMax}` +
-      (cell.author_name ? `, logged by ${cell.author_name}` : '');
+      (cell.author_name ? `, logged by ${cell.author_name}` : '') +
+      privateSuffix;
 
   const tooltip = cell.rating == null
     ? `${dateLabel} — no reflection`
     : `${dateLabel} — ${Math.round(cell.rating)}${
         scaleLabel ? ` of ${scaleMax} (${scaleLabel})` : ` of ${scaleMax}`
-      }${cell.author_name ? ` · by ${cell.author_name}` : ''}`;
+      }${cell.author_name ? ` · by ${cell.author_name}` : ''}${
+        isPrivate ? ' · filed privately' : ''
+      }`;
 
   const baseClass =
-    'border border-gray-200 dark:border-gray-700 text-[10px] font-mono text-center align-middle p-0';
+    'border border-gray-200 dark:border-gray-700 text-[10px] font-mono text-center align-middle p-0 relative';
   const innerClass = 'block w-full h-full px-1 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-400';
+  const lockOverlay = isPrivate ? (
+    <span className="pointer-events-none absolute top-0.5 right-0.5 z-10">
+      <PrivacyChip teamVisibility={cell.team_visibility} size="icon" />
+    </span>
+  ) : null;
 
   if (cell.rating == null) {
     return (
@@ -45,6 +56,7 @@ export default function TrendCell({
         <span aria-label={aria} title={tooltip} className={innerClass}>
           —
         </span>
+        {lockOverlay}
       </td>
     );
   }
@@ -55,6 +67,7 @@ export default function TrendCell({
         <span aria-label={aria} title={tooltip} className={innerClass}>
           {Math.round(cell.rating)}
         </span>
+        {lockOverlay}
       </td>
     );
   }
@@ -70,6 +83,7 @@ export default function TrendCell({
       >
         {Math.round(cell.rating)}
       </Link>
+      {lockOverlay}
     </td>
   );
 }

--- a/frontend/src/dashboards/widgets/TextResponseListWidget.jsx
+++ b/frontend/src/dashboards/widgets/TextResponseListWidget.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
+import PrivacyChip from '../../components/reflection/PrivacyChip';
 
 /**
  * TextResponseListWidget — generic widget for untagged text/textarea fields.
@@ -46,7 +47,10 @@ export default function TextResponseListWidget({ field, label }) {
                     </button>
                   )}
                 </div>
-                <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">{item.period_end}</p>
+                <p className="text-xs text-gray-400 dark:text-gray-500 mt-1 flex items-center gap-2">
+                  <span>{item.period_end}</span>
+                  <PrivacyChip teamVisibility={item.team_visibility} />
+                </p>
               </li>
             );
           })}

--- a/frontend/src/pages/MyReflectionsPage.jsx
+++ b/frontend/src/pages/MyReflectionsPage.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import api from '../api';
 import Header from '../partials/Header';
 import Sidebar from '../partials/Sidebar';
+import PrivacyChip from '../components/reflection/PrivacyChip';
 
 function StatusBadge({ submitted }) {
   return submitted ? (
@@ -171,6 +172,7 @@ export default function MyReflectionsPage() {
                             {formatDateTime(entry.submitted_at)}
                           </span>
                         )}
+                        <PrivacyChip teamVisibility={entry.team_visibility} />
                         <StatusBadge submitted={entry.submitted} />
                       </div>
                     </li>

--- a/frontend/src/pages/MyReflectionsPage.test.jsx
+++ b/frontend/src/pages/MyReflectionsPage.test.jsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import MyReflectionsPage from './MyReflectionsPage';
+
+const getMock = vi.fn();
+
+vi.mock('../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+  },
+}));
+
+vi.mock('../partials/Header', () => ({ default: () => null }));
+vi.mock('../partials/Sidebar', () => ({ default: () => null }));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <MyReflectionsPage />
+    </MemoryRouter>,
+  );
+}
+
+const SUMMARY = {
+  template: { name: 'Counselor weekly', cadence: 'weekly' },
+  streak: 2,
+  total_completed: 5,
+  current_period: null,
+  history: [
+    {
+      period_start: '2026-06-08',
+      period_end: '2026-06-14',
+      submitted: true,
+      submitted_at: '2026-06-12T10:00:00Z',
+      reflection_id: 91,
+      team_visibility: 'supervisors_only',
+    },
+    {
+      period_start: '2026-06-01',
+      period_end: '2026-06-07',
+      submitted: true,
+      submitted_at: '2026-06-05T10:00:00Z',
+      reflection_id: 92,
+      team_visibility: 'team',
+    },
+    {
+      period_start: '2026-05-25',
+      period_end: '2026-05-31',
+      submitted: false,
+      submitted_at: null,
+      reflection_id: null,
+      team_visibility: null,
+    },
+  ],
+};
+
+describe('MyReflectionsPage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    getMock.mockResolvedValue({ data: SUMMARY });
+  });
+
+  it('shows the privacy chip only on history rows filed privately', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Counselor weekly · weekly')).toBeInTheDocument());
+
+    const items = screen.getAllByRole('listitem');
+    // First item (Jun 8) is private; second (Jun 1) is team; third is unsubmitted.
+    expect(within(items[0]).getByTestId('privacy-chip')).toBeInTheDocument();
+    expect(within(items[1]).queryByTestId('privacy-chip')).toBeNull();
+    expect(within(items[2]).queryByTestId('privacy-chip')).toBeNull();
+  });
+});

--- a/frontend/src/pages/ReflectionFormPage.jsx
+++ b/frontend/src/pages/ReflectionFormPage.jsx
@@ -198,6 +198,7 @@ export default function ReflectionFormPage() {
           schema,
           answers: data.answers || answers,
           returnTo: isPrefilled ? '/tasks' : null,
+          teamVisibility: meta?.supports_privacy ? teamVisibility : 'team',
         },
       });
     } catch (err) {

--- a/frontend/src/pages/ReflectionFormPage.test.jsx
+++ b/frontend/src/pages/ReflectionFormPage.test.jsx
@@ -1,8 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import ReflectionFormPage from './ReflectionFormPage';
+
+function SummaryProbe() {
+  const loc = useLocation();
+  return (
+    <div data-testid="summary" data-state={JSON.stringify(loc.state ?? {})}>
+      Summary
+    </div>
+  );
+}
 
 const getMock = vi.fn();
 const postMock = vi.fn();
@@ -75,7 +84,7 @@ function renderPage(search = '') {
     <MemoryRouter initialEntries={[`/reflect${search}`]}>
       <Routes>
         <Route path="/reflect" element={<ReflectionFormPage />} />
-        <Route path="/reflect/summary" element={<div data-testid="summary">Summary</div>} />
+        <Route path="/reflect/summary" element={<SummaryProbe />} />
       </Routes>
     </MemoryRouter>,
   );
@@ -179,6 +188,45 @@ describe('ReflectionFormPage', () => {
     await user.click(screen.getByRole('button', { name: /Submit reflection/i }));
     await waitFor(() => expect(postMock).toHaveBeenCalled());
     expect(postMock.mock.calls[0][1].team_visibility).toBe('supervisors_only');
+    // 3.24: the summary route receives the same flag so it can render the chip.
+    await waitFor(() => expect(screen.getByTestId('summary')).toBeInTheDocument());
+    const state = JSON.parse(screen.getByTestId('summary').dataset.state);
+    expect(state.teamVisibility).toBe('supervisors_only');
+  });
+
+  it('passes teamVisibility=team to summary state for team submissions', async () => {
+    const user = userEvent.setup();
+    postMock.mockResolvedValue({ data: { id: 103 } });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Note?')).toBeInTheDocument());
+    await user.type(screen.getByTestId('reflect-input-note'), 'team note');
+    await user.type(screen.getByTestId('reflect-period-start'), '2026-06-01');
+    await user.type(screen.getByTestId('reflect-period-end'), '2026-06-07');
+    const effortButtons = screen.getAllByRole('button', { name: '2' });
+    await user.click(effortButtons[0]);
+    await user.click(screen.getByRole('button', { name: /Submit reflection/i }));
+    await waitFor(() => expect(screen.getByTestId('summary')).toBeInTheDocument());
+    const state = JSON.parse(screen.getByTestId('summary').dataset.state);
+    expect(state.teamVisibility).toBe('team');
+  });
+
+  it('passes teamVisibility=team when template does not support privacy', async () => {
+    const user = userEvent.setup();
+    getMock.mockResolvedValue({
+      data: { ...templatePayload, supports_privacy: false },
+    });
+    postMock.mockResolvedValue({ data: { id: 104 } });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Note?')).toBeInTheDocument());
+    await user.type(screen.getByTestId('reflect-input-note'), 'no toggle');
+    await user.type(screen.getByTestId('reflect-period-start'), '2026-06-01');
+    await user.type(screen.getByTestId('reflect-period-end'), '2026-06-07');
+    const effortButtons = screen.getAllByRole('button', { name: '2' });
+    await user.click(effortButtons[0]);
+    await user.click(screen.getByRole('button', { name: /Submit reflection/i }));
+    await waitFor(() => expect(screen.getByTestId('summary')).toBeInTheDocument());
+    const state = JSON.parse(screen.getByTestId('summary').dataset.state);
+    expect(state.teamVisibility).toBe('team');
   });
 
   it('shows the supervisors-only helper text only when selected', async () => {

--- a/frontend/src/pages/ReflectionSummaryPage.jsx
+++ b/frontend/src/pages/ReflectionSummaryPage.jsx
@@ -1,4 +1,5 @@
 import { Link, useLocation } from 'react-router-dom';
+import PrivacyChip from '../components/reflection/PrivacyChip';
 
 function promptText(field) {
   if (!field.prompts || typeof field.prompts !== 'object') return '';
@@ -50,16 +51,22 @@ export default function ReflectionSummaryPage() {
     );
   }
 
-  const { reflectionId, templateName, subjectName, periodStart, periodEnd, language, schema, answers, returnTo } = data;
+  const {
+    reflectionId, templateName, subjectName, periodStart, periodEnd, language,
+    schema, answers, returnTo, teamVisibility,
+  } = data;
   const backHref = returnTo || '/reflect';
   const backLabel = returnTo === '/tasks' ? '← Back to tasks' : 'Submit another';
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 px-4 py-8">
       <div className="max-w-xl mx-auto rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-sm">
-        <h1 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
-          Reflection submitted
-        </h1>
+        <div className="flex flex-wrap items-center gap-3 mb-2">
+          <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
+            Reflection submitted
+          </h1>
+          <PrivacyChip teamVisibility={teamVisibility} />
+        </div>
         <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">
           {templateName}{subjectName ? ` · About ${subjectName}` : ''}
         </p>

--- a/migration_prompts/3_24_filed_privately_chip.md
+++ b/migration_prompts/3_24_filed_privately_chip.md
@@ -1,0 +1,168 @@
+# Prompt 3.24 — "Filed privately" chip on reflection surfaces
+
+**Wave:** 3 (Crane Lake Summer 2026 Build) — UX polish for the privacy toggle
+**Estimated time:** 4-5 hours
+**Prerequisite:** Prompts 3.22 (`Reflection.team_visibility`) and 3.23 (`ReflectionTemplate.supports_privacy`) merged.
+
+**Use the context prompt at the top of `0_0_context_prompt.md` before this session.**
+
+---
+
+```
+Step 3.22 added per-reflection privacy and 3.23 added the template-level
+gate. The data is there but a supervisor scanning a dashboard has no
+visible way to tell that a given entry was filed privately. This prompt
+adds a "Filed privately" chip (and a lock icon where space is tight) on
+every surface where individual reflections are listed, so the supervisor
+can a) recognise the entry needs to be treated as sensitive and b) know
+why a co-author on their team can't see it.
+
+CONTEXT:
+- ``Reflection.team_visibility`` is already authoritative; nothing about
+  visibility changes in this prompt. The only thing changing is that the
+  flag becomes visible on read.
+- The dashboard endpoints return purpose-built payloads (not
+  ``ReflectionSerializer``), so each one needs ``team_visibility`` added
+  explicitly. The list endpoint ``/api/v1/reflections/`` already exposes
+  it via ``ReflectionSerializer`` (added in 3.22).
+- Author-facing surfaces also get the chip so an author who flipped the
+  toggle can confirm what they did. ``my-summary`` history entries and
+  the post-submission ``ReflectionSummaryPage`` are the two surfaces.
+
+Tasks:
+
+1. Backend: expose ``team_visibility`` on every dashboard payload that
+   surfaces an individual reflection. Each is a one-key addition; the
+   underlying queries already select the column.
+
+   - ``backend/bunk_logs/api/dashboards/trends.py`` -- in the
+     ``per_cell`` dict and again in the ``cells`` output per day; the
+     chip is rendered on the cell.
+   - ``backend/bunk_logs/api/dashboards/concerns.py`` -- in the ``items``
+     list (the Concerns Inbox).
+   - ``backend/bunk_logs/api/dashboards/template.py`` -- in ``_agg_text``'s
+     ``items`` list (each text response item).
+   - ``backend/bunk_logs/api/dashboards/subject.py`` -- in
+     ``recent_texts``, in each ``rating_series`` point, in each
+     ``tpl_entry["reflections"]`` row, and in ``patterns`` items that
+     carry a ``reflection_id`` (the ``low_rating`` kind). Downward-trend
+     patterns aggregate over many reflections and intentionally don't
+     carry one.
+   - ``backend/bunk_logs/api/reflections.py`` -- in the ``history``
+     entries returned by the ``my_summary`` action.
+
+   Each addition is ``"team_visibility": r.team_visibility`` (or the
+   underlying queryset row). Keep the keys named consistently across
+   surfaces so the React side can lift a single helper.
+
+2. Backend smoke tests. For each surface, one quick assertion that the
+   field appears verbatim:
+
+   - ``backend/bunk_logs/api/tests/test_reflection_api.py`` -- extend the
+     ``my_summary`` coverage with ``test_my_summary_history_exposes_team_visibility``
+     (post a private + a team reflection, assert the values come back).
+   - ``backend/bunk_logs/api/tests/test_dashboard_api.py`` (or whichever
+     test file exists for dashboards) -- add or extend tests for each
+     dashboard surface listed above with one assertion per payload that
+     ``team_visibility`` is present and equals the expected value.
+
+3. Frontend: shared chip component.
+
+   Create ``frontend/src/components/reflection/PrivacyChip.jsx``::
+
+       export default function PrivacyChip({ teamVisibility, size = 'sm' }) {
+         if (teamVisibility !== 'supervisors_only') return null;
+         // Returns a small pill with a lock glyph + "Filed privately"
+         // and a long-form tooltip explaining the contract.
+       }
+
+   - ``size="sm"`` is the default (pill chip). ``size="icon"`` renders
+     just the lock for very tight layouts (the TrendCell uses ``"icon"``).
+   - The tooltip text: "Filed privately. Only supervisors, admins, and
+     (when subject_visible is enabled) the subject can read this entry."
+   - Add ``frontend/src/components/reflection/__tests__/PrivacyChip.test.jsx``
+     with three cases: returns null on ``team`` / undefined, renders pill
+     on ``supervisors_only``, renders icon-only on ``size="icon"`` (use
+     ``getByLabelText`` to assert the accessible name).
+
+4. Frontend: wire the chip into each surface.
+
+   - ``frontend/src/dashboards/trends/TrendCell.jsx`` -- when the cell
+     has ``cell.team_visibility === 'supervisors_only'``, render a small
+     lock glyph (``size="icon"``) absolutely positioned in the
+     top-right of the cell, AND append "filed privately" to the
+     existing ``tooltip`` string and ``aria-label``. The link still
+     works -- the chip is a visual marker, not a link target.
+   - ``frontend/src/dashboards/widgets/TextResponseListWidget.jsx`` --
+     render the chip (pill) in the header line of each item, beside the
+     ``period_end``.
+   - ``frontend/src/dashboards/concerns/ConcernsInbox.jsx`` -- render
+     the chip in the badge row beside the existing ``KindBadge``.
+   - ``frontend/src/dashboards/subject/SubjectDetail.jsx`` -- the
+     subject-detail page surfaces reflections in several blocks
+     (patterns, recent_texts, rating_series, per-template reflections).
+     Render the chip in each block where a per-reflection row appears.
+   - ``frontend/src/pages/MyReflectionsPage.jsx`` -- in the history
+     ``<ul>``, render the chip next to the ``StatusBadge`` when an
+     entry is submitted and private.
+   - ``frontend/src/pages/ReflectionSummaryPage.jsx`` -- if
+     ``location.state.teamVisibility === 'supervisors_only'``, render
+     the chip below the title.
+   - ``frontend/src/pages/ReflectionFormPage.jsx`` -- the page already
+     navigates to the summary with a state object on submit. Add
+     ``teamVisibility: meta?.supports_privacy ? teamVisibility : 'team'``
+     to that state so the summary page can show the chip.
+
+5. Frontend tests:
+
+   - Add a TrendCell test asserting that when the cell has
+     ``team_visibility: 'supervisors_only'``, the lock element renders
+     and the tooltip / aria-label include the phrase ``filed privately``
+     case-insensitively.
+   - Extend the existing ``ReflectionFormPage`` "successful submit"
+     vitest to assert the navigation state argument includes
+     ``teamVisibility``.
+   - Extend ``MyReflectionsPage`` (a new file under
+     ``frontend/src/pages/__tests__/`` if one doesn't exist) with a test
+     that the chip appears for a private history entry and not for a
+     team one. Mock the ``/my-summary/`` endpoint.
+
+6. Documentation:
+
+   - Add a short bullet to ``docs/membership-role-vs-capability.md`` in
+     the "Per-reflection visibility" section noting that the chip is
+     rendered on the listed surfaces; cite the shared
+     ``PrivacyChip`` component as the single source of truth so future
+     surfaces don't fork the styling.
+
+Acceptance criteria:
+- Every dashboard endpoint that returns ``reflection_id`` for an
+  individual reflection now also returns ``team_visibility``.
+- The chip appears on:
+  - TrendCell (icon-only overlay)
+  - TextResponseListWidget items
+  - ConcernsInbox items
+  - SubjectDetail (patterns, recent texts, rating series links, per-template reflection rows)
+  - MyReflectionsPage history entries
+  - ReflectionSummaryPage post-submission view
+- The chip is ABSENT (returns null) for ``team_visibility === 'team'``
+  and for missing values.
+- ``make test-backend`` and ``make test-frontend`` both green.
+
+Out of scope:
+- Letting a viewer FLIP the flag from any of these list/detail surfaces
+  -- the toggle lives on the form, not the list. A separate "demote /
+  promote visibility from the detail page" prompt can come later if the
+  product asks for it.
+- A "supervisors only" filter chip on the reflection list page itself
+  (would let supervisors filter the queue to just private entries).
+  Queue this as a follow-up if anyone asks; it's an additive feature.
+
+Commit structure (single PR, ordered commits):
+  1. feat(3_24_filed_privately_chip): expose team_visibility on dashboard payloads
+  2. test(3_24_filed_privately_chip): pin team_visibility presence on each surface
+  3. feat(3_24_filed_privately_chip): add shared PrivacyChip component + tests
+  4. feat(3_24_filed_privately_chip): render PrivacyChip on TrendCell + text/concerns/subject widgets
+  5. feat(3_24_filed_privately_chip): render PrivacyChip on author-facing surfaces (my-reflections + summary + form-to-summary state)
+  6. docs(3_24_filed_privately_chip): document chip surfaces + reuse contract
+```


### PR DESCRIPTION
## Summary

Step 3.22 added `Reflection.team_visibility`; step 3.23 added the
template-level `supports_privacy` gate. The flag was authoritative on
the backend but the UI had no way to *show* it. This PR adds a "Filed
privately" chip (and an icon-only badge where space is tight) wherever
an individual reflection is listed, so a supervisor scanning a
dashboard immediately recognises private entries and an author can
verify their own toggle in the rear-view.

Six surfaces now render the chip:

- `TrendCell` — lock-only overlay in the cell corner, plus
  "filed privately" appended to the tooltip / aria-label.
- `TextResponseListWidget` (Template Dashboard text widget) — pill in
  the item footer.
- `ConcernsInbox` — pill in the badge row.
- `SubjectDetail` — pill on low-rating patterns, recent_texts items,
  and per-template reflection rows.
- `MyReflectionsPage` history list — pill on each privately-filed row.
- `ReflectionSummaryPage` post-submit view — pill below the title;
  `ReflectionFormPage` forwards `teamVisibility` via `location.state`.

The chip itself lives in `frontend/src/components/reflection/PrivacyChip.jsx`
as the single source of truth.

## Why a separate "expose the flag" commit

The dashboard endpoints build purpose-shaped payloads instead of going
through `ReflectionSerializer`, so each one needed `team_visibility`
added explicitly. Backend smoke tests pin its presence on every
surface so a future payload refactor can't silently drop it.

## Out of scope

- Filtering a list view down to just private entries.
- Allowing a viewer to demote / promote visibility from a list or
  detail page — the toggle still lives on the form.

## Test plan

- [x] `make test-backend` — 590 tests pass, including new smoke tests
      on trends / concerns / template / subject / my-summary.
- [x] `make test-frontend` — 186 tests pass (PrivacyChip, TrendCell
      chip overlay/absence, MyReflectionsPage chip per row,
      ReflectionFormPage forwarding of `teamVisibility`).
- [x] `ruff check bunk_logs/ config/` clean.
- [ ] Manual: file a reflection with the privacy toggle on and confirm
      the chip appears on each of the six surfaces.


Made with [Cursor](https://cursor.com)