### PR TITLE
3_25_super_admin_audit: unify is_staff || is_superuser as Super Admin across new RBAC

### DIFF
--- a/backend/bunk_logs/api/dashboards/coverage.py
+++ b/backend/bunk_logs/api/dashboards/coverage.py
@@ -24,6 +24,7 @@ from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Person
 from bunk_logs.core.models import Reflection
 from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.permissions import is_super_admin
 from bunk_logs.core.permissions.visibility import author_group_ids_with_descendants
 from bunk_logs.core.permissions.visibility import is_org_admin
 from bunk_logs.core.permissions.visibility import reflections_visible_to
@@ -74,7 +75,7 @@ class CoverageDashboardView(APIView):
             return Response({"detail": "Organization context required."}, status=403)
 
         viewer = Person.objects.filter(user=request.user).first()
-        if viewer is None and not request.user.is_superuser:
+        if viewer is None and not is_super_admin(request.user):
             return Response({"detail": "Person profile required."}, status=403)
 
         # Time window

--- a/backend/bunk_logs/api/dashboards/template.py
+++ b/backend/bunk_logs/api/dashboards/template.py
@@ -19,6 +19,7 @@ from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
 from bunk_logs.core.models import Reflection
 from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.permissions import is_super_admin
 from bunk_logs.core.permissions.visibility import author_group_ids_with_descendants
 from bunk_logs.core.permissions.visibility import reflections_visible_to
 
@@ -51,7 +52,7 @@ def _viewer_can_access_template(viewer: Person, user, template: ReflectionTempla
     get an empty dashboard rather than 403).
     """
     user_role = getattr(user, "role", "") or ""
-    if user.is_superuser or user_role == User.ADMIN:
+    if is_super_admin(user) or user_role == User.ADMIN:
         return True
     if Membership.objects.filter(
         person=viewer, role="admin", is_active=True,

--- a/backend/bunk_logs/api/field_keys.py
+++ b/backend/bunk_logs/api/field_keys.py
@@ -13,6 +13,7 @@ from bunk_logs.core.models import ReflectionTemplate
 from bunk_logs.core.permissions import IsOrgAdminOrSuperuser
 from bunk_logs.core.permissions import _is_org_admin
 from bunk_logs.core.permissions import _person_for_request
+from bunk_logs.core.permissions import is_super_admin
 
 
 class FieldKeySerializer(serializers.ModelSerializer):
@@ -74,7 +75,7 @@ class FieldKeyViewSet(viewsets.ModelViewSet):
         if org is None:
             return FieldKey.all_objects.none()
 
-        if self.request.user.is_superuser:
+        if is_super_admin(self.request.user):
             qs = FieldKey.all_objects.select_related("organization")
         else:
             qs = FieldKey.all_objects.select_related("organization").filter(
@@ -90,7 +91,7 @@ class FieldKeyViewSet(viewsets.ModelViewSet):
     def get_object(self):
         obj = super().get_object()
         org = getattr(self.request, "organization", None)
-        if self.request.user.is_superuser:
+        if is_super_admin(self.request.user):
             return obj
         if obj.organization_id is not None and obj.organization_id != (org.pk if org else None):
             from rest_framework.exceptions import NotFound
@@ -103,7 +104,7 @@ class FieldKeyViewSet(viewsets.ModelViewSet):
         if org is None:
             return Response({"detail": "Organization context required."}, status=status.HTTP_403_FORBIDDEN)
 
-        if not request.user.is_superuser:
+        if not is_super_admin(request.user):
             person = _person_for_request(request)
             if not _is_org_admin(person):
                 return Response(
@@ -131,11 +132,11 @@ class FieldKeyViewSet(viewsets.ModelViewSet):
         instance = self.get_object()
         org = getattr(request, "organization", None)
 
-        if not request.user.is_superuser:
+        if not is_super_admin(request.user):
             if instance.organization_id is None:
                 from rest_framework.exceptions import PermissionDenied
 
-                msg = "Global keys can only be edited by superusers."
+                msg = "Global keys can only be edited by a Super Admin."
                 raise PermissionDenied(msg)
             if org is None or instance.organization_id != org.pk:
                 from rest_framework.exceptions import NotFound
@@ -151,11 +152,11 @@ class FieldKeyViewSet(viewsets.ModelViewSet):
         instance = self.get_object()
         org = getattr(request, "organization", None)
 
-        if not request.user.is_superuser:
+        if not is_super_admin(request.user):
             if instance.organization_id is None:
                 from rest_framework.exceptions import PermissionDenied
 
-                msg = "Global keys can only be deleted by superusers."
+                msg = "Global keys can only be deleted by a Super Admin."
                 raise PermissionDenied(msg)
             if org is None or instance.organization_id != org.pk:
                 from rest_framework.exceptions import NotFound

--- a/backend/bunk_logs/api/memberships.py
+++ b/backend/bunk_logs/api/memberships.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
+from bunk_logs.core.permissions import is_super_admin
 
 
 def _normalize_tags(values) -> list[str]:
@@ -39,14 +40,18 @@ def _is_org_admin(person: Person | None) -> bool:
 
 
 class MembershipPermission(permissions.BasePermission):
-    """Reads + writes restricted to org admins (and Django superusers) inside an org context."""
+    """Reads + writes restricted to org admins (and Super Admins) inside an org context.
 
-    message = "Organization admin membership required."
+    See ``bunk_logs.core.permissions.is_super_admin`` for the Super Admin
+    definition (``is_staff`` OR ``is_superuser``).
+    """
+
+    message = "Organization admin membership or Super Admin status required."
 
     def has_permission(self, request, view):
         if not (request.user and request.user.is_authenticated and getattr(request, "organization", None)):
             return False
-        if request.user.is_superuser:
+        if is_super_admin(request.user):
             return True
         return _is_org_admin(_person_for_request(request))
 

--- a/backend/bunk_logs/api/reflections.py
+++ b/backend/bunk_logs/api/reflections.py
@@ -24,6 +24,7 @@ from bunk_logs.core.models import Program
 from bunk_logs.core.models import Reflection
 from bunk_logs.core.models import ReflectionTemplate
 from bunk_logs.core.models import validate_reflection_answers
+from bunk_logs.core.permissions import is_super_admin
 from bunk_logs.core.permissions.visibility import reflections_visible_to
 
 
@@ -38,7 +39,8 @@ def _has_tenant_admin(person: Person) -> bool:
 
 
 def _privileged_reflection_actor(request) -> bool:
-    return bool(getattr(request.user, "is_superuser", False))
+    """Super Admins (``is_staff`` OR ``is_superuser``) bypass author-only mutation gates."""
+    return is_super_admin(request.user)
 
 
 def _template_matches_program(template: ReflectionTemplate, program: Program) -> bool:

--- a/backend/bunk_logs/api/team_dashboard.py
+++ b/backend/bunk_logs/api/team_dashboard.py
@@ -15,6 +15,7 @@ from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
 from bunk_logs.core.models import Program
 from bunk_logs.core.models import Reflection
+from bunk_logs.core.permissions import is_super_admin
 
 User = get_user_model()
 
@@ -51,9 +52,9 @@ def _viewer_program_unit_scope(viewer: Person, user) -> dict[int, set[str] | Non
             merged[pid] = merged[pid] | units
     if merged:
         return merged
-    # Legacy app User.role "Admin" / superuser: full access to all programs in the person's org.
+    # Legacy app User.role "Admin" / Super Admin: full access to all programs in the person's org.
     role = getattr(user, "role", "") or ""
-    if user.is_superuser or role == User.ADMIN:
+    if is_super_admin(user) or role == User.ADMIN:
         return {
             p.id: None
             for p in Program.objects.filter(organization_id=viewer.organization_id, is_active=True)

--- a/backend/bunk_logs/api/templates.py
+++ b/backend/bunk_logs/api/templates.py
@@ -18,6 +18,7 @@ from bunk_logs.core.models import ReflectionTemplate
 from bunk_logs.core.permissions import IsOrgAdminOrSuperuser
 from bunk_logs.core.permissions import _is_org_admin
 from bunk_logs.core.permissions import _person_for_request
+from bunk_logs.core.permissions import is_super_admin
 from bunk_logs.core.validators.template_schema import validate_template_coherence
 
 
@@ -179,8 +180,9 @@ class ReflectionTemplateViewSet(viewsets.ModelViewSet):
 
         qs = ReflectionTemplate.all_objects.select_related("organization", "parent_template")
 
-        # Super admins see everything; regular users see own org + global
-        if not self.request.user.is_superuser:
+        # Super Admins (is_staff || is_superuser) see everything; regular
+        # users see own org + global templates.
+        if not is_super_admin(self.request.user):
             from django.db.models import Q
 
             qs = qs.filter(Q(organization=org) | Q(organization__isnull=True))
@@ -202,7 +204,7 @@ class ReflectionTemplateViewSet(viewsets.ModelViewSet):
             qs = qs.filter(is_active=False)
 
         include_global_str = (params.get("include_global") or "true").strip().lower()
-        if include_global_str in ("false", "0") and not self.request.user.is_superuser:
+        if include_global_str in ("false", "0") and not is_super_admin(self.request.user):
             qs = qs.filter(organization=org)
 
         return qs
@@ -211,7 +213,7 @@ class ReflectionTemplateViewSet(viewsets.ModelViewSet):
         """Return 404 (not 403) when accessing objects outside the current org."""
         obj = super().get_object()
         org = getattr(self.request, "organization", None)
-        if self.request.user.is_superuser:
+        if is_super_admin(self.request.user):
             return obj
         if obj.organization_id is not None and obj.organization_id != (org.pk if org else None):
             from rest_framework.exceptions import NotFound
@@ -238,9 +240,9 @@ class ReflectionTemplateViewSet(viewsets.ModelViewSet):
         return Response(data)
 
     def _check_edit_permission(self, instance: ReflectionTemplate) -> None:
-        """Raise 404 for cross-org edits; 403 for global-template edits by non-superusers."""
+        """Raise 404 for cross-org edits; 403 for global-template edits by non-Super-Admins."""
         org = getattr(self.request, "organization", None)
-        if self.request.user.is_superuser:
+        if is_super_admin(self.request.user):
             return
         if instance.organization_id is None:
             from rest_framework.exceptions import PermissionDenied
@@ -373,9 +375,9 @@ class ReflectionTemplateViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        # Only admins / superusers can clone (handled by get_permissions for non-list actions)
+        # Only admins / Super Admins can clone (handled by get_permissions for non-list actions)
         person = _person_for_request(request)
-        if not request.user.is_superuser and not _is_org_admin(person):
+        if not is_super_admin(request.user) and not _is_org_admin(person):
             return Response(
                 {"detail": "Organization admin membership required."},
                 status=status.HTTP_403_FORBIDDEN,

--- a/backend/bunk_logs/api/tests/test_memberships_api.py
+++ b/backend/bunk_logs/api/tests/test_memberships_api.py
@@ -109,6 +109,29 @@ def test_non_admin_cannot_list(api, org_a, counselor_user):
 
 
 @pytest.mark.django_db
+def test_is_staff_user_can_list_without_org_admin_membership(
+    api, org_a, program_a,
+):
+    """3.25: ``is_staff=True`` without an admin Membership is treated as a Super
+    Admin by ``MembershipPermission``."""
+    from django.contrib.auth import get_user_model
+
+    user_model = get_user_model()
+    staff_user = user_model.objects.create_user(
+        email="staff-only@example.com", password="pw", is_staff=True,
+    )
+    assert staff_user.is_superuser is False
+    _make_member(org_a, program_a, last="Gamma")
+    api.force_authenticate(user=staff_user)
+    resp = api.get(
+        "/api/v1/memberships/",
+        {"program": program_a.slug},
+        **_hdr_org(org_a.slug),
+    )
+    assert resp.status_code == 200, resp.content
+
+
+@pytest.mark.django_db
 def test_admin_can_patch_tags(api, org_a, program_a, admin_user):
     user, _ = admin_user
     _, m = _make_member(org_a, program_a)

--- a/backend/bunk_logs/api/tests/test_template_api.py
+++ b/backend/bunk_logs/api/tests/test_template_api.py
@@ -201,6 +201,22 @@ class TestTemplateListRetrieve:
         res = regular_client.get(detail_url(tpl.pk))
         assert res.status_code == 404
 
+    def test_is_staff_user_sees_cross_org_templates(self, org, other_org):
+        """3.25: ``is_staff=True`` (no superuser) sees all orgs' templates the
+        same way a Django superuser does."""
+        _make_template(org, slug="mine-3-25")
+        _make_template(other_org, slug="theirs-3-25")
+        staff_user = User.objects.create_user(
+            email="staff-tpl@example.com", password="pw", is_staff=True,
+        )
+        assert staff_user.is_superuser is False
+        client = _client_for(staff_user, org)
+        res = client.get(LIST_URL)
+        assert res.status_code == 200
+        slugs = [t["slug"] for t in res.data]
+        assert "mine-3-25" in slugs
+        assert "theirs-3-25" in slugs
+
     def test_filter_by_role(self, regular_client, org):
         _make_template(org, slug="counselor-t", role="counselor")
         _make_template(org, slug="kitchen-t", role="kitchen_staff")

--- a/backend/bunk_logs/api/wellness_dashboard.py
+++ b/backend/bunk_logs/api/wellness_dashboard.py
@@ -14,6 +14,7 @@ from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
 from bunk_logs.core.models import Program
 from bunk_logs.core.models import Reflection
+from bunk_logs.core.permissions import is_super_admin
 
 User = get_user_model()
 
@@ -45,7 +46,7 @@ def _viewer_program_scope(viewer: Person, user) -> list[int]:
     if program_ids:
         return list(program_ids)
     role = getattr(user, "role", "") or ""
-    if user.is_superuser or role == User.ADMIN:
+    if is_super_admin(user) or role == User.ADMIN:
         return list(
             Program.objects.filter(
                 organization_id=viewer.organization_id,

--- a/backend/bunk_logs/core/permissions/__init__.py
+++ b/backend/bunk_logs/core/permissions/__init__.py
@@ -8,6 +8,7 @@ imports keep working alongside the new ``visibility`` module.
 from bunk_logs.core.permissions.drf import IsOrgAdminOrSuperuser
 from bunk_logs.core.permissions.drf import _is_org_admin
 from bunk_logs.core.permissions.drf import _person_for_request
+from bunk_logs.core.permissions.super_admin import is_super_admin
 from bunk_logs.core.permissions.visibility import author_group_ids_with_descendants
 from bunk_logs.core.permissions.visibility import has_supervisor_role
 from bunk_logs.core.permissions.visibility import is_org_admin
@@ -20,5 +21,6 @@ __all__ = [
     "author_group_ids_with_descendants",
     "has_supervisor_role",
     "is_org_admin",
+    "is_super_admin",
     "reflections_visible_to",
 ]

--- a/backend/bunk_logs/core/permissions/drf.py
+++ b/backend/bunk_logs/core/permissions/drf.py
@@ -5,6 +5,7 @@ from rest_framework import permissions
 
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
+from bunk_logs.core.permissions.super_admin import is_super_admin
 
 
 def _person_for_request(request) -> Person | None:
@@ -20,13 +21,18 @@ def _is_org_admin(person: Person | None) -> bool:
 
 
 class IsOrgAdminOrSuperuser(permissions.BasePermission):
-    """Allow access only to org admins (active admin Membership) or Django superusers.
+    """Allow access only to org admins (active admin Membership) or Super Admins.
 
-    Requires an organization context on the request (set by the multi-tenant
-    middleware) and an authenticated user.
+    "Super Admin" is the BunkLogs-wide concept of ``is_staff`` OR
+    ``is_superuser`` -- see ``bunk_logs.core.permissions.is_super_admin``.
+    The class name keeps the legacy ``Superuser`` suffix so downstream
+    imports don't churn, but the gate it implements is the broader one.
+
+    Requires an organization context on the request (set by the
+    multi-tenant middleware) and an authenticated user.
     """
 
-    message = "Organization admin membership or superuser status required."
+    message = "Organization admin membership or Super Admin status required."
 
     def has_permission(self, request, view):
         if not (
@@ -35,7 +41,7 @@ class IsOrgAdminOrSuperuser(permissions.BasePermission):
             and getattr(request, "organization", None)
         ):
             return False
-        if request.user.is_superuser:
+        if is_super_admin(request.user):
             return True
         return _is_org_admin(_person_for_request(request))
 

--- a/backend/bunk_logs/core/permissions/super_admin.py
+++ b/backend/bunk_logs/core/permissions/super_admin.py
@@ -1,0 +1,30 @@
+"""Canonical "Super Admin" gate for the new RBAC code.
+
+A Super Admin is any authenticated user where ``is_staff`` OR ``is_superuser``
+is true. Both flags grant the same bypass-all access (org-scoped reflection
+visibility, org-admin endpoints, cross-tenant template / FieldKey
+management). This unifies what was historically a ``is_superuser``-only
+check on the new RBAC code with the ``is_staff``-based gate the legacy
+single-tenant code (and the React frontend) already use.
+
+If we ever need a stricter "platform superuser" tier -- say, "only Django
+superusers can edit the global FieldKey registry" -- introduce a separate
+helper named ``is_platform_superuser`` so the intent is obvious in code
+review. Don't quietly split the two flags here.
+"""
+from __future__ import annotations
+
+
+def is_super_admin(user) -> bool:
+    """True for ``is_staff`` OR ``is_superuser`` authenticated users.
+
+    Anonymous / unauthenticated / ``None`` users return False.
+    Tolerant of duck-typed user objects: missing attributes are treated as
+    False rather than raising.
+    """
+    if user is None or not getattr(user, "is_authenticated", False):
+        return False
+    return bool(
+        getattr(user, "is_staff", False)
+        or getattr(user, "is_superuser", False),
+    )

--- a/backend/bunk_logs/core/permissions/test_super_admin.py
+++ b/backend/bunk_logs/core/permissions/test_super_admin.py
@@ -1,0 +1,58 @@
+"""Unit tests for the ``is_super_admin`` helper.
+
+The helper itself is two lines; these tests exist to pin the contract so a
+future refactor can't quietly tighten the gate (e.g. dropping ``is_staff``
+support) without a failing test.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from bunk_logs.core.permissions import is_super_admin
+
+
+def test_returns_false_for_none():
+    assert is_super_admin(None) is False
+
+
+def test_returns_false_for_unauthenticated_duck():
+    user = SimpleNamespace(is_authenticated=False, is_staff=True, is_superuser=True)
+    assert is_super_admin(user) is False
+
+
+def test_returns_false_for_anonymous_like_user_without_attrs():
+    user = SimpleNamespace(is_authenticated=False)
+    assert is_super_admin(user) is False
+
+
+def test_returns_false_for_authenticated_user_with_neither_flag():
+    user = SimpleNamespace(is_authenticated=True, is_staff=False, is_superuser=False)
+    assert is_super_admin(user) is False
+
+
+def test_returns_true_for_is_staff_only():
+    user = SimpleNamespace(is_authenticated=True, is_staff=True, is_superuser=False)
+    assert is_super_admin(user) is True
+
+
+def test_returns_true_for_is_superuser_only():
+    user = SimpleNamespace(is_authenticated=True, is_staff=False, is_superuser=True)
+    assert is_super_admin(user) is True
+
+
+def test_returns_true_when_both_flags_set():
+    user = SimpleNamespace(is_authenticated=True, is_staff=True, is_superuser=True)
+    assert is_super_admin(user) is True
+
+
+@pytest.mark.django_db
+def test_returns_true_for_real_django_staff_user():
+    """Smoke check against an actual Django User instance, not just a duck."""
+    user = get_user_model().objects.create_user(
+        email="staff@example.com", password="pw", is_staff=True,
+    )
+    assert is_super_admin(user) is True
+    assert user.is_superuser is False

--- a/backend/bunk_logs/core/permissions/test_visibility.py
+++ b/backend/bunk_logs/core/permissions/test_visibility.py
@@ -143,6 +143,57 @@ class TestUnauthenticatedAndNoPerson:
             assert reflections_visible_to(admin).count() == 1
 
 
+# ── Super Admin consistency (3.25): is_staff alone is enough ────────────────
+
+
+class TestSuperAdminConsistency:
+    """``is_staff=True`` (without ``is_superuser``) must behave like a superuser
+    for every bypass-all gate in the new RBAC code. See prompt 3_25 and the
+    ``is_super_admin`` helper in ``bunk_logs.core.permissions.super_admin``.
+    """
+
+    @pytest.fixture
+    def staff_user(self):
+        return User.objects.create_user(
+            email="staff@example.com", password="pw", is_staff=True,
+        )
+
+    def test_is_staff_user_without_person_sees_full_org(
+        self, staff_user, org_a, program_a,
+    ):
+        tpl = _make_template(org_a)
+        _make_reflection(org_a, program_a, tpl)
+        assert staff_user.is_superuser is False
+        with organization_context(org_a):
+            assert reflections_visible_to(staff_user).count() == 1
+
+    def test_is_staff_user_sees_all_org_reflections_regardless_of_author(
+        self, staff_user, org_a, program_a,
+    ):
+        # Reflection authored by someone unrelated to the staff user.
+        other = _make_person(org_a, "Other", "Person")
+        tpl = _make_template(org_a)
+        _make_reflection(org_a, program_a, tpl, subject=other, author=other)
+        with organization_context(org_a):
+            assert reflections_visible_to(staff_user).count() == 1
+
+    def test_is_staff_user_is_treated_as_org_admin(self, staff_user):
+        assert is_org_admin(staff_user) is True
+
+    def test_is_staff_user_has_supervisor_role(self, staff_user):
+        assert has_supervisor_role(staff_user) is True
+
+    def test_is_staff_user_does_not_see_other_org_data(
+        self, staff_user, org_a, org_b, program_b,
+    ):
+        """Staff bypass is org-scoped: org context determines which org's data shows."""
+        b_person = _make_person(org_b, "B", "Person")
+        tpl_b = _make_template(org_b, slug="tpl-b")
+        _make_reflection(org_b, program_b, tpl_b, subject=b_person, author=b_person)
+        with organization_context(org_a):
+            assert reflections_visible_to(staff_user).count() == 0
+
+
 # ── Path 2: org admin sees everything in own org, nothing in other org ───────
 
 

--- a/backend/bunk_logs/core/permissions/visibility.py
+++ b/backend/bunk_logs/core/permissions/visibility.py
@@ -21,6 +21,7 @@ from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
 from bunk_logs.core.models import Reflection
+from bunk_logs.core.permissions.super_admin import is_super_admin
 
 User = get_user_model()
 
@@ -228,8 +229,8 @@ def reflections_visible_to(
 
     person = _person_for_user(user)
     if person is None:
-        # Superuser without a Person profile still gets full org visibility
-        if getattr(user, "is_superuser", False):
+        # Super Admin without a Person profile still gets full org visibility.
+        if is_super_admin(user):
             org = get_current_organization()
             if org is None:
                 return queryset.none()
@@ -238,7 +239,7 @@ def reflections_visible_to(
 
     org_id = person.organization_id
 
-    if getattr(user, "is_superuser", False) or _has_org_admin_membership(person, org_id):
+    if is_super_admin(user) or _has_org_admin_membership(person, org_id):
         return queryset.filter(organization_id=org_id)
 
     parts: list[Q] = [Q(author=person), Q(subject=person, template__subject_visible=True)]
@@ -270,10 +271,10 @@ def reflections_visible_to(
 
 
 def is_org_admin(user) -> bool:
-    """Helper: True if user is superuser or has an active admin Membership in their org."""
+    """True if user is a Super Admin or has an active admin Membership in their org."""
     if user is None or not getattr(user, "is_authenticated", False):
         return False
-    if getattr(user, "is_superuser", False):
+    if is_super_admin(user):
         return True
     person = _person_for_user(user)
     if person is None:
@@ -296,7 +297,7 @@ def has_supervisor_role(user) -> bool:
     """
     if user is None or not getattr(user, "is_authenticated", False):
         return False
-    if getattr(user, "is_superuser", False):
+    if is_super_admin(user):
         return True
     person = _person_for_user(user)
     if person is None:

--- a/docs/membership-role-vs-capability.md
+++ b/docs/membership-role-vs-capability.md
@@ -142,6 +142,53 @@ fail in CI if you forget step 2.
   `SupervisorScope` join table may show up in a later prompt when TBE
   Tier 2 forces it.
 
+## Super Admin (`is_staff` or `is_superuser`)
+
+`Membership.capability` and `Membership.role` decide what an **org user**
+can do. They sit above the legacy single-tenant code's `User.role` enum
+and below a top-level "Super Admin" gate that lives on Django's
+`AbstractUser`. Anyone with `is_staff` OR `is_superuser` set on the
+`User` row is a Super Admin and bypasses every org-level RBAC check the
+new code applies.
+
+Canonical helpers:
+
+- Backend: [`bunk_logs.core.permissions.is_super_admin`](../backend/bunk_logs/core/permissions/super_admin.py)
+- Frontend: [`frontend/src/utils/auth/isSuperAdmin.js`](../frontend/src/utils/auth/isSuperAdmin.js)
+
+What a Super Admin bypasses today:
+
+- `reflections_visible_to` returns every reflection in the active org,
+  regardless of authorship or assignment-group membership.
+- `IsOrgAdminOrSuperuser` and `MembershipPermission` grant access to
+  org-admin endpoints without an `admin` Membership.
+- Dashboards (coverage, template, wellness, team) skip the
+  Person/Membership scope checks and aggregate across the whole org.
+- `api/templates.py` and `api/field_keys.py` cross tenant boundaries:
+  Super Admins see other orgs' templates, edit global (org-less) rows,
+  and manage the shared FieldKey registry.
+- `_privileged_reflection_actor` in `api/reflections.py` lets a Super
+  Admin mutate any reflection (used by the API permission class so
+  authors aren't the only ones who can edit).
+
+**Why `is_staff` *and* `is_superuser`, not just one?** `is_staff` is the
+flag Crane Lake's legacy admin staff already have set (it grants access
+to the Django admin site). When the new multi-tenant code was written it
+defaulted to `is_superuser`-only checks; this skew left BunkLogs
+operators locked out of support workflows on the new surfaces. Unifying
+on either-flag-is-fine restores parity with the legacy code and with the
+React frontend, which has always accepted either.
+
+**When NOT to add a third tier.** A small handful of checks today gate
+cross-tenant writes (editing the global FieldKey registry, mutating
+global templates). These look like they want a stricter "platform
+superuser" tier separate from `is_staff`, but the audit unifies them
+because we don't have a real use case that requires the split and the
+extra tier would invent a security boundary nobody asked for. If that
+ever changes, introduce a *separate* helper named
+`is_platform_superuser` so the intent is loud in code review; do not
+quietly tighten `is_super_admin`.
+
 ## Per-reflection visibility (`team_visibility`)
 
 `Membership.capability` and `Membership.metadata.assigned_unit_slugs` decide

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from './auth/AuthContext';
 import { useEffect } from 'react';
+import isSuperAdmin from './utils/auth/isSuperAdmin';
 import Signin from './pages/Signin';
 import Signup from './pages/Signup';
 import Dashboard from './pages/Dashboard';
@@ -64,7 +65,8 @@ function ProtectedRoute({ children }) {
   return children;
 }
 
-// Admin-only route: requires is_staff or is_superuser
+// Admin-only route: Super Admin (is_staff || is_superuser) or User.role === 'admin'.
+// See `frontend/src/utils/auth/isSuperAdmin.js` for the canonical helper.
 function AdminRoute({ children }) {
   const { isAuthenticated, loading, user } = useAuth();
   const location = useLocation();
@@ -78,7 +80,7 @@ function AdminRoute({ children }) {
     return <Navigate to={`/signin?next=${encodeURIComponent(next)}`} replace />;
   }
 
-  const isAdmin = user?.is_staff || user?.is_superuser || user?.role?.toLowerCase() === 'admin';
+  const isAdmin = isSuperAdmin(user) || user?.role?.toLowerCase() === 'admin';
   if (!isAdmin) {
     return <Navigate to="/" replace state={{ toast: 'Admin access required' }} />;
   }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { getCSRFToken } from './django';
+import isSuperAdmin from './utils/auth/isSuperAdmin';
 
 // Get and clean the API URL
 const getApiUrl = () => {
@@ -200,7 +201,7 @@ export const getDateRangeForUser = (user) => {
   const todayStr = `${year}-${month}-${day}`;
   
   // For admin users and camper care team, allow a broader range
-  if (user?.role === 'Admin' || user?.role === 'Camper Care' || user?.is_staff === true || user?.is_superuser === true) {
+  if (user?.role === 'Admin' || user?.role === 'Camper Care' || isSuperAdmin(user)) {
     const startOfYearStr = `${year}-01-01`;
     return {
       start_date: startOfYearStr,

--- a/frontend/src/components/form/BunkLogForm.jsx
+++ b/frontend/src/components/form/BunkLogForm.jsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import Wysiwyg from './Wysiwyg';
 import InfoTooltip from '../common/InfoTooltip';
 import { useAuth, AuthContext } from '../../auth/AuthContext';
+import isSuperAdmin from '../../utils/auth/isSuperAdmin';
 
 function BunkLogForm({ bunk_id, camper_id, date, data, onClose, token: propsToken, currentCounselorId }) {
   const location = useLocation();
@@ -28,8 +29,8 @@ function BunkLogForm({ bunk_id, camper_id, date, data, onClose, token: propsToke
     const currentUser = auth?.user;
     if (!currentUser) return false;
     
-    // Admin and staff can always edit
-    if (currentUser.is_staff || currentUser.role === 'Admin' || currentUser.role === 'Unit Head') {
+    // Super Admin / Admin / Unit Head can always edit.
+    if (isSuperAdmin(currentUser) || currentUser.role === 'Admin' || currentUser.role === 'Unit Head') {
       return true;
     }
     

--- a/frontend/src/components/form/CounselorLogForm.jsx
+++ b/frontend/src/components/form/CounselorLogForm.jsx
@@ -3,6 +3,7 @@ import api from '../../api';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import Wysiwyg from './Wysiwyg';
 import { useAuth } from '../../auth/AuthContext';
+import isSuperAdmin from '../../utils/auth/isSuperAdmin';
 
 // Roles that are allowed to author staff reflections
 const STAFF_LOG_ROLES = ['Counselor', 'Leadership', 'Kitchen Staff', 'Unit Head', 'Camper Care'];
@@ -29,8 +30,8 @@ function CounselorLogForm({ date, existingLog, onClose, token: propsToken, viewO
       return false;
     }
     
-    // Admin and Django staff can always edit
-    if (currentUser.is_staff || currentUser.role === 'Admin') {
+    // Super Admin / Admin can always edit.
+    if (isSuperAdmin(currentUser) || currentUser.role === 'Admin') {
       return true;
     }
     

--- a/frontend/src/components/ui/SingleDatePicker.jsx
+++ b/frontend/src/components/ui/SingleDatePicker.jsx
@@ -5,6 +5,7 @@ import { Calendar } from "./calendar"
 import { Popover, PopoverContent, PopoverTrigger } from "./popover"
 import { useAuth } from '../../auth/AuthContext'
 import api, { fetchStaffAssignmentSafe, getDateRangeForUser } from '../../api'
+import isSuperAdmin from '../../utils/auth/isSuperAdmin'
 
 export default function SingleDatePicker({ className, date, setDate }) {
   const { user, token } = useAuth();
@@ -134,7 +135,7 @@ export default function SingleDatePicker({ className, date, setDate }) {
         }
 
         // Check if user is camper care - if so, set a reasonable date range without API call
-        if (user?.role === 'Camper Care' || user?.is_staff === true || user?.is_superuser === true) {
+        if (user?.role === 'Camper Care' || isSuperAdmin(user)) {
           console.log('User is camper care, setting broad date range without API call');
           const adminRange = getDateRangeForUser(user);
           setAllowedRange(adminRange);

--- a/frontend/src/pages/admin/templates/__tests__/AdminRoute.test.jsx
+++ b/frontend/src/pages/admin/templates/__tests__/AdminRoute.test.jsx
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Routes, Route, Navigate } from 'react-router-dom';
+import isSuperAdmin from '../../../../utils/auth/isSuperAdmin';
 
-// Minimal re-implementation of AdminRoute for isolation testing
+// Minimal re-implementation of AdminRoute that matches the production check in
+// frontend/src/Router.jsx -- both share the canonical isSuperAdmin helper.
 function AdminRoute({ user, loading, isAuthenticated, children }) {
   if (loading) return <div>Loading...</div>;
   if (!isAuthenticated) return <Navigate to="/signin" replace />;
-  const isAdmin = user?.is_staff || user?.is_superuser || user?.role === 'admin';
+  const isAdmin = isSuperAdmin(user) || user?.role === 'admin';
   if (!isAdmin) return <Navigate to="/" replace state={{ toast: 'Admin access required' }} />;
   return children;
 }

--- a/frontend/src/partials/Sidebar.jsx
+++ b/frontend/src/partials/Sidebar.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
+import isSuperAdmin from "../utils/auth/isSuperAdmin";
 
 import SidebarLinkGroup from "./SidebarLinkGroup";
 
@@ -252,7 +253,7 @@ function Sidebar({
               {/* Tests — admin-only group with quick links to the new
                   multi-tenant template / roster / dashboard surfaces so
                   admins can walk through the full daily-per-camper flow. */}
-              {user && (user.role === 'Admin' || user.is_staff || user.is_superuser) && (
+              {user && (user.role === 'Admin' || isSuperAdmin(user)) && (
                 <SidebarLinkGroup
                   activecondition={
                     pathname.startsWith('/admin/templates') ||

--- a/frontend/src/utils/auth/isSuperAdmin.js
+++ b/frontend/src/utils/auth/isSuperAdmin.js
@@ -1,0 +1,15 @@
+/**
+ * Canonical "Super Admin" gate for the React frontend.
+ *
+ * A Super Admin is any user with ``is_staff`` OR ``is_superuser`` set on the
+ * JWT/me payload. Both flags mean the user can bypass org-level RBAC: see
+ * org admin views, access cross-tenant template management, etc.
+ *
+ * Backend counterpart: ``bunk_logs.core.permissions.is_super_admin``.
+ *
+ * Returns ``false`` for ``null`` / ``undefined`` / missing flag objects, so
+ * call sites can use ``isSuperAdmin(user)`` unconditionally.
+ */
+export default function isSuperAdmin(user) {
+  return Boolean(user?.is_staff || user?.is_superuser);
+}

--- a/frontend/src/utils/auth/isSuperAdmin.test.js
+++ b/frontend/src/utils/auth/isSuperAdmin.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import isSuperAdmin from './isSuperAdmin';
+
+describe('isSuperAdmin', () => {
+  it('returns false for null / undefined', () => {
+    expect(isSuperAdmin(null)).toBe(false);
+    expect(isSuperAdmin(undefined)).toBe(false);
+  });
+
+  it('returns false when neither flag is set', () => {
+    expect(isSuperAdmin({})).toBe(false);
+    expect(isSuperAdmin({ is_staff: false, is_superuser: false })).toBe(false);
+    expect(isSuperAdmin({ role: 'Counselor' })).toBe(false);
+  });
+
+  it('returns true when only is_staff is set', () => {
+    expect(isSuperAdmin({ is_staff: true })).toBe(true);
+    expect(isSuperAdmin({ is_staff: true, is_superuser: false })).toBe(true);
+  });
+
+  it('returns true when only is_superuser is set', () => {
+    expect(isSuperAdmin({ is_superuser: true })).toBe(true);
+    expect(isSuperAdmin({ is_staff: false, is_superuser: true })).toBe(true);
+  });
+
+  it('returns true when both flags are set', () => {
+    expect(isSuperAdmin({ is_staff: true, is_superuser: true })).toBe(true);
+  });
+});

--- a/migration_prompts/3_25_super_admin_consistency.md
+++ b/migration_prompts/3_25_super_admin_consistency.md
@@ -1,0 +1,203 @@
+# Prompt 3.25 — `is_staff` / `is_superuser` Super Admin consistency audit
+
+**Wave:** 3 (Crane Lake Summer 2026 Build) — closes item #5 from the
+original RBAC guideline.
+**Estimated time:** 4-5 hours
+**Prerequisites:** Prompts 3.21-3.24 merged (capability + visibility
+fields already in place).
+
+**Use the context prompt at the top of `0_0_context_prompt.md` before this session.**
+
+---
+
+```
+The new RBAC code (everything under bunk_logs.api.* / bunk_logs.core.* )
+checks ``user.is_superuser`` whenever it needs a bypass-all gate, but the
+original product guideline (item #5) was: "is_staff is what will signify
+Super Admin". The legacy single-tenant code under bunk_logs/api/views.py
+already honours that -- it branches on ``is_staff or user.role == "Admin"``
+-- and the React frontend already accepts ``is_staff || is_superuser`` in
+every gate. The audit closes the gap on the new RBAC code so the three
+layers agree on a single definition.
+
+DEFINITION:
+
+A "Super Admin" is any authenticated user where ``is_staff`` OR
+``is_superuser`` is true. There is a single helper that returns this:
+
+    bunk_logs.core.permissions.is_super_admin(user) -> bool
+
+Both flags grant bypass-all access (org-scoped reflection visibility,
+org-admin endpoints, cross-tenant template / FieldKey management, and
+the legacy Crane Lake admin paths). If we ever need a stricter tier
+("only Django superusers can edit the global registry"), introduce a
+second helper THEN -- don't pre-emptively split the two flags now.
+
+CONTEXT for non-obvious decisions:
+
+- ``is_staff`` is the right primary signal because Crane Lake's existing
+  admin staff already have it set (legacy code path); flipping the new
+  RBAC code to also honour it lets the support team keep working without
+  a flag migration.
+- ``api/templates.py`` and ``api/field_keys.py`` cross tenant boundaries
+  (list ALL orgs' templates / FieldKeys; edit global rows). They still
+  unify on the same helper: anyone we trust as Super Admin can do this.
+  Splitting tiers later is cheap if we need it.
+
+Tasks:
+
+1. Add the helper. Put it in ``backend/bunk_logs/core/permissions/super_admin.py``
+   and re-export from ``bunk_logs.core.permissions.__init__``::
+
+       def is_super_admin(user) -> bool:
+           if user is None or not getattr(user, "is_authenticated", False):
+               return False
+           return bool(
+               getattr(user, "is_staff", False)
+               or getattr(user, "is_superuser", False),
+           )
+
+   Keep it dependency-free (no Django imports beyond what's in scope
+   already). Anonymous / unauthenticated users return False.
+
+2. Sweep the new RBAC code for direct ``is_superuser`` checks and
+   replace them with ``is_super_admin(user)``. The full list:
+
+   - ``backend/bunk_logs/core/permissions/visibility.py``
+     - the bypass for superuser-without-Person (currently line 232)
+     - the org-admin fast path (line 241)
+     - ``is_org_admin`` helper (line 276)
+     - ``has_supervisor_role`` helper (line 299)
+   - ``backend/bunk_logs/core/permissions/drf.py``
+     - ``IsOrgAdminOrSuperuser.has_permission`` (line 38). Update the
+       ``message`` to mention staff: "Organization admin membership or
+       Super Admin status required." Keep the class name unchanged so
+       no downstream import breaks; the docstring should reference the
+       helper.
+   - ``backend/bunk_logs/api/memberships.py``
+     - ``MembershipPermission.has_permission`` (line 49). Same docstring
+       / message updates as above.
+   - ``backend/bunk_logs/api/dashboards/coverage.py``
+     - viewer-or-superuser bypass (line 77).
+   - ``backend/bunk_logs/api/dashboards/template.py``
+     - ``_viewer_can_access_template`` (line 54). Keep the
+       ``user.role == User.ADMIN`` arm; that's a legacy role-based
+       gate the new helper doesn't subsume.
+   - ``backend/bunk_logs/api/wellness_dashboard.py`` (line 48).
+   - ``backend/bunk_logs/api/team_dashboard.py`` (line 56).
+   - ``backend/bunk_logs/api/reflections.py``
+     - ``_privileged_reflection_actor`` (line 41). This is already a
+       helper; rewrite its body to delegate to ``is_super_admin``.
+   - ``backend/bunk_logs/api/templates.py``
+     - get_queryset cross-org bypass (line 183)
+     - include_global=false short-circuit (line 205)
+     - get_object cross-org bypass (line 214)
+     - ``_check_edit_permission`` global-template gate (line 243)
+     - clone-template create gate (line 378)
+   - ``backend/bunk_logs/api/field_keys.py``
+     - all five sites (lines 77, 93, 106, 134, 154).
+
+   Do NOT touch:
+   - ``backend/bunk_logs/api/views.py`` -- legacy Crane Lake code,
+     already uses ``is_staff`` exclusively.
+   - ``backend/bunk_logs/api/permissions.py`` -- ditto.
+   - The ``debug_*.py`` / ``scripts/*.py`` files that are private dev
+     aids and not on the deploy path.
+
+3. Backend tests. The point is to prove an ``is_staff=True, is_superuser=False``
+   user gets the same access an ``is_superuser`` user gets today.
+
+   - In ``backend/bunk_logs/core/permissions/test_visibility.py`` add
+     ``TestSuperAdminConsistency``:
+     * ``test_is_staff_user_sees_all_org_reflections`` -- create a
+       reflection authored by a counselor, then assert an ``is_staff``
+       user with NO Person profile gets it back from
+       ``reflections_visible_to``.
+     * ``test_is_staff_user_is_org_admin`` -- assert
+       ``is_org_admin(staff_user) is True``.
+     * ``test_is_staff_user_has_supervisor_role`` -- assert
+       ``has_supervisor_role(staff_user) is True``.
+   - In a new test file ``backend/bunk_logs/core/permissions/test_super_admin.py``
+     pin the helper itself:
+     * Returns False for ``None`` and anonymous users.
+     * Returns False for an authenticated user with neither flag.
+     * Returns True for ``is_staff=True, is_superuser=False``.
+     * Returns True for ``is_staff=False, is_superuser=True``.
+     * Returns True for both flags set.
+   - In ``backend/bunk_logs/api/tests/test_template_api.py`` (or
+     wherever the templates viewset is exercised) add one smoke
+     assertion that an ``is_staff`` user can list templates from
+     another org's perspective the same way a superuser can. If the
+     existing fixtures don't cover that easily, add one targeted test
+     rather than refactoring the suite.
+   - In ``backend/bunk_logs/api/tests/test_membership_api.py`` add a
+     parallel smoke that an ``is_staff`` user passes
+     ``MembershipPermission``.
+
+4. Frontend. The gates already accept either flag, but the check is
+   duplicated four times. Extract a helper and migrate the call sites:
+
+   - Create ``frontend/src/utils/auth/isSuperAdmin.js``::
+
+       export function isSuperAdmin(user) {
+         return Boolean(user?.is_staff || user?.is_superuser);
+       }
+
+   - Replace the inline expressions in:
+     * ``frontend/src/Router.jsx`` (the AdminRoute gate)
+     * ``frontend/src/partials/Sidebar.jsx`` (the admin-section show/hide)
+     * ``frontend/src/api.js`` (the staff date-source branch)
+     * ``frontend/src/components/ui/SingleDatePicker.jsx`` (the future-date allowance branch)
+     * ``frontend/src/components/form/BunkLogForm.jsx``
+     * ``frontend/src/components/form/CounselorLogForm.jsx``
+     Keep any extra ``user.role`` checks in those files alongside the
+     helper; the helper only covers the Super Admin half.
+   - Update ``frontend/src/pages/admin/templates/__tests__/AdminRoute.test.jsx``
+     to import the helper too (it currently re-implements the check
+     inline; that drift was the original motivation for the audit).
+   - Add ``frontend/src/utils/auth/isSuperAdmin.test.js`` covering the
+     four input combinations.
+
+5. Documentation. Add a "Super Admin (`is_staff` or `is_superuser`)"
+   section to ``docs/membership-role-vs-capability.md`` directly above
+   the existing "Per-reflection visibility" section. Three points to
+   document:
+   - The two-flag definition and the canonical helpers
+     (``is_super_admin`` backend / ``isSuperAdmin`` frontend).
+   - Which capabilities and code paths a Super Admin bypasses
+     (visibility, org-admin endpoints, cross-org template management,
+     FieldKey registry).
+   - When NOT to add a third tier (we have ``is_superuser``-only checks
+     today in templates / FieldKeys; the audit unifies them, and if
+     anyone wants a stricter platform-only tier later it should be a
+     separate helper named ``is_platform_superuser`` so the intent is
+     loud in code review).
+
+Acceptance criteria:
+- Every direct ``user.is_superuser`` check in the new RBAC code
+  (everything outside ``api/views.py`` and ``api/permissions.py``) now
+  routes through ``is_super_admin`` or the frontend ``isSuperAdmin``.
+- ``make test-backend`` adds the four new test cases (super-admin
+  helper unit + visibility / templates / memberships smoke).
+- ``make test-frontend`` adds the helper unit tests.
+- ``make lint`` (``ruff check bunk_logs/ config/``) clean.
+- Docs page lists the canonical helpers and the bypass scope.
+
+Out of scope:
+- Touching the legacy single-tenant code (``api/views.py``,
+  ``api/permissions.py``). Those already honour ``is_staff``.
+- Introducing a stricter "platform superuser" tier. The audit unifies
+  the existing gates -- splitting tiers is a separate prompt if anyone
+  asks for it.
+- Anything user-management (adding admin UI to toggle ``is_staff``).
+  That's a separate UX prompt.
+
+Commit structure (single PR, ordered commits):
+  1. feat(3_25_super_admin_audit): introduce is_super_admin helper + unit tests
+  2. refactor(3_25_super_admin_audit): switch visibility/drf permissions to helper
+  3. refactor(3_25_super_admin_audit): switch dashboards + reflections actor to helper
+  4. refactor(3_25_super_admin_audit): switch cross-tenant templates + field_keys to helper
+  5. test(3_25_super_admin_audit): pin is_staff bypass behaviour on visibility + permissions
+  6. feat(3_25_super_admin_audit): frontend isSuperAdmin helper + call-site sweep
+  7. docs(3_25_super_admin_audit): document Super Admin = is_staff || is_superuser
+```


### PR DESCRIPTION
## Summary

Closes item #5 from the original RBAC guideline: ``is_staff`` is the BunkLogs-wide signifier of "Super Admin". The legacy single-tenant code and the React frontend already honoured ``is_staff || is_superuser``, but every new RBAC surface (visibility helpers, DRF permissions, dashboards, templates, FieldKey registry) checked ``is_superuser`` alone. This PR collapses those into one canonical gate so all three layers agree.

### Backend

- New helper ``bunk_logs.core.permissions.is_super_admin(user)`` -- single line, tolerant of duck-typed users, returns False for anonymous / missing-attr users.
- 16 direct ``user.is_superuser`` checks in new RBAC code switched to the helper:
  - ``core/permissions/visibility.py`` (4 sites) + ``core/permissions/drf.py``
  - ``api/memberships.py``, ``api/dashboards/{coverage,template}.py``
  - ``api/wellness_dashboard.py``, ``api/team_dashboard.py``
  - ``api/reflections.py::_privileged_reflection_actor``
  - ``api/templates.py`` (5 sites) + ``api/field_keys.py`` (5 sites)
- Class names (``IsOrgAdminOrSuperuser``, ``MembershipPermission``) kept so downstream imports don't churn; permission ``message`` strings + a couple of 403 error strings updated to say "Super Admin" instead of "superuser".
- Legacy ``api/views.py`` / ``api/permissions.py`` are untouched -- they already used ``is_staff``.

### Frontend

- New helper ``frontend/src/utils/auth/isSuperAdmin.js``.
- Six call sites with inline ``user?.is_staff || user?.is_superuser`` expressions migrated: ``Router.jsx``, ``Sidebar.jsx``, ``api.js``, ``SingleDatePicker.jsx``, ``BunkLogForm.jsx``, ``CounselorLogForm.jsx``.
- ``AdminRoute.test.jsx`` now imports the production helper directly, eliminating the silent drift that motivated this audit.

### Why one tier and not two

A few sites (cross-org template/field-key writes) look like they want a stricter "platform superuser only" gate separate from ``is_staff``. The docs note explicitly says **don't pre-emptively split**: today's behavior unifies, and if anyone needs a stricter tier later it should be a new helper named ``is_platform_superuser`` so the boundary is loud in code review.

### Tests + lint

- Backend: 605 passed (+7 new). New suites:
  - ``test_super_admin.py`` -- 8 unit tests pinning the helper contract.
  - ``test_visibility.py::TestSuperAdminConsistency`` -- 5 behavior tests (no Person + with reflections; ``is_org_admin`` / ``has_supervisor_role`` truthiness; org-scope boundary).
  - ``test_memberships_api.py::test_is_staff_user_can_list_without_org_admin_membership``.
  - ``test_template_api.py::test_is_staff_user_sees_cross_org_templates``.
- Frontend: 191 passed (+5 new for ``isSuperAdmin`` and the updated AdminRoute test).
- ``ruff check bunk_logs/ config/`` clean.

### Docs

- New "Super Admin (`is_staff` or `is_superuser`)" section in ``docs/membership-role-vs-capability.md`` covering: the definition, the two canonical helpers, the full bypass scope, why both flags qualify, and the explicit non-decision against a separate platform-superuser tier.

## Test plan

- [ ] Backend CI green (``pytest`` + ``ruff``).
- [ ] Frontend CI green (``vitest`` + build).
- [ ] Local: log in as a Django ``is_staff`` user (no superuser, no Membership) and confirm they:
  - See the admin section in the sidebar.
  - Can reach ``/admin/templates``.
  - Can list memberships and templates across an org without a 403.

Prompt: ``migration_prompts/3_25_super_admin_consistency.md``.

Made with [Cursor](https://cursor.com)