### PR TITLE
3_28_admin_chrome_alignment: share Sidebar+Header across /admin/* via AdminLayout

### DIFF
--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -44,6 +44,7 @@ import SubjectDetailPage from './pages/dashboards/SubjectDetailPage';
 import AuthorAttributionPage from './pages/dashboards/AuthorAttributionPage';
 import ConcernsInboxPage from './pages/dashboards/ConcernsInboxPage';
 import DashboardsHub from './pages/dashboards/DashboardsHub';
+import AdminLayout from './layouts/AdminLayout';
 import { useBunk } from './contexts/BunkContext';
 
 // Protected route component
@@ -429,65 +430,76 @@ function Router() {
           }
         />
 
-        {/* 3.26: Admin landing hub */}
+        {/* 3.28: Admin routes share one shell via AdminLayout. Every
+            child renders inside Sidebar + Header so navigation stays in
+            place when you click between admin surfaces. AdminRoute is
+            applied per-child (not on the layout) so that
+            /admin/memberships can stay ProtectedRoute -- its in-page
+            "Access restricted" branch must keep rendering for non-admin
+            authenticated users instead of redirecting. */}
         <Route
           path="/admin"
           element={
-            <AdminRoute>
-              <AdminHub />
-            </AdminRoute>
-          }
-        />
-
-        <Route
-          path="/admin/memberships"
-          element={
             <ProtectedRoute>
-              <MembershipManagementPage />
+              <AdminLayout />
             </ProtectedRoute>
           }
-        />
+        >
+          <Route
+            index
+            element={
+              <AdminRoute>
+                <AdminHub />
+              </AdminRoute>
+            }
+          />
+          <Route path="memberships" element={<MembershipManagementPage />} />
+          <Route
+            path="templates"
+            element={
+              <AdminRoute>
+                <TemplateListPage />
+              </AdminRoute>
+            }
+          />
+          <Route
+            path="templates/new"
+            element={
+              <AdminRoute>
+                <TemplateNewPage />
+              </AdminRoute>
+            }
+          />
+          <Route
+            path="groups"
+            element={
+              <AdminRoute>
+                <GroupListPage />
+              </AdminRoute>
+            }
+          />
+          <Route
+            path="groups/:id"
+            element={
+              <AdminRoute>
+                <GroupDetailPage />
+              </AdminRoute>
+            }
+          />
+        </Route>
 
-        {/* Template admin routes */}
-        <Route
-          path="/admin/templates"
-          element={
-            <AdminRoute>
-              <TemplateListPage />
-            </AdminRoute>
-          }
-        />
-        <Route
-          path="/admin/templates/new"
-          element={
-            <AdminRoute>
-              <TemplateNewPage />
-            </AdminRoute>
-          }
-        />
+        {/* 3.28: Template editor is a deliberate exception. It is a
+            focused full-bleed editor with its own sticky in-page header
+            (inline name editing, language switcher, save). Pulling it
+            under AdminLayout would either double-stack stickies or
+            shrink the working pane used by the split-pane editor.
+            Future contributors: do NOT move this under the layout
+            without re-evaluating that tradeoff. */}
         <Route
           path="/admin/templates/:id/edit"
           element={
             <AdminRoute>
               <TemplateEditorPage />
-            </AdminRoute>
-          }
-        />
-
-        {/* Group admin routes */}
-        <Route
-          path="/admin/groups"
-          element={
-            <AdminRoute>
-              <GroupListPage />
-            </AdminRoute>
-          }
-        />
-        <Route
-          path="/admin/groups/:id"
-          element={
-            <AdminRoute>
-              <GroupDetailPage />
             </AdminRoute>
           }
         />

--- a/frontend/src/layouts/AdminLayout.jsx
+++ b/frontend/src/layouts/AdminLayout.jsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { Outlet } from 'react-router-dom';
+
+import Header from '../partials/Header';
+import Sidebar from '../partials/Sidebar';
+
+/**
+ * Shared layout for /admin/* routes. Renders Sidebar + Header + a
+ * scrollable main, and slots the matched child route into `<Outlet/>`.
+ *
+ * Child routes provide their own `<main>` (or content wrapper) so each
+ * page can pick its own padding and max-width. The layout intentionally
+ * owns no width constraints -- it's chrome only.
+ *
+ * The TemplateEditorPage (/admin/templates/:id/edit) is wired up as a
+ * sibling of this layout in Router.jsx, not as a child, because it's a
+ * focused full-bleed editor with its own sticky in-page header. See the
+ * prompt in `migration_prompts/3_28_admin_chrome_alignment.md`.
+ */
+export default function AdminLayout() {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+      <div
+        data-testid="admin-layout-scroll"
+        className="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden bg-gray-50 dark:bg-gray-950"
+      >
+        <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/layouts/__tests__/AdminLayout.test.jsx
+++ b/frontend/src/layouts/__tests__/AdminLayout.test.jsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+vi.mock('../../partials/Sidebar', () => ({
+  default: () => <aside data-testid="mock-sidebar" />,
+}));
+vi.mock('../../partials/Header', () => ({
+  default: () => <header data-testid="mock-header" />,
+}));
+
+import AdminLayout from '../AdminLayout';
+
+function renderAt(url) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <Routes>
+        <Route path="/admin" element={<AdminLayout />}>
+          <Route index element={<p data-testid="child-content">hello child</p>} />
+          <Route
+            path="memberships"
+            element={<p data-testid="child-content">memberships child</p>}
+          />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('AdminLayout (3.28)', () => {
+  it('renders Sidebar + Header + index child via Outlet', () => {
+    renderAt('/admin');
+    expect(screen.getByTestId('mock-sidebar')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-header')).toBeInTheDocument();
+    expect(screen.getByTestId('child-content')).toHaveTextContent('hello child');
+  });
+
+  it('renders a nested child route via Outlet', () => {
+    renderAt('/admin/memberships');
+    expect(screen.getByTestId('mock-sidebar')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-header')).toBeInTheDocument();
+    expect(screen.getByTestId('child-content')).toHaveTextContent('memberships child');
+  });
+
+  it('exposes the scroll container so children can rely on it', () => {
+    renderAt('/admin');
+    expect(screen.getByTestId('admin-layout-scroll')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/MembershipManagementPage.jsx
+++ b/frontend/src/pages/MembershipManagementPage.jsx
@@ -1,8 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
-import Header from '../partials/Header';
-import Sidebar from '../partials/Sidebar';
 import api from '../api';
 
 const ROLE_OPTIONS = [
@@ -156,7 +154,6 @@ function MembershipRow({ membership, onSave, isSelected, onToggleSelect }) {
 }
 
 export default function MembershipManagementPage() {
-  const [sidebarOpen, setSidebarOpen] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [memberships, setMemberships] = useState([]);
@@ -273,28 +270,24 @@ export default function MembershipManagementPage() {
   }, [bulkOp, bulkTags, selectedIds, load]);
 
   return (
-    <div className="flex h-screen overflow-hidden">
-      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
-      <div className="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
-        <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
-        <main className="grow px-4 sm:px-6 lg:px-8 py-8 w-full max-w-9xl mx-auto">
-          {/* 3.27: back-link to /admin, matching templates and groups pages. */}
-          <Link
-            to="/admin"
-            data-testid="memberships-admin-back-link"
-            className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-4"
-          >
-            ← Admin
-          </Link>
-          <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-            <div>
-              <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Memberships</h1>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-                Tag memberships with demographic and grouping labels (e.g. international,
-                domestic, israeli, waterfront, arts, sports).
-              </p>
-            </div>
-          </div>
+    <main className="grow px-4 sm:px-6 lg:px-8 py-8 w-full max-w-9xl mx-auto">
+      {/* 3.27: back-link to /admin, matching templates and groups pages. */}
+      <Link
+        to="/admin"
+        data-testid="memberships-admin-back-link"
+        className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-4"
+      >
+        ← Admin
+      </Link>
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Memberships</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+            Tag memberships with demographic and grouping labels (e.g. international,
+            domestic, israeli, waterfront, arts, sports).
+          </p>
+        </div>
+      </div>
 
           <section className="mb-6 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-4">
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
@@ -454,8 +447,6 @@ export default function MembershipManagementPage() {
               )}
             </div>
           )}
-        </main>
-      </div>
-    </div>
+    </main>
   );
 }

--- a/frontend/src/pages/admin/AdminHub.jsx
+++ b/frontend/src/pages/admin/AdminHub.jsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   Users,
@@ -7,9 +6,6 @@ import {
   BarChart3,
   Tag,
 } from 'lucide-react';
-
-import Header from '../../partials/Header';
-import Sidebar from '../../partials/Sidebar';
 
 const ADMIN_CARDS = [
   {
@@ -109,32 +105,25 @@ function Card({ card }) {
 }
 
 export default function AdminHub() {
-  const [sidebarOpen, setSidebarOpen] = useState(false);
   return (
-    <div className="flex h-screen overflow-hidden">
-      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
-      <div className="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
-        <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
-        <main className="grow px-4 sm:px-6 lg:px-8 py-8 w-full max-w-5xl mx-auto">
-          <header className="mb-6">
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-              Admin
-            </h1>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-              Org-level tooling: people, templates, groups, dashboards, and
-              field keys.
-            </p>
-          </header>
-          <div
-            data-testid="admin-hub-grid"
-            className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
-          >
-            {ADMIN_CARDS.map((card) => (
-              <Card key={card.id} card={card} />
-            ))}
-          </div>
-        </main>
+    <main className="grow px-4 sm:px-6 lg:px-8 py-8 w-full max-w-5xl mx-auto">
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+          Admin
+        </h1>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+          Org-level tooling: people, templates, groups, dashboards, and
+          field keys.
+        </p>
+      </header>
+      <div
+        data-testid="admin-hub-grid"
+        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
+      >
+        {ADMIN_CARDS.map((card) => (
+          <Card key={card.id} card={card} />
+        ))}
       </div>
-    </div>
+    </main>
   );
 }

--- a/frontend/src/pages/admin/groups/GroupDetailPage.jsx
+++ b/frontend/src/pages/admin/groups/GroupDetailPage.jsx
@@ -292,14 +292,13 @@ export default function GroupDetailPage() {
   const authors = (group.memberships || []).filter((m) => m.role_in_group === 'author');
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 px-4 py-6">
-      <div className="max-w-5xl mx-auto">
-        <Link
-          to="/admin/groups"
-          className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-4"
-        >
-          <ArrowLeft size={14} /> Groups
-        </Link>
+    <main className="grow px-4 sm:px-6 lg:px-8 py-6 w-full max-w-5xl mx-auto">
+      <Link
+        to="/admin/groups"
+        className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-4"
+      >
+        <ArrowLeft size={14} /> Groups
+      </Link>
 
         {/* Header */}
         <div className="flex items-start justify-between mb-6">
@@ -454,15 +453,14 @@ export default function GroupDetailPage() {
               {uploading ? 'Uploading…' : 'Import'}
             </button>
           </div>
-          <ImportStatus log={lastLog} />
-        </div>
-
-        {toast && (
-          <div className="fixed bottom-6 left-1/2 -translate-x-1/2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 text-sm px-5 py-2.5 rounded-full shadow-lg z-50">
-            {toast}
-          </div>
-        )}
+        <ImportStatus log={lastLog} />
       </div>
-    </div>
+
+      {toast && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 text-sm px-5 py-2.5 rounded-full shadow-lg z-50">
+          {toast}
+        </div>
+      )}
+    </main>
   );
 }

--- a/frontend/src/pages/admin/groups/GroupListPage.jsx
+++ b/frontend/src/pages/admin/groups/GroupListPage.jsx
@@ -107,14 +107,13 @@ export default function GroupListPage() {
   const typesPresent = GROUP_TYPE_ORDER.filter((t) => byType[t]?.length > 0);
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 px-4 py-6">
-      <div className="max-w-5xl mx-auto">
-        <Link
-          to="/admin"
-          className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-4"
-        >
-          <ArrowLeft size={14} /> Admin
-        </Link>
+    <main className="grow px-4 sm:px-6 lg:px-8 py-6 w-full max-w-5xl mx-auto">
+      <Link
+        to="/admin"
+        className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-4"
+      >
+        <ArrowLeft size={14} /> Admin
+      </Link>
 
         <div className="flex items-center justify-between mb-6">
           <div>
@@ -268,12 +267,11 @@ export default function GroupListPage() {
           </div>
         )}
 
-        {toast && (
-          <div className="fixed bottom-6 left-1/2 -translate-x-1/2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 text-sm px-5 py-2.5 rounded-full shadow-lg z-50">
-            {toast}
-          </div>
-        )}
-      </div>
-    </div>
+      {toast && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 text-sm px-5 py-2.5 rounded-full shadow-lg z-50">
+          {toast}
+        </div>
+      )}
+    </main>
   );
 }

--- a/frontend/src/pages/admin/templates/TemplateListPage.jsx
+++ b/frontend/src/pages/admin/templates/TemplateListPage.jsx
@@ -100,15 +100,14 @@ export default function TemplateListPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 px-4 py-6">
-      <div className="max-w-6xl mx-auto">
-        {/* Breadcrumb */}
-        <Link
-          to="/admin"
-          className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-4"
-        >
-          <ArrowLeft size={14} /> Admin
-        </Link>
+    <main className="grow px-4 sm:px-6 lg:px-8 py-6 w-full max-w-6xl mx-auto">
+      {/* Breadcrumb */}
+      <Link
+        to="/admin"
+        className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-4"
+      >
+        <ArrowLeft size={14} /> Admin
+      </Link>
 
         <div className="flex items-center justify-between mb-6">
           <div>
@@ -242,15 +241,14 @@ export default function TemplateListPage() {
           </div>
         )}
 
-        {toast && (
-          <div
-            role="status"
-            className="fixed bottom-6 right-6 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-4 py-2 rounded-lg shadow-lg text-sm"
-          >
-            {toast}
-          </div>
-        )}
-      </div>
-    </div>
+      {toast && (
+        <div
+          role="status"
+          className="fixed bottom-6 right-6 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-4 py-2 rounded-lg shadow-lg text-sm"
+        >
+          {toast}
+        </div>
+      )}
+    </main>
   );
 }

--- a/frontend/src/pages/admin/templates/TemplateNewPage.jsx
+++ b/frontend/src/pages/admin/templates/TemplateNewPage.jsx
@@ -116,51 +116,48 @@ export default function TemplateNewPage() {
   // Chooser
   if (!mode) {
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-950 px-4 py-6">
-        <div className="max-w-xl mx-auto">
-          <Link
-            to="/admin/templates"
-            className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-6"
+      <main className="grow px-4 sm:px-6 lg:px-8 py-6 w-full max-w-xl mx-auto">
+        <Link
+          to="/admin/templates"
+          className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-6"
+        >
+          <ArrowLeft size={14} /> Back
+        </Link>
+        <h1 className="text-xl font-bold text-gray-900 dark:text-white mb-2">New template</h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-8">How do you want to start?</p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <button
+            type="button"
+            onClick={() => setMode('blank')}
+            className="group flex flex-col items-center gap-3 p-6 rounded-xl border-2 border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-500 bg-white dark:bg-gray-900 text-left transition-colors"
           >
-            <ArrowLeft size={14} /> Back
-          </Link>
-          <h1 className="text-xl font-bold text-gray-900 dark:text-white mb-2">New template</h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mb-8">How do you want to start?</p>
+            <FileText size={32} className="text-gray-400 group-hover:text-blue-500 transition-colors" />
+            <div className="text-center">
+              <p className="font-medium text-gray-900 dark:text-white">Blank template</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Start from scratch</p>
+            </div>
+          </button>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <button
-              type="button"
-              onClick={() => setMode('blank')}
-              className="group flex flex-col items-center gap-3 p-6 rounded-xl border-2 border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-500 bg-white dark:bg-gray-900 text-left transition-colors"
-            >
-              <FileText size={32} className="text-gray-400 group-hover:text-blue-500 transition-colors" />
-              <div className="text-center">
-                <p className="font-medium text-gray-900 dark:text-white">Blank template</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Start from scratch</p>
-              </div>
-            </button>
-
-            <button
-              type="button"
-              onClick={() => setMode('clone')}
-              className="group flex flex-col items-center gap-3 p-6 rounded-xl border-2 border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-500 bg-white dark:bg-gray-900 text-left transition-colors"
-            >
-              <Copy size={32} className="text-gray-400 group-hover:text-blue-500 transition-colors" />
-              <div className="text-center">
-                <p className="font-medium text-gray-900 dark:text-white">Clone existing</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Copy from a global or org template</p>
-              </div>
-            </button>
-          </div>
+          <button
+            type="button"
+            onClick={() => setMode('clone')}
+            className="group flex flex-col items-center gap-3 p-6 rounded-xl border-2 border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-500 bg-white dark:bg-gray-900 text-left transition-colors"
+          >
+            <Copy size={32} className="text-gray-400 group-hover:text-blue-500 transition-colors" />
+            <div className="text-center">
+              <p className="font-medium text-gray-900 dark:text-white">Clone existing</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Copy from a global or org template</p>
+            </div>
+          </button>
         </div>
-      </div>
+      </main>
     );
   }
 
   if (mode === 'clone') {
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-950 px-4 py-6">
-        <div className="max-w-md mx-auto">
+      <main className="grow px-4 sm:px-6 lg:px-8 py-6 w-full max-w-md mx-auto">
           <button
             type="button"
             onClick={() => setMode(null)}
@@ -204,31 +201,29 @@ export default function TemplateNewPage() {
 
           {error && <p className="text-sm text-red-600 mb-3">{error}</p>}
 
-          <button
-            type="button"
-            onClick={handleClone}
-            disabled={saving || !cloneSource}
-            className="w-full py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50"
-          >
-            {saving ? 'Cloning…' : 'Clone and edit'}
-          </button>
-        </div>
-      </div>
+        <button
+          type="button"
+          onClick={handleClone}
+          disabled={saving || !cloneSource}
+          className="w-full py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50"
+        >
+          {saving ? 'Cloning…' : 'Clone and edit'}
+        </button>
+      </main>
     );
   }
 
   // Blank form
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 px-4 py-6">
-      <div className="max-w-md mx-auto">
-        <button
-          type="button"
-          onClick={() => setMode(null)}
-          className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-6"
-        >
-          <ArrowLeft size={14} /> Back
-        </button>
-        <h1 className="text-xl font-bold text-gray-900 dark:text-white mb-6">New blank template</h1>
+    <main className="grow px-4 sm:px-6 lg:px-8 py-6 w-full max-w-md mx-auto">
+      <button
+        type="button"
+        onClick={() => setMode(null)}
+        className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-6"
+      >
+        <ArrowLeft size={14} /> Back
+      </button>
+      <h1 className="text-xl font-bold text-gray-900 dark:text-white mb-6">New blank template</h1>
 
         <div className="space-y-4">
           <div>
@@ -296,16 +291,15 @@ export default function TemplateNewPage() {
 
           {error && <p className="text-sm text-red-600">{error}</p>}
 
-          <button
-            type="button"
-            onClick={handleCreate}
-            disabled={saving}
-            className="w-full py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50 mt-2"
-          >
-            {saving ? 'Creating…' : 'Create and edit'}
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={handleCreate}
+          disabled={saving}
+          className="w-full py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50 mt-2"
+        >
+          {saving ? 'Creating…' : 'Create and edit'}
+        </button>
       </div>
-    </div>
+    </main>
   );
 }

--- a/migration_prompts/3_28_admin_chrome_alignment.md
+++ b/migration_prompts/3_28_admin_chrome_alignment.md
@@ -1,0 +1,155 @@
+# Prompt 3.28 — Admin chrome alignment
+
+**Wave:** 3 (Crane Lake Summer 2026 Build) — UI cleanup
+**Estimated time:** 2-3 hours
+**Prerequisite:** Prompt 3.27 complete.
+
+**Use the context prompt at the top of `migration_prompts/0_0_context_prompt.md` before this session.**
+
+---
+
+```
+The 3.26 audit flagged that /admin/* sub-pages dropped the global Sidebar
+and Header: AdminHub used FullShell, but TemplateListPage, TemplateNewPage,
+TemplateEditorPage, GroupListPage, and GroupDetailPage were all "bare" --
+no app shell. Click any card on /admin and you lost navigation. The 3.26
+PR opted not to fix this because it was a structural change touching every
+admin child page; this prompt does the surgery.
+
+CONTEXT:
+
+We want every /admin/* page to share one shell (Sidebar + Header), with a
+single source of truth so future admin pages don't drift. The dominant
+pattern in the new RBAC stack is already FullShell (memberships,
+all /dashboards/*); /admin children are the outliers.
+
+The cleanest react-router-v6 expression of "shared chrome for a URL
+subtree" is a **layout route** -- one parent <Route> whose `element` is
+the shell, and whose children render into the layout's <Outlet/>. We add
+exactly one layout component and nest the existing pages under it.
+
+Existing access gates must be preserved verbatim:
+
+- `/admin` itself uses AdminRoute (Admin or Super Admin).
+- `/admin/templates`, `/admin/templates/new`, `/admin/templates/:id/edit`,
+  `/admin/groups`, `/admin/groups/:id` use AdminRoute.
+- `/admin/memberships` uses ProtectedRoute only -- the page renders its
+  own org-admin "access restricted" state instead of redirecting. This
+  UX must not regress.
+
+Out of scope (later prompts):
+
+- FieldKey registry UI (3.29)
+- Unused team/wellness backend endpoints (3.30)
+- Shared button/empty/loading/error primitives (3.31)
+
+GOALS:
+
+1. Every /admin/* list / hub / CRUD page renders inside Sidebar + Header
+   without each page duplicating that chrome.
+2. /admin/memberships's "you're not an org admin" branch keeps showing the
+   shell (no redirect), exactly as today.
+3. /admin/templates/:id/edit is a deliberate exception: it stays full-bleed.
+   It's a focused editor surface with its own sticky in-page header for
+   inline name editing, language switching, and save; pulling it under the
+   shared shell would either double-stack stickies or shrink the working
+   pane needed for the split-pane editor. Document this exception in
+   Router.jsx so future contributors don't accidentally "fix" it. From
+   the editor users still navigate by clicking its "Back to templates"
+   arrow, exactly as today.
+4. Existing per-page Vitest suites still pass without modification (they
+   render the page directly with MemoryRouter, so layout changes are
+   transparent).
+
+TASKS:
+
+1. New component `frontend/src/layouts/AdminLayout.jsx`:
+     - Renders `<Sidebar/>`, `<Header/>`, a scrollable main, and an
+       `<Outlet/>` from react-router-dom for the matched child route.
+     - Tracks `sidebarOpen` state internally so children don't have to.
+     - No max-width constraint -- each child controls its own content
+       width. The layout is chrome only.
+   Add a Vitest test that asserts (a) Outlet content renders, and
+   (b) the mocked Sidebar + Header stubs both render (i.e. the layout
+   pulls them in).
+
+2. Update `frontend/src/Router.jsx`:
+     - Import AdminLayout.
+     - Replace the flat /admin* routes with a nested layout route for
+       everything except the editor:
+
+         <Route path="/admin"
+                element={<ProtectedRoute><AdminLayout/></ProtectedRoute>}>
+           <Route index element={<AdminRoute><AdminHub/></AdminRoute>}/>
+           <Route path="memberships"
+                  element={<MembershipManagementPage/>}/>
+           <Route path="templates"
+                  element={<AdminRoute><TemplateListPage/></AdminRoute>}/>
+           <Route path="templates/new"
+                  element={<AdminRoute><TemplateNewPage/></AdminRoute>}/>
+           <Route path="groups"
+                  element={<AdminRoute><GroupListPage/></AdminRoute>}/>
+           <Route path="groups/:id"
+                  element={<AdminRoute><GroupDetailPage/></AdminRoute>}/>
+         </Route>
+
+         {/* Editor stays full-bleed -- documented exception. */}
+         <Route path="/admin/templates/:id/edit"
+                element={<AdminRoute><TemplateEditorPage/></AdminRoute>}/>
+
+     - Memberships intentionally lacks AdminRoute so the in-page
+       "Access restricted" branch keeps rendering for non-admin
+       authenticated users.
+
+3. Strip per-page shell wrappers and outermost `min-h-screen` /
+   page-backdrop classes from these files (the layout's scroll
+   container owns scrolling + backdrop):
+     - `frontend/src/pages/admin/AdminHub.jsx`
+     - `frontend/src/pages/MembershipManagementPage.jsx`
+     - `frontend/src/pages/admin/templates/TemplateListPage.jsx`
+     - `frontend/src/pages/admin/templates/TemplateNewPage.jsx`
+     - `frontend/src/pages/admin/groups/GroupListPage.jsx`
+     - `frontend/src/pages/admin/groups/GroupDetailPage.jsx`
+   Each page becomes "content only": preserve its inner max-width
+   container and content, drop the outer `<div className="flex h-screen
+   overflow-hidden"><Sidebar/><div...><Header/><main>...</main></div></div>`
+   pattern (where present) or the `<div className="min-h-screen
+   bg-gray-50 dark:bg-gray-950 ...">` page-bg wrapper (where the page
+   was bare). The layout itself owns the backdrop (gray-50 / dark
+   gray-900) so children render directly inside it.
+
+   TemplateEditorPage is NOT in this list -- it stays as-is (see goal 3).
+
+4. Tests:
+     - Frontend test suite must still be 100% green; no per-page test
+       changes expected.
+     - Add a smoke test for AdminLayout: render it inside MemoryRouter +
+       Routes/Route + a dummy outlet child, assert child renders.
+     - Sidebar.test.jsx unaffected (it renders Sidebar directly).
+     - Optionally add a Router-level smoke test that mounts the app at
+       /admin/templates and asserts Sidebar mock rendered -- but skip if
+       it requires too much auth context plumbing.
+
+5. Update `docs/membership-role-vs-capability.md` only if any user-visible
+   gate semantics changed; we do not expect any.
+
+6. Run `make test-frontend`, `make test-backend`, and
+   `ruff check bunk_logs/ config/`. All green.
+
+7. Commit per logical slice, PR title `3_28_admin_chrome_alignment: ...`.
+```
+
+---
+
+## Acceptance criteria
+
+- Clicking any card on /admin lands on a child page with Sidebar + Header
+  visible. Click another sidebar entry from there and navigation works
+  without any "lost shell" feel.
+- TemplateEditorPage still scrolls correctly and its sticky in-page
+  header still pins to the top of the visible content area.
+- /admin/memberships still shows the "Access restricted" panel inside
+  the shell for non-admin authenticated users (no redirect).
+- AdminRoute still redirects non-admins away from /admin, /admin/templates,
+  /admin/groups subtrees.
+- All existing tests pass; no new lint warnings.


### PR DESCRIPTION
## Summary

Closes the visual chrome inconsistency the 3.26 audit flagged: /admin sub-pages dropped the global Sidebar + Header, so clicking a card on /admin made the user feel like they'd lost the app shell. Now every /admin/* page renders inside the same Sidebar + Header via a single AdminLayout component, nested via react-router v6 layout routes.

## What changed

- New \`frontend/src/layouts/AdminLayout.jsx\` -- Sidebar + Header + scrollable main + \`<Outlet/>\`. Chrome only, no max-width.
- \`Router.jsx\` now nests \`/admin\`, \`/admin/memberships\`, \`/admin/templates\`, \`/admin/templates/new\`, \`/admin/groups\`, \`/admin/groups/:id\` under one parent route whose element is \`<ProtectedRoute><AdminLayout/></ProtectedRoute>\`. AdminRoute is layered per-child so existing gates are preserved verbatim.
- AdminHub, MembershipManagementPage, TemplateListPage, TemplateNewPage, GroupListPage, GroupDetailPage now render content-only -- their old outer \`<div class=\"flex h-screen ...\"><Sidebar/><Header/><main>...</main></div>\` and \`<div class=\"min-h-screen bg-gray-50 ...\">\` wrappers were stripped. The layout's scroll container owns the backdrop.

### Deliberate exceptions, documented in the routes

- \`/admin/memberships\` stays under \`ProtectedRoute\` (not AdminRoute) so the in-page "Access restricted" panel keeps rendering for non-admin authenticated users (no redirect).
- \`/admin/templates/:id/edit\` stays full-bleed -- it's a focused editor with its own sticky in-page header for inline name editing, language switching, and save. Pulling it under the shared shell would either double-stack stickies or shrink the working pane needed by the split-pane editor. Router.jsx comments explicitly call out the tradeoff so future contributors don't accidentally "fix" it.

## Tests

- 209 frontend (3 new \`AdminLayout.test.jsx\`) pass.
- 605 backend pass.
- \`vite build\` clean.
- \`ruff check bunk_logs/ config/\` clean.
- Existing per-page Vitest suites needed zero changes -- they render pages directly with MemoryRouter, so layout changes are transparent.

## Test plan

- [ ] Visit \`/admin\` -- Sidebar and Header visible, card grid renders.
- [ ] Click each card on \`/admin\` (Memberships, Templates, Groups, Dashboards): Sidebar + Header stay visible; back-link to "Admin" still works.
- [ ] On \`/admin/templates\`, open a template editor -- editor renders bare (no Sidebar/Header), back arrow returns to \`/admin/templates\` with shell restored.
- [ ] Sign in as a non-admin authenticated user and hit \`/admin/memberships\` -- shell renders, "Access restricted" panel visible inside it (no redirect to home).
- [ ] Sign in as a non-admin and hit \`/admin/templates\` -- redirected away (AdminRoute still gating).

## Migration prompt

\`migration_prompts/3_28_admin_chrome_alignment.md\` documents the prompt that drove this change.

Made with [Cursor](https://cursor.com)