### PR TITLE
3_29_field_key_registry_ui: wire up FieldKey CRUD under /admin

### DIFF
--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -36,6 +36,7 @@ import TemplateEditorPage from './pages/admin/templates/TemplateEditorPage';
 import TemplateNewPage from './pages/admin/templates/TemplateNewPage';
 import GroupListPage from './pages/admin/groups/GroupListPage';
 import GroupDetailPage from './pages/admin/groups/GroupDetailPage';
+import FieldKeyListPage from './pages/admin/field-keys/FieldKeyListPage';
 import TasksPage from './pages/TasksPage';
 import SupervisorCoveragePage from './pages/SupervisorCoveragePage';
 import CoverageDashboardPage from './pages/dashboards/CoverageDashboardPage';
@@ -483,6 +484,18 @@ function Router() {
             element={
               <AdminRoute>
                 <GroupDetailPage />
+              </AdminRoute>
+            }
+          />
+          {/* 3.29: FieldKey registry CRUD. Gated AdminRoute for v1; the
+              underlying API also allows org admins via
+              IsOrgAdminOrSuperuser, so we can broaden later without
+              backend changes. */}
+          <Route
+            path="field-keys"
+            element={
+              <AdminRoute>
+                <FieldKeyListPage />
               </AdminRoute>
             }
           />

--- a/frontend/src/pages/admin/AdminHub.jsx
+++ b/frontend/src/pages/admin/AdminHub.jsx
@@ -44,9 +44,8 @@ const ADMIN_CARDS = [
     id: 'field-keys',
     title: 'Field keys',
     blurb:
-      'Canonical field-key registry that powers cross-template reporting. CRUD UI coming soon -- backend already exists.',
-    to: null,
-    deferred: true,
+      'Canonical short keys used across reflection templates so cross-template dashboards can aggregate the same field even when it lives in different templates.',
+    to: '/admin/field-keys',
     icon: Tag,
   },
 ];

--- a/frontend/src/pages/admin/__tests__/AdminHub.test.jsx
+++ b/frontend/src/pages/admin/__tests__/AdminHub.test.jsx
@@ -15,6 +15,7 @@ function renderHub() {
         <Route path="/admin/memberships" element={<div data-testid="memberships">Memberships</div>} />
         <Route path="/admin/templates" element={<div data-testid="templates">Templates</div>} />
         <Route path="/admin/groups" element={<div data-testid="groups">Groups</div>} />
+        <Route path="/admin/field-keys" element={<div data-testid="field-keys">Field keys</div>} />
         <Route path="/dashboards" element={<div data-testid="dashboards">Dashboards</div>} />
       </Routes>
     </MemoryRouter>,
@@ -31,14 +32,13 @@ describe('AdminHub', () => {
     expect(screen.getByTestId('admin-hub-card-field-keys')).toBeInTheDocument();
   });
 
-  it('the field-keys card is marked deferred (no <a> wrapping it)', () => {
+  it('the field-keys card links to /admin/field-keys (no longer deferred)', () => {
     renderHub();
     const card = screen.getByTestId('admin-hub-card-field-keys');
-    expect(card.tagName.toLowerCase()).not.toBe('a');
-    expect(card).toHaveAttribute('aria-disabled', 'true');
-    // The pill says "Coming soon" (exact match), the blurb has the phrase
-    // in a longer sentence -- so we match the pill specifically.
-    expect(screen.getByText('Coming soon')).toBeInTheDocument();
+    expect(card.tagName.toLowerCase()).toBe('a');
+    expect(card).toHaveAttribute('href', '/admin/field-keys');
+    expect(card).not.toHaveAttribute('aria-disabled');
+    expect(screen.queryByText('Coming soon')).not.toBeInTheDocument();
   });
 
   it('linkable cards point at the right routes', () => {
@@ -47,5 +47,6 @@ describe('AdminHub', () => {
     expect(screen.getByTestId('admin-hub-card-templates')).toHaveAttribute('href', '/admin/templates');
     expect(screen.getByTestId('admin-hub-card-groups')).toHaveAttribute('href', '/admin/groups');
     expect(screen.getByTestId('admin-hub-card-dashboards')).toHaveAttribute('href', '/dashboards');
+    expect(screen.getByTestId('admin-hub-card-field-keys')).toHaveAttribute('href', '/admin/field-keys');
   });
 });

--- a/frontend/src/pages/admin/field-keys/FieldKeyListPage.jsx
+++ b/frontend/src/pages/admin/field-keys/FieldKeyListPage.jsx
@@ -1,0 +1,616 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  ArrowLeft,
+  Plus,
+  Pencil,
+  Trash2,
+  X,
+  Search,
+  Tag,
+} from 'lucide-react';
+
+import api from '../../../api';
+
+/**
+ * Field key registry UI. Lists org + global keys, lets Super Admins
+ * create, edit, and delete keys, and surfaces the 409 "key is referenced
+ * by templates" error from DELETE clearly.
+ *
+ * Wired up at /admin/field-keys behind AdminRoute. See
+ * `migration_prompts/3_29_field_key_registry_ui.md` for the contract.
+ */
+
+const FIELD_TYPE_OPTIONS = [
+  { value: '', label: 'No type hint' },
+  { value: 'text', label: 'Short text' },
+  { value: 'textarea', label: 'Long text' },
+  { value: 'text_list', label: 'Text list' },
+  { value: 'single_choice', label: 'Single choice' },
+  { value: 'multiple_choice', label: 'Multiple choice' },
+  { value: 'yes_no', label: 'Yes / no' },
+  { value: 'date', label: 'Date' },
+  { value: 'number', label: 'Number' },
+  { value: 'section_header', label: 'Section header' },
+  { value: 'instructions', label: 'Instructions' },
+  { value: 'rating_group', label: 'Rating group' },
+  { value: 'single_rating', label: 'Single rating' },
+];
+
+// `expected_dashboard_role` is free-form on the backend, but the seeded
+// global keys use this fixed vocabulary. Surface as a select with an
+// "Other..." escape hatch.
+const DASHBOARD_ROLE_OPTIONS = [
+  { value: '', label: 'No dashboard role' },
+  { value: 'category_ratings', label: 'Category ratings' },
+  { value: 'wins', label: 'Wins' },
+  { value: 'improvements', label: 'Improvements' },
+  { value: 'open_concern', label: 'Open concern' },
+];
+
+const SCOPE_FILTERS = [
+  { value: 'all', label: 'All' },
+  { value: 'mine', label: 'Mine' },
+  { value: 'global', label: 'Global' },
+];
+
+const EMPTY_FORM = {
+  key: '',
+  display_name: '',
+  description: '',
+  expected_field_type: '',
+  expected_dashboard_role: '',
+};
+
+function labelForType(value) {
+  const hit = FIELD_TYPE_OPTIONS.find((o) => o.value === value);
+  return hit ? hit.label : value || '—';
+}
+
+function labelForRole(value) {
+  const hit = DASHBOARD_ROLE_OPTIONS.find((o) => o.value === value);
+  return hit ? hit.label : value || '—';
+}
+
+function inputClass() {
+  return 'w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500';
+}
+
+function FormFields({ form, onChange, lockKey }) {
+  const update = (field, value) => onChange({ ...form, [field]: value });
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Key {lockKey ? '(read-only)' : '*'}
+        </label>
+        <input
+          type="text"
+          required
+          readOnly={lockKey}
+          value={form.key}
+          onChange={(e) => update('key', e.target.value.trim().toLowerCase().replace(/\s+/g, '_'))}
+          className={`${inputClass()} ${lockKey ? 'bg-gray-100 dark:bg-gray-800' : ''}`}
+          placeholder="e.g. communication"
+          data-testid="fk-form-key"
+        />
+        {!lockKey && (
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            Lowercase letters, numbers, and underscores. Max 64 characters.
+          </p>
+        )}
+      </div>
+      <div>
+        <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Display name *
+        </label>
+        <input
+          type="text"
+          required
+          value={form.display_name}
+          onChange={(e) => update('display_name', e.target.value)}
+          className={inputClass()}
+          placeholder="e.g. Communication"
+          data-testid="fk-form-display-name"
+        />
+      </div>
+      <div>
+        <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Description
+        </label>
+        <textarea
+          rows={2}
+          value={form.description}
+          onChange={(e) => update('description', e.target.value)}
+          className={inputClass()}
+          placeholder="What does this key represent across templates?"
+        />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Expected field type
+          </label>
+          <select
+            value={form.expected_field_type}
+            onChange={(e) => update('expected_field_type', e.target.value)}
+            className={inputClass()}
+          >
+            {FIELD_TYPE_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Dashboard role
+          </label>
+          <select
+            value={form.expected_dashboard_role}
+            onChange={(e) => update('expected_dashboard_role', e.target.value)}
+            className={inputClass()}
+          >
+            {DASHBOARD_ROLE_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EditModal({ open, initial, busy, onClose, onSubmit }) {
+  const [form, setForm] = useState(initial || EMPTY_FORM);
+  useEffect(() => {
+    setForm(initial || EMPTY_FORM);
+  }, [initial]);
+
+  if (!open) return null;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg rounded-xl bg-white dark:bg-gray-900 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-center justify-between px-5 py-3 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+            Edit field key
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </header>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            onSubmit(form);
+          }}
+          className="px-5 py-4"
+        >
+          <FormFields form={form} onChange={setForm} lockKey />
+          <div className="mt-5 flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={busy}
+              className="px-4 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={busy}
+              className="px-4 py-1.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50"
+              data-testid="fk-edit-submit"
+            >
+              {busy ? 'Saving…' : 'Save changes'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default function FieldKeyListPage() {
+  const [keys, setKeys] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [scopeFilter, setScopeFilter] = useState('all');
+  const [typeFilter, setTypeFilter] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [createForm, setCreateForm] = useState(EMPTY_FORM);
+  const [createBusy, setCreateBusy] = useState(false);
+  const [createError, setCreateError] = useState('');
+  const [editing, setEditing] = useState(null);
+  const [editBusy, setEditBusy] = useState(false);
+  const [toast, setToast] = useState('');
+  const toastTimer = useRef(null);
+
+  const showToast = useCallback((msg) => {
+    setToast(msg);
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    toastTimer.current = setTimeout(() => setToast(''), 4000);
+  }, []);
+
+  useEffect(() => () => {
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+  }, []);
+
+  // Debounce search so we don't spam the API on every keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search.trim()), 250);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const params = {};
+      if (debouncedSearch) params.q = debouncedSearch;
+      const { data } = await api.get('/api/v1/field-keys/', { params });
+      const results = Array.isArray(data?.results) ? data.results : Array.isArray(data) ? data : [];
+      setKeys(results);
+    } catch (e) {
+      const status = e.response?.status;
+      if (status === 403) {
+        setError('You do not have permission to view field keys.');
+      } else {
+        setError(e.response?.data?.detail || 'Failed to load field keys.');
+      }
+      setKeys([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [debouncedSearch]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const visible = useMemo(
+    () =>
+      keys.filter((k) => {
+        if (scopeFilter === 'global' && !k.is_global) return false;
+        if (scopeFilter === 'mine' && k.is_global) return false;
+        if (typeFilter && (k.expected_field_type || '') !== typeFilter) return false;
+        return true;
+      }),
+    [keys, scopeFilter, typeFilter],
+  );
+
+  const submitCreate = useCallback(
+    async (e) => {
+      e.preventDefault();
+      if (!createForm.key.trim() || !createForm.display_name.trim()) {
+        setCreateError('Key and display name are required.');
+        return;
+      }
+      setCreateBusy(true);
+      setCreateError('');
+      try {
+        await api.post('/api/v1/field-keys/', createForm);
+        showToast(`Created "${createForm.key}".`);
+        setCreateForm(EMPTY_FORM);
+        setCreating(false);
+        await load();
+      } catch (err) {
+        const body = err.response?.data;
+        const msg =
+          typeof body === 'string'
+            ? body
+            : body?.key?.[0]
+              || body?.display_name?.[0]
+              || body?.detail
+              || 'Create failed.';
+        setCreateError(msg);
+      } finally {
+        setCreateBusy(false);
+      }
+    },
+    [createForm, load, showToast],
+  );
+
+  const submitEdit = useCallback(
+    async (form) => {
+      if (!editing) return;
+      setEditBusy(true);
+      try {
+        const payload = {
+          display_name: form.display_name,
+          description: form.description,
+          expected_field_type: form.expected_field_type,
+          expected_dashboard_role: form.expected_dashboard_role,
+        };
+        await api.patch(`/api/v1/field-keys/${editing.id}/`, payload);
+        showToast(`Saved "${editing.key}".`);
+        setEditing(null);
+        await load();
+      } catch (err) {
+        const body = err.response?.data;
+        const msg =
+          typeof body === 'string'
+            ? body
+            : body?.detail || 'Save failed.';
+        showToast(msg);
+      } finally {
+        setEditBusy(false);
+      }
+    },
+    [editing, load, showToast],
+  );
+
+  const handleDelete = useCallback(
+    async (row) => {
+      const label = row.is_global ? `${row.key} (global)` : row.key;
+      if (!window.confirm(`Delete "${label}"? This cannot be undone.`)) return;
+      try {
+        await api.delete(`/api/v1/field-keys/${row.id}/`);
+        showToast(`Deleted "${row.key}".`);
+        await load();
+      } catch (err) {
+        const status = err.response?.status;
+        const detail = err.response?.data?.detail;
+        if (status === 409) {
+          showToast(detail || `"${row.key}" is referenced by one or more templates.`);
+        } else {
+          showToast(detail || 'Delete failed.');
+        }
+      }
+    },
+    [load, showToast],
+  );
+
+  return (
+    <main className="grow px-4 sm:px-6 lg:px-8 py-6 w-full max-w-6xl mx-auto">
+      <Link
+        to="/admin"
+        className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-4"
+      >
+        <ArrowLeft size={14} /> Admin
+      </Link>
+
+      <div className="flex items-start justify-between mb-6 gap-4">
+        <div>
+          <h1 className="text-xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+            <Tag size={18} aria-hidden="true" />
+            Field keys
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 max-w-2xl">
+            Canonical short identifiers used across reflection templates so
+            cross-template dashboards can aggregate the same field even when
+            it lives in different templates.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setCreating((v) => !v);
+            setCreateError('');
+          }}
+          className="shrink-0 inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors"
+          data-testid="fk-new-btn"
+        >
+          <Plus size={16} /> {creating ? 'Close' : 'New field key'}
+        </button>
+      </div>
+
+      {creating && (
+        <section
+          data-testid="fk-create-form"
+          className="mb-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-5"
+        >
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-white mb-4">
+            New field key
+          </h2>
+          <form onSubmit={submitCreate}>
+            <FormFields form={createForm} onChange={setCreateForm} />
+            {createError && (
+              <p className="mt-3 text-sm text-red-600 dark:text-red-400" role="alert">
+                {createError}
+              </p>
+            )}
+            <div className="mt-4 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setCreating(false);
+                  setCreateError('');
+                }}
+                disabled={createBusy}
+                className="px-4 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={createBusy}
+                className="px-4 py-1.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50"
+                data-testid="fk-create-submit"
+              >
+                {createBusy ? 'Creating…' : 'Create field key'}
+              </button>
+            </div>
+          </form>
+        </section>
+      )}
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <div className="relative">
+          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search by key prefix…"
+            data-testid="fk-search"
+            className="pl-8 pr-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 w-64 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div className="flex gap-1">
+          {SCOPE_FILTERS.map((s) => (
+            <button
+              key={s.value}
+              type="button"
+              onClick={() => setScopeFilter(s.value)}
+              data-testid={`fk-scope-${s.value}`}
+              className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                scopeFilter === s.value
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+              }`}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+        <select
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value)}
+          aria-label="Filter by expected field type"
+          className="px-3 py-1 rounded-full text-xs border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+        >
+          <option value="">All types</option>
+          {FIELD_TYPE_OPTIONS.filter((o) => o.value).map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {error && (
+        <div className="rounded-lg bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-300 mb-4">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-sm text-gray-500 dark:text-gray-400">Loading field keys…</div>
+      ) : visible.length === 0 ? (
+        <div
+          className="text-center py-12 text-gray-500 dark:text-gray-400"
+          data-testid="fk-empty"
+        >
+          {keys.length === 0
+            ? 'No field keys yet. Create one to get started, or run `python manage.py seed_field_keys` to seed the standard global set.'
+            : 'No field keys match the current filters.'}
+        </div>
+      ) : (
+        <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+          <table className="w-full text-sm" data-testid="fk-table">
+            <thead className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+              <tr>
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">Key</th>
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">Display name</th>
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">Type</th>
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">Dashboard role</th>
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">Scope</th>
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">Created</th>
+                <th className="px-3 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+              {visible.map((row) => (
+                <tr
+                  key={row.id}
+                  data-testid={`fk-row-${row.key}`}
+                  className="hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                >
+                  <td className="px-3 py-3 font-mono text-xs text-gray-900 dark:text-white">
+                    {row.key}
+                  </td>
+                  <td className="px-3 py-3 text-gray-900 dark:text-white">
+                    {row.display_name}
+                    {row.description && (
+                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 line-clamp-2">
+                        {row.description}
+                      </p>
+                    )}
+                  </td>
+                  <td className="px-3 py-3 text-gray-600 dark:text-gray-400 text-xs">
+                    {labelForType(row.expected_field_type)}
+                  </td>
+                  <td className="px-3 py-3 text-gray-600 dark:text-gray-400 text-xs">
+                    {labelForRole(row.expected_dashboard_role)}
+                  </td>
+                  <td className="px-3 py-3">
+                    {row.is_global ? (
+                      <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300">
+                        Global
+                      </span>
+                    ) : (
+                      <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                        Org
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-3 py-3 text-gray-500 dark:text-gray-400 text-xs">
+                    {row.created_at ? new Date(row.created_at).toLocaleDateString() : '—'}
+                  </td>
+                  <td className="px-3 py-3 text-right">
+                    <div className="inline-flex items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => setEditing(row)}
+                        data-testid={`fk-edit-${row.key}`}
+                        className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline text-xs px-2 py-1"
+                      >
+                        <Pencil size={12} /> Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(row)}
+                        data-testid={`fk-delete-${row.key}`}
+                        className="inline-flex items-center gap-1 text-red-600 dark:text-red-400 hover:underline text-xs px-2 py-1"
+                      >
+                        <Trash2 size={12} /> Delete
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <EditModal
+        open={!!editing}
+        initial={editing}
+        busy={editBusy}
+        onClose={() => setEditing(null)}
+        onSubmit={submitEdit}
+      />
+
+      {toast && (
+        <div
+          role="status"
+          data-testid="fk-toast"
+          className="fixed bottom-6 left-1/2 -translate-x-1/2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 text-sm px-5 py-2.5 rounded-full shadow-lg z-50"
+        >
+          {toast}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/pages/admin/field-keys/__tests__/FieldKeyListPage.test.jsx
+++ b/frontend/src/pages/admin/field-keys/__tests__/FieldKeyListPage.test.jsx
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+const patchMock = vi.fn();
+const deleteMock = vi.fn();
+
+vi.mock('../../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: (...args) => postMock(...args),
+    patch: (...args) => patchMock(...args),
+    delete: (...args) => deleteMock(...args),
+  },
+}));
+
+import FieldKeyListPage from '../FieldKeyListPage';
+
+const KEYS = [
+  {
+    id: 1,
+    organization: null,
+    key: 'punctuality',
+    display_name: 'Punctuality',
+    description: 'Arrives on time.',
+    expected_field_type: 'rating_group',
+    expected_dashboard_role: 'category_ratings',
+    is_global: true,
+    created_at: '2025-01-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    organization: 5,
+    key: 'custom_metric',
+    display_name: 'Custom Metric',
+    description: '',
+    expected_field_type: 'text',
+    expected_dashboard_role: '',
+    is_global: false,
+    created_at: '2025-02-01T00:00:00Z',
+  },
+];
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/admin/field-keys']}>
+      <FieldKeyListPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  getMock.mockReset();
+  postMock.mockReset();
+  patchMock.mockReset();
+  deleteMock.mockReset();
+  getMock.mockResolvedValue({ data: KEYS });
+  vi.spyOn(window, 'confirm').mockReturnValue(true);
+});
+
+describe('FieldKeyListPage (3.29)', () => {
+  it('lists field keys with scope chip and type label', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('fk-table')).toBeInTheDocument());
+
+    const globalRow = screen.getByTestId('fk-row-punctuality');
+    const orgRow = screen.getByTestId('fk-row-custom_metric');
+    expect(within(globalRow).getByText('Global')).toBeInTheDocument();
+    expect(within(orgRow).getByText('Org')).toBeInTheDocument();
+    // type labels are humanized
+    expect(within(globalRow).getByText('Rating group')).toBeInTheDocument();
+    expect(within(orgRow).getByText('Short text')).toBeInTheDocument();
+  });
+
+  it('scope filter narrows rows to global and back to mine', async () => {
+    renderPage();
+    await waitFor(() => screen.getByTestId('fk-table'));
+
+    await userEvent.click(screen.getByTestId('fk-scope-global'));
+    expect(screen.getByTestId('fk-row-punctuality')).toBeInTheDocument();
+    expect(screen.queryByTestId('fk-row-custom_metric')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('fk-scope-mine'));
+    expect(screen.queryByTestId('fk-row-punctuality')).not.toBeInTheDocument();
+    expect(screen.getByTestId('fk-row-custom_metric')).toBeInTheDocument();
+  });
+
+  it('search input drives ?q= on the API call', async () => {
+    renderPage();
+    await waitFor(() => screen.getByTestId('fk-table'));
+    getMock.mockClear();
+
+    await userEvent.type(screen.getByTestId('fk-search'), 'punc');
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledWith(
+        '/api/v1/field-keys/',
+        expect.objectContaining({ params: { q: 'punc' } }),
+      );
+    });
+  });
+
+  it('creates a new field key and refreshes the list', async () => {
+    renderPage();
+    await waitFor(() => screen.getByTestId('fk-table'));
+
+    await userEvent.click(screen.getByTestId('fk-new-btn'));
+    const form = await screen.findByTestId('fk-create-form');
+    expect(form).toBeInTheDocument();
+
+    await userEvent.type(screen.getByTestId('fk-form-key'), 'energy');
+    await userEvent.type(screen.getByTestId('fk-form-display-name'), 'Energy');
+
+    postMock.mockResolvedValueOnce({ data: { id: 99 } });
+    getMock.mockResolvedValueOnce({
+      data: [
+        ...KEYS,
+        {
+          id: 99,
+          organization: 5,
+          key: 'energy',
+          display_name: 'Energy',
+          description: '',
+          expected_field_type: '',
+          expected_dashboard_role: '',
+          is_global: false,
+          created_at: '2025-03-01T00:00:00Z',
+        },
+      ],
+    });
+
+    await userEvent.click(screen.getByTestId('fk-create-submit'));
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledWith(
+        '/api/v1/field-keys/',
+        expect.objectContaining({
+          key: 'energy',
+          display_name: 'Energy',
+        }),
+      );
+    });
+    await waitFor(() => expect(screen.getByTestId('fk-row-energy')).toBeInTheDocument());
+  });
+
+  it('removes a row on successful delete', async () => {
+    renderPage();
+    await waitFor(() => screen.getByTestId('fk-table'));
+
+    deleteMock.mockResolvedValueOnce({ status: 204 });
+    getMock.mockResolvedValueOnce({ data: [KEYS[0]] }); // custom_metric removed
+
+    await userEvent.click(screen.getByTestId('fk-delete-custom_metric'));
+
+    await waitFor(() => {
+      expect(deleteMock).toHaveBeenCalledWith('/api/v1/field-keys/2/');
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('fk-row-custom_metric')).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps the row and shows toast when delete returns 409', async () => {
+    renderPage();
+    await waitFor(() => screen.getByTestId('fk-table'));
+
+    deleteMock.mockRejectedValueOnce({
+      response: {
+        status: 409,
+        data: { detail: 'Key "custom_metric" is referenced by one or more templates.' },
+      },
+    });
+
+    await userEvent.click(screen.getByTestId('fk-delete-custom_metric'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('fk-toast')).toHaveTextContent(/referenced by one or more templates/i);
+    });
+    // row is still there
+    expect(screen.getByTestId('fk-row-custom_metric')).toBeInTheDocument();
+  });
+
+  it('opens the edit modal, locks the key field, and patches on save', async () => {
+    renderPage();
+    await waitFor(() => screen.getByTestId('fk-table'));
+
+    await userEvent.click(screen.getByTestId('fk-edit-custom_metric'));
+    const submit = await screen.findByTestId('fk-edit-submit');
+    expect(submit).toBeInTheDocument();
+
+    // Key field should be read-only inside the modal
+    const keyInputs = screen.getAllByTestId('fk-form-key');
+    const modalKey = keyInputs[keyInputs.length - 1];
+    expect(modalKey).toHaveAttribute('readonly');
+
+    const nameInputs = screen.getAllByTestId('fk-form-display-name');
+    const modalName = nameInputs[nameInputs.length - 1];
+    await userEvent.clear(modalName);
+    await userEvent.type(modalName, 'Custom Metric Renamed');
+
+    patchMock.mockResolvedValueOnce({ data: {} });
+    getMock.mockResolvedValueOnce({ data: KEYS });
+
+    await userEvent.click(submit);
+
+    await waitFor(() => {
+      expect(patchMock).toHaveBeenCalledWith(
+        '/api/v1/field-keys/2/',
+        expect.objectContaining({ display_name: 'Custom Metric Renamed' }),
+      );
+    });
+  });
+});

--- a/migration_prompts/3_29_field_key_registry_ui.md
+++ b/migration_prompts/3_29_field_key_registry_ui.md
@@ -1,0 +1,159 @@
+# Prompt 3.29 — FieldKey registry UI
+
+**Wave:** 3 (Crane Lake Summer 2026 Build) — UI cleanup
+**Estimated time:** 3-4 hours
+**Prerequisite:** Prompt 3.28 complete.
+
+**Use the context prompt at the top of `migration_prompts/0_0_context_prompt.md` before this session.**
+
+---
+
+```
+The FieldKey registry has shipped to the backend (model, manager, viewset,
+seed command, validator integration) and the AdminHub already advertises
+"Field keys" as a card -- but it's marked Coming Soon because there is no
+frontend. This prompt builds the registry UI.
+
+CONTEXT:
+
+A FieldKey is a canonical short identifier (e.g. "punctuality", "wins")
+that template authors reuse across reflection templates to enable
+cross-template reporting. Backend model lives at
+`bunk_logs/core/models.py` (class FieldKey) and the API is
+`/api/v1/field-keys/` from `bunk_logs/api/field_keys.py`. Tests live in
+`bunk_logs/core/test_field_key_registry.py` and pass today.
+
+API surface, fully implemented:
+
+- GET    /api/v1/field-keys/[?q=<prefix>]   list (org + global, prefix search)
+- POST   /api/v1/field-keys/                create (always in request.organization)
+- PATCH  /api/v1/field-keys/<id>/           partial update
+- DELETE /api/v1/field-keys/<id>/           delete (409 if referenced by any template)
+
+Permissions:
+
+- list/retrieve: any authenticated user with organization context
+- create/update/delete: IsOrgAdminOrSuperuser (org admin or `is_staff`/`is_superuser`)
+- Edits to global keys (organization=null): Super Admin only
+
+Response includes:
+
+  id, organization, key, display_name, description,
+  expected_field_type, expected_dashboard_role,
+  is_global (derived), created_at
+
+Editable fields (server enforces): key, display_name, description,
+expected_field_type, expected_dashboard_role.
+
+`expected_field_type` aligns with the schema field types in
+`frontend/src/components/templates/FieldList.jsx` / `LivePreview.jsx`:
+text, textarea, text_list, single_choice, multiple_choice, yes_no, date,
+number, section_header, instructions, rating_group, single_rating.
+
+`expected_dashboard_role` is currently free-form on the backend but the
+seed command uses: category_ratings, wins, improvements, open_concern.
+
+GOALS:
+
+1. /admin/field-keys lists every field key visible to the current org
+   (org-scoped + global), with search and scope/type filters.
+2. Super Admins can create, edit, and delete keys (including global
+   keys). Org admins technically can edit their org's keys via the API,
+   but the UI gates the page behind AdminRoute (Super Admin) for v1
+   parity with templates and groups -- broaden later when org-admin
+   tooling becomes a coherent surface.
+3. Delete must surface the 409 "key is referenced" message clearly so
+   the user knows to clean up templates first.
+4. Card on AdminHub becomes a real link, not "Coming soon".
+
+OUT OF SCOPE:
+
+- Bulk import / CSV.
+- Per-key usage report ("which templates reference this key?"). Backend
+  has the data for this but it's not a v1 need; the 409 on delete is
+  enough signal for now.
+- Org-admin UI exposure. Stays AdminRoute / Super Admin only.
+
+TASKS:
+
+1. New page `frontend/src/pages/admin/field-keys/FieldKeyListPage.jsx`:
+
+   - Renders inside AdminLayout (single `<main>` with max-w-6xl).
+   - Breadcrumb back-link to /admin (matches templates and groups).
+   - Header: title + blurb + "New field key" button.
+   - Search input wired to the `?q=` API param (debounced ~250ms or
+     on Enter; either is fine).
+   - Scope filter chips: All / Mine / Global, applied client-side
+     against `is_global`.
+   - Optional secondary filter by `expected_field_type`.
+   - Inline create form (collapsible) for: key, display_name,
+     description, expected_field_type, expected_dashboard_role.
+   - Table with columns: Key, Display name, Type, Dashboard role,
+     Scope (Global/Org), Created, Actions.
+   - "Edit" opens a modal (or right drawer) with the same fields as
+     the create form; key is read-only on edit.
+   - "Delete" prompts a confirmation, then surfaces 409 detail in a
+     toast if the key is in use.
+   - Toast pattern matches GroupListPage (fixed bottom-center pill).
+   - Error states (network, 403) render a small panel above the table.
+
+2. Add tests at `frontend/src/pages/admin/field-keys/__tests__/FieldKeyListPage.test.jsx`:
+
+   - Renders list from a mocked GET response.
+   - Scope filter (Global / Mine) narrows the visible rows.
+   - "New field key" form posts and refreshes.
+   - "Delete" handles 204 (row disappears) and 409 (toast surfaces the
+     server-supplied detail and the row remains).
+   - Search input drives `?q=` on the API call.
+
+3. Update `frontend/src/Router.jsx`:
+
+   - Add `<Route path="field-keys" element={<AdminRoute><FieldKeyListPage/></AdminRoute>}/>`
+     under the existing AdminLayout parent.
+
+4. Update `frontend/src/pages/admin/AdminHub.jsx`:
+
+   - Replace the deferred `field-keys` card with a live one:
+       to: '/admin/field-keys'
+       deferred: false
+       blurb: rewrite to past tense ("Canonical short keys used across
+       reflection templates to enable cross-template reporting.").
+
+5. Update `frontend/src/pages/admin/__tests__/AdminHub.test.jsx`:
+
+   - Remove the "Coming soon" expectation for the field-keys card.
+   - Assert the card now links to /admin/field-keys.
+
+6. Optional but nice:
+   - Sidebar: do NOT add a field-keys entry. The AdminHub card is the
+     entry point; sidebar would crowd the admin section. The deep-link
+     is also discoverable from the AdminHub card.
+
+7. Documentation:
+   - Update `docs/membership-role-vs-capability.md` only if any
+     access-tier copy needs to change. We do not expect any.
+
+8. Run `make test-frontend`, `make test-backend`, `ruff check
+   bunk_logs/ config/`, and `vite build`. All green.
+
+9. Commit + PR: `3_29_field_key_registry_ui: ...`.
+```
+
+---
+
+## Acceptance criteria
+
+- Navigating to /admin/field-keys as a Super Admin shows the list of
+  org-visible + global keys.
+- Search narrows by prefix.
+- Scope filter (All / Mine / Global) filters rows in the table.
+- New key flow creates a key under the current org and it appears in the
+  list.
+- Editing a key (display_name, description, type hint, dashboard role)
+  persists.
+- Deleting a key that is referenced by a template surfaces the server's
+  "Key is referenced..." message and keeps the row.
+- Deleting an unused key removes it from the list.
+- AdminHub card links to /admin/field-keys and is no longer marked
+  "Coming soon".
+- All existing tests still pass; new tests for FieldKeyListPage pass.


### PR DESCRIPTION
## Summary

The FieldKey registry has had its backend (model, viewset, seed command, validator hook, full test suite) for several waves, but the AdminHub card was still marked "Coming soon" because nothing on the frontend consumed it. This PR ships the read/write UI and lights up the card.

## What changed

- **New page** \`frontend/src/pages/admin/field-keys/FieldKeyListPage.jsx\`:
  - List with debounced prefix search (\`?q=\`), scope filter (All / Mine / Global), and expected-type filter.
  - Inline create form (collapsible) with key, display name, description, expected field type, expected dashboard role.
  - Edit modal with the same fields. \`key\` is locked on edit because the API treats it as immutable.
  - Delete with browser confirm; surfaces the 409 "referenced by templates" detail in a toast and keeps the row when the key is in use.
  - Friendly empty state that points at \`python manage.py seed_field_keys\` for a fresh install.
- **\`Router.jsx\`** adds \`/admin/field-keys\` as a child of the AdminLayout route. Gated by \`AdminRoute\` for v1 (the API also allows org admins via \`IsOrgAdminOrSuperuser\`, so we can broaden later without backend changes).
- **\`AdminHub.jsx\`** flips the field-keys card from deferred to linkable and updates the blurb to describe the live destination.
- **\`AdminHub.test.jsx\`** asserts the card is now a real \`<a>\` pointing at \`/admin/field-keys\` and that "Coming soon" no longer renders.

## Out of scope (deferred)

- Bulk CSV import for keys.
- Per-key usage report ("which templates reference this key"). The 409 on delete is enough signal for now.
- Org-admin UI exposure; remains AdminRoute / Super Admin only until org-admin tooling becomes a coherent surface.

## Tests

- 216 frontend tests pass; 7 new in \`FieldKeyListPage.test.jsx\` covering list, scope filter, debounced \`?q=\` search, create, 204 delete, 409 delete, and edit modal with locked key field.
- \`vite build\` clean.
- \`ruff check bunk_logs/ config/\` clean. Backend untouched.

## Test plan

- [ ] As a Super Admin, navigate \`/admin\` → click "Field keys"; list renders.
- [ ] Type a prefix in search; rows narrow and API receives \`?q=\`.
- [ ] Click "New field key" → fill key + display name → submit; new row appears.
- [ ] Edit a key; only display name / description / type / dashboard role are editable.
- [ ] Delete an unused key; row disappears with toast.
- [ ] Delete a key referenced by a template; row stays and toast surfaces "referenced by one or more templates".
- [ ] On a fresh dev DB run \`make manage CMD="seed_field_keys"\` and confirm the 9 standard global keys show up.

## Migration prompt

\`migration_prompts/3_29_field_key_registry_ui.md\` documents the prompt that drove this change.

Made with [Cursor](https://cursor.com)