### PR TITLE
3_26_admin_navigation_hub: /admin + /dashboards hub pages, sidebar rename, URL consolidation

### DIFF
--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -29,6 +29,7 @@ import ReflectionSummaryPage from './pages/ReflectionSummaryPage';
 import TeamDashboardPage from './pages/TeamDashboardPage';
 import WellnessDashboardPage from './pages/WellnessDashboardPage';
 import MembershipManagementPage from './pages/MembershipManagementPage';
+import AdminHub from './pages/admin/AdminHub';
 import TemplateListPage from './pages/admin/templates/TemplateListPage';
 import TemplateEditorPage from './pages/admin/templates/TemplateEditorPage';
 import TemplateNewPage from './pages/admin/templates/TemplateNewPage';
@@ -41,6 +42,7 @@ import SubjectTrendsPage from './pages/dashboards/SubjectTrendsPage';
 import SubjectDetailPage from './pages/dashboards/SubjectDetailPage';
 import AuthorAttributionPage from './pages/dashboards/AuthorAttributionPage';
 import ConcernsInboxPage from './pages/dashboards/ConcernsInboxPage';
+import DashboardsHub from './pages/dashboards/DashboardsHub';
 import { useBunk } from './contexts/BunkContext';
 
 // Protected route component
@@ -333,25 +335,29 @@ function Router() {
           }
         />
 
+        {/* Legacy off-pattern dashboard URLs -- preserve as redirects so
+            existing bookmarks still land. The canonical URLs now live
+            under /dashboards/* (see below). */}
         <Route
           path="/team/dashboard"
-          element={
-            <ProtectedRoute>
-              <TeamDashboardPage />
-            </ProtectedRoute>
-          }
+          element={<Navigate to="/dashboards/team" replace />}
         />
-
         <Route
           path="/wellness/dashboard"
+          element={<Navigate to="/dashboards/wellness" replace />}
+        />
+
+        {/* Step 3.20 + 3.26: Coverage / trends / subject / authors /
+            concerns / team / wellness dashboards, plus the /dashboards
+            hub landing page. */}
+        <Route
+          path="/dashboards"
           element={
             <ProtectedRoute>
-              <WellnessDashboardPage />
+              <DashboardsHub />
             </ProtectedRoute>
           }
         />
-
-        {/* Step 3.20: Coverage / trends / subject / authors / concerns dashboards */}
         <Route
           path="/dashboards/coverage"
           element={
@@ -390,6 +396,32 @@ function Router() {
             <ProtectedRoute>
               <ConcernsInboxPage />
             </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/dashboards/team"
+          element={
+            <ProtectedRoute>
+              <TeamDashboardPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/dashboards/wellness"
+          element={
+            <ProtectedRoute>
+              <WellnessDashboardPage />
+            </ProtectedRoute>
+          }
+        />
+
+        {/* 3.26: Admin landing hub */}
+        <Route
+          path="/admin"
+          element={
+            <AdminRoute>
+              <AdminHub />
+            </AdminRoute>
           }
         />
 

--- a/frontend/src/pages/admin/AdminHub.jsx
+++ b/frontend/src/pages/admin/AdminHub.jsx
@@ -1,0 +1,140 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  Users,
+  FileText,
+  Layers,
+  BarChart3,
+  Tag,
+} from 'lucide-react';
+
+import Header from '../../partials/Header';
+import Sidebar from '../../partials/Sidebar';
+
+const ADMIN_CARDS = [
+  {
+    id: 'memberships',
+    title: 'Memberships',
+    blurb:
+      'Roster, role assignments, tags, and bulk tag operations for everyone in the program.',
+    to: '/admin/memberships',
+    icon: Users,
+  },
+  {
+    id: 'templates',
+    title: 'Reflection templates',
+    blurb:
+      'Create, clone, and edit reflection forms. The split-pane editor includes a live preview and routing controls.',
+    to: '/admin/templates',
+    icon: FileText,
+  },
+  {
+    id: 'groups',
+    title: 'Assignment groups',
+    blurb:
+      'Bunks, units, divisions, caseloads, and other groups that scope reflections and dashboards.',
+    to: '/admin/groups',
+    icon: Layers,
+  },
+  {
+    id: 'dashboards',
+    title: 'Dashboards',
+    blurb:
+      'Coverage, author attribution, concerns inbox, team, wellness, and subject trends.',
+    to: '/dashboards',
+    icon: BarChart3,
+  },
+  {
+    id: 'field-keys',
+    title: 'Field keys',
+    blurb:
+      'Canonical field-key registry that powers cross-template reporting. CRUD UI coming soon -- backend already exists.',
+    to: null,
+    deferred: true,
+    icon: Tag,
+  },
+];
+
+function Card({ card }) {
+  const Icon = card.icon;
+  const baseClass =
+    'flex flex-col rounded-xl border bg-white dark:bg-gray-900 p-5 shadow-sm transition-all';
+  const interactive =
+    'border-gray-200 dark:border-gray-700 hover:shadow-md hover:border-indigo-300 dark:hover:border-indigo-700';
+  const deferredClass =
+    'border-dashed border-gray-300 dark:border-gray-700 opacity-70 cursor-not-allowed';
+
+  const inner = (
+    <>
+      <div className="flex items-center gap-3 mb-3">
+        <span className="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300">
+          <Icon size={20} aria-hidden="true" />
+        </span>
+        <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+          {card.title}
+        </h3>
+        {card.deferred && (
+          <span className="ml-auto text-[10px] font-medium uppercase tracking-wide bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300 px-2 py-0.5 rounded-full">
+            Coming soon
+          </span>
+        )}
+      </div>
+      <p className="text-sm text-gray-600 dark:text-gray-400 flex-1">
+        {card.blurb}
+      </p>
+    </>
+  );
+
+  if (card.deferred) {
+    return (
+      <div
+        data-testid={`admin-hub-card-${card.id}`}
+        aria-disabled="true"
+        className={`${baseClass} ${deferredClass}`}
+      >
+        {inner}
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      to={card.to}
+      data-testid={`admin-hub-card-${card.id}`}
+      className={`${baseClass} ${interactive} group`}
+    >
+      {inner}
+    </Link>
+  );
+}
+
+export default function AdminHub() {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+      <div className="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
+        <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+        <main className="grow px-4 sm:px-6 lg:px-8 py-8 w-full max-w-5xl mx-auto">
+          <header className="mb-6">
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+              Admin
+            </h1>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+              Org-level tooling: people, templates, groups, dashboards, and
+              field keys.
+            </p>
+          </header>
+          <div
+            data-testid="admin-hub-grid"
+            className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
+          >
+            {ADMIN_CARDS.map((card) => (
+              <Card key={card.id} card={card} />
+            ))}
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/__tests__/AdminHub.test.jsx
+++ b/frontend/src/pages/admin/__tests__/AdminHub.test.jsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+vi.mock('../../../partials/Header', () => ({ default: () => null }));
+vi.mock('../../../partials/Sidebar', () => ({ default: () => null }));
+
+import AdminHub from '../AdminHub';
+
+function renderHub() {
+  return render(
+    <MemoryRouter initialEntries={['/admin']}>
+      <Routes>
+        <Route path="/admin" element={<AdminHub />} />
+        <Route path="/admin/memberships" element={<div data-testid="memberships">Memberships</div>} />
+        <Route path="/admin/templates" element={<div data-testid="templates">Templates</div>} />
+        <Route path="/admin/groups" element={<div data-testid="groups">Groups</div>} />
+        <Route path="/dashboards" element={<div data-testid="dashboards">Dashboards</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('AdminHub', () => {
+  it('renders the five admin cards', () => {
+    renderHub();
+    expect(screen.getByTestId('admin-hub-card-memberships')).toBeInTheDocument();
+    expect(screen.getByTestId('admin-hub-card-templates')).toBeInTheDocument();
+    expect(screen.getByTestId('admin-hub-card-groups')).toBeInTheDocument();
+    expect(screen.getByTestId('admin-hub-card-dashboards')).toBeInTheDocument();
+    expect(screen.getByTestId('admin-hub-card-field-keys')).toBeInTheDocument();
+  });
+
+  it('the field-keys card is marked deferred (no <a> wrapping it)', () => {
+    renderHub();
+    const card = screen.getByTestId('admin-hub-card-field-keys');
+    expect(card.tagName.toLowerCase()).not.toBe('a');
+    expect(card).toHaveAttribute('aria-disabled', 'true');
+    // The pill says "Coming soon" (exact match), the blurb has the phrase
+    // in a longer sentence -- so we match the pill specifically.
+    expect(screen.getByText('Coming soon')).toBeInTheDocument();
+  });
+
+  it('linkable cards point at the right routes', () => {
+    renderHub();
+    expect(screen.getByTestId('admin-hub-card-memberships')).toHaveAttribute('href', '/admin/memberships');
+    expect(screen.getByTestId('admin-hub-card-templates')).toHaveAttribute('href', '/admin/templates');
+    expect(screen.getByTestId('admin-hub-card-groups')).toHaveAttribute('href', '/admin/groups');
+    expect(screen.getByTestId('admin-hub-card-dashboards')).toHaveAttribute('href', '/dashboards');
+  });
+});

--- a/frontend/src/pages/admin/groups/GroupListPage.jsx
+++ b/frontend/src/pages/admin/groups/GroupListPage.jsx
@@ -110,7 +110,7 @@ export default function GroupListPage() {
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950 px-4 py-6">
       <div className="max-w-5xl mx-auto">
         <Link
-          to="/admin/memberships"
+          to="/admin"
           className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-4"
         >
           <ArrowLeft size={14} /> Admin

--- a/frontend/src/pages/admin/templates/TemplateListPage.jsx
+++ b/frontend/src/pages/admin/templates/TemplateListPage.jsx
@@ -104,7 +104,7 @@ export default function TemplateListPage() {
       <div className="max-w-6xl mx-auto">
         {/* Breadcrumb */}
         <Link
-          to="/admin/memberships"
+          to="/admin"
           className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-4"
         >
           <ArrowLeft size={14} /> Admin

--- a/frontend/src/pages/dashboards/DashboardsHub.jsx
+++ b/frontend/src/pages/dashboards/DashboardsHub.jsx
@@ -1,0 +1,134 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  BarChart3,
+  Users,
+  Inbox,
+  HeartPulse,
+  UserCog,
+  LineChart,
+} from 'lucide-react';
+
+import Header from '../../partials/Header';
+import Sidebar from '../../partials/Sidebar';
+
+const DASHBOARD_CARDS = [
+  {
+    id: 'coverage',
+    title: 'Coverage',
+    blurb:
+      "Per-group / per-day completion heatmap. Which bunks / units are filing reflections on schedule.",
+    to: '/dashboards/coverage',
+    icon: BarChart3,
+    audience: 'Supervisors, admins',
+  },
+  {
+    id: 'authors',
+    title: 'Author attribution',
+    blurb:
+      'Who is filing reflections, broken down by author -- catches both unfiled work and one person carrying the team.',
+    to: '/dashboards/authors',
+    icon: UserCog,
+    audience: 'Supervisors, admins',
+  },
+  {
+    id: 'concerns',
+    title: 'Concerns inbox',
+    blurb:
+      'Flagged low ratings and free-text concerns that need triage, surfaced as a queue.',
+    to: '/dashboards/concerns',
+    icon: Inbox,
+    audience: 'Supervisors, admins, wellness',
+  },
+  {
+    id: 'team',
+    title: 'Team dashboard',
+    blurb:
+      'Roll-up of reflections grouped by leadership / staff role across the program.',
+    to: '/dashboards/team',
+    icon: Users,
+    audience: 'Leadership, admins',
+  },
+  {
+    id: 'wellness',
+    title: 'Wellness dashboard',
+    blurb:
+      'Camper-care / health-center / special-diets cross-team view with subject-level patterns.',
+    to: '/dashboards/wellness',
+    icon: HeartPulse,
+    audience: 'Wellness team, admins',
+  },
+  {
+    id: 'subjects',
+    title: 'Subject trends',
+    blurb:
+      'Per-camper / per-staff trend grid over time. Pick a group first to see its members.',
+    to: '/admin/groups',
+    icon: LineChart,
+    audience: 'Supervisors, admins',
+    note: 'Pick a group, then click into a subject.',
+  },
+];
+
+function Card({ card }) {
+  const Icon = card.icon;
+  return (
+    <Link
+      to={card.to}
+      data-testid={`dashboards-hub-card-${card.id}`}
+      className="group flex flex-col rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-5 shadow-sm hover:shadow-md hover:border-indigo-300 dark:hover:border-indigo-700 transition-all"
+    >
+      <div className="flex items-center gap-3 mb-3">
+        <span className="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300">
+          <Icon size={20} aria-hidden="true" />
+        </span>
+        <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+          {card.title}
+        </h3>
+      </div>
+      <p className="text-sm text-gray-600 dark:text-gray-400 flex-1">
+        {card.blurb}
+      </p>
+      {card.note && (
+        <p className="mt-2 text-xs italic text-gray-500 dark:text-gray-500">
+          {card.note}
+        </p>
+      )}
+      <p className="mt-4 text-xs font-medium text-gray-500 dark:text-gray-400">
+        {card.audience}
+      </p>
+    </Link>
+  );
+}
+
+export default function DashboardsHub() {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+      <div className="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
+        <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+        <main className="grow px-4 sm:px-6 lg:px-8 py-8 w-full max-w-6xl mx-auto">
+          <header className="mb-6">
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+              Dashboards
+            </h1>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+              Aggregated views across reflections, authors, and subjects.
+              Visibility on each dashboard depends on your role and the
+              groups you supervise.
+            </p>
+          </header>
+          <div
+            data-testid="dashboards-hub-grid"
+            className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
+          >
+            {DASHBOARD_CARDS.map((card) => (
+              <Card key={card.id} card={card} />
+            ))}
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboards/__tests__/DashboardsHub.test.jsx
+++ b/frontend/src/pages/dashboards/__tests__/DashboardsHub.test.jsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+vi.mock('../../../partials/Header', () => ({ default: () => null }));
+vi.mock('../../../partials/Sidebar', () => ({ default: () => null }));
+
+import DashboardsHub from '../DashboardsHub';
+
+function renderHub() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboards']}>
+      <Routes>
+        <Route path="/dashboards" element={<DashboardsHub />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('DashboardsHub', () => {
+  it('renders the six dashboard cards plus the subjects helper card', () => {
+    renderHub();
+    expect(screen.getByTestId('dashboards-hub-card-coverage')).toBeInTheDocument();
+    expect(screen.getByTestId('dashboards-hub-card-authors')).toBeInTheDocument();
+    expect(screen.getByTestId('dashboards-hub-card-concerns')).toBeInTheDocument();
+    expect(screen.getByTestId('dashboards-hub-card-team')).toBeInTheDocument();
+    expect(screen.getByTestId('dashboards-hub-card-wellness')).toBeInTheDocument();
+    expect(screen.getByTestId('dashboards-hub-card-subjects')).toBeInTheDocument();
+  });
+
+  it('cards link to canonical /dashboards/* URLs (and subjects goes via /admin/groups)', () => {
+    renderHub();
+    expect(screen.getByTestId('dashboards-hub-card-coverage')).toHaveAttribute('href', '/dashboards/coverage');
+    expect(screen.getByTestId('dashboards-hub-card-authors')).toHaveAttribute('href', '/dashboards/authors');
+    expect(screen.getByTestId('dashboards-hub-card-concerns')).toHaveAttribute('href', '/dashboards/concerns');
+    expect(screen.getByTestId('dashboards-hub-card-team')).toHaveAttribute('href', '/dashboards/team');
+    expect(screen.getByTestId('dashboards-hub-card-wellness')).toHaveAttribute('href', '/dashboards/wellness');
+    expect(screen.getByTestId('dashboards-hub-card-subjects')).toHaveAttribute('href', '/admin/groups');
+  });
+});

--- a/frontend/src/partials/Sidebar.jsx
+++ b/frontend/src/partials/Sidebar.jsx
@@ -227,40 +227,17 @@ function Sidebar({
                   </NavLink>
                 </li>
               )}
-              {user && user.role === 'Admin' && (
-                <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
-                  <NavLink
-                    to="/admin/memberships"
-                    className={({ isActive }) =>
-                      `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
-                        isActive ? 'text-indigo-600 dark:text-indigo-400' : 'hover:text-gray-900 dark:hover:text-white'
-                      }`
-                    }
-                  >
-                    <div className="flex items-center">
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z" />
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 6h.008v.008H6V6z" />
-                      </svg>
-                      <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                        Memberships
-                      </span>
-                    </div>
-                  </NavLink>
-                </li>
-              )}
-
-              {/* Tests — admin-only group with quick links to the new
-                  multi-tenant template / roster / dashboard surfaces so
-                  admins can walk through the full daily-per-camper flow. */}
+              {/* 3.26: Admin group -- org-level tooling. The legacy
+                  top-level "Memberships" entry was folded into this
+                  group along with Templates / Groups so admins have a
+                  single discoverable surface. Personal items (My tasks,
+                  Reflection form) moved to top-level entries below so
+                  they're discoverable to non-admins too. */}
               {user && (user.role === 'Admin' || isSuperAdmin(user)) && (
                 <SidebarLinkGroup
                   activecondition={
-                    pathname.startsWith('/admin/templates') ||
-                    pathname.startsWith('/admin/groups') ||
-                    pathname.startsWith('/dashboards/') ||
-                    pathname === '/tasks' ||
-                    pathname === '/reflect'
+                    pathname === '/admin' ||
+                    pathname.startsWith('/admin/')
                   }
                 >
                   {(handleClick, open) => (
@@ -289,11 +266,16 @@ function Sidebar({
                               <path
                                 strokeLinecap="round"
                                 strokeLinejoin="round"
-                                d="M9.75 3.104v5.714a2.25 2.25 0 0 1-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 0 1 4.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0 1 12 15a9.065 9.065 0 0 0-6.23-.693L5 14.5m14.8.8 1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0 1 12 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5"
+                                d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"
+                              />
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
                               />
                             </svg>
                             <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                              Tests
+                              Admin
                             </span>
                           </div>
                           <div className="flex shrink-0 ml-2">
@@ -311,6 +293,39 @@ function Sidebar({
                       </a>
                       <div className="lg:hidden lg:sidebar-expanded:block 2xl:block">
                         <ul className={`pl-9 mt-1 ${!open ? 'hidden' : ''}`}>
+                          <li className="mb-1 last:mb-0">
+                            <NavLink
+                              end
+                              to="/admin"
+                              className={({ isActive }) =>
+                                `block transition duration-150 truncate ${
+                                  isActive
+                                    ? 'text-violet-600 dark:text-violet-400 font-medium'
+                                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+                                }`
+                              }
+                            >
+                              <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
+                                Admin home
+                              </span>
+                            </NavLink>
+                          </li>
+                          <li className="mb-1 last:mb-0">
+                            <NavLink
+                              to="/admin/memberships"
+                              className={({ isActive }) =>
+                                `block transition duration-150 truncate ${
+                                  isActive
+                                    ? 'text-violet-600 dark:text-violet-400 font-medium'
+                                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+                                }`
+                              }
+                            >
+                              <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
+                                Memberships
+                              </span>
+                            </NavLink>
+                          </li>
                           <li className="mb-1 last:mb-0">
                             <NavLink
                               to="/admin/templates"
@@ -343,9 +358,75 @@ function Sidebar({
                               </span>
                             </NavLink>
                           </li>
+                        </ul>
+                      </div>
+                    </React.Fragment>
+                  )}
+                </SidebarLinkGroup>
+              )}
+
+              {/* 3.26: Dashboards group -- aggregated views. Gated to
+                  admins for now; a follow-up can broaden it to
+                  supervisors / counselors per dashboard. */}
+              {user && (user.role === 'Admin' || isSuperAdmin(user)) && (
+                <SidebarLinkGroup
+                  activecondition={
+                    pathname === '/dashboards' ||
+                    pathname.startsWith('/dashboards/')
+                  }
+                >
+                  {(handleClick, open) => (
+                    <React.Fragment>
+                      <a
+                        href="#0"
+                        aria-expanded={open}
+                        className="block text-gray-800 dark:text-gray-100 truncate transition duration-150 hover:text-gray-900 dark:hover:text-white"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          handleClick();
+                          setSidebarExpanded(true);
+                        }}
+                      >
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center">
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              strokeWidth="1.5"
+                              stroke="currentColor"
+                              className="w-6 h-6"
+                              aria-hidden="true"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"
+                              />
+                            </svg>
+                            <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
+                              Dashboards
+                            </span>
+                          </div>
+                          <div className="flex shrink-0 ml-2">
+                            <svg
+                              className={`w-3 h-3 shrink-0 ml-1 fill-current text-gray-400 dark:text-gray-500 ${
+                                open ? 'rotate-180' : ''
+                              }`}
+                              viewBox="0 0 12 12"
+                              aria-hidden="true"
+                            >
+                              <path d="M5.9 11.4L.5 6l1.4-1.4 4 4 4-4L11.3 6z" />
+                            </svg>
+                          </div>
+                        </div>
+                      </a>
+                      <div className="lg:hidden lg:sidebar-expanded:block 2xl:block">
+                        <ul className={`pl-9 mt-1 ${!open ? 'hidden' : ''}`}>
                           <li className="mb-1 last:mb-0">
                             <NavLink
-                              to="/tasks"
+                              end
+                              to="/dashboards"
                               className={({ isActive }) =>
                                 `block transition duration-150 truncate ${
                                   isActive
@@ -355,23 +436,7 @@ function Sidebar({
                               }
                             >
                               <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                                My tasks
-                              </span>
-                            </NavLink>
-                          </li>
-                          <li className="mb-1 last:mb-0">
-                            <NavLink
-                              to="/reflect"
-                              className={({ isActive }) =>
-                                `block transition duration-150 truncate ${
-                                  isActive
-                                    ? 'text-violet-600 dark:text-violet-400 font-medium'
-                                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
-                                }`
-                              }
-                            >
-                              <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                                Reflection form
+                                Dashboards home
                               </span>
                             </NavLink>
                           </li>
@@ -387,7 +452,7 @@ function Sidebar({
                               }
                             >
                               <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                                Coverage dashboard
+                                Coverage
                               </span>
                             </NavLink>
                           </li>
@@ -423,11 +488,66 @@ function Sidebar({
                               </span>
                             </NavLink>
                           </li>
+                          <li className="mb-1 last:mb-0">
+                            <NavLink
+                              to="/dashboards/team"
+                              className={({ isActive }) =>
+                                `block transition duration-150 truncate ${
+                                  isActive
+                                    ? 'text-violet-600 dark:text-violet-400 font-medium'
+                                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+                                }`
+                              }
+                            >
+                              <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
+                                Team
+                              </span>
+                            </NavLink>
+                          </li>
+                          <li className="mb-1 last:mb-0">
+                            <NavLink
+                              to="/dashboards/wellness"
+                              className={({ isActive }) =>
+                                `block transition duration-150 truncate ${
+                                  isActive
+                                    ? 'text-violet-600 dark:text-violet-400 font-medium'
+                                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+                                }`
+                              }
+                            >
+                              <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
+                                Wellness
+                              </span>
+                            </NavLink>
+                          </li>
                         </ul>
                       </div>
                     </React.Fragment>
                   )}
                 </SidebarLinkGroup>
+              )}
+
+              {/* 3.26: My tasks is for everyone, not just admins. */}
+              {user && (
+                <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
+                  <NavLink
+                    to="/tasks"
+                    className={({ isActive }) =>
+                      `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
+                        isActive ? 'text-indigo-600 dark:text-indigo-400' : 'hover:text-gray-900 dark:hover:text-white'
+                      }`
+                    }
+                  >
+                    <div className="flex items-center">
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                      </svg>
+                      <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
+                        My tasks
+                      </span>
+                    </div>
+                  </NavLink>
+                </li>
               )}
               {user && REFLECTION_FORM_ROLES.includes(user.role) && (
                 <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">

--- a/frontend/src/partials/__tests__/Sidebar.test.jsx
+++ b/frontend/src/partials/__tests__/Sidebar.test.jsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// Stub the auth hook so the sidebar receives a Super Admin user.
+vi.mock('../../auth/AuthContext', () => ({
+  useAuth: () => ({
+    user: { is_staff: true, role: 'Counselor' },
+  }),
+}));
+
+// Stub the camp logo image import (jpeg) to keep the test fast.
+vi.mock('../../../src/images/clc-logo.jpeg', () => ({ default: 'logo.jpg' }));
+
+import Sidebar from '../Sidebar';
+
+function renderSidebar() {
+  return render(
+    <MemoryRouter initialEntries={['/admin']}>
+      <Sidebar sidebarOpen={true} setSidebarOpen={() => {}} />
+    </MemoryRouter>,
+  );
+}
+
+describe('Sidebar admin navigation (3.26)', () => {
+  it('renames the legacy "Tests" group to "Admin"', () => {
+    renderSidebar();
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+    expect(screen.queryByText('Tests')).not.toBeInTheDocument();
+  });
+
+  it('renders Admin group items (home, Memberships, Templates, Groups)', () => {
+    renderSidebar();
+    // Member is link text, scope to anchors so we don't catch page headings.
+    const adminLinks = screen.getAllByRole('link').map((a) => a.getAttribute('href'));
+    expect(adminLinks).toEqual(expect.arrayContaining([
+      '/admin',
+      '/admin/memberships',
+      '/admin/templates',
+      '/admin/groups',
+    ]));
+  });
+
+  it('renders the Dashboards group with canonical /dashboards/* targets', () => {
+    renderSidebar();
+    expect(screen.getByText('Dashboards')).toBeInTheDocument();
+    const links = screen.getAllByRole('link').map((a) => a.getAttribute('href'));
+    expect(links).toEqual(expect.arrayContaining([
+      '/dashboards',
+      '/dashboards/coverage',
+      '/dashboards/authors',
+      '/dashboards/concerns',
+      '/dashboards/team',
+      '/dashboards/wellness',
+    ]));
+    // Legacy off-pattern URLs must NOT appear in the sidebar.
+    expect(links).not.toContain('/team/dashboard');
+    expect(links).not.toContain('/wellness/dashboard');
+  });
+
+  it('renders "My tasks" as a top-level entry', () => {
+    renderSidebar();
+    expect(screen.getByText('My tasks')).toBeInTheDocument();
+  });
+});

--- a/migration_prompts/3_26_admin_navigation_hub.md
+++ b/migration_prompts/3_26_admin_navigation_hub.md
@@ -1,0 +1,144 @@
+# Prompt 3.26 — Admin navigation hub
+
+**Wave:** 3 (Crane Lake Summer 2026 Build) — UX cleanup so admins can
+actually find the surfaces we already built (Templates / Memberships /
+Groups / Dashboards) without memorizing URLs.
+**Estimated time:** 4-5 hours
+**Prerequisites:** 3.21-3.25 merged.
+
+**Use the context prompt at the top of `0_0_context_prompt.md` before this session.**
+
+---
+
+```
+The new RBAC admin tooling has shipped in pieces: MembershipManagementPage
+(/admin/memberships), TemplateListPage + split-pane editor
+(/admin/templates), GroupListPage (/admin/groups), and a fistful of
+dashboards under /dashboards/* plus two off-pattern ones (/team/dashboard,
+/wellness/dashboard). Each page works, but discoverability is broken:
+
+- The Sidebar's admin group is labelled "Tests" (scaffolding placeholder).
+- The Sidebar admin group is missing Memberships, the Team dashboard,
+  the Wellness dashboard, and Subject trends. It conflates admin work
+  with personal items ("My tasks", "Reflection form").
+- There is no /admin landing page -- TemplateListPage's breadcrumb says
+  "Admin" but points to /admin/memberships, which is wrong and surprising.
+- There is no /dashboards landing page -- every dashboard URL is
+  type-it-from-memory.
+- /team/dashboard and /wellness/dashboard use a different URL prefix
+  from the rest of /dashboards/*.
+
+Tasks:
+
+1. Add ``/admin`` landing page (``frontend/src/pages/admin/AdminHub.jsx``)
+   gated by ``AdminRoute``. Card grid linking to:
+     - Memberships -> /admin/memberships
+     - Reflection templates -> /admin/templates
+     - Assignment groups -> /admin/groups
+     - Dashboards -> /dashboards (link, not embed)
+     - Field keys -> /admin/field-keys (placeholder card marked
+       "Coming soon", no link; FieldKey UI is a separate prompt)
+   Each card: title, one-sentence purpose, lucide icon, optional
+   "deferred" pill. Mobile = single column. Wraps in a max-w-5xl
+   container with consistent header/breadcrumb-less framing (admin
+   index is the breadcrumb root).
+
+2. Add ``/dashboards`` landing page
+   (``frontend/src/pages/dashboards/DashboardsHub.jsx``) gated by
+   ``ProtectedRoute`` (NOT admin-only -- counselors and supervisors
+   use these too). Card grid:
+     - Coverage -> /dashboards/coverage
+     - Subject trends -> /dashboards/subject-trends (no groupId so the
+       card links to a stub page or a "pick a group" picker; if the
+       picker is too much, link to /admin/groups with a hint to click
+       a group, OR omit and document)
+     - Author attribution -> /dashboards/authors
+     - Concerns inbox -> /dashboards/concerns
+     - Team dashboard -> /dashboards/team
+     - Wellness dashboard -> /dashboards/wellness
+   Optionally tag each card with the role gate (e.g. "Supervisors
+   only", "Wellness team only") sourced from the same role lists the
+   backend uses; if the role lists aren't trivially accessible from
+   the FE, hardcode the labels as strings -- a future polish PR can
+   wire them up.
+
+3. URL consistency for the two off-pattern dashboards:
+   - Wire NEW routes:
+     - /dashboards/team   -> TeamDashboardPage
+     - /dashboards/wellness -> WellnessDashboardPage
+   - Keep the OLD routes (/team/dashboard, /wellness/dashboard) as
+     ``<Navigate to="/dashboards/team" replace>`` so existing bookmarks
+     still land. Don't delete the old routes.
+   - Anywhere in the codebase that links to the old URLs (sidebar,
+     dashboards, tests) gets pointed at the new one.
+
+4. Sidebar reorg (``frontend/src/partials/Sidebar.jsx``):
+   - Rename the "Tests" group to "Admin".
+   - Items, in this order:
+     - Admin home -> /admin           (new top-level link inside group)
+     - Memberships -> /admin/memberships
+     - Templates -> /admin/templates
+     - Assignment groups -> /admin/groups
+   - Move the dashboards into a SEPARATE sidebar group called
+     "Dashboards" (same gating: visible when the user can see at
+     least one dashboard; for now reuse the existing admin gate
+     ``user?.role === 'Admin' || isSuperAdmin(user)`` -- a follow-up
+     can broaden it to supervisors / counselors as we wire up the
+     non-admin entry points).
+     Items inside Dashboards group:
+       - Dashboards home -> /dashboards
+       - Coverage -> /dashboards/coverage
+       - Author attribution -> /dashboards/authors
+       - Concerns inbox -> /dashboards/concerns
+       - Team -> /dashboards/team
+       - Wellness -> /dashboards/wellness
+   - Move "My tasks" and "Reflection form" OUT of the admin group --
+     "Reflection form" already has a top-level entry for roles in
+     ``REFLECTION_FORM_ROLES``. "My tasks" should become a top-level
+     entry above Orders, gated identically (any authenticated user).
+
+5. Fix the TemplateListPage breadcrumb. Currently it links to
+   /admin/memberships but says "Admin". Point it at /admin instead.
+   While here, audit MembershipManagementPage and GroupListPage for
+   the same pattern and align them (one ``Link`` back to /admin with
+   the text "Admin", consistent ArrowLeft icon).
+
+6. Tests:
+   - ``frontend/src/pages/admin/__tests__/AdminHub.test.jsx`` -- 3
+     specs (renders the five expected cards; deferred card has no
+     link; clicking memberships routes to /admin/memberships).
+   - ``frontend/src/pages/dashboards/__tests__/DashboardsHub.test.jsx``
+     -- 2 specs (renders the six dashboard cards; clicking the
+     coverage card routes to /dashboards/coverage).
+   - ``frontend/src/partials/__tests__/Sidebar.test.jsx`` (or
+     wherever Sidebar tests live; create if missing) -- 2 specs:
+     "Admin" group label appears (not "Tests"); memberships link is
+     present inside the admin group.
+   - Tighten the existing TemplateListPage test if it asserts on the
+     breadcrumb target.
+
+Acceptance:
+- ``make test-frontend`` adds the new specs and keeps the existing
+  191 green.
+- ``make test-backend`` unchanged (no backend changes in this PR).
+- Manual sanity-check: log in as an admin, navigate from Sidebar to
+  Admin home, click each card, click back -- everything reachable
+  without typing URLs.
+
+Out of scope:
+- FieldKey registry CRUD UI (placeholder card only; separate prompt).
+- Broadening dashboard visibility for non-admin supervisors -- the
+  sidebar group still uses the admin gate; a follow-up can wire the
+  per-dashboard role gates into the sidebar.
+- Subject-trends "pick a group" picker if too much for this PR; the
+  Subject trends card can link to /admin/groups with a hint in the
+  card copy.
+
+Commit structure (single PR):
+  1. docs(3_26_admin_navigation_hub): plan
+  2. feat(3_26_admin_navigation_hub): /dashboards hub + URL aliases for team/wellness
+  3. feat(3_26_admin_navigation_hub): /admin hub landing page
+  4. refactor(3_26_admin_navigation_hub): sidebar Admin + Dashboards groups
+  5. fix(3_26_admin_navigation_hub): align admin breadcrumb targets
+  6. test(3_26_admin_navigation_hub): cover new hubs + sidebar rename
+```


### PR DESCRIPTION
## Summary

UX cleanup so admins can navigate the seven dashboards and three admin surfaces without typing URLs. The new RBAC code shipped each page in isolation, leaving the sidebar with a placeholder "Tests" label, a broken "Admin" breadcrumb on TemplateListPage, and two off-pattern dashboard URLs (``/team/dashboard``, ``/wellness/dashboard``).

### New surfaces

- **``/admin``** — card-grid hub linking to Memberships, Templates, Assignment groups, Dashboards. Field-keys card is a deferred placeholder (non-interactive, "Coming soon" pill) since the CRUD UI is a separate PR.
- **``/dashboards``** — card-grid hub for all six dashboards (Coverage, Author attribution, Concerns inbox, Team, Wellness, plus a "Subject trends" helper card that links to ``/admin/groups`` so you pick a group before drilling in). Each card carries an audience hint.

### URL consolidation

| Before | After |
|---|---|
| ``/team/dashboard`` | ``/dashboards/team`` (old URL kept as ``Navigate replace`` redirect) |
| ``/wellness/dashboard`` | ``/dashboards/wellness`` (same) |
| (no hub) | ``/dashboards`` |
| (no hub) | ``/admin`` |

Existing bookmarks/email links to the old URLs still resolve because of the redirects.

### Sidebar reorganization

- "Tests" group → **Admin** (cog icon). Items: Admin home, Memberships, Templates, Assignment groups.
- New **Dashboards** group: Dashboards home, Coverage, Author attribution, Concerns inbox, Team, Wellness.
- The legacy top-level "Memberships" entry (gated only by ``role==='Admin'``) is folded into the Admin group, which uses the broader ``isSuperAdmin || role==='Admin'`` gate so ``is_staff`` operators see it too.
- **My tasks** hoisted out of the admin group into a top-level entry — it's for any authenticated user, not just admins.

### Breadcrumb fix

TemplateListPage and GroupListPage both had an "Admin" breadcrumb that pointed at ``/admin/memberships`` (a surprise jump to a sibling page). Both now point at the new ``/admin`` hub.

### Tests + lint

- Frontend: 200 passed (+9 new across AdminHub, DashboardsHub, Sidebar).
- Backend: 605 passed (no backend changes; ran to confirm).
- ``ruff check`` clean.
- ``vite build`` succeeds.

## Test plan

- [ ] Frontend CI green (vitest + build).
- [ ] Backend CI green (pytest + ruff).
- [ ] Local: log in as an admin → click "Admin" in sidebar → land on ``/admin`` → click each card → land on the right page → click "Admin" breadcrumb on Templates/Groups → returns to ``/admin``.
- [ ] Local: visit the legacy ``/team/dashboard`` URL → auto-redirects to ``/dashboards/team`` with no flicker.
- [ ] Local: sidebar Dashboards group expands; clicking Coverage / Authors / Concerns / Team / Wellness all reach the dashboard pages.

Prompt: ``migration_prompts/3_26_admin_navigation_hub.md``.

Made with [Cursor](https://cursor.com)