### PR TITLE
3_27_wayfinding_and_broken_links: fix dead deep-links + sidebar/breadcrumb cleanup

### DIFF
--- a/backend/bunk_logs/api/reflections.py
+++ b/backend/bunk_logs/api/reflections.py
@@ -223,8 +223,22 @@ class ReflectionTemplateSummarySerializer(serializers.ModelSerializer):
 
 class ReflectionSerializer(serializers.ModelSerializer):
     template_meta = ReflectionTemplateSummarySerializer(source="template", read_only=True)
+    localized_schema = serializers.SerializerMethodField()
     program_slug = serializers.SlugField(write_only=True, required=False)
     answers = serializers.JSONField()
+
+    def get_localized_schema(self, obj):
+        """Localized template schema for the reflection's saved language.
+
+        Lets a read-only viewer render prompts + answers without a second
+        round-trip to ``/api/v1/templates/<id>/``. Only returned when the
+        instance is fully hydrated (i.e. has a saved template + language).
+        """
+        template = getattr(obj, "template", None)
+        if template is None or not getattr(template, "schema", None):
+            return None
+        language = getattr(obj, "language", None) or "en"
+        return _localize_schema(template.schema, language)
     subject = serializers.PrimaryKeyRelatedField(
         queryset=Person.all_objects.all(),
         allow_null=True,
@@ -256,6 +270,7 @@ class ReflectionSerializer(serializers.ModelSerializer):
             "submission_id",
             "template",
             "template_meta",
+            "localized_schema",
             "submitted_by",
             "period_start",
             "period_end",

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -24,6 +24,7 @@ import AdminBunkLogs from './pages/AdminBunkLogs';
 import StaffMemberHistory from './pages/StaffMemberHistory';
 import MigrationDashboard from './pages/MigrationDashboard';
 import MyReflectionsPage from './pages/MyReflectionsPage';
+import ReflectionDetailPage from './pages/ReflectionDetailPage';
 import ReflectionFormPage from './pages/ReflectionFormPage';
 import ReflectionSummaryPage from './pages/ReflectionSummaryPage';
 import TeamDashboardPage from './pages/TeamDashboardPage';
@@ -331,6 +332,19 @@ function Router() {
           element={
             <ProtectedRoute>
               <MyReflectionsPage />
+            </ProtectedRoute>
+          }
+        />
+
+        {/* 3.27: Single-reflection read-only viewer. Replaces the broken
+            /reflect/summary?reflection=<id> deep-links from concerns /
+            subject / trends, and unblocks the coverage popover "View"
+            button on /tasks (which already routes here). */}
+        <Route
+          path="/reflections/:id"
+          element={
+            <ProtectedRoute>
+              <ReflectionDetailPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/dashboards/concerns/ConcernsInbox.jsx
+++ b/frontend/src/dashboards/concerns/ConcernsInbox.jsx
@@ -128,7 +128,7 @@ export default function ConcernsInbox({ payload, onChanged }) {
                   )}
                   <p className="mt-2 text-xs">
                     <Link
-                      to={`/reflect/summary?reflection=${it.reflection_id}`}
+                      to={`/reflections/${it.reflection_id}?returnTo=/dashboards/concerns`}
                       className="text-indigo-700 dark:text-indigo-300 hover:underline"
                     >
                       Open reflection

--- a/frontend/src/dashboards/subject/SubjectDetail.jsx
+++ b/frontend/src/dashboards/subject/SubjectDetail.jsx
@@ -100,7 +100,7 @@ function ConcernsList({ concerns }) {
                 <PrivacyChip teamVisibility={c.team_visibility} />
                 {c.reflection_id && (
                   <Link
-                    to={`/reflect/summary?reflection=${c.reflection_id}`}
+                    to={`/reflections/${c.reflection_id}`}
                     className="underline"
                   >
                     View reflection
@@ -188,7 +188,7 @@ export default function SubjectDetail({ payload }) {
                       </span>
                       <PrivacyChip teamVisibility={r.team_visibility} />
                       <Link
-                        to={`/reflect/summary?reflection=${r.id}`}
+                        to={`/reflections/${r.id}`}
                         className="underline"
                       >
                         view

--- a/frontend/src/dashboards/trends/TrendCell.jsx
+++ b/frontend/src/dashboards/trends/TrendCell.jsx
@@ -12,8 +12,8 @@ function formatShortDate(iso) {
  * Single colored cell for the Subject Trend Grid.
  *
  * Renders as a button so it's keyboard-reachable. When a reflection_id is
- * present, clicking navigates to /reflect/summary?reflection=<id>; otherwise
- * the button is disabled (no-data state).
+ * present, clicking navigates to /reflections/<id>; otherwise the cell is
+ * a non-interactive label (no-data state).
  */
 export default function TrendCell({
   cell,
@@ -75,7 +75,7 @@ export default function TrendCell({
   return (
     <td className={baseClass} style={{ backgroundColor: fill, color }}>
       <Link
-        to={`/reflect/summary?reflection=${cell.reflection_id}`}
+        to={`/reflections/${cell.reflection_id}`}
         aria-label={aria}
         title={tooltip}
         className={innerClass}

--- a/frontend/src/pages/MembershipManagementPage.jsx
+++ b/frontend/src/pages/MembershipManagementPage.jsx
@@ -278,6 +278,14 @@ export default function MembershipManagementPage() {
       <div className="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
         <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
         <main className="grow px-4 sm:px-6 lg:px-8 py-8 w-full max-w-9xl mx-auto">
+          {/* 3.27: back-link to /admin, matching templates and groups pages. */}
+          <Link
+            to="/admin"
+            data-testid="memberships-admin-back-link"
+            className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-4"
+          >
+            ← Admin
+          </Link>
           <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
             <div>
               <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Memberships</h1>

--- a/frontend/src/pages/ReflectionDetailPage.jsx
+++ b/frontend/src/pages/ReflectionDetailPage.jsx
@@ -1,0 +1,230 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
+
+import api from '../api';
+import Header from '../partials/Header';
+import Sidebar from '../partials/Sidebar';
+import PrivacyChip from '../components/reflection/PrivacyChip';
+
+function promptText(field) {
+  if (!field?.prompts || typeof field.prompts !== 'object') return '';
+  const v = Object.values(field.prompts)[0];
+  return typeof v === 'string' ? v : '';
+}
+
+function categoryLabel(cat) {
+  if (!cat?.labels || typeof cat.labels !== 'object') return cat?.key || '';
+  const v = Object.values(cat.labels)[0];
+  return typeof v === 'string' ? v : cat.key || '';
+}
+
+function formatAnswer(field, value) {
+  if (value === undefined || value === null || value === '') return '—';
+  if (field.type === 'rating_group' && value && typeof value === 'object') {
+    return Object.entries(value)
+      .map(([k, v]) => {
+        const cat = (field.categories || []).find((c) => c.key === k);
+        const label = cat ? categoryLabel(cat) : k;
+        return `${label}: ${v}`;
+      })
+      .join('; ');
+  }
+  if (Array.isArray(value)) return value.join(', ') || '—';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+function formatDate(iso) {
+  if (!iso) return '';
+  const d = new Date(`${iso}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatDateTime(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function ErrorPanel({ title, body, backHref, backLabel }) {
+  return (
+    <div className="rounded-xl border border-amber-200 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-900 p-5">
+      <h2 className="text-base font-semibold text-amber-900 dark:text-amber-100 mb-1">
+        {title}
+      </h2>
+      <p className="text-sm text-amber-900 dark:text-amber-100">{body}</p>
+      <div className="mt-4">
+        <Link
+          to={backHref}
+          className="text-sm font-medium text-amber-900 dark:text-amber-100 underline"
+        >
+          {backLabel}
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default function ReflectionDetailPage() {
+  const { id } = useParams();
+  const [searchParams] = useSearchParams();
+  const returnTo = searchParams.get('returnTo') || '/my-reflections';
+
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [reflection, setReflection] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [errorState, setErrorState] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setErrorState(null);
+    api
+      .get(`/api/v1/reflections/${id}/`)
+      .then((r) => {
+        if (cancelled) return;
+        setReflection(r.data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        const httpStatus = err.response?.status;
+        if (httpStatus === 404) {
+          setErrorState({
+            title: 'Reflection not found',
+            body:
+              "We couldn't find that reflection. It may have been deleted, or you may have followed a stale link.",
+          });
+        } else if (httpStatus === 403) {
+          setErrorState({
+            title: 'You don\u2019t have access',
+            body:
+              'You do not have permission to view this reflection. If you think this is wrong, ask an admin.',
+          });
+        } else {
+          setErrorState({
+            title: 'Something went wrong',
+            body:
+              err.response?.data?.detail
+              || 'Could not load this reflection. Please try again.',
+          });
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const schema = reflection?.localized_schema;
+  const fields = Array.isArray(schema?.fields) ? schema.fields : [];
+  const templateName = reflection?.template_meta?.name;
+  const periodStart = reflection?.period_start;
+  const periodEnd = reflection?.period_end;
+  const language = reflection?.language;
+
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+      <div className="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
+        <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+        <main className="grow px-4 sm:px-6 lg:px-8 py-8 w-full max-w-2xl mx-auto">
+          <div className="mb-4">
+            <Link
+              to={returnTo}
+              className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 underline"
+            >
+              ← Back
+            </Link>
+          </div>
+
+          {loading && (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Loading reflection…
+            </p>
+          )}
+
+          {!loading && errorState && (
+            <ErrorPanel
+              title={errorState.title}
+              body={errorState.body}
+              backHref={returnTo}
+              backLabel="Back to where I was"
+            />
+          )}
+
+          {!loading && !errorState && reflection && (
+            <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-sm">
+              <div className="flex flex-wrap items-center gap-3 mb-2">
+                <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
+                  Reflection
+                </h1>
+                <PrivacyChip teamVisibility={reflection.team_visibility} />
+              </div>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                {templateName}
+              </p>
+              <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                #{reflection.id}
+                {periodStart && (
+                  <>
+                    {' · '}
+                    {formatDate(periodStart)}
+                    {periodStart !== periodEnd && (
+                      <>
+                        {' → '}
+                        {formatDate(periodEnd)}
+                      </>
+                    )}
+                  </>
+                )}
+                {language && <> · {language}</>}
+              </p>
+              {reflection.submitted_at && (
+                <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                  Submitted {formatDateTime(reflection.submitted_at)}
+                </p>
+              )}
+
+              {fields.length === 0 ? (
+                <p className="mt-6 text-sm text-gray-500 dark:text-gray-400 italic">
+                  This reflection's template has no fields to display.
+                </p>
+              ) : (
+                <ul className="mt-6 space-y-4">
+                  {fields.map((field) => (
+                    <li
+                      key={field.key}
+                      className="border-b border-gray-100 dark:border-gray-700 pb-3 last:border-0"
+                    >
+                      <p className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                        {field.type === 'rating_group'
+                          ? 'Ratings'
+                          : promptText(field) || field.key}
+                      </p>
+                      <p className="mt-1 text-sm text-gray-600 dark:text-gray-400 whitespace-pre-wrap">
+                        {formatAnswer(field, reflection.answers?.[field.key])}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ReflectionDetailPage.test.jsx
+++ b/frontend/src/pages/ReflectionDetailPage.test.jsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+import ReflectionDetailPage from './ReflectionDetailPage';
+
+const getMock = vi.fn();
+
+vi.mock('../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+  },
+}));
+
+vi.mock('../partials/Header', () => ({ default: () => null }));
+vi.mock('../partials/Sidebar', () => ({ default: () => null }));
+
+function renderAt(url) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <Routes>
+        <Route path="/reflections/:id" element={<ReflectionDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const FULL_REFLECTION = {
+  id: 91,
+  language: 'en',
+  period_start: '2026-06-08',
+  period_end: '2026-06-14',
+  team_visibility: 'supervisors_only',
+  submitted_at: '2026-06-12T10:00:00Z',
+  template_meta: {
+    id: 7,
+    name: 'Counselor weekly',
+    cadence: 'weekly',
+  },
+  localized_schema: {
+    fields: [
+      {
+        key: 'wins',
+        type: 'short_text',
+        prompts: { en: 'What went well?' },
+      },
+      {
+        key: 'support',
+        type: 'long_text',
+        prompts: { en: 'Where do you need support?' },
+      },
+    ],
+  },
+  answers: {
+    wins: 'Strong start',
+    support: 'Some space to think',
+  },
+};
+
+describe('ReflectionDetailPage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  it('loads and renders prompts + answers with privacy chip when filed privately', async () => {
+    getMock.mockResolvedValueOnce({ data: FULL_REFLECTION });
+    renderAt('/reflections/91');
+
+    await waitFor(() =>
+      expect(screen.getByText('Counselor weekly')).toBeInTheDocument(),
+    );
+
+    expect(getMock).toHaveBeenCalledWith('/api/v1/reflections/91/');
+    expect(screen.getByText('What went well?')).toBeInTheDocument();
+    expect(screen.getByText('Strong start')).toBeInTheDocument();
+    expect(screen.getByText('Where do you need support?')).toBeInTheDocument();
+    expect(screen.getByText('Some space to think')).toBeInTheDocument();
+    expect(screen.getByTestId('privacy-chip')).toBeInTheDocument();
+  });
+
+  it('renders a friendly panel on 403', async () => {
+    getMock.mockRejectedValueOnce({ response: { status: 403 } });
+    renderAt('/reflections/91');
+
+    await waitFor(() =>
+      expect(screen.getByText(/don.t have access/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('renders a friendly panel on 404', async () => {
+    getMock.mockRejectedValueOnce({ response: { status: 404 } });
+    renderAt('/reflections/91');
+
+    await waitFor(() =>
+      expect(screen.getByText(/reflection not found/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('hides the privacy chip when the reflection is not filed privately', async () => {
+    getMock.mockResolvedValueOnce({
+      data: { ...FULL_REFLECTION, team_visibility: 'team' },
+    });
+    renderAt('/reflections/91');
+
+    await waitFor(() =>
+      expect(screen.getByText('Counselor weekly')).toBeInTheDocument(),
+    );
+
+    expect(screen.queryByTestId('privacy-chip')).toBeNull();
+  });
+});

--- a/frontend/src/pages/admin/groups/GroupDetailPage.jsx
+++ b/frontend/src/pages/admin/groups/GroupDetailPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, UserPlus, Trash2, Upload, RotateCcw, CheckCircle, XCircle } from 'lucide-react';
+import { ArrowLeft, BarChart3, UserPlus, Trash2, Upload, RotateCcw, CheckCircle, XCircle } from 'lucide-react';
 import api from '../../../api';
 
 function PersonSearchInput({ orgContext, onSelect }) {
@@ -344,14 +344,24 @@ export default function GroupDetailPage() {
               {!group.is_active && <span className="ml-2 text-red-500">(inactive)</span>}
             </p>
           </div>
-          <button
-            type="button"
-            onClick={handleDeactivate}
-            disabled={!group.is_active}
-            className="text-xs text-gray-400 hover:text-red-500 dark:hover:text-red-400 underline disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            Deactivate
-          </button>
+          <div className="flex items-center gap-3">
+            <Link
+              to={`/dashboards/subject-trends/${id}`}
+              data-testid="group-subject-trends-link"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+            >
+              <BarChart3 size={14} aria-hidden="true" />
+              View subject trends →
+            </Link>
+            <button
+              type="button"
+              onClick={handleDeactivate}
+              disabled={!group.is_active}
+              className="text-xs text-gray-400 hover:text-red-500 dark:hover:text-red-400 underline disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Deactivate
+            </button>
+          </div>
         </div>
 
         {/* Add member */}

--- a/frontend/src/partials/Sidebar.jsx
+++ b/frontend/src/partials/Sidebar.jsx
@@ -104,11 +104,16 @@ function Sidebar({
             <ul className="mt-3">
               {/* Role-specific dashboard links */}
 
+              {/* 3.27: Counselors land on the legacy bunk-log counselor home,
+                  not the new reflection history. The "My reflections" entry
+                  for the new reflection model lives below alongside the
+                  Program reflection link so it appears for every role that
+                  can author reflections. */}
               {user && user.role === 'Counselor' && (
                 <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
-                  <NavLink 
-                    to="/counselor-dashboard" 
-                    className={({ isActive }) => 
+                  <NavLink
+                    to="/counselor-dashboard"
+                    className={({ isActive }) =>
                       `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
                         isActive ? "text-blue-600 dark:text-blue-400" : "hover:text-gray-900 dark:hover:text-white"
                       }`
@@ -116,10 +121,10 @@ function Sidebar({
                   >
                     <div className="flex items-center">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
                       </svg>
                       <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                        My Reflections
+                        Counselor home
                       </span>
                     </div>
                   </NavLink>
@@ -188,7 +193,7 @@ function Sidebar({
               {user && ['Admin', 'Leadership'].includes(user.role) && (
                 <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
                   <NavLink
-                    to="/team/dashboard"
+                    to="/dashboards/team"
                     className={({ isActive }) =>
                       `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
                         isActive ? 'text-teal-600 dark:text-teal-400' : 'hover:text-gray-900 dark:hover:text-white'
@@ -209,7 +214,7 @@ function Sidebar({
               {user && ['Admin', 'Camper Care'].includes(user.role) && (
                 <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
                   <NavLink
-                    to="/wellness/dashboard"
+                    to="/dashboards/wellness"
                     className={({ isActive }) =>
                       `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
                         isActive ? 'text-teal-600 dark:text-teal-400' : 'hover:text-gray-900 dark:hover:text-white'
@@ -565,6 +570,30 @@ function Sidebar({
                       </svg>
                       <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
                         Program reflection
+                      </span>
+                    </div>
+                  </NavLink>
+                </li>
+              )}
+              {/* 3.27: Personal reflection history. Available to every role
+                  that can author reflections so it isn't only reachable from
+                  the post-submit screen. */}
+              {user && REFLECTION_FORM_ROLES.includes(user.role) && (
+                <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
+                  <NavLink
+                    to="/my-reflections"
+                    className={({ isActive }) =>
+                      `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
+                        isActive ? 'text-indigo-600 dark:text-indigo-400' : 'hover:text-gray-900 dark:hover:text-white'
+                      }`
+                    }
+                  >
+                    <div className="flex items-center">
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z" />
+                      </svg>
+                      <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
+                        My reflections
                       </span>
                     </div>
                   </NavLink>

--- a/frontend/src/partials/__tests__/Sidebar.test.jsx
+++ b/frontend/src/partials/__tests__/Sidebar.test.jsx
@@ -63,3 +63,22 @@ describe('Sidebar admin navigation (3.26)', () => {
     expect(screen.getByText('My tasks')).toBeInTheDocument();
   });
 });
+
+describe('Sidebar wayfinding (3.27)', () => {
+  it('renames the Counselor role entry from "My Reflections" to "Counselor home"', () => {
+    renderSidebar();
+    // Counselor role link now reads "Counselor home" and is the only entry
+    // pointing at the legacy /counselor-dashboard.
+    expect(screen.getByText('Counselor home')).toBeInTheDocument();
+    expect(screen.queryByText('My Reflections')).not.toBeInTheDocument();
+    const links = screen.getAllByRole('link').map((a) => a.getAttribute('href'));
+    expect(links).toContain('/counselor-dashboard');
+  });
+
+  it('exposes "My reflections" as a top-level entry pointing at /my-reflections', () => {
+    renderSidebar();
+    expect(screen.getByText('My reflections')).toBeInTheDocument();
+    const links = screen.getAllByRole('link').map((a) => a.getAttribute('href'));
+    expect(links).toContain('/my-reflections');
+  });
+});

--- a/frontend/src/partials/tasks/ReflectionTasksPanel.jsx
+++ b/frontend/src/partials/tasks/ReflectionTasksPanel.jsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import api from '../../api';
 
 // ---------------------------------------------------------------------------
@@ -394,12 +394,33 @@ export default function ReflectionTasksPanel({ variant = 'page' }) {
     day: 'numeric',
   });
 
+  // 3.27: surface /supervisor/coverage only when the viewer is an author of
+  // at least one roster group. Plain self-only reflectors don't see the link
+  // because the page would be empty for them.
+  const showCoverageLink = useMemo(
+    () =>
+      Array.isArray(tasks)
+      && tasks.some((t) => t.assignment_group),
+    [tasks],
+  );
+
   const inner = (
     <>
       {!embedded && (
-        <header className="mb-6">
-          <h1 className="text-xl font-semibold text-gray-900 dark:text-white">Today</h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{headingLabel}</p>
+        <header className="mb-6 flex items-start justify-between gap-3">
+          <div>
+            <h1 className="text-xl font-semibold text-gray-900 dark:text-white">Today</h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{headingLabel}</p>
+          </div>
+          {showCoverageLink && (
+            <Link
+              to="/supervisor/coverage"
+              data-testid="tasks-coverage-link"
+              className="shrink-0 inline-flex items-center gap-1 mt-1 rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+            >
+              Coverage →
+            </Link>
+          )}
         </header>
       )}
 

--- a/migration_prompts/3_27_wayfinding_and_broken_links.md
+++ b/migration_prompts/3_27_wayfinding_and_broken_links.md
@@ -1,0 +1,184 @@
+# Prompt 3.27 — Wayfinding fixes and broken summary deep-links
+
+**Wave:** 3 (Crane Lake Summer 2026 Build) — UI cleanup
+**Estimated time:** 3-4 hours
+**Prerequisite:** Prompt 3.26 complete.
+
+**Use the context prompt at the top of `migration_prompts/0_0_context_prompt.md` before this session.**
+
+---
+
+```
+After the admin/dashboards hubs landed in 3.26, an audit surfaced several real
+functional bugs in the new RBAC stack plus some leftover wayfinding gaps. This
+prompt fixes them in a single small slice. Polishy "design tokens" work is
+deferred to 3.31; this PR is strictly about routes that don't work, links that
+don't go where the label suggests, and orphan pages that nothing links to.
+
+CONTEXT:
+
+Audit findings (Wave 3 only; legacy single-tenant pages were ignored):
+
+1) Broken `/reflect/summary?reflection=<id>` deep links. Three new dashboard
+   components generate links of this form:
+     - frontend/src/dashboards/concerns/ConcernsInbox.jsx ("Open reflection")
+     - frontend/src/dashboards/subject/SubjectDetail.jsx (two: "View
+       reflection" on concerning patterns, "view" on each reflection row)
+     - frontend/src/dashboards/trends/TrendCell.jsx (the colored cell link)
+   But `ReflectionSummaryPage` only reads `location.state` set by the form's
+   post-submit redirect. Query-string visits land on the "No reflection
+   summary to show" branch. All four call sites are silently broken.
+
+   ReflectionTasksPanel.jsx (coverage popover "View" button) also navigates to
+   `/reflections/${reflection_id}`, but that route does not exist in
+   Router.jsx, so it 404s and bounces to /dashboard. Same underlying gap.
+
+2) Counselor sidebar misroute. For `user.role === 'Counselor'`, Sidebar.jsx
+   renders a link labeled "My Reflections" that points to /counselor-dashboard
+   (the legacy Crane Lake bunk-log home, not the new reflection history).
+   The actual /my-reflections page is only reachable from the post-submit
+   summary footer — undiscoverable from the shell.
+
+3) Orphan routes. `/dashboards/subject-trends/:groupId` and
+   `/supervisor/coverage` are declared in Router.jsx but have no inbound
+   link anywhere in `frontend/src` (sidebar, hub cards, or inline). Either
+   they need a discovery path or they should be removed.
+
+4) Stale sidebar URLs. Sidebar still uses /team/dashboard and
+   /wellness/dashboard. Those work via the 3.26 redirects but are
+   inconsistent with the canonical /dashboards/* scheme we standardized on.
+
+5) Missing back-link on memberships. /admin/templates and /admin/groups
+   both have a "← Admin" back link (3.26). /admin/memberships does not.
+
+Out of scope for this PR (covered by later prompts):
+
+- Admin-page chrome alignment (sub-pages without Sidebar/Header) → 3.28
+- FieldKey registry CRUD UI → 3.29
+- Unused team/wellness JSON endpoints → 3.30
+- Shared button/empty/loading/error primitives → 3.31
+
+GOALS:
+
+A. /reflect/summary?reflection= deep links work, OR are replaced by a route
+   that does. After this PR every "View reflection" / "Open reflection"
+   /trend-cell link lands on the right reflection.
+
+B. /reflections/:id is a real, permission-aware read-only viewer for one
+   reflection.
+
+C. Counselor sidebar entry is honest about its destination.
+
+D. /dashboards/subject-trends/:groupId and /supervisor/coverage are reachable
+   by clicking, not just by typing the URL.
+
+E. Sidebar leadership / wellness items point at the canonical /dashboards/*
+   URLs (the redirects stay in place for old bookmarks).
+
+F. /admin/memberships has a "← Admin" back link, matching templates/groups.
+
+TASKS:
+
+1. Backend: extend ReflectionSerializer with a SerializerMethodField named
+   `localized_schema` that returns `_localize_schema(obj.template.schema,
+   obj.language)` for instance reads. This lets the new detail page render
+   without a separate /api/v1/templates/<id>/ round trip. Add the field to
+   Meta.fields and ensure existing tests still pass (it's additive).
+
+2. Frontend: new component `ReflectionDetailPage.jsx` under `frontend/src/pages/`.
+     - Reads `:id` from useParams, fetches `/api/v1/reflections/<id>/`,
+       and renders prompts + answers in the same visual style as
+       ReflectionSummaryPage. Uses the FullShell layout (Sidebar + Header)
+       — this is a real navigable page, not a one-shot post-submit screen.
+     - Renders PrivacyChip from `team_visibility`.
+     - On 403 / 404 from the backend, shows a friendly "You don't have
+       access to this reflection or it doesn't exist." panel with a "Back to
+       my reflections" link.
+     - Honors `returnTo` query param if present so back-link goes where the
+       linker expected.
+   Add `frontend/src/pages/__tests__/ReflectionDetailPage.test.jsx` covering
+   loading, success, 403, and 404 cases.
+
+3. Frontend: route in `Router.jsx`:
+     <Route path="/reflections/:id"
+            element={<ProtectedRoute><ReflectionDetailPage/></ProtectedRoute>}/>
+   Keep /reflect/summary unchanged (it's still used by the post-submit flow).
+
+4. Frontend: update the three broken call sites to link to
+   `/reflections/<id>` (drop the `?reflection=` form):
+     - ConcernsInbox.jsx
+     - SubjectDetail.jsx (both places)
+     - TrendCell.jsx
+   ReflectionTasksPanel.jsx already uses /reflections/<id>; with the route
+   added, its CoveragePopover "View" button works without code changes.
+
+5. Frontend: in `Sidebar.jsx`:
+     a) For role === 'Counselor', rename the existing "My Reflections" item
+        to "Counselor home" (more honest about /counselor-dashboard) and
+        keep the target unchanged.
+     b) For users in REFLECTION_FORM_ROLES (Counselor, Admin, Unit Head,
+        Camper Care), add a sibling "My reflections" item beneath the
+        existing "Program reflection" entry, pointing to /my-reflections.
+        Pick a distinct icon (e.g. clipboard-list).
+     c) Change the Leadership "Unit health (LT)" link from /team/dashboard
+        to /dashboards/team.
+     d) Change the Camper Care / Admin "Wellness team" link from
+        /wellness/dashboard to /dashboards/wellness.
+
+6. Frontend: discovery for orphan routes.
+     a) GroupDetailPage.jsx — under the group title or actions row, add a
+        "View subject trends →" link to `/dashboards/subject-trends/${id}`.
+     b) ReflectionTasksPanel.jsx — in the header (variant === 'page'), add a
+        secondary "Coverage →" link to /supervisor/coverage. Render the
+        link only when at least one task in the fetched list has an
+        `assignment_group` (i.e. the viewer is an author of some roster
+        group, which is the cohort that benefits from the coverage view).
+        Plain self-only reflectors don't see the link.
+
+7. Frontend: in MembershipManagementPage.jsx, add a "← Admin" back link at
+   the top of the main column, mirroring TemplateListPage / GroupListPage.
+
+8. Tests:
+     - ReflectionDetailPage.test.jsx (item 2).
+     - Sidebar.test.jsx — add cases asserting:
+         · /team/dashboard is no longer present
+         · /wellness/dashboard is no longer present
+         · /dashboards/team and /dashboards/wellness ARE present
+         · "Counselor home" replaces "My Reflections" for role=Counselor
+         · "My reflections" → /my-reflections appears for the relevant roles
+     - GroupDetailPage already has no Vitest; add a small render test that
+       the "View subject trends" link is present.
+     - ReflectionTasksPanel — extend its existing test (if any) or add one
+       to assert the coverage link appears only when group tasks are present.
+
+9. Migration prompt + commit per logical slice. PR title matches
+   `3_27_wayfinding_and_broken_links: ...`.
+
+10. Run `make test-frontend`, `make test-backend`, and
+    `ruff check bunk_logs/ config/` from `backend/`. All must pass.
+
+11. Update docs/membership-role-vs-capability.md only if a fix actually
+    changes a documented behavior — most of these are bug fixes; no doc
+    changes expected.
+```
+
+---
+
+## Acceptance criteria
+
+- Clicking "Open reflection" on a concerns inbox row navigates to a
+  read-only page for that reflection.
+- Clicking a colored cell in the subject trend grid navigates to that
+  reflection.
+- Clicking "View" in a coverage popover from /tasks navigates to that
+  reflection (and does NOT bounce to /dashboard).
+- /my-reflections is reachable from the sidebar by all REFLECTION_FORM_ROLES
+  without bookmarking.
+- /dashboards/subject-trends/:groupId is reachable from
+  /admin/groups/:id by clicking.
+- /supervisor/coverage is reachable from /tasks by clicking, but the
+  entry point appears only for users who would have any data on that page.
+- Leadership and Camper Care users on the sidebar go directly to
+  /dashboards/team / /dashboards/wellness (no redirect bounce).
+- /admin/memberships shows a "← Admin" back link.
+- No new lint warnings; all test suites green.


### PR DESCRIPTION
## Summary

Post-3.26 audit turned up real functional bugs in the new RBAC stack. This PR
fixes them in a single small slice. Polish (design tokens, shared primitives)
is deferred to 3.31; admin-page chrome alignment is its own follow-up (3.28).

### Functional bugs fixed

- **/reflect/summary?reflection=&lt;id&gt; deep-links were broken.** Three
  components generated them (concerns inbox, subject detail × 2, trend cell)
  but the summary page only reads `location.state`. Repointed to a real route.
- **/reflections/:id had no handler.** ReflectionTasksPanel's CoveragePopover
  &ldquo;View&rdquo; button already navigated there and silently 404'd to
  `/dashboard`. Now wired up to a real read-only viewer.
- **Counselor sidebar misrouted.** Item was labeled &ldquo;My Reflections&rdquo;
  but pointed at `/counselor-dashboard` (the legacy bunk-log home). Renamed
  to &ldquo;Counselor home&rdquo;; the new /my-reflections page now has its
  own top-level entry.

### Wayfinding gaps closed

- /dashboards/subject-trends/:groupId is now reachable from GroupDetailPage.
- /supervisor/coverage is now reachable from /tasks (only when the viewer
  actually authors roster-group tasks).
- /admin/memberships now has a &ldquo;← Admin&rdquo; back link matching
  Templates and Groups.
- Sidebar Leadership / Wellness links point at the canonical /dashboards/*
  URLs directly (the 3.26 redirects remain in place for old bookmarks).

### New / changed files

- `backend/bunk_logs/api/reflections.py` — adds `localized_schema`
  SerializerMethodField (additive).
- `frontend/src/pages/ReflectionDetailPage.jsx` + test — new viewer at
  `/reflections/:id` with FullShell layout, PrivacyChip, and friendly 403 /
  404 panels.
- `frontend/src/Router.jsx` — registers `/reflections/:id`.
- `frontend/src/dashboards/{concerns,subject,trends}/*.jsx` — repoint three
  broken deep-links.
- `frontend/src/partials/Sidebar.jsx` + test — counselor label rename, new
  &ldquo;My reflections&rdquo; top-level entry, canonical /dashboards/* URLs.
- `frontend/src/partials/tasks/ReflectionTasksPanel.jsx` — conditional
  &ldquo;Coverage →&rdquo; header link.
- `frontend/src/pages/admin/groups/GroupDetailPage.jsx` — &ldquo;View subject
  trends →&rdquo; action.
- `frontend/src/pages/MembershipManagementPage.jsx` — &ldquo;← Admin&rdquo;
  back link.
- `migration_prompts/3_27_wayfinding_and_broken_links.md` — slice spec.

### What this is NOT

Scope notes from the audit deferred to follow-up PRs:

- **3.28 admin chrome alignment** — admin sub-pages (templates, groups) still
  don't include Sidebar/Header. Single layout-route refactor.
- **3.29 FieldKey registry UI** — the deferred &ldquo;Coming soon&rdquo; hub
  card.
- **3.30 backend cleanup** — unused `dashboards/team/` and `dashboards/
  wellness/` JSON endpoints.
- **3.31 design tokens** — shared button color, loading/empty/error
  primitives.

## Test plan

- [x] `make test-frontend` — 210/210 green (4 new in ReflectionDetailPage, 2
      new in Sidebar).
- [x] `make test-backend` — 605/605 green.
- [x] `ruff check bunk_logs/ config/` — clean.
- [x] `vite build` — clean (existing chunk-size warnings unchanged).
- [ ] Manual: click &ldquo;Open reflection&rdquo; from a concerns row → lands
      on /reflections/:id with the right content.
- [ ] Manual: click a colored cell in subject trend grid → same.
- [ ] Manual: from /tasks, open coverage popover on a covered subject → click
      &ldquo;View&rdquo; → lands on /reflections/:id (no longer bounces).
- [ ] Manual: open /reflections/&lt;some-id-you-can't-see&gt; → friendly 403
      panel.
- [ ] Manual: counselor login → sidebar reads &ldquo;Counselor home&rdquo;
      and &ldquo;My reflections&rdquo;.
- [ ] Manual: open /admin/groups/&lt;id&gt; → &ldquo;View subject trends&rdquo;
      visible; clicking lands on the trend grid.
- [ ] Manual: open /tasks as a roster-group author → &ldquo;Coverage →&rdquo;
      link visible; as a self-only reflector → not visible.

Made with [Cursor](https://cursor.com)