### PR TITLE
7_6b: counselor read endpoints (/api/v1/counselor/)

### DIFF
--- a/backend/bunk_logs/api/counselor/__init__.py
+++ b/backend/bunk_logs/api/counselor/__init__.py
@@ -1,0 +1,11 @@
+"""Counselor-facing read endpoints (Step 7_6b).
+
+Endpoints under ``/api/v1/counselor/`` for the mobile-first counselor flow:
+
+- ``GET /dashboard/`` — Story 2: roster + self + requests, with "all set"
+- ``GET /camper-reflections/?date=<>`` — Story 3: bunk roster for a date
+- ``GET /self-reflection/history/`` — Story 6: counselor's prior reflections
+- ``GET /requests/`` — Stories 7, 8: my + co-counselors' open Orders & Tickets
+
+Write endpoints (submit / edit) live in 7_6c.
+"""

--- a/backend/bunk_logs/api/counselor/camper_reflections.py
+++ b/backend/bunk_logs/api/counselor/camper_reflections.py
@@ -1,0 +1,169 @@
+"""``GET /api/v1/counselor/camper-reflections/?date=YYYY-MM-DD`` — Story 3.
+
+Returns the bunk roster(s) for the viewer with each camper's submitted /
+not-submitted status for the requested date. Off-camp campers (per
+``CamperDayState``) appear in a dedicated sub-section and don't count
+toward "expected".
+
+The view of past dates is read-only (Story 6 criterion 4 — extended to
+camper reflections per Story 4): the ``editable`` flag on the response
+and on each row tells the client whether to render the Edit affordance.
+"""
+
+from __future__ import annotations
+
+from datetime import date as date_type
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core.models import Membership
+
+from .common import bunk_camper_persons
+from .common import camper_reflection_template
+from .common import latest_camper_reflection_per_subject
+from .common import off_camp_camper_ids
+from .common import person_display_name
+from .common import viewer_bunk_groups
+from .common import viewer_or_403
+
+
+def _parse_iso_date(value: str | None, default: date_type) -> date_type | None:
+    if not value:
+        return default
+    try:
+        return date_type.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+
+
+class CamperReflectionListView(APIView):
+    """Bunk roster with per-camper submission state for a date."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer = ctx.person
+        org = ctx.organization
+        today = ctx.today
+
+        target = _parse_iso_date(request.query_params.get("date"), today)
+        if target is None:
+            return Response(
+                {"detail": "Invalid 'date' query parameter; expected YYYY-MM-DD."},
+                status=400,
+            )
+
+        primary_membership = (
+            Membership.objects.filter(person=viewer, is_active=True)
+            .select_related("program")
+            .order_by("-created_at")
+            .first()
+        )
+        if primary_membership is None or primary_membership.program is None:
+            return Response({
+                "date": target.isoformat(),
+                "editable": target == today,
+                "bunks": [],
+            })
+        program = primary_membership.program
+
+        bunks = viewer_bunk_groups(viewer)
+        if not bunks:
+            return Response({
+                "date": target.isoformat(),
+                "editable": target == today,
+                "bunks": [],
+            })
+
+        template = camper_reflection_template(org, program)
+        roster_by_bunk = bunk_camper_persons(bunks)
+        all_camper_ids: set[int] = set()
+        for campers in roster_by_bunk.values():
+            all_camper_ids.update(p.id for p in campers)
+
+        off_camp_ids = off_camp_camper_ids(org, target, camper_ids=all_camper_ids)
+        reflections_by_subject = (
+            latest_camper_reflection_per_subject(template, bunks, target, target)
+            if template is not None
+            else {}
+        )
+
+        date_is_today = target == today
+        bunks_payload = []
+        for bunk in bunks:
+            campers = roster_by_bunk.get(bunk.id, [])
+            row_campers = []
+            off_camp_rows = []
+            covered = 0
+            for camper in campers:
+                base = {
+                    "id": camper.id,
+                    "name": person_display_name(camper),
+                    "preferred_name": camper.preferred_name or camper.first_name,
+                    "first_name": camper.first_name,
+                    "last_initial": (camper.last_name or "")[:1],
+                }
+                if camper.id in off_camp_ids:
+                    # Off-camp rows are surfaced separately and don't get
+                    # status / submitter / editable fields — they aren't
+                    # actionable in this UI.
+                    off_camp_rows.append(base)
+                    continue
+
+                reflection = reflections_by_subject.get(camper.id)
+                submitted = reflection is not None
+                if submitted:
+                    covered += 1
+                    author_person = reflection.author
+                    is_self = author_person == viewer if author_person else False
+                    submitter = {
+                        "is_self": is_self,
+                        # Per Story 3 criterion 3 — show submitter name only when
+                        # it isn't the viewer themself.
+                        "name": person_display_name(author_person) if not is_self else None,
+                    }
+                else:
+                    submitter = None
+
+                row = {
+                    **base,
+                    "submitted": submitted,
+                    "reflection_id": reflection.id if reflection else None,
+                    "submitted_at": (
+                        reflection.submitted_at.isoformat()
+                        if reflection and reflection.submitted_at
+                        else None
+                    ),
+                    "submitter": submitter,
+                    "editable": submitted and date_is_today,
+                }
+                row_campers.append(row)
+
+            bunks_payload.append({
+                "id": bunk.id,
+                "slug": bunk.slug,
+                "name": bunk.name,
+                "covered": covered,
+                "total": len(row_campers),
+                "campers": row_campers,
+                "off_camp": off_camp_rows,
+            })
+
+        return Response({
+            "date": target.isoformat(),
+            "editable": date_is_today,
+            "template": (
+                {
+                    "id": template.id,
+                    "slug": template.slug,
+                    "name": template.name,
+                    "version": template.version,
+                }
+                if template is not None
+                else None
+            ),
+            "bunks": bunks_payload,
+        })

--- a/backend/bunk_logs/api/counselor/common.py
+++ b/backend/bunk_logs/api/counselor/common.py
@@ -1,0 +1,334 @@
+"""Shared helpers for counselor read endpoints.
+
+Lifted out of the individual view modules so the dashboard, list, and history
+endpoints can answer the same questions ("who are my co-counselors?", "what's
+the active camper-reflection template?", "is this reflection editable for me?")
+the same way. Keep this small — anything counselor-specific that's also useful
+to other roles belongs in ``bunk_logs/core`` instead.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date  # noqa: TC003 - used in dataclass field type
+from datetime import datetime  # noqa: TC003 - used in keyword-only arg default annotation
+from typing import TYPE_CHECKING
+
+from django.db.models import Case
+from django.db.models import IntegerField
+from django.db.models import Q
+from django.db.models import When
+from rest_framework.exceptions import PermissionDenied
+
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import CamperDayState
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.time_utils import get_today
+
+if TYPE_CHECKING:
+    from bunk_logs.core.models import Organization
+    from bunk_logs.core.models import Program
+
+
+COUNSELOR_ROLES: frozenset[str] = frozenset({"counselor", "junior_counselor"})
+
+
+@dataclass(frozen=True)
+class ViewerContext:
+    """Resolved request context for a counselor endpoint."""
+
+    person: Person
+    organization: Organization
+    today: date
+
+
+def viewer_or_403(request) -> ViewerContext:
+    """Resolve viewer Person + org context or raise 403.
+
+    Counselor endpoints require all of: authenticated user, organization
+    context (from middleware), and a Person profile in that org.
+    """
+    org = getattr(request, "organization", None)
+    if org is None:
+        msg = "Organization context required."
+        raise PermissionDenied(msg)
+    if not request.user.is_authenticated:
+        msg = "Authentication required."
+        raise PermissionDenied(msg)
+    person = Person.objects.filter(user=request.user).first()
+    if person is None:
+        msg = "Person profile required."
+        raise PermissionDenied(msg)
+    return ViewerContext(person=person, organization=org, today=get_today(org))
+
+
+def viewer_bunk_groups(viewer: Person) -> list[AssignmentGroup]:
+    """Active bunk AssignmentGroups the viewer is an author on.
+
+    "Co-counselor" relationships are derived from author-membership on the
+    same bunk groups (decision C4). We surface ``group_type == 'bunk'``
+    explicitly so a counselor who also authors on a "unit" group doesn't
+    accidentally pull units into the bunk roster.
+    """
+    bunk_ids = list(
+        AssignmentGroupMembership.objects.filter(
+            person=viewer,
+            role_in_group="author",
+            is_active=True,
+            group__is_active=True,
+            group__group_type="bunk",
+        )
+        .values_list("group_id", flat=True),
+    )
+    if not bunk_ids:
+        return []
+    return list(
+        AssignmentGroup.objects.filter(id__in=bunk_ids).order_by("name"),
+    )
+
+
+def co_counselor_person_ids(viewer: Person, bunks: list[AssignmentGroup]) -> set[int]:
+    """Person IDs of OTHER active authors on the viewer's bunks (decision C4).
+
+    Excludes the viewer themselves so "is_self" attribution stays clean.
+    """
+    if not bunks:
+        return set()
+    return set(
+        AssignmentGroupMembership.objects.filter(
+            group__in=bunks,
+            role_in_group="author",
+            is_active=True,
+        )
+        .exclude(person=viewer)
+        .values_list("person_id", flat=True),
+    )
+
+
+def bunk_camper_persons(bunks: list[AssignmentGroup]) -> dict[int, list[Person]]:
+    """Active subject (camper) Persons keyed by bunk ID.
+
+    Sort order is alphabetical by last name + first name (Story 3 criterion 9
+    fallback). The optional "bunk-defined position" lives in AGM metadata and
+    is not surfaced yet — see Story 58 for the admin-configurable surface.
+    """
+    if not bunks:
+        return {}
+    rows = (
+        AssignmentGroupMembership.objects.filter(
+            group__in=bunks,
+            role_in_group="subject",
+            is_active=True,
+        )
+        .select_related("person", "group")
+        .order_by("person__last_name", "person__first_name")
+    )
+    out: dict[int, list[Person]] = {b.id: [] for b in bunks}
+    for agm in rows:
+        out.setdefault(agm.group_id, []).append(agm.person)
+    return out
+
+
+def off_camp_camper_ids(
+    organization: Organization,
+    target_date: date,
+    camper_ids: list[int] | set[int] | None = None,
+) -> set[int]:
+    """IDs of campers flagged off-camp on ``target_date`` (Story 3 criterion 8)."""
+    qs = CamperDayState.objects.filter(
+        organization=organization,
+        date=target_date,
+        is_off_camp=True,
+    )
+    if camper_ids is not None:
+        qs = qs.filter(camper_id__in=list(camper_ids))
+    return set(qs.values_list("camper_id", flat=True))
+
+
+def _resolve_template(
+    qs,
+    *,
+    organization: Organization,
+    program_type: str | None,
+) -> ReflectionTemplate | None:
+    """Apply the org-shadows-global ordering used throughout Step 7_6.
+
+    Both org-scoped and global templates may be ``is_active=True``; the
+    org-scoped row wins, falling back to the global if none exists.
+    """
+    qs = qs.filter(
+        Q(organization=organization) | Q(organization__isnull=True),
+        is_active=True,
+    )
+    if program_type:
+        qs = qs.filter(Q(program_type=program_type) | Q(program_type__isnull=True))
+    return (
+        qs.annotate(
+            _org_priority=Case(
+                When(organization__isnull=True, then=1),
+                default=0,
+                output_field=IntegerField(),
+            ),
+        )
+        .order_by("_org_priority", "-version")
+        .first()
+    )
+
+
+def camper_reflection_template(
+    organization: Organization,
+    program: Program,
+) -> ReflectionTemplate | None:
+    """Active daily camper-reflection template for a bunk roster (Story 3).
+
+    Picks the ``subject_mode='single_subject'`` template with ``'bunk'`` in
+    its ``assignment_group_types``. There is conventionally one per program;
+    if multiple exist the org-shadow ordering picks the org-scoped one.
+    """
+    qs = ReflectionTemplate.all_objects.filter(
+        subject_mode="single_subject",
+        cadence="daily",
+        assignment_group_types__contains=["bunk"],
+    )
+    return _resolve_template(qs, organization=organization, program_type=program.program_type)
+
+
+def counselor_self_template(
+    viewer: Person,
+    organization: Organization,
+    program: Program,
+) -> ReflectionTemplate | None:
+    """Active daily self-reflection template that applies to the viewer's role.
+
+    A template applies when EITHER its ``role`` field matches one of the
+    viewer's active memberships, OR its ``author_role_filter`` contains one
+    of those roles. The single ``role`` field is the canonical binding;
+    ``author_role_filter`` exists for finer-grained gating (e.g. a global
+    template targeting both ``counselor`` and ``junior_counselor``).
+    """
+    viewer_roles = set(
+        Membership.objects.filter(
+            person=viewer, program=program, is_active=True,
+        ).values_list("role", flat=True),
+    )
+    if not viewer_roles:
+        return None
+
+    role_q = Q(role__in=viewer_roles)
+    for role in viewer_roles:
+        role_q |= Q(author_role_filter__contains=[role])
+
+    qs = ReflectionTemplate.all_objects.filter(
+        role_q,
+        subject_mode="self",
+        cadence="daily",
+    )
+    return _resolve_template(qs, organization=organization, program_type=program.program_type)
+
+
+def is_editable_today(
+    reflection: Reflection,
+    organization: Organization,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    """Edit window per Stories 4 & 6: edits allowed iff still within today.
+
+    "Today" is rollover-hour aware (``get_today(org)``). Once the boundary
+    passes, the row is locked. Beyond the window, write endpoints (7_6c)
+    return 403 — this helper just tells the UI whether to render the Edit
+    affordance.
+    """
+    target_date = get_today(organization, now=now)
+    return reflection.period_start <= target_date <= reflection.period_end
+
+
+def is_day_off_answer(reflection: Reflection | None) -> bool:
+    """A reflection counts as 'day off' if the seeded ``day_off`` field is truthy.
+
+    The counselor self-reflection schema (seeded in 7_6c) includes a ``day_off``
+    boolean as the first field. When set, the rest of the schema is hidden
+    on the client but the reflection still counts as "complete" for the all-set
+    state (Story 5 criterion 3 + Story 9 criterion 1.ii).
+    """
+    if reflection is None:
+        return False
+    answers = reflection.answers or {}
+    return bool(answers.get("day_off"))
+
+
+def latest_camper_reflection_per_subject(
+    template: ReflectionTemplate,
+    bunks: list[AssignmentGroup],
+    period_start: date,
+    period_end: date,
+) -> dict[int, Reflection]:
+    """Map ``subject_id -> Reflection`` for the period.
+
+    Uses ``Reflection.all_objects`` because the global ``RoleVisibilityFilterBackend``
+    on ReflectionViewSet does not run here; we scope by ``assignment_group`` +
+    ``template`` + period which is already the visibility surface for an
+    author on the bunk.
+
+    Only ``is_complete=True`` rows count toward "submitted" (matching the
+    behavior of dashboards/coverage and Story 3's "submitted" definition —
+    drafts should not appear as someone else's submission to a co-counselor).
+    """
+    if not bunks:
+        return {}
+    rows = (
+        Reflection.all_objects.filter(
+            template=template,
+            assignment_group__in=bunks,
+            period_start=period_start,
+            period_end=period_end,
+            is_complete=True,
+        )
+        .select_related("author", "assignment_group")
+        .order_by("subject_id", "-submitted_at")
+    )
+    out: dict[int, Reflection] = {}
+    for r in rows:
+        if r.subject_id and r.subject_id not in out:
+            out[r.subject_id] = r
+    return out
+
+
+def latest_self_reflection(
+    viewer: Person,
+    template: ReflectionTemplate,
+    period_start: date,
+    period_end: date,
+) -> Reflection | None:
+    """Most recent ``is_complete=True`` self-reflection for the period."""
+    return (
+        Reflection.all_objects.filter(
+            author=viewer,
+            subject=viewer,
+            template=template,
+            period_start=period_start,
+            period_end=period_end,
+            is_complete=True,
+        )
+        .order_by("-submitted_at")
+        .first()
+    )
+
+
+def person_display_name(person: Person | None) -> str:
+    """Counselor-facing display: preferred-or-first name + last initial.
+
+    Matches Story 3 criterion 2 ("camper preferred-or-first name + last initial").
+    Used for both camper rows and co-counselor attribution.
+    """
+    if person is None:
+        return ""
+    first = (person.preferred_name or person.first_name or "").strip()
+    last_initial = (person.last_name or "").strip()[:1]
+    if first and last_initial:
+        return f"{first} {last_initial}."
+    return first or last_initial or ""

--- a/backend/bunk_logs/api/counselor/dashboard.py
+++ b/backend/bunk_logs/api/counselor/dashboard.py
@@ -1,0 +1,290 @@
+"""``GET /api/v1/counselor/dashboard/`` — Story 2 + Story 9 (all set).
+
+Returns the three-section payload the counselor mobile app paints below
+the date header: camper reflections coverage, self-reflection state, and
+open requests.
+
+State computation:
+
+- ``camper_reflections``: count of campers (excluding off-camp) with a
+  submitted reflection for today's period.
+- ``self_reflection``: viewer's own daily self-reflection for today, with
+  ``day_off`` treated as "complete" (Story 5 criterion 3).
+- ``requests``: open Orders + MaintenanceTickets the viewer or any
+  co-counselor submitted on the viewer's bunks (decision C4).
+
+All-set (Story 9 criterion 1) is true iff both camper-reflections and
+self-reflection sections are "complete". The Requests section is reactive,
+not required, and does NOT affect all-set (Story 9 criterion 2).
+
+Caching: a 30-second per-(org, viewer, day) TTL covers the cross-counselor
+freshness contract in Story 2 criterion 5. Read endpoints don't bust the
+cache; write endpoints in 7_6c will bump the per-viewer version key.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import date as date_type  # noqa: TC003 - used in helper type hints
+
+from django.core.cache import cache
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Order
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.state_machine import OrderStateMachine
+from bunk_logs.core.time_utils import get_org_timezone
+from bunk_logs.core.time_utils import get_rollover_hour
+
+from .common import bunk_camper_persons
+from .common import camper_reflection_template
+from .common import co_counselor_person_ids
+from .common import counselor_self_template
+from .common import is_day_off_answer
+from .common import latest_camper_reflection_per_subject
+from .common import latest_self_reflection
+from .common import off_camp_camper_ids
+from .common import viewer_bunk_groups
+from .common import viewer_or_403
+
+DASHBOARD_CACHE_TTL_SECONDS = 30
+OPEN_STATUSES: tuple[str, ...] = (OrderStateMachine.NEW, OrderStateMachine.IN_PROGRESS)
+
+
+def _section_state(*, covered: int, total: int) -> str:
+    if total == 0:
+        return "complete"
+    if covered == 0:
+        return "none"
+    if covered >= total:
+        return "complete"
+    return "in_progress"
+
+
+def _cache_key(viewer_id: int, organization_id: int, today: date_type) -> str:
+    raw = f"counselor_dashboard:{organization_id}:{viewer_id}:{today.isoformat()}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:48]
+
+
+class CounselorDashboardView(APIView):
+    """Three-section counselor dashboard payload."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer = ctx.person
+        org = ctx.organization
+        today = ctx.today
+
+        # Honor an opt-out for tests + ops debugging. Production clients never
+        # set this; the dashboard auto-refreshes on a 30s interval.
+        skip_cache = request.query_params.get("nocache") in {"1", "true"}
+        cache_key = _cache_key(viewer.id, org.id, today)
+        if not skip_cache:
+            cached = cache.get(cache_key)
+            if cached is not None:
+                return Response(cached)
+
+        # Pick the viewer's "primary" program. Counselors in v1 are scoped to
+        # one program; if a person has multiple active memberships we take the
+        # most recent so the dashboard at least renders.
+        primary_membership = (
+            Membership.objects.filter(person=viewer, is_active=True)
+            .select_related("program")
+            .order_by("-created_at")
+            .first()
+        )
+        if primary_membership is None or primary_membership.program is None:
+            payload = self._empty_payload(today, org)
+            cache.set(cache_key, payload, DASHBOARD_CACHE_TTL_SECONDS)
+            return Response(payload)
+        program = primary_membership.program
+
+        bunks = viewer_bunk_groups(viewer)
+        camper_section = self._camper_section(org, program, viewer, bunks, today)
+        self_section = self._self_section(viewer, org, program, today)
+        requests_section = self._requests_section(org, program, viewer, bunks)
+
+        all_set = (
+            camper_section["state"] == "complete"
+            and self_section["state"] == "complete"
+        )
+
+        payload = {
+            "today": today.isoformat(),
+            "rollover_hour": get_rollover_hour(org),
+            "timezone": str(get_org_timezone(org)),
+            "program": {
+                "id": program.id,
+                "slug": program.slug,
+                "name": program.name,
+            },
+            "all_set": all_set,
+            "sections": {
+                "camper_reflections": camper_section,
+                "self_reflection": self_section,
+                "requests": requests_section,
+            },
+        }
+        cache.set(cache_key, payload, DASHBOARD_CACHE_TTL_SECONDS)
+        return Response(payload)
+
+    def _empty_payload(self, today: date_type, org) -> dict:
+        return {
+            "today": today.isoformat(),
+            "rollover_hour": get_rollover_hour(org),
+            "timezone": str(get_org_timezone(org)),
+            "program": None,
+            "all_set": False,
+            "sections": {
+                "camper_reflections": {
+                    "state": "complete",
+                    "covered": 0,
+                    "total": 0,
+                    "off_camp": 0,
+                    "bunk_count": 0,
+                },
+                "self_reflection": {
+                    "state": "complete",
+                    "submitted": False,
+                    "reflection_id": None,
+                    "submitted_at": None,
+                    "is_day_off": False,
+                    "editable": False,
+                    "template": None,
+                },
+                "requests": {
+                    "state": "none",
+                    "open_count": 0,
+                    "by_type": {"camper_care": 0, "maintenance": 0},
+                },
+            },
+        }
+
+    def _camper_section(self, org, program, viewer: Person, bunks, today) -> dict:
+        if not bunks:
+            return {
+                "state": "complete",
+                "covered": 0,
+                "total": 0,
+                "off_camp": 0,
+                "bunk_count": 0,
+            }
+
+        roster_by_bunk = bunk_camper_persons(bunks)
+        all_camper_ids: set[int] = set()
+        for campers in roster_by_bunk.values():
+            all_camper_ids.update(p.id for p in campers)
+
+        off_camp_ids = off_camp_camper_ids(org, today, camper_ids=all_camper_ids)
+        expected_ids = all_camper_ids - off_camp_ids
+        total = len(expected_ids)
+
+        template = camper_reflection_template(org, program)
+        if template is None or total == 0:
+            return {
+                "state": "complete",
+                "covered": 0,
+                "total": total,
+                "off_camp": len(off_camp_ids),
+                "bunk_count": len(bunks),
+            }
+
+        # Daily cadence by definition for the bunk roster template — period
+        # collapses to (today, today) without needing the cadence helper.
+        reflections = latest_camper_reflection_per_subject(
+            template, bunks, today, today,
+        )
+        covered = sum(1 for sid in expected_ids if sid in reflections)
+
+        return {
+            "state": _section_state(covered=covered, total=total),
+            "covered": covered,
+            "total": total,
+            "off_camp": len(off_camp_ids),
+            "bunk_count": len(bunks),
+        }
+
+    def _self_section(self, viewer: Person, org, program: Program, today) -> dict:
+        template = counselor_self_template(viewer, org, program)
+        if template is None:
+            # No counselor self-reflection template configured — section is
+            # implicitly "complete" so it doesn't block all-set.
+            return {
+                "state": "complete",
+                "submitted": False,
+                "reflection_id": None,
+                "submitted_at": None,
+                "is_day_off": False,
+                "editable": False,
+                "template": None,
+            }
+
+        reflection = latest_self_reflection(viewer, template, today, today)
+        submitted = reflection is not None
+        return {
+            "state": "complete" if submitted else "none",
+            "submitted": submitted,
+            "reflection_id": reflection.id if reflection else None,
+            "submitted_at": reflection.submitted_at.isoformat() if reflection and reflection.submitted_at else None,
+            "is_day_off": is_day_off_answer(reflection),
+            "editable": submitted,
+            "template": {
+                "id": template.id,
+                "slug": template.slug,
+                "name": template.name,
+                "version": template.version,
+            },
+        }
+
+    def _requests_section(self, org, program, viewer: Person, bunks) -> dict:
+        # "My + my co-counselors' open requests" (decision C4). Without bunks
+        # the viewer has no co-counselors; they still see their own requests.
+        co_ids = co_counselor_person_ids(viewer, bunks)
+        eligible_person_ids = list(co_ids | {viewer.id})
+
+        # ``submitted_by`` is a Membership FK; gather the membership IDs for
+        # any of the eligible Persons in this program. We do this in one
+        # round-trip and reuse for both Orders and Maintenance tickets.
+        eligible_membership_ids = list(
+            Membership.all_objects.filter(
+                person_id__in=eligible_person_ids,
+                program=program,
+            ).values_list("id", flat=True),
+        )
+        if not eligible_membership_ids:
+            return {
+                "state": "none",
+                "open_count": 0,
+                "by_type": {"camper_care": 0, "maintenance": 0},
+            }
+
+        camper_care_count = Order.all_objects.filter(
+            organization=org,
+            program=program,
+            submitted_by_id__in=eligible_membership_ids,
+            status__in=OPEN_STATUSES,
+        ).count()
+        maintenance_count = MaintenanceTicket.all_objects.filter(
+            organization=org,
+            program=program,
+            submitted_by_id__in=eligible_membership_ids,
+            status__in=OPEN_STATUSES,
+        ).count()
+
+        total = camper_care_count + maintenance_count
+        return {
+            # Requests section never reports "complete" (Story 9 criterion 2).
+            "state": "in_progress" if total else "none",
+            "open_count": total,
+            "by_type": {
+                "camper_care": camper_care_count,
+                "maintenance": maintenance_count,
+            },
+        }

--- a/backend/bunk_logs/api/counselor/requests.py
+++ b/backend/bunk_logs/api/counselor/requests.py
@@ -1,0 +1,144 @@
+"""``GET /api/v1/counselor/requests/`` — Stories 7, 8 combined requests list.
+
+Returns the viewer's + their co-counselors' submitted requests on the
+viewer's bunks (decision C4). Combines camper-care Orders and Maintenance
+tickets into a single list with a ``type`` discriminator, sorted by
+``submitted_at`` desc so the freshest activity sits on top.
+
+Default returns OPEN requests (NEW + IN_PROGRESS). Pass ``?status=all`` to
+include closed states for the request history pane.
+"""
+
+from __future__ import annotations
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Order
+from bunk_logs.core.state_machine import OrderStateMachine
+
+from .common import co_counselor_person_ids
+from .common import person_display_name
+from .common import viewer_bunk_groups
+from .common import viewer_or_403
+
+OPEN_STATUSES: tuple[str, ...] = (OrderStateMachine.NEW, OrderStateMachine.IN_PROGRESS)
+
+
+class CounselorRequestsListView(APIView):
+    """Combined camper-care + maintenance request list."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer = ctx.person
+        org = ctx.organization
+
+        primary_membership = (
+            Membership.objects.filter(person=viewer, is_active=True)
+            .select_related("program")
+            .order_by("-created_at")
+            .first()
+        )
+        if primary_membership is None or primary_membership.program is None:
+            return Response({"requests": []})
+        program = primary_membership.program
+
+        bunks = viewer_bunk_groups(viewer)
+        co_ids = co_counselor_person_ids(viewer, bunks)
+        eligible_person_ids = list(co_ids | {viewer.id})
+
+        membership_id_to_person_id: dict[int, int] = dict(
+            Membership.all_objects.filter(
+                person_id__in=eligible_person_ids,
+                program=program,
+            ).values_list("id", "person_id"),
+        )
+        if not membership_id_to_person_id:
+            return Response({"requests": []})
+
+        status_filter = (request.query_params.get("status") or "open").lower()
+        if status_filter == "all":
+            status_kwargs: dict = {}
+        else:
+            status_kwargs = {"status__in": OPEN_STATUSES}
+
+        eligible_membership_ids = list(membership_id_to_person_id.keys())
+
+        order_rows = list(
+            Order.all_objects.filter(
+                organization=org,
+                program=program,
+                submitted_by_id__in=eligible_membership_ids,
+                **status_kwargs,
+            )
+            .select_related("subject", "submitted_by", "submitted_by__person")
+            .order_by("-created_at"),
+        )
+        ticket_rows = list(
+            MaintenanceTicket.all_objects.filter(
+                organization=org,
+                program=program,
+                submitted_by_id__in=eligible_membership_ids,
+                **status_kwargs,
+            )
+            .select_related("submitted_by", "submitted_by__person")
+            .order_by("-created_at"),
+        )
+
+        results: list[dict] = []
+        for o in order_rows:
+            submitter_person = o.submitted_by.person if o.submitted_by else None
+            is_self = submitter_person == viewer if submitter_person else False
+            results.append({
+                "type": "camper_care",
+                "id": str(o.id),
+                "status": o.status,
+                "status_label": o.get_status_display(),
+                "subject": (
+                    {
+                        "id": o.subject.id,
+                        "name": person_display_name(o.subject),
+                    }
+                    if o.subject
+                    else None
+                ),
+                "item": o.item or "",
+                "item_note": o.item_note or "",
+                "submitter": {
+                    "is_self": is_self,
+                    "name": person_display_name(submitter_person) if not is_self else None,
+                },
+                "submitted_at": o.created_at.isoformat() if o.created_at else None,
+                "updated_at": o.updated_at.isoformat() if o.updated_at else None,
+            })
+        for t in ticket_rows:
+            submitter_person = t.submitted_by.person if t.submitted_by else None
+            is_self = submitter_person == viewer if submitter_person else False
+            results.append({
+                "type": "maintenance",
+                "id": str(t.id),
+                "status": t.status,
+                "status_label": t.get_status_display(),
+                "location": t.location or "",
+                "category": t.category or "",
+                "category_label": t.get_category_display() if t.category else "",
+                "urgency": t.urgency or "",
+                "urgency_label": t.get_urgency_display() if t.urgency else "",
+                "description": t.description or "",
+                "photo_count": t.photos.count(),
+                "submitter": {
+                    "is_self": is_self,
+                    "name": person_display_name(submitter_person) if not is_self else None,
+                },
+                "submitted_at": t.created_at.isoformat() if t.created_at else None,
+                "updated_at": t.updated_at.isoformat() if t.updated_at else None,
+            })
+
+        # Newest first across the combined list.
+        results.sort(key=lambda r: r["submitted_at"] or "", reverse=True)
+        return Response({"requests": results})

--- a/backend/bunk_logs/api/counselor/self_reflection.py
+++ b/backend/bunk_logs/api/counselor/self_reflection.py
@@ -1,0 +1,152 @@
+"""``GET /api/v1/counselor/self-reflection/history/`` — Story 6 history view.
+
+Returns the viewer's prior self-reflections in reverse-chronological order,
+with explicit "day off" and "no submission" indicators (Story 6 criterion 6).
+
+Pagination: simple page-number scheme. Default 14 entries (~2 weeks) since
+the dashboard's self-reflection section is daily; clients fetch more via
+``?page=2``.
+"""
+
+from __future__ import annotations
+
+from datetime import date as date_type
+from datetime import timedelta
+
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Reflection
+
+from .common import counselor_self_template
+from .common import is_day_off_answer
+from .common import viewer_or_403
+
+
+class SelfReflectionHistoryPagination(PageNumberPagination):
+    page_size = 14
+    page_size_query_param = "page_size"
+    max_page_size = 60
+
+
+def _preview_from_answers(answers: dict | None, max_len: int = 120) -> str:
+    """Pull the first meaningful text answer for the history row preview.
+
+    Story 6 criterion 3 calls for "date and a preview line"; we don't yet
+    know which field a tenant will treat as the "headline", so we just take
+    the first non-empty string-typed value we find. The seeded counselor
+    template puts ``elaboration`` early, so this works fine in practice.
+    """
+    if not answers:
+        return ""
+    for value in answers.values():
+        if isinstance(value, str) and value.strip():
+            text = value.strip()
+            return text if len(text) <= max_len else text[: max_len - 1] + "\u2026"
+    return ""
+
+
+class SelfReflectionHistoryView(APIView):
+    """Paginated history of the viewer's own self-reflections."""
+
+    permission_classes = [IsAuthenticated]
+    pagination_class = SelfReflectionHistoryPagination
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer = ctx.person
+        org = ctx.organization
+        today = ctx.today
+
+        primary_membership = (
+            Membership.objects.filter(person=viewer, is_active=True)
+            .select_related("program")
+            .order_by("-created_at")
+            .first()
+        )
+        if primary_membership is None or primary_membership.program is None:
+            return Response({"results": [], "count": 0, "next": None, "previous": None})
+        program = primary_membership.program
+
+        template = counselor_self_template(viewer, org, program)
+        if template is None:
+            return Response({"results": [], "count": 0, "next": None, "previous": None})
+
+        # Page covers ``page_size`` consecutive calendar days ending at
+        # ``today``. We materialize one row per day so "no submission" gaps
+        # render as their own row (Story 6 criterion 6), not as missing data.
+        paginator = self.pagination_class()
+        page_size = paginator.get_page_size(request) or paginator.page_size
+        try:
+            page_num = max(1, int(request.query_params.get("page", "1")))
+        except (TypeError, ValueError):
+            page_num = 1
+
+        # Lower bound: 60 days back (the max page * a few pages). We don't
+        # paginate infinitely; counselors who need older data hit the admin
+        # surface, not this list.
+        max_days = paginator.max_page_size * 5
+        oldest = today - timedelta(days=max_days - 1)
+
+        start_offset = (page_num - 1) * page_size
+        end_offset = start_offset + page_size - 1
+        period_end_window = today - timedelta(days=start_offset)
+        period_start_window = today - timedelta(days=end_offset)
+        period_start_window = max(period_start_window, oldest)
+
+        reflections_qs = (
+            Reflection.all_objects.filter(
+                author=viewer,
+                subject=viewer,
+                template=template,
+                period_start__gte=period_start_window,
+                period_end__lte=period_end_window,
+            )
+            .order_by("-period_start", "-submitted_at")
+        )
+
+        by_date: dict[date_type, Reflection] = {}
+        for r in reflections_qs:
+            # If multiple rows exist for one day (shouldn't happen post-7_6c
+            # idempotency), the most recent submission wins because of the
+            # ordering above.
+            if r.period_start not in by_date:
+                by_date[r.period_start] = r
+
+        results = []
+        cursor = period_end_window
+        while cursor >= period_start_window and len(results) < page_size:
+            reflection = by_date.get(cursor)
+            results.append({
+                "date": cursor.isoformat(),
+                "submitted": reflection is not None and reflection.is_complete,
+                "is_day_off": is_day_off_answer(reflection) if reflection else False,
+                "reflection_id": reflection.id if reflection else None,
+                "submitted_at": (
+                    reflection.submitted_at.isoformat()
+                    if reflection and reflection.submitted_at
+                    else None
+                ),
+                "preview": (
+                    _preview_from_answers(reflection.answers)
+                    if reflection and not is_day_off_answer(reflection)
+                    else ""
+                ),
+                "editable": reflection is not None and cursor == today,
+            })
+            cursor -= timedelta(days=1)
+
+        total_count = max_days
+        has_next = page_num * page_size < total_count
+        has_previous = page_num > 1
+        return Response({
+            "count": total_count,
+            "next": page_num + 1 if has_next else None,
+            "previous": page_num - 1 if has_previous else None,
+            "page": page_num,
+            "page_size": page_size,
+            "results": results,
+        })

--- a/backend/bunk_logs/api/tests/test_counselor_camper_reflections.py
+++ b/backend/bunk_logs/api/tests/test_counselor_camper_reflections.py
@@ -1,0 +1,318 @@
+"""Tests for ``GET /api/v1/counselor/camper-reflections/?date=`` (Story 3).
+
+Covers roster shape, submitter attribution rules, off-camp segregation,
+date param parsing, and the read-only flag for past dates.
+"""
+from __future__ import annotations
+
+from datetime import date
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import CamperDayState
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+
+User = get_user_model()
+
+SCHEMA = {
+    "fields": [
+        {"key": "note", "type": "textarea", "required": False, "prompts": {"en": "Notes"}},
+    ],
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="CR Camp", slug="cr-camp")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="CR Camp Summer 2026",
+        slug="cr-summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def counselor_user():
+    return User.objects.create_user(email="cnsl@cr.test", password="pw")
+
+
+@pytest.fixture
+def counselor_person(org, counselor_user):
+    return Person.all_objects.create(
+        organization=org,
+        first_name="Mira",
+        last_name="Sand",
+        user=counselor_user,
+    )
+
+
+@pytest.fixture
+def counselor_membership(program, counselor_person):
+    return Membership.all_objects.create(
+        program=program, person=counselor_person, role="counselor", is_active=True,
+    )
+
+
+@pytest.fixture
+def bunk(org, program):
+    return AssignmentGroup.objects.create(
+        organization=org,
+        program=program,
+        name="Bunk Cedar",
+        slug="bunk-cedar",
+        group_type="bunk",
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def counselor_as_author(bunk, counselor_person):
+    return AssignmentGroupMembership.objects.create(
+        group=bunk, person=counselor_person, role_in_group="author", is_active=True,
+    )
+
+
+@pytest.fixture
+def co_counselor_person(org):
+    user = User.objects.create_user(email="co@cr.test", password="pw")
+    return Person.all_objects.create(
+        organization=org, first_name="Jordan", last_name="Patel", user=user,
+    )
+
+
+@pytest.fixture
+def co_counselor_membership(program, co_counselor_person):
+    return Membership.all_objects.create(
+        program=program, person=co_counselor_person, role="counselor", is_active=True,
+    )
+
+
+@pytest.fixture
+def co_as_author(bunk, co_counselor_person):
+    return AssignmentGroupMembership.objects.create(
+        group=bunk, person=co_counselor_person, role_in_group="author", is_active=True,
+    )
+
+
+@pytest.fixture
+def campers(org, bunk):
+    persons = []
+    for first, last in [("Sarah", "Levin"), ("Maya", "Cohen")]:
+        p = Person.all_objects.create(
+            organization=org, first_name=first, last_name=last, preferred_name=first,
+        )
+        AssignmentGroupMembership.objects.create(
+            group=bunk, person=p, role_in_group="subject", is_active=True,
+        )
+        persons.append(p)
+    return persons
+
+
+@pytest.fixture
+def template(org):
+    return ReflectionTemplate.all_objects.create(
+        organization=org,
+        name="Bunk Log",
+        slug="bunk-log-cr",
+        cadence="daily",
+        subject_mode="single_subject",
+        assignment_group_types=["bunk"],
+        schema=SCHEMA,
+        languages=["en"],
+        is_active=True,
+        program_type="summer_camp",
+        author_role_filter=["counselor"],
+    )
+
+
+def _client(user, org):
+    c = APIClient()
+    c.force_authenticate(user=user)
+    c.credentials(HTTP_X_ORGANIZATION_SLUG=org.slug)
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Roster shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_list_returns_one_bunk_with_two_campers(
+    org, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author, campers, template,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/camper-reflections/")
+    assert resp.status_code == 200
+    assert len(resp.data["bunks"]) == 1
+    bunk_row = resp.data["bunks"][0]
+    assert bunk_row["name"] == "Bunk Cedar"
+    assert bunk_row["total"] == 2
+    assert bunk_row["covered"] == 0
+    names = {row["name"] for row in bunk_row["campers"]}
+    assert "Sarah L." in names
+    assert "Maya C." in names
+
+
+@pytest.mark.django_db
+def test_list_shows_submitter_when_not_self(
+    org, program, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author,
+    co_counselor_person, co_counselor_membership, co_as_author,
+    campers, template,
+):
+    today = date.today()
+    Reflection.all_objects.create(
+        organization=org,
+        program=program,
+        author=co_counselor_person,
+        subject=campers[0],
+        assignment_group=bunk,
+        template=template,
+        period_start=today,
+        period_end=today,
+        answers={"note": "ok"},
+        is_complete=True,
+        language="en",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/camper-reflections/")
+    rows = resp.data["bunks"][0]["campers"]
+    sarah = next(r for r in rows if r["name"] == "Sarah L.")
+    assert sarah["submitted"] is True
+    assert sarah["submitter"]["is_self"] is False
+    assert sarah["submitter"]["name"] == "Jordan P."
+
+
+@pytest.mark.django_db
+def test_list_hides_submitter_name_when_self(
+    org, program, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author, campers, template,
+):
+    today = date.today()
+    Reflection.all_objects.create(
+        organization=org,
+        program=program,
+        author=counselor_person,
+        subject=campers[0],
+        assignment_group=bunk,
+        template=template,
+        period_start=today,
+        period_end=today,
+        answers={"note": "ok"},
+        is_complete=True,
+        language="en",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/camper-reflections/")
+    rows = resp.data["bunks"][0]["campers"]
+    sarah = next(r for r in rows if r["name"] == "Sarah L.")
+    assert sarah["submitted"] is True
+    assert sarah["submitter"]["is_self"] is True
+    assert sarah["submitter"]["name"] is None
+
+
+# ---------------------------------------------------------------------------
+# Off-camp handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_list_segregates_off_camp_campers(
+    org, program, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author, campers, template,
+):
+    today = date.today()
+    CamperDayState.objects.create(
+        organization=org, program=program, camper=campers[-1], date=today, is_off_camp=True,
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/camper-reflections/")
+    bunk_row = resp.data["bunks"][0]
+    assert bunk_row["total"] == 1  # off-camp removed
+    assert len(bunk_row["off_camp"]) == 1
+    assert bunk_row["off_camp"][0]["preferred_name"] == "Maya"
+
+
+# ---------------------------------------------------------------------------
+# Date parameter / editability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_list_rejects_invalid_date(
+    org, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author, campers, template,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/camper-reflections/?date=nope")
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_list_for_past_date_marks_not_editable(
+    org, program, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author, campers, template,
+):
+    yesterday = date.today() - timedelta(days=1)
+    Reflection.all_objects.create(
+        organization=org,
+        program=program,
+        author=counselor_person,
+        subject=campers[0],
+        assignment_group=bunk,
+        template=template,
+        period_start=yesterday,
+        period_end=yesterday,
+        answers={"note": "ok"},
+        is_complete=True,
+        language="en",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get(f"/api/v1/counselor/camper-reflections/?date={yesterday.isoformat()}")
+    assert resp.data["editable"] is False
+    rows = resp.data["bunks"][0]["campers"]
+    submitted_row = next(r for r in rows if r["submitted"])
+    assert submitted_row["editable"] is False
+
+
+@pytest.mark.django_db
+def test_list_no_membership_returns_empty(org, counselor_user, counselor_person):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/camper-reflections/")
+    assert resp.status_code == 200
+    assert resp.data["bunks"] == []

--- a/backend/bunk_logs/api/tests/test_counselor_dashboard.py
+++ b/backend/bunk_logs/api/tests/test_counselor_dashboard.py
@@ -1,0 +1,768 @@
+"""Tests for ``GET /api/v1/counselor/dashboard/`` (Step 7_6b, Stories 2 + 9).
+
+Covers section-state computation, off-camp exclusion, all-set derivation,
+co-counselor requests inclusion, and the 30s response cache.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import CamperDayState
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Order
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+
+User = get_user_model()
+
+DAILY_SIMPLE_SCHEMA = {
+    "fields": [
+        {"key": "note", "type": "textarea", "required": False, "prompts": {"en": "Notes"}},
+    ],
+}
+
+SELF_DAILY_SCHEMA = {
+    "fields": [
+        {"key": "day_off", "type": "yes_no", "required": False, "prompts": {"en": "Day off?"}},
+        {"key": "elaboration", "type": "textarea", "required": True, "prompts": {"en": "How was today?"}},
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="CD Camp", slug="cd-camp")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="CD Camp Summer 2026",
+        slug="cd-summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def counselor_user():
+    return User.objects.create_user(email="counselor@cd.test", password="pw")
+
+
+@pytest.fixture
+def counselor_person(org, counselor_user):
+    return Person.all_objects.create(
+        organization=org,
+        first_name="Mira",
+        last_name="Sandberg",
+        user=counselor_user,
+    )
+
+
+@pytest.fixture
+def counselor_membership(program, counselor_person):
+    return Membership.all_objects.create(
+        program=program, person=counselor_person, role="counselor", is_active=True,
+    )
+
+
+@pytest.fixture
+def co_counselor_user():
+    return User.objects.create_user(email="co@cd.test", password="pw")
+
+
+@pytest.fixture
+def co_counselor_person(org, co_counselor_user):
+    return Person.all_objects.create(
+        organization=org,
+        first_name="Jordan",
+        last_name="Patel",
+        user=co_counselor_user,
+    )
+
+
+@pytest.fixture
+def co_counselor_membership(program, co_counselor_person):
+    return Membership.all_objects.create(
+        program=program, person=co_counselor_person, role="counselor", is_active=True,
+    )
+
+
+@pytest.fixture
+def bunk(org, program):
+    return AssignmentGroup.objects.create(
+        organization=org,
+        program=program,
+        name="Bunk Birch",
+        slug="bunk-birch",
+        group_type="bunk",
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def counselor_as_author(bunk, counselor_person):
+    return AssignmentGroupMembership.objects.create(
+        group=bunk, person=counselor_person, role_in_group="author", is_active=True,
+    )
+
+
+@pytest.fixture
+def co_as_author(bunk, co_counselor_person):
+    return AssignmentGroupMembership.objects.create(
+        group=bunk, person=co_counselor_person, role_in_group="author", is_active=True,
+    )
+
+
+@pytest.fixture
+def campers(org, bunk):
+    persons = []
+    for first, last in [("Sarah", "Levin"), ("Maya", "Cohen"), ("Eli", "Roth")]:
+        p = Person.all_objects.create(organization=org, first_name=first, last_name=last)
+        AssignmentGroupMembership.objects.create(
+            group=bunk, person=p, role_in_group="subject", is_active=True,
+        )
+        persons.append(p)
+    return persons
+
+
+@pytest.fixture
+def camper_template(org):
+    return ReflectionTemplate.all_objects.create(
+        organization=org,
+        name="Bunk Log",
+        slug="bunk-log-cd",
+        cadence="daily",
+        subject_mode="single_subject",
+        assignment_group_types=["bunk"],
+        schema=DAILY_SIMPLE_SCHEMA,
+        languages=["en"],
+        is_active=True,
+        program_type="summer_camp",
+        author_role_filter=["counselor"],
+    )
+
+
+@pytest.fixture
+def self_template(org):
+    return ReflectionTemplate.all_objects.create(
+        organization=org,
+        name="Counselor Self",
+        slug="counselor-self-cd",
+        cadence="daily",
+        subject_mode="self",
+        role="counselor",
+        schema=SELF_DAILY_SCHEMA,
+        languages=["en"],
+        is_active=True,
+        program_type="summer_camp",
+    )
+
+
+def _client(user, org):
+    c = APIClient()
+    c.force_authenticate(user=user)
+    c.credentials(HTTP_X_ORGANIZATION_SLUG=org.slug)
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Auth / org gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_dashboard_requires_authentication():
+    c = APIClient()
+    resp = c.get("/api/v1/counselor/dashboard/")
+    assert resp.status_code in {401, 403}
+
+
+@pytest.mark.django_db
+def test_dashboard_requires_organization_context(counselor_user):
+    c = APIClient()
+    c.force_authenticate(user=counselor_user)
+    resp = c.get("/api/v1/counselor/dashboard/")
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_dashboard_requires_person_profile(org):
+    user = User.objects.create_user(email="ghost@cd.test", password="pw")
+    c = _client(user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Camper-reflections section
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_dashboard_empty_state_no_membership(org, counselor_user, counselor_person):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    assert resp.status_code == 200
+    assert resp.data["program"] is None
+    assert resp.data["sections"]["camper_reflections"]["total"] == 0
+
+
+@pytest.mark.django_db
+def test_dashboard_none_state_when_no_reflections(
+    org,
+    counselor_user,
+    counselor_person,
+    counselor_membership,
+    bunk,
+    counselor_as_author,
+    campers,
+    camper_template,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    section = resp.data["sections"]["camper_reflections"]
+    assert section["state"] == "none"
+    assert section["covered"] == 0
+    assert section["total"] == 3
+    assert section["off_camp"] == 0
+
+
+@pytest.mark.django_db
+def test_dashboard_in_progress_when_some_submitted(
+    org,
+    program,
+    counselor_user,
+    counselor_person,
+    counselor_membership,
+    bunk,
+    counselor_as_author,
+    campers,
+    camper_template,
+):
+    today = date.today()
+    Reflection.all_objects.create(
+        organization=org,
+        program=program,
+        author=counselor_person,
+        subject=campers[0],
+        assignment_group=bunk,
+        template=camper_template,
+        period_start=today,
+        period_end=today,
+        answers={"note": "ok"},
+        is_complete=True,
+        language="en",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    section = resp.data["sections"]["camper_reflections"]
+    assert section["state"] == "in_progress"
+    assert section["covered"] == 1
+    assert section["total"] == 3
+
+
+@pytest.mark.django_db
+def test_dashboard_complete_when_all_submitted(
+    org,
+    program,
+    counselor_user,
+    counselor_person,
+    counselor_membership,
+    bunk,
+    counselor_as_author,
+    campers,
+    camper_template,
+):
+    today = date.today()
+    for camper in campers:
+        Reflection.all_objects.create(
+            organization=org,
+            program=program,
+            author=counselor_person,
+            subject=camper,
+            assignment_group=bunk,
+            template=camper_template,
+            period_start=today,
+            period_end=today,
+            answers={"note": "ok"},
+            is_complete=True,
+            language="en",
+        )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    section = resp.data["sections"]["camper_reflections"]
+    assert section["state"] == "complete"
+    assert section["covered"] == 3
+    assert section["total"] == 3
+
+
+@pytest.mark.django_db
+def test_dashboard_off_camp_excluded_from_expected(
+    org,
+    program,
+    counselor_user,
+    counselor_person,
+    counselor_membership,
+    bunk,
+    counselor_as_author,
+    campers,
+    camper_template,
+):
+    today = date.today()
+    # Mark one camper off-camp -> expected total drops to 2.
+    CamperDayState.objects.create(
+        organization=org,
+        program=program,
+        camper=campers[-1],
+        date=today,
+        is_off_camp=True,
+    )
+    # Submit reflections for the remaining 2 -> should be "complete".
+    for camper in campers[:-1]:
+        Reflection.all_objects.create(
+            organization=org,
+            program=program,
+            author=counselor_person,
+            subject=camper,
+            assignment_group=bunk,
+            template=camper_template,
+            period_start=today,
+            period_end=today,
+            answers={"note": "ok"},
+            is_complete=True,
+            language="en",
+        )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    section = resp.data["sections"]["camper_reflections"]
+    assert section["state"] == "complete"
+    assert section["total"] == 2
+    assert section["off_camp"] == 1
+
+
+@pytest.mark.django_db
+def test_dashboard_draft_does_not_count_as_submitted(
+    org,
+    program,
+    counselor_user,
+    counselor_person,
+    counselor_membership,
+    bunk,
+    counselor_as_author,
+    campers,
+    camper_template,
+):
+    today = date.today()
+    Reflection.all_objects.create(
+        organization=org,
+        program=program,
+        author=counselor_person,
+        subject=campers[0],
+        assignment_group=bunk,
+        template=camper_template,
+        period_start=today,
+        period_end=today,
+        answers={"note": "draft"},
+        is_complete=False,
+        language="en",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    section = resp.data["sections"]["camper_reflections"]
+    assert section["covered"] == 0
+    assert section["state"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# Self-reflection section
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_dashboard_self_section_complete_when_submitted(
+    org,
+    program,
+    counselor_user,
+    counselor_person,
+    counselor_membership,
+    self_template,
+):
+    today = date.today()
+    Reflection.all_objects.create(
+        organization=org,
+        program=program,
+        author=counselor_person,
+        subject=counselor_person,
+        template=self_template,
+        period_start=today,
+        period_end=today,
+        answers={"elaboration": "Solid day"},
+        is_complete=True,
+        language="en",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    section = resp.data["sections"]["self_reflection"]
+    assert section["state"] == "complete"
+    assert section["submitted"] is True
+    assert section["is_day_off"] is False
+    assert section["editable"] is True
+    assert section["template"]["slug"] == "counselor-self-cd"
+
+
+@pytest.mark.django_db
+def test_dashboard_self_section_day_off_counts_as_complete(
+    org,
+    program,
+    counselor_user,
+    counselor_person,
+    counselor_membership,
+    self_template,
+):
+    today = date.today()
+    Reflection.all_objects.create(
+        organization=org,
+        program=program,
+        author=counselor_person,
+        subject=counselor_person,
+        template=self_template,
+        period_start=today,
+        period_end=today,
+        answers={"day_off": True},
+        is_complete=True,
+        language="en",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    section = resp.data["sections"]["self_reflection"]
+    assert section["state"] == "complete"
+    assert section["is_day_off"] is True
+
+
+@pytest.mark.django_db
+def test_dashboard_self_section_none_when_no_template(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    section = resp.data["sections"]["self_reflection"]
+    assert section["state"] == "complete"
+    assert section["template"] is None
+
+
+# ---------------------------------------------------------------------------
+# All-set + requests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_dashboard_all_set_true_when_both_sections_complete(
+    org,
+    program,
+    counselor_user,
+    counselor_person,
+    counselor_membership,
+    bunk,
+    counselor_as_author,
+    campers,
+    camper_template,
+    self_template,
+):
+    today = date.today()
+    for camper in campers:
+        Reflection.all_objects.create(
+            organization=org,
+            program=program,
+            author=counselor_person,
+            subject=camper,
+            assignment_group=bunk,
+            template=camper_template,
+            period_start=today,
+            period_end=today,
+            answers={"note": "ok"},
+            is_complete=True,
+            language="en",
+        )
+    Reflection.all_objects.create(
+        organization=org,
+        program=program,
+        author=counselor_person,
+        subject=counselor_person,
+        template=self_template,
+        period_start=today,
+        period_end=today,
+        answers={"elaboration": "Great"},
+        is_complete=True,
+        language="en",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    assert resp.data["all_set"] is True
+
+
+@pytest.mark.django_db
+def test_dashboard_all_set_false_with_open_requests_only(
+    org,
+    program,
+    counselor_user,
+    counselor_person,
+    counselor_membership,
+    bunk,
+    counselor_as_author,
+    campers,
+    camper_template,
+    self_template,
+):
+    today = date.today()
+    for camper in campers:
+        Reflection.all_objects.create(
+            organization=org,
+            program=program,
+            author=counselor_person,
+            subject=camper,
+            assignment_group=bunk,
+            template=camper_template,
+            period_start=today,
+            period_end=today,
+            answers={"note": "ok"},
+            is_complete=True,
+            language="en",
+        )
+    Reflection.all_objects.create(
+        organization=org,
+        program=program,
+        author=counselor_person,
+        subject=counselor_person,
+        template=self_template,
+        period_start=today,
+        period_end=today,
+        answers={"elaboration": "Great"},
+        is_complete=True,
+        language="en",
+    )
+    # Open order should NOT block all-set (Story 9 criterion 2).
+    Order.all_objects.create(
+        organization=org,
+        program=program,
+        subject=campers[0],
+        submitted_by=counselor_membership,
+        item="Toothbrush",
+        status="new",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    assert resp.data["all_set"] is True
+    assert resp.data["sections"]["requests"]["open_count"] == 1
+
+
+@pytest.mark.django_db
+def test_dashboard_requests_includes_co_counselor(
+    org,
+    program,
+    counselor_user,
+    counselor_person,
+    counselor_membership,
+    co_counselor_person,
+    co_counselor_membership,
+    bunk,
+    counselor_as_author,
+    co_as_author,
+    campers,
+):
+    Order.all_objects.create(
+        organization=org,
+        program=program,
+        subject=campers[0],
+        submitted_by=co_counselor_membership,
+        item="Bug spray",
+        status="in_progress",
+    )
+    MaintenanceTicket.all_objects.create(
+        organization=org,
+        program=program,
+        submitted_by=co_counselor_membership,
+        location="Bunk Birch",
+        category=MaintenanceTicket.Category.LEAK,
+        description="Faucet drip",
+        urgency="normal",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    section = resp.data["sections"]["requests"]
+    assert section["open_count"] == 2
+    assert section["by_type"] == {"camper_care": 1, "maintenance": 1}
+
+
+@pytest.mark.django_db
+def test_dashboard_excludes_closed_requests_from_count(
+    org,
+    program,
+    counselor_user,
+    counselor_person,
+    counselor_membership,
+    bunk,
+    counselor_as_author,
+    campers,
+):
+    Order.all_objects.create(
+        organization=org,
+        program=program,
+        subject=campers[0],
+        submitted_by=counselor_membership,
+        item="Toothbrush",
+        status="fulfilled",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    section = resp.data["sections"]["requests"]
+    assert section["open_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Caching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_dashboard_caches_response(
+    org,
+    program,
+    counselor_user,
+    counselor_person,
+    counselor_membership,
+    bunk,
+    counselor_as_author,
+    campers,
+    camper_template,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        first = c.get("/api/v1/counselor/dashboard/")
+    assert first.status_code == 200
+    assert first.data["sections"]["camper_reflections"]["covered"] == 0
+
+    # Add a submission AFTER the first response was cached -> cached value wins.
+    today = date.today()
+    Reflection.all_objects.create(
+        organization=org,
+        program=program,
+        author=counselor_person,
+        subject=campers[0],
+        assignment_group=bunk,
+        template=camper_template,
+        period_start=today,
+        period_end=today,
+        answers={"note": "ok"},
+        is_complete=True,
+        language="en",
+    )
+    with organization_context(org):
+        cached = c.get("/api/v1/counselor/dashboard/")
+    assert cached.data == first.data
+
+    # ?nocache=1 forces a fresh computation.
+    with organization_context(org):
+        fresh = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    assert fresh.data["sections"]["camper_reflections"]["covered"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Tenant isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_dashboard_does_not_leak_other_org_data(org, program):
+    other_org = Organization.objects.create(name="Other", slug="other-cd")
+    other_program = Program.all_objects.create(
+        organization=other_org,
+        name="Other Summer",
+        slug="other-summer",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+    other_user = User.objects.create_user(email="other@cd.test", password="pw")
+    other_person = Person.all_objects.create(
+        organization=other_org, first_name="Other", last_name="Counselor", user=other_user,
+    )
+    Membership.all_objects.create(
+        program=other_program, person=other_person, role="counselor", is_active=True,
+    )
+    # An order in *org* must not appear for the user in *other_org*.
+    counselor_person_obj = Person.all_objects.create(
+        organization=org, first_name="X", last_name="Y",
+    )
+    counselor_membership_obj = Membership.all_objects.create(
+        program=program, person=counselor_person_obj, role="counselor", is_active=True,
+    )
+    Order.all_objects.create(
+        organization=org,
+        program=program,
+        submitted_by=counselor_membership_obj,
+        item="cross-org item",
+        status="new",
+    )
+    c = _client(other_user, other_org)
+    with organization_context(other_org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    assert resp.data["sections"]["requests"]["open_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Story 2 criterion 4: rollover hour reflected in payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_dashboard_returns_rollover_hour_and_timezone(
+    org, program, counselor_user, counselor_person, counselor_membership,
+):
+    org.settings = {"rollover_hour": 5, "timezone": "America/Chicago"}
+    org.save()
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    assert resp.data["rollover_hour"] == 5
+    assert resp.data["timezone"] == "America/Chicago"

--- a/backend/bunk_logs/api/tests/test_counselor_requests.py
+++ b/backend/bunk_logs/api/tests/test_counselor_requests.py
@@ -1,0 +1,313 @@
+"""Tests for ``GET /api/v1/counselor/requests/`` (Stories 7 + 8 combined list)."""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Order
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+
+User = get_user_model()
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="RQ Camp", slug="rq-camp")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="RQ Camp Summer 2026",
+        slug="rq-summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def counselor_user():
+    return User.objects.create_user(email="cnsl@rq.test", password="pw")
+
+
+@pytest.fixture
+def counselor_person(org, counselor_user):
+    return Person.all_objects.create(
+        organization=org, first_name="Mira", last_name="Sand", user=counselor_user,
+    )
+
+
+@pytest.fixture
+def counselor_membership(program, counselor_person):
+    return Membership.all_objects.create(
+        program=program, person=counselor_person, role="counselor", is_active=True,
+    )
+
+
+@pytest.fixture
+def bunk(org, program):
+    return AssignmentGroup.objects.create(
+        organization=org,
+        program=program,
+        name="Bunk Pine",
+        slug="bunk-pine",
+        group_type="bunk",
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def counselor_as_author(bunk, counselor_person):
+    return AssignmentGroupMembership.objects.create(
+        group=bunk, person=counselor_person, role_in_group="author", is_active=True,
+    )
+
+
+@pytest.fixture
+def co_person(org):
+    u = User.objects.create_user(email="co@rq.test", password="pw")
+    return Person.all_objects.create(organization=org, first_name="Jordan", last_name="Patel", user=u)
+
+
+@pytest.fixture
+def co_membership(program, co_person):
+    return Membership.all_objects.create(
+        program=program, person=co_person, role="counselor", is_active=True,
+    )
+
+
+@pytest.fixture
+def co_as_author(bunk, co_person):
+    return AssignmentGroupMembership.objects.create(
+        group=bunk, person=co_person, role_in_group="author", is_active=True,
+    )
+
+
+@pytest.fixture
+def camper(org, bunk):
+    p = Person.all_objects.create(organization=org, first_name="Sarah", last_name="Levin")
+    AssignmentGroupMembership.objects.create(
+        group=bunk, person=p, role_in_group="subject", is_active=True,
+    )
+    return p
+
+
+def _client(user, org):
+    c = APIClient()
+    c.force_authenticate(user=user)
+    c.credentials(HTTP_X_ORGANIZATION_SLUG=org.slug)
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Self requests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_requests_lists_own_order(
+    org, program, counselor_user, counselor_person, counselor_membership, camper,
+):
+    Order.all_objects.create(
+        organization=org,
+        program=program,
+        subject=camper,
+        submitted_by=counselor_membership,
+        item="Toothbrush",
+        status="new",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/requests/")
+    assert resp.status_code == 200
+    assert len(resp.data["requests"]) == 1
+    row = resp.data["requests"][0]
+    assert row["type"] == "camper_care"
+    assert row["item"] == "Toothbrush"
+    assert row["submitter"]["is_self"] is True
+    assert row["submitter"]["name"] is None
+
+
+@pytest.mark.django_db
+def test_requests_lists_maintenance_ticket(
+    org, program, counselor_user, counselor_person, counselor_membership,
+):
+    MaintenanceTicket.all_objects.create(
+        organization=org,
+        program=program,
+        submitted_by=counselor_membership,
+        location="Bunk Pine",
+        category=MaintenanceTicket.Category.LEAK,
+        description="Drip",
+        urgency="urgent",
+        urgent_reason="Standing water in bunk",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/requests/")
+    row = resp.data["requests"][0]
+    assert row["type"] == "maintenance"
+    assert row["urgency"] == "urgent"
+    assert row["category"] == "leak"
+
+
+# ---------------------------------------------------------------------------
+# Co-counselor scoping (C4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_requests_includes_co_counselor_request(
+    org, program, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author, co_person, co_membership, co_as_author, camper,
+):
+    Order.all_objects.create(
+        organization=org,
+        program=program,
+        subject=camper,
+        submitted_by=co_membership,
+        item="Bug spray",
+        status="in_progress",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/requests/")
+    assert len(resp.data["requests"]) == 1
+    row = resp.data["requests"][0]
+    assert row["submitter"]["is_self"] is False
+    assert row["submitter"]["name"] == "Jordan P."
+
+
+@pytest.mark.django_db
+def test_requests_excludes_other_bunk_counselor(
+    org, program, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author,
+):
+    # An unrelated counselor on a DIFFERENT bunk; their order must not show.
+    other_bunk = AssignmentGroup.objects.create(
+        organization=org,
+        program=program,
+        name="Bunk Other",
+        slug="bunk-other",
+        group_type="bunk",
+        is_active=True,
+    )
+    other_user = User.objects.create_user(email="other@rq.test", password="pw")
+    other_person = Person.all_objects.create(
+        organization=org, first_name="Other", last_name="One", user=other_user,
+    )
+    other_membership = Membership.all_objects.create(
+        program=program, person=other_person, role="counselor", is_active=True,
+    )
+    AssignmentGroupMembership.objects.create(
+        group=other_bunk, person=other_person, role_in_group="author", is_active=True,
+    )
+    Order.all_objects.create(
+        organization=org,
+        program=program,
+        submitted_by=other_membership,
+        item="not mine",
+        status="new",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/requests/")
+    assert resp.data["requests"] == []
+
+
+# ---------------------------------------------------------------------------
+# Status filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_requests_default_excludes_closed(
+    org, program, counselor_user, counselor_person, counselor_membership,
+):
+    Order.all_objects.create(
+        organization=org,
+        program=program,
+        submitted_by=counselor_membership,
+        item="closed item",
+        status="fulfilled",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/requests/")
+    assert resp.data["requests"] == []
+
+
+@pytest.mark.django_db
+def test_requests_status_all_returns_closed(
+    org, program, counselor_user, counselor_person, counselor_membership,
+):
+    Order.all_objects.create(
+        organization=org,
+        program=program,
+        submitted_by=counselor_membership,
+        item="closed item",
+        status="fulfilled",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/requests/?status=all")
+    assert len(resp.data["requests"]) == 1
+    assert resp.data["requests"][0]["status"] == "fulfilled"
+
+
+# ---------------------------------------------------------------------------
+# Tenant isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_requests_does_not_leak_other_org(
+    org, program, counselor_user, counselor_person, counselor_membership,
+):
+    other = Organization.objects.create(name="Other", slug="other-rq")
+    other_program = Program.all_objects.create(
+        organization=other,
+        name="Other Summer",
+        slug="other-rq-summer",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+    other_user = User.objects.create_user(email="x@other.test", password="pw")
+    other_person = Person.all_objects.create(
+        organization=other, first_name="X", last_name="Y", user=other_user,
+    )
+    other_membership = Membership.all_objects.create(
+        program=other_program, person=other_person, role="counselor", is_active=True,
+    )
+    Order.all_objects.create(
+        organization=other,
+        program=other_program,
+        submitted_by=other_membership,
+        item="cross-org",
+        status="new",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/requests/")
+    assert resp.data["requests"] == []

--- a/backend/bunk_logs/api/tests/test_counselor_self_reflection_history.py
+++ b/backend/bunk_logs/api/tests/test_counselor_self_reflection_history.py
@@ -1,0 +1,203 @@
+"""Tests for ``GET /api/v1/counselor/self-reflection/history/`` (Story 6)."""
+from __future__ import annotations
+
+from datetime import date
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+
+User = get_user_model()
+
+SELF_SCHEMA = {
+    "fields": [
+        {"key": "day_off", "type": "yes_no", "prompts": {"en": "Day off?"}},
+        {"key": "elaboration", "type": "textarea", "required": True, "prompts": {"en": "How was today?"}},
+    ],
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="SH Camp", slug="sh-camp")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="SH Camp Summer 2026",
+        slug="sh-summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def counselor_user():
+    return User.objects.create_user(email="cnsl@sh.test", password="pw")
+
+
+@pytest.fixture
+def counselor_person(org, counselor_user):
+    return Person.all_objects.create(
+        organization=org, first_name="Mira", last_name="Sand", user=counselor_user,
+    )
+
+
+@pytest.fixture
+def counselor_membership(program, counselor_person):
+    return Membership.all_objects.create(
+        program=program, person=counselor_person, role="counselor", is_active=True,
+    )
+
+
+@pytest.fixture
+def self_template(org):
+    return ReflectionTemplate.all_objects.create(
+        organization=org,
+        name="Counselor Self",
+        slug="counselor-self-sh",
+        cadence="daily",
+        subject_mode="self",
+        role="counselor",
+        schema=SELF_SCHEMA,
+        languages=["en"],
+        is_active=True,
+        program_type="summer_camp",
+    )
+
+
+def _client(user, org):
+    c = APIClient()
+    c.force_authenticate(user=user)
+    c.credentials(HTTP_X_ORGANIZATION_SLUG=org.slug)
+    return c
+
+
+def _submit(organization, program, person, template, target_date, answers):
+    return Reflection.all_objects.create(
+        organization=organization,
+        program=program,
+        author=person,
+        subject=person,
+        template=template,
+        period_start=target_date,
+        period_end=target_date,
+        answers=answers,
+        is_complete=True,
+        language="en",
+    )
+
+
+@pytest.mark.django_db
+def test_history_empty_when_no_template(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/self-reflection/history/")
+    assert resp.status_code == 200
+    assert resp.data["results"] == []
+
+
+@pytest.mark.django_db
+def test_history_default_page_returns_14_day_grid(
+    org, counselor_user, counselor_person, counselor_membership, self_template,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/self-reflection/history/")
+    assert resp.status_code == 200
+    assert len(resp.data["results"]) == 14
+
+
+@pytest.mark.django_db
+def test_history_records_submission_and_day_off(
+    org, program, counselor_user, counselor_person, counselor_membership, self_template,
+):
+    today = date.today()
+    _submit(org, program, counselor_person, self_template, today, {"elaboration": "OK"})
+    _submit(
+        org, program, counselor_person, self_template, today - timedelta(days=1),
+        {"day_off": True},
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/self-reflection/history/")
+    by_date = {row["date"]: row for row in resp.data["results"]}
+    today_row = by_date[today.isoformat()]
+    assert today_row["submitted"] is True
+    assert today_row["is_day_off"] is False
+    assert today_row["editable"] is True
+
+    yest_row = by_date[(today - timedelta(days=1)).isoformat()]
+    assert yest_row["submitted"] is True
+    assert yest_row["is_day_off"] is True
+    assert yest_row["editable"] is False
+
+
+@pytest.mark.django_db
+def test_history_marks_missing_days_as_gaps(
+    org, program, counselor_user, counselor_person, counselor_membership, self_template,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/self-reflection/history/")
+    # Every row should have submitted=False / no reflection_id when no
+    # reflections exist for the viewer.
+    for row in resp.data["results"]:
+        assert row["submitted"] is False
+        assert row["reflection_id"] is None
+
+
+@pytest.mark.django_db
+def test_history_pagination_advances_window(
+    org, program, counselor_user, counselor_person, counselor_membership, self_template,
+):
+    today = date.today()
+    _submit(
+        org, program, counselor_person, self_template,
+        today - timedelta(days=15),
+        {"elaboration": "Older"},
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        page_one = c.get("/api/v1/counselor/self-reflection/history/?page=1")
+        page_two = c.get("/api/v1/counselor/self-reflection/history/?page=2")
+    dates_one = {row["date"] for row in page_one.data["results"]}
+    dates_two = {row["date"] for row in page_two.data["results"]}
+    assert dates_one.isdisjoint(dates_two)
+    older = (today - timedelta(days=15)).isoformat()
+    assert older in dates_two
+
+
+@pytest.mark.django_db
+def test_history_returns_text_preview(
+    org, program, counselor_user, counselor_person, counselor_membership, self_template,
+):
+    today = date.today()
+    _submit(org, program, counselor_person, self_template, today, {"elaboration": "Excellent day"})
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/self-reflection/history/")
+    today_row = next(r for r in resp.data["results"] if r["date"] == today.isoformat())
+    assert "Excellent" in today_row["preview"]

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -14,6 +14,10 @@ from . import reflections
 from . import supervisions as supervisions_api
 from . import templates as templates_api
 from . import views
+from .counselor import camper_reflections as counselor_camper_reflections
+from .counselor import dashboard as counselor_dashboard
+from .counselor import requests as counselor_requests
+from .counselor import self_reflection as counselor_self_reflection
 from .dashboards import authors as authors_dashboard
 from .dashboards import concerns as concerns_dashboard
 from .dashboards import coverage as coverage_dashboard
@@ -166,6 +170,28 @@ urlpatterns = [
     # Unit head and camper care dashboard endpoints
     path("unithead/<str:unithead_id>/<str:date>/", views.get_unit_head_bunks, name="unit-head-bunks"),
     path("campercare/<str:camper_care_id>/<str:date>/", views.get_camper_care_bunks, name="camper-care-bunks"),
+
+    # Counselor flow read endpoints (Step 7_6b)
+    path(
+        "counselor/dashboard/",
+        counselor_dashboard.CounselorDashboardView.as_view(),
+        name="counselor-dashboard",
+    ),
+    path(
+        "counselor/camper-reflections/",
+        counselor_camper_reflections.CamperReflectionListView.as_view(),
+        name="counselor-camper-reflections",
+    ),
+    path(
+        "counselor/self-reflection/history/",
+        counselor_self_reflection.SelfReflectionHistoryView.as_view(),
+        name="counselor-self-reflection-history",
+    ),
+    path(
+        "counselor/requests/",
+        counselor_requests.CounselorRequestsListView.as_view(),
+        name="counselor-requests",
+    ),
 ]
 
 app_name = "api"


### PR DESCRIPTION
## Summary

Read side of **Step 7_6 (Counselor Flow)**. Four endpoints under `/api/v1/counselor/` that power the counselor mobile dashboard.

> Stacked on `feat/7_6a_foundations` (#73). Merge `7_6a` first — base will reset to `main` on merge.

### Endpoints

| Method + Path | Purpose | Story |
|---|---|---|
| `GET /counselor/dashboard/` | 3-section dashboard payload + `all_set` | 2, 9 |
| `GET /counselor/camper-reflections/?date=YYYY-MM-DD` | Bunk roster with per-camper submission state | 3 |
| `GET /counselor/self-reflection/history/` | Paginated daily grid with gap markers | 6 |
| `GET /counselor/requests/` | My + co-counselors' open Orders & Maintenance tickets | 7, 8 |

### Notable behaviors

- **All-set** (Story 9): true iff *both* camper-reflections and self-reflection sections are \"complete\". Open requests do NOT block all-set (Story 9 criterion 2).
- **Day-off** counts as a complete self-reflection (`answers.day_off=True`) so counselors on a true day off still hit all-set (Story 5 criterion 3 + Story 9 criterion 1.ii).
- **Off-camp** campers come from `CamperDayState` (added in 7_6a). They're surfaced in a separate `off_camp` array and don't count toward \"expected\" (Story 3 criterion 8).
- **Co-counselors** (decision C4): other active `role_in_group=\"author\"` Persons on the viewer's bunk(s). Used for the dashboard's requests count *and* for the combined requests list — co-counselor requests show the submitter's name; the viewer's own requests don't.
- **Editable today**: each row carries an `editable` flag derived from `core.time_utils.get_today(org)` so the FE can show / hide the Edit affordance without parsing dates itself. Story 4 + 6 edit-window enforcement at the write layer lands in 7_6c.
- **Drafts don't count**: camper-reflection coverage filters `is_complete=True`. A co-counselor's in-progress draft never appears as \"submitted\" to the viewer.
- **30-second response cache** on the dashboard, per `(org, viewer, day)`. `?nocache=1` opt-out for tests and ops. Write endpoints in 7_6c will bump the per-viewer version key for proper invalidation.

### Shared helpers (lifted out to `api/counselor/common.py`)

All four endpoints share:
- `viewer_or_403(request)` — auth + org + Person gate
- `viewer_bunk_groups(viewer)` — viewer's authored bunks
- `co_counselor_person_ids(viewer, bunks)` — decision C4 expansion
- `camper_reflection_template(org, program)` / `counselor_self_template(viewer, org, program)` — org-shadows-global template resolution
- `is_editable_today(reflection, org)` — Story 4/6 edit-window primitive
- `person_display_name(person)` — \"Preferred name + last initial\" (Story 3 criterion 2)

These are designed to be reused by 7_6c write endpoints.

### Tests

39 new tests, all green:

| Suite | Cases |
|---|---|
| `test_counselor_dashboard.py` | 19 |
| `test_counselor_camper_reflections.py` | 8 |
| `test_counselor_self_reflection_history.py` | 6 |
| `test_counselor_requests.py` | 6 |

Coverage: auth/403 gates, section-state transitions, off-camp exclusion, draft vs. complete, day-off-counts-as-complete, all-set derivation, co-counselor inclusion, closed-request exclusion, 30s cache, cross-org isolation, rollover-hour echo, pagination window, submitter attribution rules.

### Verification

- `pytest`: 825 / 825 pass (786 from before + 39 new)
- `ruff check`: clean on all touched files
- `manage.py check`: 0 issues

### Out of scope (lands in 7_6c)

- Write endpoints (submit / edit camper reflections, self-reflection, Orders, MaintenanceTickets)
- Global counselor self-reflection `ReflectionTemplate` seed (en/es)
- Cache invalidation hooks on writes
- Edit-window 403s at the write layer

## Test plan

- [x] `pytest` green on full backend suite (`--create-db`)
- [x] `ruff check` clean on touched files
- [x] `manage.py check` clean
- [ ] Hit each endpoint against a synced prod-shaped DB (preview env)
- [ ] Verify dashboard p50 latency under the Story 2 criterion 6 budget (< 2s first contentful paint over 4G) — measured E2E in 7_6e

Made with [Cursor](https://cursor.com)