### PR TITLE
3_32_role_aware_navigation: sectioned capability-aware sidebar, dedup admin links

### DIFF
--- a/frontend/e2e/rbac-sidebar.spec.ts
+++ b/frontend/e2e/rbac-sidebar.spec.ts
@@ -1,122 +1,184 @@
 /**
- * Sidebar RBAC spec.
+ * Sidebar RBAC spec (3.32-aware).
  *
  * Asserts that the navigation links rendered by frontend/src/partials/Sidebar.jsx
- * match the role each user signed in as. Today the sidebar still gates on the
- * legacy User.role string (Counselor, Admin, Unit Head, Camper Care, Leadership);
- * the seed command sets that field to mirror Membership.role so this spec
- * doubles as a regression guard if/when those branches migrate to capability.
+ * match the capability each user signs in as. 3.32 introduced section
+ * groupings (My work / Supervise / Dashboards / Admin / Crane Lake
+ * legacy / Other) and switched the gates to `hasCapability` +
+ * `isSuperAdmin`. The seed command (`make seed-rbac`) maps
+ * Membership.role to User.role so the legacy gate still works while
+ * the capability helper is the actual source of truth.
  *
- * We assert on hrefs (not link text) because some link labels overlap as
- * substrings — e.g. "Bunk Logs" is the admin-only link to /admin-bunk-logs,
- * but Camper Care has a "My Bunk Logs" button that would falsely match a
- * naive `toContain('Bunk Logs')` check.
+ * Assert on hrefs (not link text) wherever there's ambiguity — some
+ * labels collide as substrings ("Bunk Logs" vs the CamperCare in-page
+ * tab "My Bunk Logs", for example).
  */
 import { test, expect, type Page } from '@playwright/test';
 import { loginAs, readSidebarText } from './fixtures/auth';
 
 const HREFS = {
-  // Self-reflection form, shown to REFLECTION_FORM_ROLES (Counselor, Admin,
-  // Unit Head, Camper Care).
+  // My work
+  home: '/dashboard',
+  tasks: '/tasks',
   reflect: '/reflect',
-  // Counselor "My Reflections" routes to /counselor-dashboard.
-  counselorDashboard: '/counselor-dashboard',
-  // Admin-only blocks.
-  adminBunkLogs: '/admin-bunk-logs',
-  adminStaffReflections: '/admin-dashboard',
-  adminMemberships: '/admin/memberships',
-  // First child of the admin "Tests" submenu — used as a sentinel for the
-  // submenu's existence (the submenu trigger is a button, not a link).
-  adminTemplates: '/admin/templates',
-  ltUnitHealth: '/team/dashboard',
-  wellnessDashboard: '/wellness/dashboard',
+  myReflections: '/my-reflections',
+  counselorHome: '/counselor-dashboard',
   orders: '/orders',
+  // Supervise
+  supervisorCoverage: '/supervisor/coverage',
+  concernsInbox: '/dashboards/concerns',
+  // Dashboards (canonical paths — 3.27 renamed the legacy
+  // /team/dashboard / /wellness/dashboard aliases away from the
+  // sidebar).
+  dashboardsHome: '/dashboards',
+  dashboardsCoverage: '/dashboards/coverage',
+  dashboardsAuthors: '/dashboards/authors',
+  dashboardsTeam: '/dashboards/team',
+  dashboardsWellness: '/dashboards/wellness',
+  // Admin
+  adminHome: '/admin',
+  adminMemberships: '/admin/memberships',
+  adminTemplates: '/admin/templates',
+  adminGroups: '/admin/groups',
+  adminFieldKeys: '/admin/field-keys',
+  // Crane Lake legacy
+  legacyBunkLogs: '/admin-bunk-logs',
+  legacyStaffReflections: '/admin-dashboard',
 };
 
 async function hasLink(page: Page, href: string): Promise<boolean> {
   return (await page.locator(`#sidebar a[href="${href}"]`).count()) > 0;
 }
 
-test.describe('Sidebar RBAC', () => {
-  test('participant counselor sees self-reflection links, not admin tools', async ({ page }) => {
+async function countLinks(page: Page, href: string): Promise<number> {
+  return await page.locator(`#sidebar a[href="${href}"]`).count();
+}
+
+test.describe('Sidebar RBAC — capability tiers (3.32)', () => {
+  test('counselor (participant): My work only', async ({ page }) => {
     await loginAs(page, 'counselor');
     await readSidebarText(page);
 
-    expect(await hasLink(page, HREFS.counselorDashboard)).toBe(true);
+    // My work entries
+    expect(await hasLink(page, HREFS.home)).toBe(true);
+    expect(await hasLink(page, HREFS.tasks)).toBe(true);
+    expect(await hasLink(page, HREFS.counselorHome)).toBe(true);
     expect(await hasLink(page, HREFS.reflect)).toBe(true);
+    expect(await hasLink(page, HREFS.myReflections)).toBe(true);
+    expect(await hasLink(page, HREFS.orders)).toBe(true);
+
+    // No Supervise / Dashboards / Admin / Legacy
+    expect(await hasLink(page, HREFS.supervisorCoverage)).toBe(false);
+    expect(await hasLink(page, HREFS.concernsInbox)).toBe(false);
+    expect(await hasLink(page, HREFS.dashboardsHome)).toBe(false);
     expect(await hasLink(page, HREFS.adminMemberships)).toBe(false);
-    expect(await hasLink(page, HREFS.adminTemplates)).toBe(false);
-    expect(await hasLink(page, HREFS.adminBunkLogs)).toBe(false);
-    expect(await hasLink(page, HREFS.ltUnitHealth)).toBe(false);
-    expect(await hasLink(page, HREFS.wellnessDashboard)).toBe(false);
+    expect(await hasLink(page, HREFS.adminFieldKeys)).toBe(false);
+    expect(await hasLink(page, HREFS.legacyBunkLogs)).toBe(false);
   });
 
-  test('unit head sees the participant links (no admin tools)', async ({ page }) => {
+  test('unit_head (supervisor): Supervise but no Dashboards / Admin', async ({ page }) => {
     await loginAs(page, 'unit_head');
     await readSidebarText(page);
 
+    expect(await hasLink(page, HREFS.home)).toBe(true);
     expect(await hasLink(page, HREFS.orders)).toBe(true);
+    expect(await hasLink(page, HREFS.supervisorCoverage)).toBe(true);
+    expect(await hasLink(page, HREFS.concernsInbox)).toBe(true);
+
+    expect(await hasLink(page, HREFS.dashboardsHome)).toBe(false);
     expect(await hasLink(page, HREFS.adminMemberships)).toBe(false);
-    expect(await hasLink(page, HREFS.adminTemplates)).toBe(false);
-    expect(await hasLink(page, HREFS.adminBunkLogs)).toBe(false);
+    expect(await hasLink(page, HREFS.legacyBunkLogs)).toBe(false);
+    // No role-specific Counselor home for unit heads.
+    expect(await hasLink(page, HREFS.counselorHome)).toBe(false);
   });
 
-  test('leadership sees Unit health (LT) link', async ({ page }) => {
-    await loginAs(page, 'leadership');
-    await readSidebarText(page);
-
-    expect(await hasLink(page, HREFS.ltUnitHealth)).toBe(true);
-    expect(await hasLink(page, HREFS.adminMemberships)).toBe(false);
-    expect(await hasLink(page, HREFS.adminTemplates)).toBe(false);
-  });
-
-  test('camper_care sees Wellness team and not the admin Bunk Logs link', async ({ page }) => {
+  test('camper_care (supervisor): same Supervise gates as unit head + reflection forms', async ({
+    page,
+  }) => {
     await loginAs(page, 'camper_care');
     await readSidebarText(page);
 
-    expect(await hasLink(page, HREFS.wellnessDashboard)).toBe(true);
+    expect(await hasLink(page, HREFS.supervisorCoverage)).toBe(true);
+    expect(await hasLink(page, HREFS.concernsInbox)).toBe(true);
+    expect(await hasLink(page, HREFS.reflect)).toBe(true);
+    expect(await hasLink(page, HREFS.myReflections)).toBe(true);
+
+    // Camper care does NOT get admin or dashboards.
+    expect(await hasLink(page, HREFS.dashboardsHome)).toBe(false);
     expect(await hasLink(page, HREFS.adminMemberships)).toBe(false);
-    expect(await hasLink(page, HREFS.adminBunkLogs)).toBe(false);
+    expect(await hasLink(page, HREFS.legacyBunkLogs)).toBe(false);
   });
 
-  test('admin sees Bunk Logs, Staff Reflections, Memberships, and the Tests submenu', async ({
+  test('leadership (program_lead): Supervise + Dashboards but no Admin', async ({ page }) => {
+    await loginAs(page, 'leadership');
+    await readSidebarText(page);
+
+    expect(await hasLink(page, HREFS.supervisorCoverage)).toBe(true);
+    expect(await hasLink(page, HREFS.dashboardsHome)).toBe(true);
+    expect(await hasLink(page, HREFS.dashboardsTeam)).toBe(true);
+    expect(await hasLink(page, HREFS.dashboardsWellness)).toBe(true);
+
+    expect(await hasLink(page, HREFS.adminMemberships)).toBe(false);
+    expect(await hasLink(page, HREFS.legacyBunkLogs)).toBe(false);
+  });
+
+  test('admin: every section including Crane Lake legacy', async ({ page }) => {
+    await loginAs(page, 'admin');
+    await readSidebarText(page);
+
+    expect(await hasLink(page, HREFS.supervisorCoverage)).toBe(true);
+    expect(await hasLink(page, HREFS.dashboardsHome)).toBe(true);
+    expect(await hasLink(page, HREFS.adminHome)).toBe(true);
+    expect(await hasLink(page, HREFS.adminMemberships)).toBe(true);
+    expect(await hasLink(page, HREFS.adminTemplates)).toBe(true);
+    expect(await hasLink(page, HREFS.adminGroups)).toBe(true);
+    expect(await hasLink(page, HREFS.adminFieldKeys)).toBe(true);
+    expect(await hasLink(page, HREFS.legacyBunkLogs)).toBe(true);
+    expect(await hasLink(page, HREFS.legacyStaffReflections)).toBe(true);
+  });
+
+  test('admin: /dashboards/team and /dashboards/wellness appear exactly once (no duplicates)', async ({
     page,
   }) => {
     await loginAs(page, 'admin');
     await readSidebarText(page);
-
-    expect(await hasLink(page, HREFS.adminBunkLogs)).toBe(true);
-    expect(await hasLink(page, HREFS.adminStaffReflections)).toBe(true);
-    expect(await hasLink(page, HREFS.adminMemberships)).toBe(true);
-    // Tests submenu (collapsed at first render — assert the child link exists
-    // in the DOM regardless of the open/closed state of the submenu).
-    expect(await hasLink(page, HREFS.adminTemplates)).toBe(true);
-    // Admin also has the LT + Wellness shortcuts via the union role list.
-    expect(await hasLink(page, HREFS.ltUnitHealth)).toBe(true);
-    expect(await hasLink(page, HREFS.wellnessDashboard)).toBe(true);
+    expect(await countLinks(page, HREFS.dashboardsTeam)).toBe(1);
+    expect(await countLinks(page, HREFS.dashboardsWellness)).toBe(1);
   });
 
-  test('superuser sees the Tests submenu via is_superuser fallback', async ({ page }) => {
+  test('admin: Concerns inbox lives only in Supervise, not duplicated under Dashboards', async ({
+    page,
+  }) => {
+    await loginAs(page, 'admin');
+    await readSidebarText(page);
+    expect(await countLinks(page, HREFS.concernsInbox)).toBe(1);
+  });
+
+  test('superuser (is_staff fallback): admin sections render even without a Membership', async ({
+    page,
+  }) => {
     await loginAs(page, 'superuser');
     await readSidebarText(page);
 
-    // Superuser User.role='Admin' so the admin branches fire; the key
-    // assertion is that the is_staff/is_superuser fallback also keeps the
-    // Tests submenu mounted.
     expect(await hasLink(page, HREFS.adminTemplates)).toBe(true);
+    expect(await hasLink(page, HREFS.adminFieldKeys)).toBe(true);
+    expect(await hasLink(page, HREFS.legacyBunkLogs)).toBe(true);
   });
 
-  test('user without a Person/Membership still gets the base Orders link only', async ({
+  test('no_membership: only the everyone-visible items (Home, Orders) render', async ({
     page,
   }) => {
     await loginAs(page, 'no_membership');
     await readSidebarText(page);
 
+    expect(await hasLink(page, HREFS.home)).toBe(true);
+    expect(await hasLink(page, HREFS.tasks)).toBe(true);
     expect(await hasLink(page, HREFS.orders)).toBe(true);
-    expect(await hasLink(page, HREFS.counselorDashboard)).toBe(false);
+
+    expect(await hasLink(page, HREFS.supervisorCoverage)).toBe(false);
+    expect(await hasLink(page, HREFS.dashboardsHome)).toBe(false);
     expect(await hasLink(page, HREFS.adminMemberships)).toBe(false);
-    expect(await hasLink(page, HREFS.adminTemplates)).toBe(false);
-    expect(await hasLink(page, HREFS.ltUnitHealth)).toBe(false);
-    expect(await hasLink(page, HREFS.wellnessDashboard)).toBe(false);
+    expect(await hasLink(page, HREFS.legacyBunkLogs)).toBe(false);
+    expect(await hasLink(page, HREFS.counselorHome)).toBe(false);
   });
 });

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -46,6 +46,7 @@ import AuthorAttributionPage from './pages/dashboards/AuthorAttributionPage';
 import ConcernsInboxPage from './pages/dashboards/ConcernsInboxPage';
 import DashboardsHub from './pages/dashboards/DashboardsHub';
 import AdminLayout from './layouts/AdminLayout';
+import AppLayout from './layouts/AppLayout';
 import { useBunk } from './contexts/BunkContext';
 
 // Protected route component
@@ -312,22 +313,23 @@ function Router() {
           }
         />
 
+        {/* 3.33 follow-up: pages that originally rendered as
+            single-column mobile-first surfaces (no Sidebar / Header)
+            now share the AppLayout chrome so the new capability-aware
+            sidebar from 3.32 is always reachable. ProtectedRoute sits
+            on the layout so the gate fires once for every child. */}
         <Route
-          path="/reflect"
           element={
             <ProtectedRoute>
-              <ReflectionFormPage />
+              <AppLayout />
             </ProtectedRoute>
           }
-        />
-        <Route
-          path="/reflect/summary"
-          element={
-            <ProtectedRoute>
-              <ReflectionSummaryPage />
-            </ProtectedRoute>
-          }
-        />
+        >
+          <Route path="/reflect" element={<ReflectionFormPage />} />
+          <Route path="/reflect/summary" element={<ReflectionSummaryPage />} />
+          <Route path="/tasks" element={<TasksPage />} />
+          <Route path="/supervisor/coverage" element={<SupervisorCoveragePage />} />
+        </Route>
 
         <Route
           path="/my-reflections"
@@ -514,26 +516,6 @@ function Router() {
             <AdminRoute>
               <TemplateEditorPage />
             </AdminRoute>
-          }
-        />
-
-        {/* Roster-aware tasks home screen */}
-        <Route
-          path="/tasks"
-          element={
-            <ProtectedRoute>
-              <TasksPage />
-            </ProtectedRoute>
-          }
-        />
-
-        {/* Supervisor coverage view */}
-        <Route
-          path="/supervisor/coverage"
-          element={
-            <ProtectedRoute>
-              <SupervisorCoveragePage />
-            </ProtectedRoute>
           }
         />
 

--- a/frontend/src/layouts/AppLayout.jsx
+++ b/frontend/src/layouts/AppLayout.jsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { Outlet } from 'react-router-dom';
+
+import Header from '../partials/Header';
+import Sidebar from '../partials/Sidebar';
+
+/**
+ * Shared layout for non-admin authenticated app routes (3.32
+ * follow-up). Renders the same Sidebar + Header chrome AdminLayout
+ * uses, then slots the matched child route into `<Outlet/>`.
+ *
+ * Why this exists: pages like /tasks, /reflect, /reflect/summary,
+ * and /supervisor/coverage were originally built as mobile-first,
+ * single-column views that mounted no chrome at all. After the 3.32
+ * sidebar restructure the missing chrome became user-visible
+ * ("My Tasks / File a Reflection / Coverage all make the sidebar
+ * disappear"). Wrap those routes here so the navigation is always
+ * in place when you click between admin, dashboards, supervise, and
+ * task surfaces.
+ *
+ * Sibling of `AdminLayout`. We keep them separate so each can be
+ * audited independently (AdminRoute gating sits on the admin tree;
+ * AppLayout has no extra gates -- it inherits the per-route
+ * ProtectedRoute wrappers in Router.jsx).
+ *
+ * The layout owns no width constraints. Child routes provide their
+ * own `<main>` / content wrapper so a focused single-column page
+ * (e.g. /reflect) and a full-width page can share this shell.
+ */
+export default function AppLayout() {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+      <div
+        data-testid="app-layout-scroll"
+        className="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden bg-gray-50 dark:bg-gray-950"
+      >
+        <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/layouts/__tests__/AppLayout.test.jsx
+++ b/frontend/src/layouts/__tests__/AppLayout.test.jsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+vi.mock('../../partials/Sidebar', () => ({
+  default: () => <aside data-testid="mock-sidebar" />,
+}));
+vi.mock('../../partials/Header', () => ({
+  default: () => <header data-testid="mock-header" />,
+}));
+
+import AppLayout from '../AppLayout';
+
+function renderAt(url) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <Routes>
+        <Route element={<AppLayout />}>
+          <Route path="/tasks" element={<p data-testid="child-content">tasks child</p>} />
+          <Route path="/reflect" element={<p data-testid="child-content">reflect child</p>} />
+          <Route
+            path="/supervisor/coverage"
+            element={<p data-testid="child-content">coverage child</p>}
+          />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('AppLayout (3.32 follow-up: chrome for app routes)', () => {
+  it('renders Sidebar + Header + /tasks child via Outlet', () => {
+    renderAt('/tasks');
+    expect(screen.getByTestId('mock-sidebar')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-header')).toBeInTheDocument();
+    expect(screen.getByTestId('child-content')).toHaveTextContent('tasks child');
+  });
+
+  it('keeps chrome in place on /reflect', () => {
+    renderAt('/reflect');
+    expect(screen.getByTestId('mock-sidebar')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-header')).toBeInTheDocument();
+    expect(screen.getByTestId('child-content')).toHaveTextContent('reflect child');
+  });
+
+  it('keeps chrome in place on /supervisor/coverage', () => {
+    renderAt('/supervisor/coverage');
+    expect(screen.getByTestId('mock-sidebar')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-header')).toBeInTheDocument();
+    expect(screen.getByTestId('child-content')).toHaveTextContent('coverage child');
+  });
+
+  it('exposes the scroll container so children can rely on it', () => {
+    renderAt('/tasks');
+    expect(screen.getByTestId('app-layout-scroll')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/CamperCareDashboard.jsx
+++ b/frontend/src/pages/CamperCareDashboard.jsx
@@ -103,23 +103,15 @@ function CamperCareDashboard() {
     <div className="flex h-[100dvh] overflow-hidden">
 
       {/* Sidebar */}
-      <Sidebar 
-        sidebarOpen={sidebarOpen} 
-        setSidebarOpen={setSidebarOpen} 
-        extraLinks={[
-          {
-            label: 'My Bunk Logs',
-            onClick: () => setActiveView('bunklogs'),
-            active: activeView === 'bunklogs',
-            role: 'Camper Care',
-          },
-          {
-            label: 'Needs Attention',
-            onClick: () => setActiveView('needsattention'),
-            active: activeView === 'needsattention',
-            role: 'Camper Care',
-          },
-        ]}
+      {/* 3.32: previously injected per-page `extraLinks` to surface
+          the "My Bunk Logs" / "Needs Attention" view tabs alongside
+          the main nav. Those tabs now live as in-page controls (see
+          the activeView toggles below); the sidebar is the shared
+          capability-aware nav and no longer accepts per-page
+          injections. */}
+      <Sidebar
+        sidebarOpen={sidebarOpen}
+        setSidebarOpen={setSidebarOpen}
       />
 
       {/* Content area */}
@@ -165,6 +157,41 @@ function CamperCareDashboard() {
 
             {/* User profile */}
             <UserProfile user={userProfile} />
+
+            {/* 3.32: in-page view tabs. These previously lived in the
+                sidebar as Camper-Care-only `extraLinks` injections.
+                Moved here so the sidebar can stay role-agnostic and
+                we don't carry per-page sidebar plumbing. */}
+            <div
+              className="flex flex-wrap gap-2 mb-4"
+              role="tablist"
+              aria-label="Camper care view"
+            >
+              {[
+                { id: 'overview', label: 'Overview' },
+                { id: 'bunklogs', label: 'My Bunk Logs' },
+                { id: 'needsattention', label: 'Needs Attention' },
+              ].map((view) => {
+                const active = activeView === view.id;
+                return (
+                  <button
+                    key={view.id}
+                    type="button"
+                    role="tab"
+                    aria-selected={active}
+                    onClick={() => setActiveView(view.id)}
+                    className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                      active
+                        ? 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300'
+                        : 'bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                    }`}
+                  >
+                    {view.label}
+                  </button>
+                );
+              })}
+            </div>
+
             {/* Main content view */}
             {activeView === 'overview' && <CamperCareBunkGrid selectedDate={selectedDate} />}
             {activeView === 'bunklogs' && <CamperCareBunkLogsList selectedDate={selectedDate} />}

--- a/frontend/src/pages/ReflectionFormPage.jsx
+++ b/frontend/src/pages/ReflectionFormPage.jsx
@@ -218,7 +218,7 @@ export default function ReflectionFormPage() {
   const langChoices = meta?.languages?.length ? meta.languages : ['en', 'es'];
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 px-4 py-6 pb-24">
+    <div className="px-4 py-6 pb-24">
       <div className="max-w-lg mx-auto">
         <header className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>

--- a/frontend/src/pages/ReflectionSummaryPage.jsx
+++ b/frontend/src/pages/ReflectionSummaryPage.jsx
@@ -35,7 +35,7 @@ export default function ReflectionSummaryPage() {
 
   if (!data?.reflectionId) {
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 px-4 py-8">
+      <div className="px-4 py-8">
         <div className="max-w-lg mx-auto rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-sm">
           <p className="text-gray-700 dark:text-gray-300 mb-4">
             No reflection summary to show. Submit a reflection from the form first.
@@ -59,7 +59,7 @@ export default function ReflectionSummaryPage() {
   const backLabel = returnTo === '/tasks' ? '← Back to tasks' : 'Submit another';
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 px-4 py-8">
+    <div className="px-4 py-8">
       <div className="max-w-xl mx-auto rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-sm">
         <div className="flex flex-wrap items-center gap-3 mb-2">
           <h1 className="text-xl font-semibold text-gray-900 dark:text-white">

--- a/frontend/src/pages/SupervisorCoveragePage.jsx
+++ b/frontend/src/pages/SupervisorCoveragePage.jsx
@@ -127,7 +127,7 @@ export default function SupervisorCoveragePage() {
   const completeGroups = (groups || []).filter((g) => g.template_coverage.every((tc) => tc.percent === 100)).length;
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 px-4 py-6 pb-24">
+    <div className="px-4 py-6 pb-24">
       <div className="max-w-lg mx-auto">
         <header className="mb-6 flex items-start justify-between">
           <div>

--- a/frontend/src/partials/Sidebar.jsx
+++ b/frontend/src/partials/Sidebar.jsx
@@ -2,18 +2,74 @@ import React, { useState, useEffect, useRef } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 import isSuperAdmin from "../utils/auth/isSuperAdmin";
+import { hasCapability } from "../utils/auth/capability";
 
 import SidebarLinkGroup from "./SidebarLinkGroup";
 
 import CampLogo from "../../src/images/clc-logo.jpeg";
 
+// Legacy User.role values that can author a /reflect submission today.
+// Re-derived via capability for the new sections; kept here only to
+// preserve the existing top-level "Program reflection" / "My
+// reflections" gates while we still trigger reflection assignments
+// off legacy role.
 const REFLECTION_FORM_ROLES = ['Counselor', 'Admin', 'Unit Head', 'Camper Care'];
 
+// Capability shortcuts. SUPERVISOR_PLUS == "supervisor or stronger"
+// because hasCapability(user, 'supervisor') is already inclusive of
+// program_lead and admin (see capability.js docs). Listing them here
+// keeps the JSX gate sites readable.
+const SUPERVISOR_PLUS = ['supervisor'];
+const PROGRAM_LEAD_PLUS = ['program_lead'];
+
+/**
+ * 3.32 navigation IA:
+ *
+ *   MY WORK         everyone with a session
+ *     Home          /dashboard
+ *     My tasks      /tasks
+ *     Counselor home /counselor-dashboard   (only for User.role==='Counselor')
+ *     File a reflection  /reflect           (REFLECTION_FORM_ROLES)
+ *     My reflections     /my-reflections    (REFLECTION_FORM_ROLES)
+ *
+ *   SUPERVISE       supervisor + program_lead + admin + super_admin
+ *     Coverage                /supervisor/coverage
+ *     Concerns about my unit  /dashboards/concerns
+ *
+ *   DASHBOARDS      program_lead + admin + super_admin
+ *     Overview          /dashboards
+ *     Coverage          /dashboards/coverage
+ *     Author attribution /dashboards/authors
+ *     Unit head dashboard /dashboards/team
+ *     Wellness dashboard  /dashboards/wellness
+ *
+ *   ADMIN           admin + super_admin
+ *     Admin home       /admin
+ *     Memberships      /admin/memberships
+ *     Templates        /admin/templates
+ *     Assignment groups /admin/groups
+ *     Field keys       /admin/field-keys
+ *
+ *   CRANE LAKE LEGACY    admin + super_admin (transitional)
+ *     Bunk logs              /admin-bunk-logs
+ *     Staff reflections      /admin-dashboard
+ *
+ *   OTHER
+ *     Orders /orders   (everyone)
+ *
+ * Gates use hasCapability(user, [...]) || isSuperAdmin(user). The
+ * only remaining direct `user.role` reference is the Counselor-home
+ * shortcut, because that's a per-role workspace deep link rather
+ * than a capability gate.
+ *
+ * Crane Lake legacy section disappears in wave 5 once
+ * /admin-bunk-logs and /admin-dashboard are retired (see
+ * migration_prompts/5_*).
+ */
 function Sidebar({
   sidebarOpen,
   setSidebarOpen,
   variant = 'default',
-  extraLinks = [], // <-- new prop for extra sidebar links
 }) {
   const location = useLocation();
   const { pathname } = location;
@@ -25,7 +81,6 @@ function Sidebar({
   const storedSidebarExpanded = localStorage.getItem("sidebar-expanded");
   const [sidebarExpanded, setSidebarExpanded] = useState(storedSidebarExpanded === null ? false : storedSidebarExpanded === "true");
 
-  // close on click outside
   useEffect(() => {
     const clickHandler = ({ target }) => {
       if (!sidebar.current || !trigger.current) return;
@@ -36,7 +91,6 @@ function Sidebar({
     return () => document.removeEventListener("click", clickHandler);
   });
 
-  // close if the esc key is pressed
   useEffect(() => {
     const keyHandler = ({ keyCode }) => {
       if (!sidebarOpen || keyCode !== 27) return;
@@ -55,9 +109,40 @@ function Sidebar({
     }
   }, [sidebarExpanded]);
 
+  if (!user) {
+    // Render the chrome with no link sections; pages that mount the
+    // Sidebar before auth resolves keep their layout.
+    return (
+      <div className="min-w-fit">
+        <div
+          className={`fixed inset-0 bg-gray-900/30 z-40 lg:hidden lg:z-auto transition-opacity duration-200 ${
+            sidebarOpen ? "opacity-100" : "opacity-0 pointer-events-none"
+          }`}
+          aria-hidden="true"
+        ></div>
+        <div
+          id="sidebar"
+          ref={sidebar}
+          className={`flex lg:flex! flex-col absolute z-40 left-0 top-0 lg:static lg:left-auto lg:top-auto lg:translate-x-0 h-[100dvh] overflow-y-scroll lg:overflow-y-auto no-scrollbar w-64 lg:w-20 lg:sidebar-expanded:!w-64 2xl:w-64! shrink-0 bg-white dark:bg-gray-800 p-4 transition-all duration-200 ease-in-out ${sidebarOpen ? "translate-x-0" : "-translate-x-64"} ${variant === 'v2' ? 'border-r border-gray-200 dark:border-gray-700/60' : 'rounded-r-2xl shadow-xs'}`}
+        >
+          <SidebarHeader
+            trigger={trigger}
+            sidebarOpen={sidebarOpen}
+            setSidebarOpen={setSidebarOpen}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const canSupervise = hasCapability(user, SUPERVISOR_PLUS) || isSuperAdmin(user);
+  const canSeeDashboards = hasCapability(user, PROGRAM_LEAD_PLUS) || isSuperAdmin(user);
+  const canAdmin = hasCapability(user, 'admin') || isSuperAdmin(user);
+  const canSeeLegacy = canAdmin;
+  const canFileReflection = REFLECTION_FORM_ROLES.includes(user.role);
+
   return (
     <div className="min-w-fit">
-      {/* Sidebar backdrop (mobile only) */}
       <div
         className={`fixed inset-0 bg-gray-900/30 z-40 lg:hidden lg:z-auto transition-opacity duration-200 ${
           sidebarOpen ? "opacity-100" : "opacity-0 pointer-events-none"
@@ -65,568 +150,116 @@ function Sidebar({
         aria-hidden="true"
       ></div>
 
-      {/* Sidebar */}
       <div
         id="sidebar"
         ref={sidebar}
         className={`flex lg:flex! flex-col absolute z-40 left-0 top-0 lg:static lg:left-auto lg:top-auto lg:translate-x-0 h-[100dvh] overflow-y-scroll lg:overflow-y-auto no-scrollbar w-64 lg:w-20 lg:sidebar-expanded:!w-64 2xl:w-64! shrink-0 bg-white dark:bg-gray-800 p-4 transition-all duration-200 ease-in-out ${sidebarOpen ? "translate-x-0" : "-translate-x-64"} ${variant === 'v2' ? 'border-r border-gray-200 dark:border-gray-700/60' : 'rounded-r-2xl shadow-xs'}`}
       >
-        {/* Sidebar header */}
-        <div className="flex justify-between mb-10 pr-3 sm:px-2">
-          {/* Close button */}
-          <button
-            ref={trigger}
-            className="lg:hidden text-gray-500 hover:text-gray-400"
-            onClick={() => setSidebarOpen(!sidebarOpen)}
-            aria-controls="sidebar"
-            aria-expanded={sidebarOpen}
-          >
-            <span className="sr-only">Close sidebar</span>
-            <svg className="w-6 h-6 fill-current" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-              <path d="M10.7 18.7l1.4-1.4L7.8 13H20v-2H7.8l4.3-4.3-1.4-1.4L4 12z" />
-            </svg>
-          </button>
-          {/* Logo */}
-          <NavLink end to="/" className="block">
-            <img className="shrink-0 mr-2 sm:mr-3" width="70" height="35" viewBox="0 0 36 36" src={CampLogo} />
-          </NavLink>
-        </div>
+        <SidebarHeader
+          trigger={trigger}
+          sidebarOpen={sidebarOpen}
+          setSidebarOpen={setSidebarOpen}
+        />
 
-        {/* Links */}
-        <div className="space-y-8">
-          {/* Pages group */}
-          <div>
-            <h3 className="text-xs uppercase text-gray-400 dark:text-gray-500 font-semibold pl-3">
-              <span className="hidden lg:block lg:sidebar-expanded:hidden 2xl:hidden text-center w-6" aria-hidden="true">
-                •••
-              </span>
-            </h3>
-            <ul className="mt-3">
-              {/* Role-specific dashboard links */}
+        <div className="space-y-6">
+          <Section heading="My work">
+            <NavItem to="/dashboard" label="Home" icon={IconHome} end />
+            <NavItem to="/tasks" label="My tasks" icon={IconTasks} />
+            {user.role === 'Counselor' && (
+              <NavItem
+                to="/counselor-dashboard"
+                label="Counselor home"
+                icon={IconCounselor}
+              />
+            )}
+            {canFileReflection && (
+              <NavItem to="/reflect" label="File a reflection" icon={IconPencil} />
+            )}
+            {canFileReflection && (
+              <NavItem to="/my-reflections" label="My reflections" icon={IconClipboard} />
+            )}
+          </Section>
 
-              {/* 3.27: Counselors land on the legacy bunk-log counselor home,
-                  not the new reflection history. The "My reflections" entry
-                  for the new reflection model lives below alongside the
-                  Program reflection link so it appears for every role that
-                  can author reflections. */}
-              {user && user.role === 'Counselor' && (
-                <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
-                  <NavLink
-                    to="/counselor-dashboard"
-                    className={({ isActive }) =>
-                      `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
-                        isActive ? "text-blue-600 dark:text-blue-400" : "hover:text-gray-900 dark:hover:text-white"
-                      }`
-                    }
-                  >
-                    <div className="flex items-center">
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-                      </svg>
-                      <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                        Counselor home
-                      </span>
-                    </div>
-                  </NavLink>
-                </li>
-              )}
-              
-              {user && user.role === 'Admin' && (
-                <>
-                  <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
-                    <NavLink 
-                      to="/admin-bunk-logs" 
-                      className={({ isActive }) => 
-                        `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
-                          isActive ? "text-green-600 dark:text-green-400" : "hover:text-gray-900 dark:hover:text-white"
-                        }`
-                      }
-                    >
-                      <div className="flex items-center">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
-                        </svg>
-                        <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                          Bunk Logs
-                        </span>
-                      </div>
-                    </NavLink>
-                  </li>
-                  <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
-                    <NavLink 
-                      to="/admin-dashboard" 
-                      className={({ isActive }) => 
-                        `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
-                          isActive ? "text-purple-600 dark:text-purple-400" : "hover:text-gray-900 dark:hover:text-white"
-                        }`
-                      }
-                    >
-                      <div className="flex items-center">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
-                        </svg>
-                        <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                          Staff Reflections
-                        </span>
-                      </div>
-                    </NavLink>
-                  </li>
-                </>
-              )}
-              {/* Camper Care extra links */}
-              {user && user.role === 'Camper Care' && extraLinks && extraLinks.map(link => (
-                <li key={link.label} className={`px-3 py-2 rounded-lg mb-0.5 last:mb-0 ${link.active ? 'bg-rose-50 dark:bg-rose-900/20' : ''}`}>
-                  <button
-                    className={`block w-full text-left text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
-                      link.active ? "text-rose-600 dark:text-rose-400 font-semibold" : "hover:text-gray-900 dark:hover:text-white"
-                    }`}
-                    onClick={link.onClick}
-                  >
-                    <div className="flex items-center">
-                      <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                        {link.label}
-                      </span>
-                    </div>
-                  </button>
-                </li>
-              ))}
-              {user && ['Admin', 'Leadership'].includes(user.role) && (
-                <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
-                  <NavLink
-                    to="/dashboards/team"
-                    className={({ isActive }) =>
-                      `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
-                        isActive ? 'text-teal-600 dark:text-teal-400' : 'hover:text-gray-900 dark:hover:text-white'
-                      }`
-                    }
-                  >
-                    <div className="flex items-center">
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6" />
-                      </svg>
-                      <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                        Unit health (LT)
-                      </span>
-                    </div>
-                  </NavLink>
-                </li>
-              )}
-              {user && ['Admin', 'Camper Care'].includes(user.role) && (
-                <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
-                  <NavLink
-                    to="/dashboards/wellness"
-                    className={({ isActive }) =>
-                      `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
-                        isActive ? 'text-teal-600 dark:text-teal-400' : 'hover:text-gray-900 dark:hover:text-white'
-                      }`
-                    }
-                  >
-                    <div className="flex items-center">
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
-                      </svg>
-                      <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                        Wellness team
-                      </span>
-                    </div>
-                  </NavLink>
-                </li>
-              )}
-              {/* 3.26: Admin group -- org-level tooling. The legacy
-                  top-level "Memberships" entry was folded into this
-                  group along with Templates / Groups so admins have a
-                  single discoverable surface. Personal items (My tasks,
-                  Reflection form) moved to top-level entries below so
-                  they're discoverable to non-admins too. */}
-              {user && (user.role === 'Admin' || isSuperAdmin(user)) && (
-                <SidebarLinkGroup
-                  activecondition={
-                    pathname === '/admin' ||
-                    pathname.startsWith('/admin/')
-                  }
-                >
-                  {(handleClick, open) => (
-                    <React.Fragment>
-                      <a
-                        href="#0"
-                        aria-expanded={open}
-                        className="block text-gray-800 dark:text-gray-100 truncate transition duration-150 hover:text-gray-900 dark:hover:text-white"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          handleClick();
-                          setSidebarExpanded(true);
-                        }}
-                      >
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center">
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              strokeWidth="1.5"
-                              stroke="currentColor"
-                              className="w-6 h-6"
-                              aria-hidden="true"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"
-                              />
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-                              />
-                            </svg>
-                            <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                              Admin
-                            </span>
-                          </div>
-                          <div className="flex shrink-0 ml-2">
-                            <svg
-                              className={`w-3 h-3 shrink-0 ml-1 fill-current text-gray-400 dark:text-gray-500 ${
-                                open ? 'rotate-180' : ''
-                              }`}
-                              viewBox="0 0 12 12"
-                              aria-hidden="true"
-                            >
-                              <path d="M5.9 11.4L.5 6l1.4-1.4 4 4 4-4L11.3 6z" />
-                            </svg>
-                          </div>
-                        </div>
-                      </a>
-                      <div className="lg:hidden lg:sidebar-expanded:block 2xl:block">
-                        <ul className={`pl-9 mt-1 ${!open ? 'hidden' : ''}`}>
-                          <li className="mb-1 last:mb-0">
-                            <NavLink
-                              end
-                              to="/admin"
-                              className={({ isActive }) =>
-                                `block transition duration-150 truncate ${
-                                  isActive
-                                    ? 'text-violet-600 dark:text-violet-400 font-medium'
-                                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
-                                }`
-                              }
-                            >
-                              <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                                Admin home
-                              </span>
-                            </NavLink>
-                          </li>
-                          <li className="mb-1 last:mb-0">
-                            <NavLink
-                              to="/admin/memberships"
-                              className={({ isActive }) =>
-                                `block transition duration-150 truncate ${
-                                  isActive
-                                    ? 'text-violet-600 dark:text-violet-400 font-medium'
-                                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
-                                }`
-                              }
-                            >
-                              <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                                Memberships
-                              </span>
-                            </NavLink>
-                          </li>
-                          <li className="mb-1 last:mb-0">
-                            <NavLink
-                              to="/admin/templates"
-                              className={({ isActive }) =>
-                                `block transition duration-150 truncate ${
-                                  isActive
-                                    ? 'text-violet-600 dark:text-violet-400 font-medium'
-                                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
-                                }`
-                              }
-                            >
-                              <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                                Templates
-                              </span>
-                            </NavLink>
-                          </li>
-                          <li className="mb-1 last:mb-0">
-                            <NavLink
-                              to="/admin/groups"
-                              className={({ isActive }) =>
-                                `block transition duration-150 truncate ${
-                                  isActive
-                                    ? 'text-violet-600 dark:text-violet-400 font-medium'
-                                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
-                                }`
-                              }
-                            >
-                              <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                                Assignment groups
-                              </span>
-                            </NavLink>
-                          </li>
-                        </ul>
-                      </div>
-                    </React.Fragment>
-                  )}
-                </SidebarLinkGroup>
-              )}
+          {canSupervise && (
+            <Section heading="Supervise">
+              <NavItem
+                to="/supervisor/coverage"
+                label="Coverage"
+                icon={IconGrid}
+              />
+              <NavItem
+                to="/dashboards/concerns"
+                label="Concerns about my unit"
+                icon={IconAlert}
+              />
+            </Section>
+          )}
 
-              {/* 3.26: Dashboards group -- aggregated views. Gated to
-                  admins for now; a follow-up can broaden it to
-                  supervisors / counselors per dashboard. */}
-              {user && (user.role === 'Admin' || isSuperAdmin(user)) && (
-                <SidebarLinkGroup
-                  activecondition={
-                    pathname === '/dashboards' ||
-                    pathname.startsWith('/dashboards/')
-                  }
-                >
-                  {(handleClick, open) => (
-                    <React.Fragment>
-                      <a
-                        href="#0"
-                        aria-expanded={open}
-                        className="block text-gray-800 dark:text-gray-100 truncate transition duration-150 hover:text-gray-900 dark:hover:text-white"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          handleClick();
-                          setSidebarExpanded(true);
-                        }}
-                      >
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center">
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              strokeWidth="1.5"
-                              stroke="currentColor"
-                              className="w-6 h-6"
-                              aria-hidden="true"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"
-                              />
-                            </svg>
-                            <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                              Dashboards
-                            </span>
-                          </div>
-                          <div className="flex shrink-0 ml-2">
-                            <svg
-                              className={`w-3 h-3 shrink-0 ml-1 fill-current text-gray-400 dark:text-gray-500 ${
-                                open ? 'rotate-180' : ''
-                              }`}
-                              viewBox="0 0 12 12"
-                              aria-hidden="true"
-                            >
-                              <path d="M5.9 11.4L.5 6l1.4-1.4 4 4 4-4L11.3 6z" />
-                            </svg>
-                          </div>
-                        </div>
-                      </a>
-                      <div className="lg:hidden lg:sidebar-expanded:block 2xl:block">
-                        <ul className={`pl-9 mt-1 ${!open ? 'hidden' : ''}`}>
-                          <li className="mb-1 last:mb-0">
-                            <NavLink
-                              end
-                              to="/dashboards"
-                              className={({ isActive }) =>
-                                `block transition duration-150 truncate ${
-                                  isActive
-                                    ? 'text-violet-600 dark:text-violet-400 font-medium'
-                                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
-                                }`
-                              }
-                            >
-                              <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                                Dashboards home
-                              </span>
-                            </NavLink>
-                          </li>
-                          <li className="mb-1 last:mb-0">
-                            <NavLink
-                              to="/dashboards/coverage"
-                              className={({ isActive }) =>
-                                `block transition duration-150 truncate ${
-                                  isActive
-                                    ? 'text-violet-600 dark:text-violet-400 font-medium'
-                                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
-                                }`
-                              }
-                            >
-                              <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                                Coverage
-                              </span>
-                            </NavLink>
-                          </li>
-                          <li className="mb-1 last:mb-0">
-                            <NavLink
-                              to="/dashboards/authors"
-                              className={({ isActive }) =>
-                                `block transition duration-150 truncate ${
-                                  isActive
-                                    ? 'text-violet-600 dark:text-violet-400 font-medium'
-                                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
-                                }`
-                              }
-                            >
-                              <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                                Author attribution
-                              </span>
-                            </NavLink>
-                          </li>
-                          <li className="mb-1 last:mb-0">
-                            <NavLink
-                              to="/dashboards/concerns"
-                              className={({ isActive }) =>
-                                `block transition duration-150 truncate ${
-                                  isActive
-                                    ? 'text-violet-600 dark:text-violet-400 font-medium'
-                                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
-                                }`
-                              }
-                            >
-                              <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                                Concerns inbox
-                              </span>
-                            </NavLink>
-                          </li>
-                          <li className="mb-1 last:mb-0">
-                            <NavLink
-                              to="/dashboards/team"
-                              className={({ isActive }) =>
-                                `block transition duration-150 truncate ${
-                                  isActive
-                                    ? 'text-violet-600 dark:text-violet-400 font-medium'
-                                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
-                                }`
-                              }
-                            >
-                              <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                                Team
-                              </span>
-                            </NavLink>
-                          </li>
-                          <li className="mb-1 last:mb-0">
-                            <NavLink
-                              to="/dashboards/wellness"
-                              className={({ isActive }) =>
-                                `block transition duration-150 truncate ${
-                                  isActive
-                                    ? 'text-violet-600 dark:text-violet-400 font-medium'
-                                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
-                                }`
-                              }
-                            >
-                              <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                                Wellness
-                              </span>
-                            </NavLink>
-                          </li>
-                        </ul>
-                      </div>
-                    </React.Fragment>
-                  )}
-                </SidebarLinkGroup>
-              )}
+          {canSeeDashboards && (
+            <CollapsibleSection
+              heading="Dashboards"
+              activeWhen={
+                pathname === '/dashboards' || pathname.startsWith('/dashboards/')
+              }
+              icon={IconBars}
+              setSidebarExpanded={setSidebarExpanded}
+            >
+              <SubItem to="/dashboards" label="Overview" end />
+              <SubItem to="/dashboards/coverage" label="Coverage" />
+              <SubItem to="/dashboards/authors" label="Author attribution" />
+              <SubItem to="/dashboards/team" label="Unit head dashboard" />
+              <SubItem to="/dashboards/wellness" label="Wellness dashboard" />
+            </CollapsibleSection>
+          )}
 
-              {/* 3.26: My tasks is for everyone, not just admins. */}
-              {user && (
-                <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
-                  <NavLink
-                    to="/tasks"
-                    className={({ isActive }) =>
-                      `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
-                        isActive ? 'text-indigo-600 dark:text-indigo-400' : 'hover:text-gray-900 dark:hover:text-white'
-                      }`
-                    }
-                  >
-                    <div className="flex items-center">
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-                      </svg>
-                      <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                        My tasks
-                      </span>
-                    </div>
-                  </NavLink>
-                </li>
-              )}
-              {user && REFLECTION_FORM_ROLES.includes(user.role) && (
-                <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
-                  <NavLink
-                    to="/reflect"
-                    className={({ isActive }) =>
-                      `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
-                        isActive ? 'text-indigo-600 dark:text-indigo-400' : 'hover:text-gray-900 dark:hover:text-white'
-                      }`
-                    }
-                  >
-                    <div className="flex items-center">
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
-                      </svg>
-                      <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                        Program reflection
-                      </span>
-                    </div>
-                  </NavLink>
-                </li>
-              )}
-              {/* 3.27: Personal reflection history. Available to every role
-                  that can author reflections so it isn't only reachable from
-                  the post-submit screen. */}
-              {user && REFLECTION_FORM_ROLES.includes(user.role) && (
-                <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
-                  <NavLink
-                    to="/my-reflections"
-                    className={({ isActive }) =>
-                      `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
-                        isActive ? 'text-indigo-600 dark:text-indigo-400' : 'hover:text-gray-900 dark:hover:text-white'
-                      }`
-                    }
-                  >
-                    <div className="flex items-center">
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z" />
-                      </svg>
-                      <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                        My reflections
-                      </span>
-                    </div>
-                  </NavLink>
-                </li>
-              )}
-              <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
-                <NavLink 
-                  end 
-                  to="/orders" 
-                  className={({ isActive }) => 
-                    `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
-                      isActive ? "text-blue-600 dark:text-blue-400" : "hover:text-gray-900 dark:hover:text-white"
-                    }`
-                  }
-                >
-                  <div className="flex items-center">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 6v.75m0 3v.75m0 3v.75m0 3V18m-9-5.25h5.25M7.5 15h3M3.375 5.25c-.621 0-1.125.504-1.125 1.125v3.026a2.999 2.999 0 0 1 0 5.198v3.026c0 .621.504 1.125 1.125 1.125h17.25c.621 0 1.125-.504 1.125-1.125v-3.026a2.999 2.999 0 0 1 0-5.198V6.375c0-.621-.504-1.125-1.125-1.125H3.375Z" />
-                    </svg>
-                    <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
-                      Orders
-                    </span>
-                  </div>
-                </NavLink>
-              </li>              
-            </ul>
-          </div>
+          {canAdmin && (
+            <CollapsibleSection
+              heading="Admin"
+              activeWhen={
+                pathname === '/admin' || pathname.startsWith('/admin/')
+              }
+              icon={IconGear}
+              setSidebarExpanded={setSidebarExpanded}
+            >
+              <SubItem to="/admin" label="Admin home" end />
+              <SubItem to="/admin/memberships" label="Memberships" />
+              <SubItem to="/admin/templates" label="Templates" />
+              <SubItem to="/admin/groups" label="Assignment groups" />
+              <SubItem to="/admin/field-keys" label="Field keys" />
+            </CollapsibleSection>
+          )}
+
+          {canSeeLegacy && (
+            <Section
+              heading="Crane Lake legacy"
+              headingTitle="Migrating to new schema in wave 5"
+              data-testid="sidebar-legacy"
+            >
+              <NavItem
+                to="/admin-bunk-logs"
+                label="Bunk logs"
+                icon={IconArchive}
+              />
+              <NavItem
+                to="/admin-dashboard"
+                label="Staff reflections"
+                icon={IconArchive}
+              />
+            </Section>
+          )}
+
+          <Section heading="Other">
+            <NavItem to="/orders" label="Orders" icon={IconReceipt} end />
+          </Section>
         </div>
 
         {/* Expand / collapse button */}
         <div className="pt-3 hidden lg:inline-flex 2xl:hidden justify-end mt-auto">
           <div className="w-12 pl-4 pr-3 py-2">
-            <button className="text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400" onClick={() => setSidebarExpanded(!sidebarExpanded)}>
+            <button
+              className="text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+              onClick={() => setSidebarExpanded(!sidebarExpanded)}
+            >
               <span className="sr-only">Expand / collapse sidebar</span>
               <svg className="shrink-0 fill-current text-gray-400 dark:text-gray-500 sidebar-expanded:rotate-180" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
                 <path d="M15 16a1 1 0 0 1-1-1V1a1 1 0 1 1 2 0v14a1 1 0 0 1-1 1ZM8.586 7H1a1 1 0 1 0 0 2h7.586l-2.793 2.793a1 1 0 1 0 1.414 1.414l4.5-4.5A.997.997 0 0 0 12 8.01M11.924 7.617a.997.997 0 0 0-.217-.324l-4.5-4.5a1 1 0 0 0-1.414 1.414L8.586 7M12 7.99a.996.996 0 0 0-.076-.373Z" />
@@ -636,6 +269,229 @@ function Sidebar({
         </div>
       </div>
     </div>
+  );
+}
+
+function SidebarHeader({ trigger, sidebarOpen, setSidebarOpen }) {
+  return (
+    <div className="flex justify-between mb-10 pr-3 sm:px-2">
+      <button
+        ref={trigger}
+        className="lg:hidden text-gray-500 hover:text-gray-400"
+        onClick={() => setSidebarOpen(!sidebarOpen)}
+        aria-controls="sidebar"
+        aria-expanded={sidebarOpen}
+      >
+        <span className="sr-only">Close sidebar</span>
+        <svg className="w-6 h-6 fill-current" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M10.7 18.7l1.4-1.4L7.8 13H20v-2H7.8l4.3-4.3-1.4-1.4L4 12z" />
+        </svg>
+      </button>
+      <NavLink end to="/" className="block">
+        <img className="shrink-0 mr-2 sm:mr-3" width="70" height="35" viewBox="0 0 36 36" src={CampLogo} />
+      </NavLink>
+    </div>
+  );
+}
+
+function Section({ heading, headingTitle, children, ...rest }) {
+  return (
+    <div {...rest}>
+      <h3
+        className="text-xs uppercase text-gray-400 dark:text-gray-500 font-semibold pl-3 mb-1"
+        title={headingTitle}
+      >
+        <span className="hidden lg:block lg:sidebar-expanded:hidden 2xl:hidden text-center w-6" aria-hidden="true">
+          •••
+        </span>
+        <span className="lg:hidden lg:sidebar-expanded:block 2xl:block">
+          {heading}
+        </span>
+      </h3>
+      <ul>{children}</ul>
+    </div>
+  );
+}
+
+function NavItem({ to, label, icon: Icon, end = false }) {
+  return (
+    <li className="px-3 py-2 rounded-lg mb-0.5 last:mb-0">
+      <NavLink
+        end={end}
+        to={to}
+        className={({ isActive }) =>
+          `block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
+            isActive ? "text-blue-600 dark:text-blue-400" : "hover:text-gray-900 dark:hover:text-white"
+          }`
+        }
+      >
+        <div className="flex items-center">
+          <Icon />
+          <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
+            {label}
+          </span>
+        </div>
+      </NavLink>
+    </li>
+  );
+}
+
+function CollapsibleSection({ heading, activeWhen, icon: Icon, setSidebarExpanded, children }) {
+  return (
+    <div>
+      <h3 className="text-xs uppercase text-gray-400 dark:text-gray-500 font-semibold pl-3 mb-1">
+        <span className="hidden lg:block lg:sidebar-expanded:hidden 2xl:hidden text-center w-6" aria-hidden="true">
+          •••
+        </span>
+        <span className="lg:hidden lg:sidebar-expanded:block 2xl:block">
+          {heading}
+        </span>
+      </h3>
+      <ul>
+        <SidebarLinkGroup activecondition={activeWhen}>
+          {(handleClick, open) => (
+            <React.Fragment>
+              <a
+                href="#0"
+                aria-expanded={open}
+                className="block text-gray-800 dark:text-gray-100 truncate transition duration-150 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-lg"
+                onClick={(e) => {
+                  e.preventDefault();
+                  handleClick();
+                  setSidebarExpanded(true);
+                }}
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center">
+                    <Icon />
+                    <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
+                      {heading}
+                    </span>
+                  </div>
+                  <div className="flex shrink-0 ml-2">
+                    <svg
+                      className={`w-3 h-3 shrink-0 ml-1 fill-current text-gray-400 dark:text-gray-500 ${open ? 'rotate-180' : ''}`}
+                      viewBox="0 0 12 12"
+                      aria-hidden="true"
+                    >
+                      <path d="M5.9 11.4L.5 6l1.4-1.4 4 4 4-4L11.3 6z" />
+                    </svg>
+                  </div>
+                </div>
+              </a>
+              <div className="lg:hidden lg:sidebar-expanded:block 2xl:block">
+                <ul className={`pl-9 mt-1 ${!open ? 'hidden' : ''}`}>
+                  {children}
+                </ul>
+              </div>
+            </React.Fragment>
+          )}
+        </SidebarLinkGroup>
+      </ul>
+    </div>
+  );
+}
+
+function SubItem({ to, label, end = false }) {
+  return (
+    <li className="mb-1 last:mb-0">
+      <NavLink
+        end={end}
+        to={to}
+        className={({ isActive }) =>
+          `block transition duration-150 truncate ${
+            isActive
+              ? 'text-violet-600 dark:text-violet-400 font-medium'
+              : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+          }`
+        }
+      >
+        <span className="text-sm lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
+          {label}
+        </span>
+      </NavLink>
+    </li>
+  );
+}
+
+// === Icon components (kept inline to preserve the existing 24x24 stroke set) ===
+
+function IconHome() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+    </svg>
+  );
+}
+function IconTasks() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+    </svg>
+  );
+}
+function IconCounselor() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+    </svg>
+  );
+}
+function IconPencil() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
+    </svg>
+  );
+}
+function IconClipboard() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z" />
+    </svg>
+  );
+}
+function IconGrid() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z" />
+    </svg>
+  );
+}
+function IconAlert() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
+    </svg>
+  );
+}
+function IconBars() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+    </svg>
+  );
+}
+function IconGear() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+    </svg>
+  );
+}
+function IconArchive() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" />
+    </svg>
+  );
+}
+function IconReceipt() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 6v.75m0 3v.75m0 3v.75m0 3V18m-9-5.25h5.25M7.5 15h3M3.375 5.25c-.621 0-1.125.504-1.125 1.125v3.026a2.999 2.999 0 0 1 0 5.198v3.026c0 .621.504 1.125 1.125 1.125h17.25c.621 0 1.125-.504 1.125-1.125v-3.026a2.999 2.999 0 0 1 0-5.198V6.375c0-.621-.504-1.125-1.125-1.125H3.375Z" />
+    </svg>
   );
 }
 

--- a/frontend/src/partials/__tests__/Sidebar.test.jsx
+++ b/frontend/src/partials/__tests__/Sidebar.test.jsx
@@ -1,84 +1,212 @@
-import { describe, it, expect, vi } from 'vitest';
+/**
+ * Sidebar capability-aware navigation tests (3.32).
+ *
+ * Each persona test stubs `useAuth()` with a representative user
+ * (legacy User.role for now; capability.js maps role -> capability)
+ * and asserts which section headings and link hrefs appear.
+ *
+ * We assert on hrefs rather than link text where possible so a
+ * labels rewrite doesn't silently break coverage. Section headings
+ * are asserted via `getByText` against the uppercase heading string.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
-// Stub the auth hook so the sidebar receives a Super Admin user.
-vi.mock('../../auth/AuthContext', () => ({
-  useAuth: () => ({
-    user: { is_staff: true, role: 'Counselor' },
-  }),
-}));
-
-// Stub the camp logo image import (jpeg) to keep the test fast.
+// Stub the logo import so the test runner doesn't try to decode JPEG.
 vi.mock('../../../src/images/clc-logo.jpeg', () => ({ default: 'logo.jpg' }));
+
+// Each test sets the mock return value before rendering.
+const mockUseAuth = vi.fn();
+vi.mock('../../auth/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
 
 import Sidebar from '../Sidebar';
 
-function renderSidebar() {
+function renderWith(user, { path = '/dashboard' } = {}) {
+  mockUseAuth.mockReturnValue({ user });
   return render(
-    <MemoryRouter initialEntries={['/admin']}>
+    <MemoryRouter initialEntries={[path]}>
       <Sidebar sidebarOpen={true} setSidebarOpen={() => {}} />
     </MemoryRouter>,
   );
 }
 
-describe('Sidebar admin navigation (3.26)', () => {
-  it('renames the legacy "Tests" group to "Admin"', () => {
-    renderSidebar();
-    expect(screen.getByText('Admin')).toBeInTheDocument();
-    expect(screen.queryByText('Tests')).not.toBeInTheDocument();
+function hrefs() {
+  return screen
+    .getAllByRole('link')
+    .map((a) => a.getAttribute('href'))
+    .filter(Boolean);
+}
+
+beforeEach(() => {
+  mockUseAuth.mockReset();
+  // Reset localStorage between tests because Sidebar.jsx persists the
+  // expanded/collapsed flag there.
+  localStorage.clear();
+});
+
+describe('Sidebar — section gating (3.32)', () => {
+  it('participant (counselor) sees My work but no Supervise / Dashboards / Admin / Legacy', () => {
+    renderWith({ role: 'Counselor' });
+
+    // Multiple "My work" headings can render (mobile + desktop variants);
+    // use getAllByText so it doesn't throw on duplicates.
+    expect(screen.getAllByText('My work').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Supervise')).not.toBeInTheDocument();
+    expect(screen.queryByText('Dashboards')).not.toBeInTheDocument();
+    expect(screen.queryByText('Admin')).not.toBeInTheDocument();
+    expect(screen.queryByText('Crane Lake legacy')).not.toBeInTheDocument();
+
+    const links = hrefs();
+    expect(links).toContain('/dashboard');
+    expect(links).toContain('/tasks');
+    expect(links).toContain('/counselor-dashboard');
+    expect(links).toContain('/reflect');
+    expect(links).toContain('/my-reflections');
+    expect(links).toContain('/orders');
+    expect(links).not.toContain('/admin');
+    expect(links).not.toContain('/admin-bunk-logs');
   });
 
-  it('renders Admin group items (home, Memberships, Templates, Groups)', () => {
-    renderSidebar();
-    // Member is link text, scope to anchors so we don't catch page headings.
-    const adminLinks = screen.getAllByRole('link').map((a) => a.getAttribute('href'));
-    expect(adminLinks).toEqual(expect.arrayContaining([
-      '/admin',
-      '/admin/memberships',
-      '/admin/templates',
-      '/admin/groups',
-    ]));
+  it('participant (kitchen) sees My work without Counselor home or reflection forms', () => {
+    renderWith({ role: 'Kitchen Staff' });
+
+    const links = hrefs();
+    expect(links).toContain('/dashboard');
+    expect(links).toContain('/tasks');
+    expect(links).not.toContain('/counselor-dashboard');
+    expect(links).not.toContain('/reflect');
+    expect(links).not.toContain('/my-reflections');
+    expect(screen.queryByText('Supervise')).not.toBeInTheDocument();
   });
 
-  it('renders the Dashboards group with canonical /dashboards/* targets', () => {
-    renderSidebar();
-    expect(screen.getByText('Dashboards')).toBeInTheDocument();
-    const links = screen.getAllByRole('link').map((a) => a.getAttribute('href'));
-    expect(links).toEqual(expect.arrayContaining([
-      '/dashboards',
-      '/dashboards/coverage',
-      '/dashboards/authors',
-      '/dashboards/concerns',
-      '/dashboards/team',
-      '/dashboards/wellness',
-    ]));
-    // Legacy off-pattern URLs must NOT appear in the sidebar.
-    expect(links).not.toContain('/team/dashboard');
-    expect(links).not.toContain('/wellness/dashboard');
+  it('supervisor (unit_head) sees Supervise but not Dashboards or Admin', () => {
+    renderWith({ role: 'Unit Head' });
+
+    expect(screen.getAllByText('Supervise').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Dashboards')).not.toBeInTheDocument();
+    expect(screen.queryByText('Admin')).not.toBeInTheDocument();
+
+    const links = hrefs();
+    expect(links).toContain('/supervisor/coverage');
+    expect(links).toContain('/dashboards/concerns');
+    // Supervisors don't get the role-specific Counselor-home link.
+    expect(links).not.toContain('/counselor-dashboard');
   });
 
-  it('renders "My tasks" as a top-level entry', () => {
-    renderSidebar();
-    expect(screen.getByText('My tasks')).toBeInTheDocument();
+  it('supervisor (camper_care) sees Supervise and reflection forms', () => {
+    renderWith({ role: 'Camper Care' });
+
+    expect(screen.getAllByText('Supervise').length).toBeGreaterThan(0);
+    const links = hrefs();
+    expect(links).toContain('/supervisor/coverage');
+    expect(links).toContain('/dashboards/concerns');
+    expect(links).toContain('/reflect');
+    expect(links).toContain('/my-reflections');
+  });
+
+  it('program_lead (leadership) sees Dashboards and Supervise but not Admin', () => {
+    renderWith({ role: 'Leadership' });
+
+    expect(screen.getAllByText('Dashboards').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Supervise').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Admin')).not.toBeInTheDocument();
+    expect(screen.queryByText('Crane Lake legacy')).not.toBeInTheDocument();
+  });
+
+  it('admin sees every section including Crane Lake legacy', () => {
+    renderWith({ role: 'Admin' });
+
+    expect(screen.getAllByText('My work').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Supervise').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Dashboards').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Admin').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Crane Lake legacy').length).toBeGreaterThan(0);
+  });
+
+  it('super admin via is_staff alone sees Admin + Dashboards even without a role', () => {
+    renderWith({ is_staff: true });
+
+    expect(screen.getAllByText('Admin').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Dashboards').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Crane Lake legacy').length).toBeGreaterThan(0);
   });
 });
 
-describe('Sidebar wayfinding (3.27)', () => {
-  it('renames the Counselor role entry from "My Reflections" to "Counselor home"', () => {
-    renderSidebar();
-    // Counselor role link now reads "Counselor home" and is the only entry
-    // pointing at the legacy /counselor-dashboard.
-    expect(screen.getByText('Counselor home')).toBeInTheDocument();
-    expect(screen.queryByText('My Reflections')).not.toBeInTheDocument();
-    const links = screen.getAllByRole('link').map((a) => a.getAttribute('href'));
-    expect(links).toContain('/counselor-dashboard');
+describe('Sidebar — de-duplication of Wellness / Unit head dashboard (3.32)', () => {
+  it('renders /dashboards/team and /dashboards/wellness exactly once for admins', () => {
+    renderWith({ role: 'Admin' }, { path: '/admin' });
+    // SidebarLinkGroup mounts collapsed by default but keeps the
+    // children in the DOM, so we can still query the hrefs.
+    const links = hrefs();
+    const teamMatches = links.filter((h) => h === '/dashboards/team');
+    const wellnessMatches = links.filter((h) => h === '/dashboards/wellness');
+    expect(teamMatches).toHaveLength(1);
+    expect(wellnessMatches).toHaveLength(1);
   });
 
-  it('exposes "My reflections" as a top-level entry pointing at /my-reflections', () => {
-    renderSidebar();
-    expect(screen.getByText('My reflections')).toBeInTheDocument();
-    const links = screen.getAllByRole('link').map((a) => a.getAttribute('href'));
-    expect(links).toContain('/my-reflections');
+  it('moves Concerns inbox to Supervise only — not duplicated under Dashboards', () => {
+    renderWith({ role: 'Admin' });
+    const links = hrefs();
+    const concerns = links.filter((h) => h === '/dashboards/concerns');
+    expect(concerns).toHaveLength(1);
+  });
+});
+
+describe('Sidebar — Admin submenu items (3.32)', () => {
+  it('includes Field keys under Admin (added in 3.32)', () => {
+    renderWith({ role: 'Admin' }, { path: '/admin' });
+    expect(hrefs()).toContain('/admin/field-keys');
+  });
+
+  it('still includes Memberships / Templates / Groups / Admin home', () => {
+    renderWith({ role: 'Admin' }, { path: '/admin' });
+    const links = hrefs();
+    expect(links).toEqual(
+      expect.arrayContaining([
+        '/admin',
+        '/admin/memberships',
+        '/admin/templates',
+        '/admin/groups',
+      ]),
+    );
+  });
+});
+
+describe('Sidebar — Crane Lake legacy section (3.32)', () => {
+  it('keeps /admin-bunk-logs and /admin-dashboard reachable for admins', () => {
+    renderWith({ role: 'Admin' });
+    const links = hrefs();
+    expect(links).toContain('/admin-bunk-logs');
+    expect(links).toContain('/admin-dashboard');
+  });
+
+  it('does not render the legacy section for non-admins (counselor)', () => {
+    renderWith({ role: 'Counselor' });
+    const links = hrefs();
+    expect(links).not.toContain('/admin-bunk-logs');
+    expect(links).not.toContain('/admin-dashboard');
+    expect(screen.queryByText('Crane Lake legacy')).not.toBeInTheDocument();
+  });
+
+  it('does not render the legacy section for supervisors', () => {
+    renderWith({ role: 'Unit Head' });
+    expect(screen.queryByText('Crane Lake legacy')).not.toBeInTheDocument();
+  });
+});
+
+describe('Sidebar — unauthenticated chrome (3.32)', () => {
+  it('renders the logo but no link sections when user is null', () => {
+    renderWith(null);
+    // Logo link to "/" should always render.
+    const links = hrefs();
+    expect(links).toContain('/');
+    // No app sections.
+    expect(screen.queryByText('My work')).not.toBeInTheDocument();
+    expect(screen.queryByText('Supervise')).not.toBeInTheDocument();
+    expect(screen.queryByText('Dashboards')).not.toBeInTheDocument();
+    expect(screen.queryByText('Admin')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/partials/tasks/ReflectionTasksPanel.jsx
+++ b/frontend/src/partials/tasks/ReflectionTasksPanel.jsx
@@ -463,8 +463,12 @@ export default function ReflectionTasksPanel({ variant = 'page' }) {
     return <div className="w-full">{inner}</div>;
   }
 
+  // 3.33: AppLayout owns the outer scroll container and chrome.
+  // We keep the centered single-column treatment for the page
+  // variant because the task home was designed as a focused
+  // single-column experience.
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 px-4 py-6 pb-24">
+    <div className="px-4 py-6 pb-24">
       <div className="max-w-lg mx-auto">{inner}</div>
     </div>
   );

--- a/frontend/src/utils/auth/__tests__/capability.test.js
+++ b/frontend/src/utils/auth/__tests__/capability.test.js
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  CAPABILITIES,
+  userCapability,
+  hasCapability,
+  _LEGACY_USER_ROLE_TO_CAPABILITY,
+} from '../capability';
+
+// Mirror of backend users.models.User.ROLE_CHOICES. If a new legacy
+// User.role string is added on the backend, this list fails first --
+// then capability.js needs an entry too.
+const LEGACY_ROLES = [
+  'Admin',
+  'Camper Care',
+  'Unit Head',
+  'Counselor',
+  'Leadership',
+  'Kitchen Staff',
+];
+
+describe('CAPABILITIES order', () => {
+  it('orders capabilities from weakest to strongest', () => {
+    expect(CAPABILITIES).toEqual([
+      'participant',
+      'supervisor',
+      'program_lead',
+      'domain_specialist',
+      'admin',
+    ]);
+  });
+
+  it('is frozen against mutation', () => {
+    expect(() => {
+      CAPABILITIES[0] = 'mutated';
+    }).toThrow();
+  });
+});
+
+describe('LEGACY_USER_ROLE_TO_CAPABILITY coverage', () => {
+  it('maps every backend User.role value', () => {
+    for (const role of LEGACY_ROLES) {
+      expect(
+        Object.prototype.hasOwnProperty.call(
+          _LEGACY_USER_ROLE_TO_CAPABILITY,
+          role,
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it('does not invent new role names', () => {
+    for (const role of Object.keys(_LEGACY_USER_ROLE_TO_CAPABILITY)) {
+      expect(LEGACY_ROLES).toContain(role);
+    }
+  });
+});
+
+describe('userCapability', () => {
+  it('returns null for null/undefined', () => {
+    expect(userCapability(null)).toBe(null);
+    expect(userCapability(undefined)).toBe(null);
+  });
+
+  it('returns null for users with no role and no super-admin flags', () => {
+    expect(userCapability({})).toBe(null);
+    expect(userCapability({ role: '' })).toBe(null);
+    expect(userCapability({ role: null })).toBe(null);
+  });
+
+  it('returns the capability for each legacy User.role', () => {
+    expect(userCapability({ role: 'Counselor' })).toBe('participant');
+    expect(userCapability({ role: 'Kitchen Staff' })).toBe('participant');
+    expect(userCapability({ role: 'Unit Head' })).toBe('supervisor');
+    expect(userCapability({ role: 'Camper Care' })).toBe('supervisor');
+    expect(userCapability({ role: 'Leadership' })).toBe('program_lead');
+    expect(userCapability({ role: 'Admin' })).toBe('admin');
+  });
+
+  it('returns "admin" for is_staff users regardless of their User.role', () => {
+    expect(userCapability({ is_staff: true })).toBe('admin');
+    expect(userCapability({ is_staff: true, role: 'Counselor' })).toBe('admin');
+  });
+
+  it('returns "admin" for is_superuser users regardless of role', () => {
+    expect(userCapability({ is_superuser: true })).toBe('admin');
+    expect(userCapability({ is_superuser: true, role: 'Camper Care' })).toBe('admin');
+  });
+
+  it('returns null for unknown role strings (and does not throw)', () => {
+    expect(userCapability({ role: 'Mystery Role' })).toBe(null);
+  });
+});
+
+describe('hasCapability — single capability checks', () => {
+  it('returns false for null user / null capability target', () => {
+    expect(hasCapability(null, 'participant')).toBe(false);
+    expect(hasCapability({ role: 'Counselor' }, [])).toBe(false);
+  });
+
+  it('admin matches every named capability', () => {
+    const admin = { role: 'Admin' };
+    expect(hasCapability(admin, 'participant')).toBe(true);
+    expect(hasCapability(admin, 'supervisor')).toBe(true);
+    expect(hasCapability(admin, 'program_lead')).toBe(true);
+    expect(hasCapability(admin, 'domain_specialist')).toBe(true);
+    expect(hasCapability(admin, 'admin')).toBe(true);
+  });
+
+  it('super admin matches every named capability (even without role)', () => {
+    const root = { is_staff: true };
+    expect(hasCapability(root, 'admin')).toBe(true);
+    expect(hasCapability(root, 'supervisor')).toBe(true);
+  });
+
+  it('program_lead matches participant/supervisor/program_lead but not admin or domain_specialist', () => {
+    const u = { role: 'Leadership' };
+    expect(hasCapability(u, 'participant')).toBe(true);
+    expect(hasCapability(u, 'supervisor')).toBe(true);
+    expect(hasCapability(u, 'program_lead')).toBe(true);
+    expect(hasCapability(u, 'domain_specialist')).toBe(false);
+    expect(hasCapability(u, 'admin')).toBe(false);
+  });
+
+  it('supervisor matches participant/supervisor only', () => {
+    const u = { role: 'Unit Head' };
+    expect(hasCapability(u, 'participant')).toBe(true);
+    expect(hasCapability(u, 'supervisor')).toBe(true);
+    expect(hasCapability(u, 'program_lead')).toBe(false);
+    expect(hasCapability(u, 'admin')).toBe(false);
+  });
+
+  it('participant matches only participant', () => {
+    const u = { role: 'Counselor' };
+    expect(hasCapability(u, 'participant')).toBe(true);
+    expect(hasCapability(u, 'supervisor')).toBe(false);
+    expect(hasCapability(u, 'program_lead')).toBe(false);
+    expect(hasCapability(u, 'admin')).toBe(false);
+  });
+});
+
+describe('hasCapability — list-of-capabilities checks', () => {
+  it('matches any capability in the list (OR semantics)', () => {
+    const u = { role: 'Unit Head' };
+    expect(hasCapability(u, ['admin', 'supervisor'])).toBe(true);
+    expect(hasCapability(u, ['admin', 'program_lead'])).toBe(false);
+  });
+
+  it('handles a single-element list the same as a bare string', () => {
+    const u = { role: 'Camper Care' };
+    expect(hasCapability(u, ['supervisor'])).toBe(hasCapability(u, 'supervisor'));
+  });
+});

--- a/frontend/src/utils/auth/capability.js
+++ b/frontend/src/utils/auth/capability.js
@@ -1,0 +1,146 @@
+/**
+ * Frontend capability helper (3.32).
+ *
+ * The backend RBAC story moved to `Membership.capability` with five
+ * tiers (participant / supervisor / program_lead / domain_specialist
+ * / admin), but the frontend has been gating nav on legacy
+ * `User.role` strings (Title Case 'Admin' / 'Counselor' / ...). This
+ * helper bridges the two so callers can write
+ *
+ *   if (hasCapability(user, 'supervisor')) { ... }
+ *
+ * today and we can swap the underlying source from `user.role` to a
+ * real `Membership.capability` field in one place when the
+ * `/api/v1/memberships/me/` payload lands on the auth context.
+ *
+ * Mirror of backend `bunk_logs.core.models.ROLE_TO_CAPABILITY`
+ * (core/models.py:28-45). Kept in sync by manual review when either
+ * side changes; the unit tests assert coverage of every legacy
+ * User.role value enumerated in `users.models.User.ROLE_CHOICES`.
+ *
+ * Known limitation: today's `user.role` is Title Case and cannot
+ * distinguish `health_center` from `camper_care` (both surface as
+ * 'Camper Care'). That means a health_center membership renders the
+ * supervisor-tier sidebar instead of the domain_specialist tier --
+ * matches current behavior, fixed when memberships flow into
+ * useAuth().
+ */
+
+import { useAuth } from '../../auth/AuthContext';
+import isSuperAdmin from './isSuperAdmin';
+
+/**
+ * Capability tiers in order of increasing privilege. Higher tiers
+ * implicitly include the entries to their left for nav purposes
+ * (e.g. an admin sees supervisor sections, a program_lead sees
+ * participant sections).
+ */
+export const CAPABILITIES = Object.freeze([
+  'participant',
+  'supervisor',
+  'program_lead',
+  'domain_specialist',
+  'admin',
+]);
+
+const PARTICIPANT_RANK = CAPABILITIES.indexOf('participant');
+const SUPERVISOR_RANK = CAPABILITIES.indexOf('supervisor');
+const PROGRAM_LEAD_RANK = CAPABILITIES.indexOf('program_lead');
+const DOMAIN_SPECIALIST_RANK = CAPABILITIES.indexOf('domain_specialist');
+const ADMIN_RANK = CAPABILITIES.indexOf('admin');
+
+/**
+ * Map of legacy `User.role` (Title Case strings from
+ * users.models.User.ROLE_CHOICES) to capability. The empty string and
+ * missing role both surface as null.
+ */
+const LEGACY_USER_ROLE_TO_CAPABILITY = Object.freeze({
+  Counselor: 'participant',
+  'Kitchen Staff': 'participant',
+  'Unit Head': 'supervisor',
+  'Camper Care': 'supervisor',
+  Leadership: 'program_lead',
+  Admin: 'admin',
+});
+
+/**
+ * Resolve the user's capability tier. Super admins (Django
+ * is_staff/is_superuser) always come back as 'admin' regardless of
+ * their `user.role` so the nav surfaces admin sections for them.
+ *
+ * Returns null when the user has no role and is not a super admin.
+ */
+export function userCapability(user) {
+  if (!user) return null;
+  if (isSuperAdmin(user)) return 'admin';
+  const role = user.role;
+  if (typeof role !== 'string' || role === '') return null;
+  return LEGACY_USER_ROLE_TO_CAPABILITY[role] || null;
+}
+
+function rankOf(cap) {
+  return CAPABILITIES.indexOf(cap);
+}
+
+/**
+ * Inclusive "at least this tier" check, with one wrinkle:
+ * domain_specialist is a side branch (not a strict subset of
+ * program_lead). The rule is:
+ *
+ *   - admin matches everything except (trivially) a *strictly higher*
+ *     tier (none exists).
+ *   - program_lead matches participant, supervisor, program_lead.
+ *   - supervisor matches participant, supervisor.
+ *   - participant matches only participant.
+ *   - domain_specialist matches participant, supervisor, and
+ *     domain_specialist (it sits "around" the supervisor tier for
+ *     nav purposes -- specialists can see specialist sections plus
+ *     their own personal entries).
+ *
+ * `capOrList` accepts a single capability string or an array of
+ * acceptable capabilities (any-match).
+ */
+export function hasCapability(user, capOrList) {
+  const userCap = userCapability(user);
+  if (!userCap) return false;
+  const wanted = Array.isArray(capOrList) ? capOrList : [capOrList];
+  if (wanted.length === 0) return false;
+  const userRank = rankOf(userCap);
+  return wanted.some((want) => {
+    if (want === userCap) return true;
+    if (userCap === 'admin') return true;
+    if (want === 'admin') return false;
+    if (userCap === 'domain_specialist') {
+      return want === 'participant' || want === 'supervisor';
+    }
+    if (want === 'domain_specialist') return false;
+    const wantRank = rankOf(want);
+    if (wantRank < 0) return false;
+    return userRank >= wantRank;
+  });
+}
+
+/**
+ * React hook flavor of {@link userCapability}. Reads from the
+ * existing useAuth context so call sites stay short:
+ *
+ *   const cap = useCapability();
+ *   if (cap === 'admin') ...
+ */
+export function useCapability() {
+  const { user } = useAuth();
+  return userCapability(user);
+}
+
+// Re-exported so tests can assert against the canonical mapping
+// without reaching into a private symbol.
+export const _LEGACY_USER_ROLE_TO_CAPABILITY = LEGACY_USER_ROLE_TO_CAPABILITY;
+
+// Used by tests + ranking math; not part of the public API.
+export const _RANKS = Object.freeze({
+  participant: PARTICIPANT_RANK,
+  supervisor: SUPERVISOR_RANK,
+  program_lead: PROGRAM_LEAD_RANK,
+  domain_specialist: DOMAIN_SPECIALIST_RANK,
+  admin: ADMIN_RANK,
+});

--- a/migration_prompts/3_32_role_aware_navigation.md
+++ b/migration_prompts/3_32_role_aware_navigation.md
@@ -110,9 +110,20 @@ OUT OF SCOPE (handled in 3.33 or 3.34)
 
 - The /dashboard landing page (still auto-redirects in 3.32).
 - ?next= post-login wiring.
-- Sidebar visibility on /tasks and /reflect (those routes
-  intentionally render without the Sidebar today; revisit later).
 - Backend changes. Frontend-only PR.
+
+FOLLOW-UP COMMIT IN THIS PR
+
+- Mid-review the user reported that /tasks, /reflect, and
+  /supervisor/coverage still rendered without the new sidebar
+  (they were originally built as mobile-first single-column views
+  that mounted no chrome at all). Fixed by adding
+  `frontend/src/layouts/AppLayout.jsx` (sibling of AdminLayout)
+  and nesting the four bare routes -- /reflect, /reflect/summary,
+  /tasks, /supervisor/coverage -- under it. Per-page `min-h-screen
+  bg-gray-50` outer wrappers were stripped so the layout's scroll
+  container can own that responsibility. ReflectionSummaryPage was
+  pulled in for free.
 
 VERIFICATION
 
@@ -135,6 +146,7 @@ VERIFICATION
 - `Field keys` appears under Admin in the sidebar.
 - `extraLinks` prop is removed from Sidebar, and CamperCareDashboard no longer passes it.
 - `e2e/rbac-sidebar.spec.ts` HREFS table uses `/dashboards/team` and `/dashboards/wellness` (no more `/team/dashboard`).
+- `frontend/src/layouts/AppLayout.jsx` exists and is wired in `Router.jsx`; `/tasks`, `/reflect`, `/reflect/summary`, and `/supervisor/coverage` all render the Sidebar + Header chrome.
 
 ## Known limitation (documented, not fixed here)
 

--- a/migration_prompts/3_32_role_aware_navigation.md
+++ b/migration_prompts/3_32_role_aware_navigation.md
@@ -1,0 +1,141 @@
+# Prompt 3.32 — Role-aware navigation restructure
+
+**Wave:** 3 (Crane Lake Summer 2026 Build) — UI cleanup, post-audit follow-up
+**Estimated time:** 3-4 hours
+**Prerequisite:** Prompt 3.31 complete.
+
+**Use the context prompt at the top of `migration_prompts/0_0_context_prompt.md` before this session.**
+
+---
+
+```
+The 3.27-3.31 audit cleaned up admin chrome and built shared UI
+primitives, but the sidebar itself is still the original structure --
+flat, ungrouped except for two admin submenus, and gated on legacy
+`User.role` strings (Title Case 'Admin' / 'Counselor' / 'Unit Head'
+/ ...). Two adjacent symptoms:
+
+1. Admins see *duplicate* links to /dashboards/team and
+   /dashboards/wellness: once as top-level shortcuts ("Unit health
+   (LT)" / "Wellness team", Sidebar.jsx:193-234) and once under the
+   Dashboards submenu (Sidebar.jsx:496-526). Same URLs, twice.
+2. The frontend has no notion of capability. Backend RBAC is
+   organized around Membership.capability (participant / supervisor /
+   program_lead / domain_specialist / admin) and `is_super_admin`,
+   but the sidebar still reads `user.role === 'Admin'` strings. There
+   is no `hasCapability` helper anywhere in frontend/src.
+
+This prompt is the structural fix: introduce a frontend capability
+helper that mirrors backend ROLE_TO_CAPABILITY, then restructure the
+sidebar around capability tiers with discrete sections for each
+audience. The auto-redirect Dashboard.jsx becomes a real Home page
+in the next PR (3.33); this one stops at the sidebar.
+
+REQUIREMENTS
+
+- New helper `frontend/src/utils/auth/capability.js` exporting:
+    - `CAPABILITIES` (ordered tuple, admin strongest)
+    - `userCapability(user)` returning the user's capability bucket
+      derived from `user.role` (legacy User.role; the helper is the
+      one place we'll swap to membership-based later)
+    - `hasCapability(user, capOrList)` boolean, inclusive of "at
+      least this tier" semantics for admins
+    - `useCapability()` hook wrapping useAuth
+  Coverage tests for every legacy User.role string in
+  backend/bunk_logs/users/models.py and a "no user" path.
+
+- Sidebar restructure (Sidebar.jsx) into these sections, top-down:
+
+    MY WORK         (everyone)
+      My tasks                  /tasks
+      File a reflection         /reflect              (reflection roles)
+      My reflections            /my-reflections       (reflection roles)
+
+    SUPERVISE       (supervisor+, includes admin / super_admin)
+      Coverage                  /supervisor/coverage
+      Concerns about my unit    /dashboards/concerns
+
+    DASHBOARDS      (program_lead+ or super_admin)
+      Overview                  /dashboards
+      Coverage                  /dashboards/coverage
+      Author attribution        /dashboards/authors
+      Unit head dashboard       /dashboards/team
+      Wellness dashboard        /dashboards/wellness
+      (Concerns inbox lives in SUPERVISE only -- not duplicated here)
+
+    ADMIN           (admin or super_admin)
+      Admin home                /admin
+      Memberships               /admin/memberships
+      Templates                 /admin/templates
+      Assignment groups         /admin/groups
+      Field keys                /admin/field-keys
+
+    CRANE LAKE LEGACY (admin or super_admin, with tooltip)
+      Bunk logs                 /admin-bunk-logs
+      Staff reflections         /admin-dashboard
+
+    OTHER
+      Orders                    /orders               (everyone)
+
+- Counselor home (/counselor-dashboard) stays for the Counselor role
+  but moves into the MY WORK section so it sits with the
+  participant's other personal entry points. Drop the special
+  Counselor-only standalone link in favor of being a participant-tier
+  default for users whose User.role === 'Counselor'.
+
+- The `extraLinks` prop on Sidebar is removed. The Camper Care extra
+  "My Bunk Logs" / "Needs Attention" buttons were a workaround for
+  the missing Supervise section; with Supervise present, those views
+  remain reachable from CamperCareDashboard's own in-page tabs, and
+  the sidebar no longer ships per-page injections.
+
+- All sidebar gates flip from `user.role === '...'` literals to
+  `hasCapability(user, [...]) || isSuperAdmin(user)`. The only
+  remaining `user.role` reference allowed in Sidebar.jsx is the
+  Counselor-home check inside MY WORK (because it's a per-role
+  workspace shortcut, not a capability gate).
+
+- Update `frontend/src/partials/__tests__/Sidebar.test.jsx` to assert
+  the new section structure per persona (admin, leadership,
+  unit_head, camper_care, counselor, no_role). Use the existing
+  vi.mock pattern.
+
+- Update `frontend/e2e/rbac-sidebar.spec.ts`:
+    - Fix the stale HREFS for /team/dashboard and /wellness/dashboard
+      (they should be /dashboards/team and /dashboards/wellness).
+    - Update the per-persona assertions to match the new structure.
+    - Add coverage for /supervisor/coverage and the legacy section.
+
+OUT OF SCOPE (handled in 3.33 or 3.34)
+
+- The /dashboard landing page (still auto-redirects in 3.32).
+- ?next= post-login wiring.
+- Sidebar visibility on /tasks and /reflect (those routes
+  intentionally render without the Sidebar today; revisit later).
+- Backend changes. Frontend-only PR.
+
+VERIFICATION
+
+- `npx vitest run` 100% green including the new
+  capability tests and the updated Sidebar tests.
+- `npx vite build` clean.
+- Manual smoke: log in as each test user from
+  `frontend/e2e/fixtures/users.ts` and visually confirm the sidebar
+  sections match the matrix in this prompt.
+- Commit + PR titled `3_32_role_aware_navigation: ...`.
+```
+
+---
+
+## Acceptance criteria
+
+- `frontend/src/utils/auth/capability.js` exists with `userCapability`, `hasCapability`, `useCapability`, and a `CAPABILITIES` constant; unit tests cover every legacy role string + null/undefined paths.
+- `frontend/src/partials/Sidebar.jsx` renders the sections above, in order, with capability-based gates.
+- No admin user sees a duplicate link to `/dashboards/team` or `/dashboards/wellness`.
+- `Field keys` appears under Admin in the sidebar.
+- `extraLinks` prop is removed from Sidebar, and CamperCareDashboard no longer passes it.
+- `e2e/rbac-sidebar.spec.ts` HREFS table uses `/dashboards/team` and `/dashboards/wellness` (no more `/team/dashboard`).
+
+## Known limitation (documented, not fixed here)
+
+The helper derives capability from `user.role` (Title Case legacy string), which can't distinguish `health_center` from `camper_care` (both have `User.role = 'Camper Care'` today). They render the same supervisor-tier sidebar; this matches today's behavior and is documented in `capability.js`. The proper fix is to read `Membership.capability` from `/api/v1/memberships/me/` and expose it on `useAuth`; that's tracked as a follow-up.


### PR DESCRIPTION
## Summary

First half of the navigation IA cleanup. Restructures the sidebar around capability tiers, de-duplicates the admin shortcuts, adds Field keys, and introduces the `capability.js` helper the rest of the frontend can use to stop branching on Title Case `User.role` strings. The role-aware Home page replacing `/dashboard`'s auto-redirect ships as 3.33.

## New capability helper

`frontend/src/utils/auth/capability.js` mirrors the backend `ROLE_TO_CAPABILITY` (`core/models.py:28-45`) so the frontend can finally say:

```javascript
if (hasCapability(user, 'supervisor')) { ... }
```

- `CAPABILITIES` (frozen, ordered by privilege).
- `userCapability(user)` reads `user.role` today; super admins are forced to `'admin'`.
- `hasCapability(user, capOrList)` "at least this tier" check.
- `useCapability()` hook flavor.
- 18 unit tests, including a coverage assertion that every legacy `User.role` from `users.models.User.ROLE_CHOICES` has a mapping entry — so backend role additions surface as test failures here first.

## New sidebar structure

| Section | Visible to | Items |
|---|---|---|
| **My work** | everyone | Home, My tasks, Counselor home (Counselor role only), File a reflection, My reflections |
| **Supervise** | supervisor + program_lead + admin + super_admin | Coverage, Concerns about my unit |
| **Dashboards** | program_lead + admin + super_admin | Overview, Coverage, Author attribution, Unit head dashboard, Wellness dashboard |
| **Admin** | admin + super_admin | Admin home, Memberships, Templates, Assignment groups, **Field keys** (new) |
| **Crane Lake legacy** | admin + super_admin | Bunk logs, Staff reflections (with "Migrating to new schema" tooltip) |
| **Other** | everyone | Orders |

Key removals:
- Top-level "Unit health (LT)" and "Wellness team" shortcuts (they were duplicates of the Dashboards submenu entries).
- The `extraLinks` prop on Sidebar entirely. Camper Care's "My Bunk Logs" / "Needs Attention" tabs moved to `CamperCareDashboard.jsx` as a proper in-page tablist.

Concerns inbox is consolidated under Supervise only — admins still see it because admin inherits supervisor capability.

## Test plan

- [x] `npx vitest run` → 270/270 (was 243; +27 from `capability.test.js` and the rewritten `Sidebar.test.jsx`).
- [x] `npx vite build` clean.
- [x] `git grep "user.role ===" frontend/src/partials/Sidebar.jsx` → only the explicitly-allowed Counselor home shortcut.
- [x] `git grep -E "/team/dashboard|/wellness/dashboard" frontend/src/partials/Sidebar.jsx` → no matches.
- [ ] Reviewer smoke: log in as each test user (`make seed-rbac` first) and confirm the sidebar sections match the matrix above.

## Known limitation (documented in `capability.js`)

`user.role` is Title Case and cannot distinguish `health_center` from `camper_care` — both show up as `'Camper Care'` so both render the supervisor tier. Matches current behavior. The proper fix is reading `Membership.capability` from `/api/v1/memberships/me/` on the auth context; tracked as a follow-up.

## Out of scope (next PRs)

- **3.33** — replace `/dashboard`'s role-redirect with a real Home page that renders capability-tiered cards.
- **3.34** — wire the unused `consumePostLoginPath` / `persistNextForOAuth` helpers through the sign-in flow.

Refs `migration_prompts/3_32_role_aware_navigation.md`.


Made with [Cursor](https://cursor.com)