### PR TITLE
feat(api): counselor flow write endpoints (7_6c)

### DIFF
--- a/backend/bunk_logs/api/counselor/camper_care_requests.py
+++ b/backend/bunk_logs/api/counselor/camper_care_requests.py
@@ -1,0 +1,118 @@
+"""``POST /api/v1/counselor/camper-care-requests/`` — Story 7.
+
+Counselor-side submission for a Camper Care request. Idempotent on
+``(program, client_submission_id)`` so the offline queue can retry.
+"""
+
+from __future__ import annotations
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
+from rest_framework import status
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Order
+
+from .common import co_counselor_person_ids
+from .common import find_existing_by_client_submission_id
+from .common import invalidate_dashboard_for_viewers
+from .common import viewer_bunk_groups
+from .common import viewer_or_403
+from .responses import order_response
+from .serializers import CamperCareRequestCreateSerializer
+
+
+class CamperCareRequestCreateView(APIView):
+    """Counselor POST for a Camper Care request."""
+
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["post", "head", "options"]
+
+    def post(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer, org, today = ctx.person, ctx.organization, ctx.today
+
+        serializer = CamperCareRequestCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        payload = serializer.validated_data
+
+        primary_membership = (
+            Membership.objects.filter(person=viewer, is_active=True)
+            .select_related("program")
+            .order_by("-created_at")
+            .first()
+        )
+        if primary_membership is None or primary_membership.program is None:
+            msg = "No active program membership."
+            raise PermissionDenied(msg)
+        program = primary_membership.program
+
+        existing = find_existing_by_client_submission_id(
+            Order, program=program,
+            client_submission_id=payload["client_submission_id"],
+        )
+        if existing is not None:
+            return Response(order_response(existing), status=status.HTTP_200_OK)
+
+        # Subject is optional but if supplied must be a camper on one of
+        # the viewer's bunks (Story 7 criterion 2.i). Bunk-scoped requests
+        # without a subject are allowed for "the bunk in general" needs.
+        subject_id = payload.get("subject_id")
+        if subject_id is not None:
+            bunks = viewer_bunk_groups(viewer)
+            allowed_camper_ids = set(
+                AssignmentGroupMembership.all_objects.filter(
+                    group__in=bunks, role_in_group="subject", is_active=True,
+                ).values_list("person_id", flat=True),
+            )
+            if subject_id not in allowed_camper_ids:
+                raise PermissionDenied(
+                    {"subject_id": "Camper is not on any of your bunks."},
+                )
+
+        with transaction.atomic():
+            order = Order(
+                organization=org,
+                program=program,
+                subject_id=subject_id,
+                submitted_by=primary_membership,
+                item=payload["item"],
+                item_note=payload.get("item_note", ""),
+                description=payload.get("description", ""),
+                client_submission_id=payload["client_submission_id"],
+            )
+            try:
+                order.full_clean()
+            except DjangoValidationError as e:
+                return Response(
+                    e.message_dict if hasattr(e, "message_dict") else str(e),
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            order.save()
+
+        audit_module.created(
+            primary_membership,
+            order,
+            after_state={
+                "item": order.item,
+                "item_note": order.item_note,
+                "description": order.description,
+                "status": order.status,
+                "subject_id": order.subject_id,
+            },
+            content_type="order",
+        )
+
+        # Bust caches for viewer + all co-counselors so the dashboard's
+        # requests section reflects the new row within seconds.
+        bunks = viewer_bunk_groups(viewer)
+        co_ids = co_counselor_person_ids(viewer, bunks)
+        invalidate_dashboard_for_viewers(org, co_ids | {viewer.id}, today)
+
+        return Response(order_response(order), status=status.HTTP_201_CREATED)

--- a/backend/bunk_logs/api/counselor/camper_reflections.py
+++ b/backend/bunk_logs/api/counselor/camper_reflections.py
@@ -14,19 +14,38 @@ from __future__ import annotations
 
 from datetime import date as date_type
 
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
+from rest_framework import status
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import reflection_snapshot
+from bunk_logs.core.models import validate_reflection_answers
+from bunk_logs.core.translation import enqueue_translation_for_reflection
 
 from .common import bunk_camper_persons
 from .common import camper_reflection_template
+from .common import co_counselor_person_ids
+from .common import enforce_edit_window
+from .common import find_existing_by_client_submission_id
+from .common import invalidate_dashboard_for_viewers
 from .common import latest_camper_reflection_per_subject
 from .common import off_camp_camper_ids
 from .common import person_display_name
 from .common import viewer_bunk_groups
+from .common import viewer_can_edit_camper_reflection
 from .common import viewer_or_403
+from .responses import reflection_response
+from .serializers import CamperReflectionCreateSerializer
+from .serializers import CamperReflectionUpdateSerializer
 
 
 def _parse_iso_date(value: str | None, default: date_type) -> date_type | None:
@@ -167,3 +186,219 @@ class CamperReflectionListView(APIView):
             ),
             "bunks": bunks_payload,
         })
+
+    def post(self, request, *args, **kwargs):
+        """Submit a camper reflection (Story 3).
+
+        Idempotent on ``(program, client_submission_id)`` — duplicate POSTs
+        get the existing row back with HTTP 200 so the offline queue can
+        replay safely. New submissions return HTTP 201 with the full
+        reflection payload.
+        """
+        ctx = viewer_or_403(request)
+        viewer, org, today = ctx.person, ctx.organization, ctx.today
+
+        serializer = CamperReflectionCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        payload = serializer.validated_data
+
+        primary_membership = (
+            Membership.objects.filter(person=viewer, is_active=True)
+            .select_related("program")
+            .order_by("-created_at")
+            .first()
+        )
+        if primary_membership is None or primary_membership.program is None:
+            msg = "No active program membership."
+            raise PermissionDenied(msg)
+        program = primary_membership.program
+
+        existing = find_existing_by_client_submission_id(
+            Reflection, program=program,
+            client_submission_id=payload["client_submission_id"],
+        )
+        if existing is not None:
+            return Response(reflection_response(existing), status=status.HTTP_200_OK)
+
+        bunk = AssignmentGroup.all_objects.filter(
+            id=payload["assignment_group_id"],
+            organization=org,
+            group_type="bunk",
+            is_active=True,
+        ).first()
+        if bunk is None:
+            raise PermissionDenied({"assignment_group_id": "Bunk not found."})
+
+        # Story 3 criterion 1: viewer must be an active author on the bunk.
+        is_author = AssignmentGroupMembership.all_objects.filter(
+            group=bunk, person=viewer, role_in_group="author", is_active=True,
+        ).exists()
+        if not is_author:
+            msg = "You are not an author on this bunk."
+            raise PermissionDenied(msg)
+
+        # Story 3 criterion 2: subject must be an active camper in the bunk roster.
+        roster_camper_ids = set(
+            AssignmentGroupMembership.all_objects.filter(
+                group=bunk, role_in_group="subject", is_active=True,
+            ).values_list("person_id", flat=True),
+        )
+        if payload["subject_id"] not in roster_camper_ids:
+            raise PermissionDenied(
+                {"subject_id": "Camper is not on this bunk."},
+            )
+
+        # Story 3 criterion 8: off-camp campers can't have reflections submitted.
+        off_camp = off_camp_camper_ids(org, today, camper_ids=[payload["subject_id"]])
+        if payload["subject_id"] in off_camp:
+            raise PermissionDenied(
+                {"subject_id": "Camper is marked off-camp today."},
+            )
+
+        template = camper_reflection_template(org, program)
+        if template is None:
+            msg = "No camper-reflection template configured for this program."
+            raise PermissionDenied(msg)
+
+        try:
+            validate_reflection_answers(template.schema, payload["answers"])
+        except DjangoValidationError as e:
+            return Response(
+                e.message_dict if hasattr(e, "message_dict") else {"answers": str(e)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        with transaction.atomic():
+            reflection = Reflection(
+                organization=org,
+                program=program,
+                subject_id=payload["subject_id"],
+                author=viewer,
+                assignment_group=bunk,
+                template=template,
+                submitted_by=request.user,
+                period_start=today,
+                period_end=today,
+                answers=payload["answers"],
+                language=payload["language"],
+                team_visibility=payload["team_visibility"],
+                is_complete=True,
+                client_submission_id=payload["client_submission_id"],
+            )
+            try:
+                reflection.full_clean()
+            except DjangoValidationError as e:
+                return Response(
+                    e.message_dict if hasattr(e, "message_dict") else str(e),
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            reflection.save()
+
+        audit_module.created(
+            primary_membership,
+            reflection,
+            after_state=reflection_snapshot(reflection),
+            content_type="reflection",
+        )
+        enqueue_translation_for_reflection(reflection)
+        _invalidate_dashboards_for_bunk(org, viewer, bunk, today)
+
+        return Response(reflection_response(reflection), status=status.HTTP_201_CREATED)
+
+
+class CamperReflectionDetailView(APIView):
+    """PATCH for a single camper reflection (Story 4)."""
+
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["patch", "head", "options"]
+
+    def patch(self, request, reflection_id: int, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer, org, today = ctx.person, ctx.organization, ctx.today
+
+        reflection = Reflection.all_objects.filter(
+            id=reflection_id, organization=org,
+        ).select_related("template", "assignment_group", "program").first()
+        if reflection is None:
+            return Response(
+                {"detail": "Reflection not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        # Story 4 criterion 2: any current bunk author may edit (not just
+        # the original author). The audit row records who actually edited.
+        if not viewer_can_edit_camper_reflection(viewer, reflection):
+            msg = "You are not an author on this reflection's bunk."
+            raise PermissionDenied(msg)
+        enforce_edit_window(reflection, org)
+
+        serializer = CamperReflectionUpdateSerializer(data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        payload = serializer.validated_data
+
+        before = reflection_snapshot(reflection)
+
+        answers = payload.get("answers", reflection.answers)
+        language = payload.get("language", reflection.language)
+        team_visibility = payload.get("team_visibility", reflection.team_visibility)
+
+        if "answers" in payload:
+            try:
+                validate_reflection_answers(reflection.template.schema, answers)
+            except DjangoValidationError as e:
+                return Response(
+                    e.message_dict if hasattr(e, "message_dict") else {"answers": str(e)},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+        reflection.answers = answers
+        reflection.language = language
+        reflection.team_visibility = team_visibility
+
+        try:
+            reflection.full_clean()
+        except DjangoValidationError as e:
+            return Response(
+                e.message_dict if hasattr(e, "message_dict") else str(e),
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        reflection.save()
+        after = reflection_snapshot(reflection)
+
+        if before != after:
+            actor_membership = (
+                Membership.objects.filter(
+                    person=viewer, program=reflection.program, is_active=True,
+                )
+                .order_by("-created_at")
+                .first()
+            )
+            audit_module.edited(
+                actor_membership or request.user,
+                reflection,
+                before,
+                after,
+                content_type="reflection",
+            )
+        if (
+            before.get("answers") != after.get("answers")
+            or before.get("language") != after.get("language")
+        ):
+            enqueue_translation_for_reflection(reflection)
+        if reflection.assignment_group_id:
+            _invalidate_dashboards_for_bunk(
+                org, viewer, reflection.assignment_group, today,
+            )
+
+        return Response(reflection_response(reflection), status=status.HTTP_200_OK)
+
+
+def _invalidate_dashboards_for_bunk(org, viewer, bunk, today):
+    """Bust the dashboard cache for viewer + all co-counselors on this bunk.
+
+    Used by camper-reflection writes so a counselor's submission shows up on
+    their bunkmate's dashboard within seconds rather than after the 30s TTL
+    expires (Story 2 criterion 5).
+    """
+    co_ids = co_counselor_person_ids(viewer, [bunk])
+    invalidate_dashboard_for_viewers(org, co_ids | {viewer.id}, today)

--- a/backend/bunk_logs/api/counselor/common.py
+++ b/backend/bunk_logs/api/counselor/common.py
@@ -14,6 +14,7 @@ from datetime import date  # noqa: TC003 - used in dataclass field type
 from datetime import datetime  # noqa: TC003 - used in keyword-only arg default annotation
 from typing import TYPE_CHECKING
 
+from django.core.cache import cache
 from django.db.models import Case
 from django.db.models import IntegerField
 from django.db.models import Q
@@ -317,6 +318,98 @@ def latest_self_reflection(
         .order_by("-submitted_at")
         .first()
     )
+
+
+def enforce_edit_window(
+    reflection: Reflection,
+    organization: Organization,
+    *,
+    now: datetime | None = None,
+) -> None:
+    """Raise ``PermissionDenied`` if the reflection is outside today's edit window.
+
+    Companion to ``is_editable_today`` for write endpoints. Stories 4 & 6:
+    edits allowed iff the reflection's period still includes "today" (rollover
+    aware). The bool helper lights up the Edit affordance on the read side;
+    this helper enforces it on the write side.
+    """
+    if is_editable_today(reflection, organization, now=now):
+        return
+    msg = "This reflection can no longer be edited (the edit window has closed)."
+    raise PermissionDenied(msg)
+
+
+def viewer_can_edit_camper_reflection(
+    viewer: Person,
+    reflection: Reflection,
+) -> bool:
+    """Story 4 criterion 2: any active bunk author may edit today's submissions.
+
+    Not just the original author — the second counselor on the same bunk also
+    has Edit. Permission is gated on current author-membership of the
+    reflection's ``assignment_group``; the viewer does not need to have been
+    an author when the row was created.
+    """
+    if reflection.assignment_group_id is None:
+        return False
+    return AssignmentGroupMembership.objects.filter(
+        group_id=reflection.assignment_group_id,
+        person=viewer,
+        role_in_group="author",
+        is_active=True,
+    ).exists()
+
+
+def dashboard_cache_key(viewer_id: int, organization_id: int, today: date) -> str:
+    """Canonical key for the counselor dashboard cache.
+
+    Single source of truth so write paths can target the same keys the
+    dashboard view writes. Format mirrors the prior inline key in
+    ``dashboard.py``; the prefix exists so future flush hooks can wildcard
+    on ``counselor_dashboard:`` if we add a cache backend that supports it.
+    """
+    return f"counselor_dashboard:{organization_id}:{viewer_id}:{today.isoformat()}"
+
+
+def invalidate_dashboard_for_viewers(
+    organization: Organization,
+    viewer_ids: list[int] | set[int],
+    today: date,
+) -> None:
+    """Delete dashboard cache entries for the given viewers on ``today``.
+
+    Write endpoints call this after a successful create/update so the
+    affected counselor (and any co-counselors whose all-set state changed)
+    see fresh data within seconds. Deliberately limited to "today" — past
+    cache entries are TTL-expired well before being meaningful.
+    """
+    if not viewer_ids:
+        return
+    keys = [dashboard_cache_key(vid, organization.id, today) for vid in viewer_ids]
+    cache.delete_many(keys)
+
+
+def find_existing_by_client_submission_id(
+    manager,
+    *,
+    program,
+    client_submission_id,
+):
+    """Idempotent replay lookup for write endpoints.
+
+    Returns the existing row if ``(program, client_submission_id)`` already
+    has one, else ``None``. Callers should serialize the existing row with
+    HTTP 200 (not 201) per the 7_6 spec contract — clients retrying a flaky
+    POST get the same canonical record back instead of duplicate writes.
+
+    Uses ``all_objects`` so soft-deleted rows still match and block silent
+    duplicate creation; if you need to handle resurrection that's a separate
+    contract.
+    """
+    if not client_submission_id or program is None:
+        return None
+    base = getattr(manager, "all_objects", manager)
+    return base.filter(program=program, client_submission_id=client_submission_id).first()
 
 
 def person_display_name(person: Person | None) -> str:

--- a/backend/bunk_logs/api/counselor/dashboard.py
+++ b/backend/bunk_logs/api/counselor/dashboard.py
@@ -24,7 +24,6 @@ cache; write endpoints in 7_6c will bump the per-viewer version key.
 
 from __future__ import annotations
 
-import hashlib
 from datetime import date as date_type  # noqa: TC003 - used in helper type hints
 
 from django.core.cache import cache
@@ -45,6 +44,7 @@ from .common import bunk_camper_persons
 from .common import camper_reflection_template
 from .common import co_counselor_person_ids
 from .common import counselor_self_template
+from .common import dashboard_cache_key as _cache_key
 from .common import is_day_off_answer
 from .common import latest_camper_reflection_per_subject
 from .common import latest_self_reflection
@@ -64,11 +64,6 @@ def _section_state(*, covered: int, total: int) -> str:
     if covered >= total:
         return "complete"
     return "in_progress"
-
-
-def _cache_key(viewer_id: int, organization_id: int, today: date_type) -> str:
-    raw = f"counselor_dashboard:{organization_id}:{viewer_id}:{today.isoformat()}"
-    return hashlib.sha256(raw.encode()).hexdigest()[:48]
 
 
 class CounselorDashboardView(APIView):

--- a/backend/bunk_logs/api/counselor/maintenance_tickets.py
+++ b/backend/bunk_logs/api/counselor/maintenance_tickets.py
@@ -1,0 +1,196 @@
+"""Counselor maintenance ticket write endpoints (Story 8).
+
+- ``POST /api/v1/counselor/maintenance-tickets/`` — create a ticket, optionally
+  with photos attached via multipart ``photos`` fields.
+- ``POST /api/v1/counselor/maintenance-tickets/<uuid>/photos/`` — add follow-up
+  photos to a ticket the viewer submitted (decision C5).
+
+Photos are stored via the configured ``DEFAULT_FILE_STORAGE`` backend: S3 in
+production (with presigned URLs) and the local filesystem in dev / tests.
+"""
+
+from __future__ import annotations
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
+from rest_framework import status
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.parsers import FormParser
+from rest_framework.parsers import JSONParser
+from rest_framework.parsers import MultiPartParser
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import TicketPhoto
+
+from .common import co_counselor_person_ids
+from .common import find_existing_by_client_submission_id
+from .common import invalidate_dashboard_for_viewers
+from .common import viewer_bunk_groups
+from .common import viewer_or_403
+from .responses import maintenance_ticket_response
+from .responses import ticket_photo_response
+from .serializers import MaintenanceTicketCreateSerializer
+from .serializers import MaintenanceTicketPhotoUploadSerializer
+
+
+def _ticket_after_state(ticket: MaintenanceTicket) -> dict:
+    return {
+        "location": ticket.location,
+        "category": ticket.category,
+        "description": ticket.description,
+        "urgency": ticket.urgency,
+        "urgent_reason": ticket.urgent_reason,
+        "status": ticket.status,
+    }
+
+
+class MaintenanceTicketCreateView(APIView):
+    """Counselor POST for a new maintenance ticket."""
+
+    permission_classes = [IsAuthenticated]
+    parser_classes = [MultiPartParser, FormParser, JSONParser]
+    http_method_names = ["post", "head", "options"]
+
+    def post(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer, org, today = ctx.person, ctx.organization, ctx.today
+
+        serializer = MaintenanceTicketCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        payload = serializer.validated_data
+
+        # Pull photos straight off ``request.FILES`` rather than through the
+        # serializer; ListField + multipart don't compose (see the serializer
+        # docstring). Validation happens via per-photo ImageField below.
+        photos = []
+        if hasattr(request.FILES, "getlist"):
+            photos = request.FILES.getlist("photos")
+        if photos:
+            photo_validator = MaintenanceTicketPhotoUploadSerializer
+            for f in photos:
+                p_ser = photo_validator(data={"image": f})
+                p_ser.is_valid(raise_exception=True)
+
+        primary_membership = (
+            Membership.objects.filter(person=viewer, is_active=True)
+            .select_related("program")
+            .order_by("-created_at")
+            .first()
+        )
+        if primary_membership is None or primary_membership.program is None:
+            msg = "No active program membership."
+            raise PermissionDenied(msg)
+        program = primary_membership.program
+
+        existing = find_existing_by_client_submission_id(
+            MaintenanceTicket, program=program,
+            client_submission_id=payload["client_submission_id"],
+        )
+        if existing is not None:
+            return Response(
+                maintenance_ticket_response(existing), status=status.HTTP_200_OK,
+            )
+
+        with transaction.atomic():
+            ticket = MaintenanceTicket(
+                organization=org,
+                program=program,
+                submitted_by=primary_membership,
+                location=payload["location"],
+                category=payload["category"],
+                description=payload.get("description", ""),
+                urgency=payload["urgency"],
+                urgent_reason=payload.get("urgent_reason", ""),
+                client_submission_id=payload["client_submission_id"],
+            )
+            try:
+                ticket.full_clean()
+            except DjangoValidationError as e:
+                return Response(
+                    e.message_dict if hasattr(e, "message_dict") else str(e),
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            ticket.save()
+
+            for image in photos:
+                TicketPhoto.objects.create(
+                    ticket=ticket,
+                    image=image,
+                    uploaded_by=primary_membership,
+                    is_followup=False,
+                )
+
+        audit_module.created(
+            primary_membership,
+            ticket,
+            after_state=_ticket_after_state(ticket),
+            content_type="maintenance_ticket",
+        )
+
+        bunks = viewer_bunk_groups(viewer)
+        co_ids = co_counselor_person_ids(viewer, bunks)
+        invalidate_dashboard_for_viewers(org, co_ids | {viewer.id}, today)
+
+        return Response(
+            maintenance_ticket_response(ticket), status=status.HTTP_201_CREATED,
+        )
+
+
+class MaintenanceTicketPhotoCreateView(APIView):
+    """POST a follow-up photo to an existing ticket (decision C5)."""
+
+    permission_classes = [IsAuthenticated]
+    parser_classes = [MultiPartParser, FormParser]
+    http_method_names = ["post", "head", "options"]
+
+    def post(self, request, ticket_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer, org = ctx.person, ctx.organization
+
+        ticket = (
+            MaintenanceTicket.all_objects.filter(id=ticket_id, organization=org)
+            .select_related("submitted_by")
+            .first()
+        )
+        if ticket is None:
+            return Response(
+                {"detail": "Ticket not found."}, status=status.HTTP_404_NOT_FOUND,
+            )
+
+        # Counselors may only add follow-ups to tickets THEY submitted
+        # (decision C5). Cross-counselor follow-ups are out of scope until
+        # bunk-team co-ownership is decided.
+        viewer_membership_ids = set(
+            Membership.objects.filter(person=viewer, is_active=True)
+            .values_list("id", flat=True),
+        )
+        if ticket.submitted_by_id not in viewer_membership_ids:
+            msg = "You can only add photos to tickets you submitted."
+            raise PermissionDenied(msg)
+
+        serializer = MaintenanceTicketPhotoUploadSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        payload = serializer.validated_data
+
+        uploader_membership = (
+            Membership.objects.filter(person=viewer, is_active=True)
+            .order_by("-created_at")
+            .first()
+        )
+
+        photo = TicketPhoto.objects.create(
+            ticket=ticket,
+            image=payload["image"],
+            caption=payload.get("caption", ""),
+            uploaded_by=uploader_membership,
+            is_followup=True,
+        )
+
+        return Response(
+            ticket_photo_response(photo), status=status.HTTP_201_CREATED,
+        )

--- a/backend/bunk_logs/api/counselor/responses.py
+++ b/backend/bunk_logs/api/counselor/responses.py
@@ -1,0 +1,118 @@
+"""Shared response shapers for counselor write endpoints.
+
+Consolidated so create / patch responses across all four resources agree on
+the same camper, ticket, and reflection payloads — and so the list endpoints
+(7_6b) and write endpoints (7_6c) can converge over time.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bunk_logs.core.content_visibility import audience_labels
+from bunk_logs.core.content_visibility import reflection_content_type
+from bunk_logs.core.content_visibility import reflection_is_private
+
+if TYPE_CHECKING:
+    from bunk_logs.core.models import MaintenanceTicket
+    from bunk_logs.core.models import Order
+    from bunk_logs.core.models import Reflection
+    from bunk_logs.core.models import TicketPhoto
+
+
+def reflection_response(reflection: Reflection) -> dict:
+    """Counselor-facing reflection payload.
+
+    Includes ``audience`` so the client can render the AudienceDisclosure
+    component without a separate call (Step 7_6 item 11). Computed server-side
+    because the role -> label mapping is i18n-managed in core.
+    """
+    audience = audience_labels(
+        reflection_content_type(reflection),
+        is_sensitive=bool(reflection.is_sensitive),
+        is_private=reflection_is_private(reflection),
+    )
+    return {
+        "id": reflection.id,
+        "subject_id": reflection.subject_id,
+        "author_id": reflection.author_id,
+        "assignment_group_id": reflection.assignment_group_id,
+        "template": {
+            "id": reflection.template_id,
+            "slug": reflection.template.slug if reflection.template_id else None,
+            "version": reflection.template.version if reflection.template_id else None,
+        },
+        "client_submission_id": (
+            str(reflection.client_submission_id)
+            if reflection.client_submission_id
+            else None
+        ),
+        "answers": reflection.answers,
+        "language": reflection.language,
+        "team_visibility": reflection.team_visibility,
+        "is_complete": reflection.is_complete,
+        "period_start": reflection.period_start.isoformat(),
+        "period_end": reflection.period_end.isoformat(),
+        "submitted_at": (
+            reflection.submitted_at.isoformat() if reflection.submitted_at else None
+        ),
+        "updated_at": (
+            reflection.updated_at.isoformat() if reflection.updated_at else None
+        ),
+        "audience": audience,
+    }
+
+
+def order_response(order: Order) -> dict:
+    """Counselor-facing camper-care request payload."""
+    return {
+        "id": str(order.id),
+        "status": order.status,
+        "subject_id": order.subject_id,
+        "submitted_by_id": order.submitted_by_id,
+        "item": order.item,
+        "item_note": order.item_note,
+        "description": order.description,
+        "client_submission_id": (
+            str(order.client_submission_id) if order.client_submission_id else None
+        ),
+        "created_at": order.created_at.isoformat() if order.created_at else None,
+        "updated_at": order.updated_at.isoformat() if order.updated_at else None,
+    }
+
+
+def ticket_photo_response(photo: TicketPhoto) -> dict:
+    """Maintenance ticket photo payload.
+
+    The ``image`` URL is whatever the configured storage backend returns —
+    a presigned S3 URL in production (``AWS_QUERYSTRING_AUTH=True``) and a
+    local ``/media/`` path in dev / tests.
+    """
+    return {
+        "id": str(photo.id),
+        "image_url": photo.image.url if photo.image else None,
+        "caption": photo.caption,
+        "is_followup": photo.is_followup,
+        "created_at": photo.created_at.isoformat() if photo.created_at else None,
+    }
+
+
+def maintenance_ticket_response(ticket: MaintenanceTicket) -> dict:
+    """Counselor-facing maintenance ticket payload (including photos)."""
+    photos = [ticket_photo_response(p) for p in ticket.photos.all()]
+    return {
+        "id": str(ticket.id),
+        "status": ticket.status,
+        "location": ticket.location,
+        "category": ticket.category,
+        "description": ticket.description,
+        "urgency": ticket.urgency,
+        "urgent_reason": ticket.urgent_reason,
+        "submitted_by_id": ticket.submitted_by_id,
+        "client_submission_id": (
+            str(ticket.client_submission_id) if ticket.client_submission_id else None
+        ),
+        "photos": photos,
+        "created_at": ticket.created_at.isoformat() if ticket.created_at else None,
+        "updated_at": ticket.updated_at.isoformat() if ticket.updated_at else None,
+    }

--- a/backend/bunk_logs/api/counselor/self_reflection.py
+++ b/backend/bunk_logs/api/counselor/self_reflection.py
@@ -13,17 +13,31 @@ from __future__ import annotations
 from datetime import date as date_type
 from datetime import timedelta
 
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
+from rest_framework import status
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from bunk_logs.core import audit as audit_module
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import reflection_snapshot
+from bunk_logs.core.models import validate_reflection_answers
+from bunk_logs.core.translation import enqueue_translation_for_reflection
 
 from .common import counselor_self_template
+from .common import enforce_edit_window
+from .common import find_existing_by_client_submission_id
+from .common import invalidate_dashboard_for_viewers
 from .common import is_day_off_answer
 from .common import viewer_or_403
+from .responses import reflection_response
+from .serializers import SelfReflectionCreateSerializer
+from .serializers import SelfReflectionUpdateSerializer
 
 
 class SelfReflectionHistoryPagination(PageNumberPagination):
@@ -150,3 +164,195 @@ class SelfReflectionHistoryView(APIView):
             "page_size": page_size,
             "results": results,
         })
+
+
+def _day_off_answers() -> dict:
+    """Canonical "day off" answer payload (Story 5 criterion 3)."""
+    return {"day_off": True}
+
+
+def _resolve_self_program_and_template(viewer, org):
+    primary_membership = (
+        Membership.objects.filter(person=viewer, is_active=True)
+        .select_related("program")
+        .order_by("-created_at")
+        .first()
+    )
+    if primary_membership is None or primary_membership.program is None:
+        msg = "No active program membership."
+        raise PermissionDenied(msg)
+    program = primary_membership.program
+    template = counselor_self_template(viewer, org, program)
+    if template is None:
+        msg = "No counselor self-reflection template configured."
+        raise PermissionDenied(msg)
+    return primary_membership, program, template
+
+
+class SelfReflectionCreateView(APIView):
+    """POST a counselor self-reflection for today (Story 5)."""
+
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["post", "head", "options"]
+
+    def post(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer, org, today = ctx.person, ctx.organization, ctx.today
+
+        serializer = SelfReflectionCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        payload = serializer.validated_data
+
+        membership, program, template = _resolve_self_program_and_template(viewer, org)
+
+        existing = find_existing_by_client_submission_id(
+            Reflection, program=program,
+            client_submission_id=payload["client_submission_id"],
+        )
+        if existing is not None:
+            return Response(reflection_response(existing), status=status.HTTP_200_OK)
+
+        # ``day_off`` is the documented shortcut: minimal payload, marked
+        # complete, no further validation of the rest of the schema.
+        if payload["day_off"]:
+            answers = _day_off_answers()
+        else:
+            answers = payload.get("answers") or {}
+            try:
+                validate_reflection_answers(template.schema, answers)
+            except DjangoValidationError as e:
+                return Response(
+                    e.message_dict if hasattr(e, "message_dict") else {"answers": str(e)},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+        with transaction.atomic():
+            reflection = Reflection(
+                organization=org,
+                program=program,
+                subject=viewer,
+                author=viewer,
+                assignment_group=None,
+                template=template,
+                submitted_by=request.user,
+                period_start=today,
+                period_end=today,
+                answers=answers,
+                language=payload["language"],
+                team_visibility=Reflection.TeamVisibility.TEAM,
+                is_complete=True,
+                client_submission_id=payload["client_submission_id"],
+            )
+            try:
+                reflection.full_clean()
+            except DjangoValidationError as e:
+                return Response(
+                    e.message_dict if hasattr(e, "message_dict") else str(e),
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            reflection.save()
+
+        audit_module.created(
+            membership,
+            reflection,
+            after_state=reflection_snapshot(reflection),
+            content_type="reflection",
+        )
+        if not payload["day_off"]:
+            enqueue_translation_for_reflection(reflection)
+        invalidate_dashboard_for_viewers(org, {viewer.id}, today)
+
+        return Response(reflection_response(reflection), status=status.HTTP_201_CREATED)
+
+
+class SelfReflectionDetailView(APIView):
+    """PATCH a self-reflection within today's edit window (Story 6)."""
+
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["patch", "head", "options"]
+
+    def patch(self, request, reflection_id: int, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer, org, today = ctx.person, ctx.organization, ctx.today
+
+        reflection = (
+            Reflection.all_objects.filter(id=reflection_id, organization=org)
+            .select_related("template", "program")
+            .first()
+        )
+        if reflection is None:
+            return Response(
+                {"detail": "Reflection not found."}, status=status.HTTP_404_NOT_FOUND,
+            )
+        if reflection.author_id != viewer.id or reflection.subject_id != viewer.id:
+            msg = "You can only edit your own self-reflection."
+            raise PermissionDenied(msg)
+        enforce_edit_window(reflection, org)
+
+        serializer = SelfReflectionUpdateSerializer(data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        payload = serializer.validated_data
+
+        before = reflection_snapshot(reflection)
+
+        if "day_off" in payload:
+            if payload["day_off"]:
+                answers = _day_off_answers()
+            else:
+                answers = payload.get("answers") or reflection.answers or {}
+                try:
+                    validate_reflection_answers(reflection.template.schema, answers)
+                except DjangoValidationError as e:
+                    return Response(
+                        e.message_dict if hasattr(e, "message_dict") else {"answers": str(e)},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+        elif "answers" in payload:
+            answers = payload["answers"]
+            try:
+                validate_reflection_answers(reflection.template.schema, answers)
+            except DjangoValidationError as e:
+                return Response(
+                    e.message_dict if hasattr(e, "message_dict") else {"answers": str(e)},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+        else:
+            answers = reflection.answers
+
+        language = payload.get("language", reflection.language)
+
+        reflection.answers = answers
+        reflection.language = language
+        try:
+            reflection.full_clean()
+        except DjangoValidationError as e:
+            return Response(
+                e.message_dict if hasattr(e, "message_dict") else str(e),
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        reflection.save()
+        after = reflection_snapshot(reflection)
+
+        if before != after:
+            actor_membership = (
+                Membership.objects.filter(
+                    person=viewer, program=reflection.program, is_active=True,
+                )
+                .order_by("-created_at")
+                .first()
+            )
+            audit_module.edited(
+                actor_membership or request.user,
+                reflection,
+                before,
+                after,
+                content_type="reflection",
+            )
+        if (
+            before.get("answers") != after.get("answers")
+            or before.get("language") != after.get("language")
+        ) and not is_day_off_answer(reflection):
+            enqueue_translation_for_reflection(reflection)
+        invalidate_dashboard_for_viewers(org, {viewer.id}, today)
+
+        return Response(reflection_response(reflection), status=status.HTTP_200_OK)

--- a/backend/bunk_logs/api/counselor/serializers.py
+++ b/backend/bunk_logs/api/counselor/serializers.py
@@ -1,0 +1,184 @@
+"""Write-side serializers for the counselor flow (Step 7_6c).
+
+Each serializer here is intentionally a flat ``serializers.Serializer`` (not
+``ModelSerializer``) so the views can hand-shape the create / update logic
+without the field locking that ``ReflectionSerializer`` ships for the
+admin-facing path. The views own: subject + bunk authorization, template
+resolution, idempotency, audit emission, and cache invalidation. These
+serializers own: field types, required-ness, and per-field shape validation.
+
+Response shaping lives in :mod:`bunk_logs.api.counselor.responses` so list
+endpoints, create responses, and patch responses agree on the same camper /
+counselor / template payload.
+"""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Reflection
+
+# ---------------------------------------------------------------------------
+# Reflections
+# ---------------------------------------------------------------------------
+
+
+class CamperReflectionCreateSerializer(serializers.Serializer):
+    """Counselor POST body for a single camper reflection.
+
+    The bunk is provided as ``assignment_group_id`` (canonical) with
+    ``bunk_id`` accepted as an alias to match the client form schema. The
+    template is **not** client-supplied — the view resolves it via
+    ``camper_reflection_template`` so a misconfigured client can't submit
+    against the wrong schema.
+    """
+
+    subject_id = serializers.IntegerField()
+    assignment_group_id = serializers.IntegerField(required=False)
+    bunk_id = serializers.IntegerField(required=False, write_only=True)
+    answers = serializers.JSONField()
+    language = serializers.CharField(max_length=10, default="en")
+    team_visibility = serializers.ChoiceField(
+        choices=Reflection.TeamVisibility.choices,
+        default=Reflection.TeamVisibility.TEAM,
+    )
+    client_submission_id = serializers.UUIDField()
+
+    def validate(self, attrs):
+        ag = attrs.get("assignment_group_id") or attrs.get("bunk_id")
+        if not ag:
+            msg = "assignment_group_id (or bunk_id) is required."
+            raise serializers.ValidationError({"assignment_group_id": msg})
+        attrs["assignment_group_id"] = ag
+        attrs.pop("bunk_id", None)
+        return attrs
+
+
+class CamperReflectionUpdateSerializer(serializers.Serializer):
+    """Counselor PATCH body for an existing camper reflection.
+
+    Only the mutable fields are editable; ``subject``, ``assignment_group``,
+    ``template``, and ``period_*`` are locked once the row exists. ``answers``
+    and ``language`` are independently optional so a counselor can fix a
+    typo without re-sending the entire payload.
+    """
+
+    answers = serializers.JSONField(required=False)
+    language = serializers.CharField(max_length=10, required=False)
+    team_visibility = serializers.ChoiceField(
+        choices=Reflection.TeamVisibility.choices,
+        required=False,
+    )
+
+    def validate(self, attrs):
+        if not attrs:
+            msg = "At least one field must be provided."
+            raise serializers.ValidationError(msg)
+        return attrs
+
+
+class SelfReflectionCreateSerializer(serializers.Serializer):
+    """Counselor POST body for daily self-reflection.
+
+    ``day_off`` is a UX shortcut: when true the view fills ``answers`` with
+    ``{"day_off": true}`` regardless of what the client sends, so the offline
+    queue doesn't need to know the full schema to record a day off. When
+    false the client is responsible for sending a complete ``answers`` payload
+    that satisfies the seeded counselor self-reflection schema.
+    """
+
+    answers = serializers.JSONField(required=False)
+    day_off = serializers.BooleanField(default=False)
+    language = serializers.CharField(max_length=10, default="en")
+    client_submission_id = serializers.UUIDField()
+
+    def validate(self, attrs):
+        if not attrs.get("day_off") and not attrs.get("answers"):
+            msg = "answers is required unless day_off is true."
+            raise serializers.ValidationError({"answers": msg})
+        return attrs
+
+
+class SelfReflectionUpdateSerializer(serializers.Serializer):
+    """Counselor PATCH body for self-reflection within the edit window."""
+
+    answers = serializers.JSONField(required=False)
+    day_off = serializers.BooleanField(required=False)
+    language = serializers.CharField(max_length=10, required=False)
+
+    def validate(self, attrs):
+        if not attrs:
+            msg = "At least one field must be provided."
+            raise serializers.ValidationError(msg)
+        return attrs
+
+
+# ---------------------------------------------------------------------------
+# Camper-care requests (Order)
+# ---------------------------------------------------------------------------
+
+
+class CamperCareRequestCreateSerializer(serializers.Serializer):
+    """Counselor POST body for a Camper Care request (Story 7).
+
+    ``item`` is free-text but the client surfaces an autocomplete from
+    :class:`OrderItemSuggestion`. We store the literal label so admin edits
+    to the suggestion list don't rewrite history. ``subject_id`` is the
+    target camper Person; null when the request is bunk-scoped (rare).
+    """
+
+    subject_id = serializers.IntegerField(required=False, allow_null=True)
+    item = serializers.CharField(max_length=120)
+    item_note = serializers.CharField(
+        required=False, allow_blank=True, default="",
+    )
+    description = serializers.CharField(
+        required=False, allow_blank=True, default="",
+    )
+    client_submission_id = serializers.UUIDField()
+
+
+# ---------------------------------------------------------------------------
+# Maintenance tickets
+# ---------------------------------------------------------------------------
+
+
+class MaintenanceTicketCreateSerializer(serializers.Serializer):
+    """Counselor POST body for a Maintenance ticket (Story 8).
+
+    Photos are NOT validated here — multipart QueryDict + DRF's ListField
+    don't compose cleanly (the field collapses repeated keys to a single
+    value), so the view reaches into ``request.FILES`` directly to collect
+    the upload list and validate each item individually. ``urgent_reason``
+    is enforced by ``MaintenanceTicket.clean()`` when urgency = ``urgent``.
+    """
+
+    location = serializers.CharField(max_length=255)
+    category = serializers.ChoiceField(
+        choices=MaintenanceTicket.Category.choices,
+    )
+    description = serializers.CharField(allow_blank=True, default="")
+    urgency = serializers.ChoiceField(
+        choices=MaintenanceTicket.Urgency.choices,
+        default=MaintenanceTicket.Urgency.NORMAL,
+    )
+    urgent_reason = serializers.CharField(
+        required=False, allow_blank=True, default="",
+    )
+    client_submission_id = serializers.UUIDField()
+
+
+class MaintenanceTicketPhotoUploadSerializer(serializers.Serializer):
+    """Follow-up photo upload (decision C5).
+
+    Counselors can add additional photos to their own open tickets after the
+    initial submission. The view marks these with ``is_followup=True`` so
+    the maintenance team UI can render them in chronological context under
+    the original submission.
+    """
+
+    image = serializers.ImageField()
+    caption = serializers.CharField(
+        max_length=255, required=False, allow_blank=True, default="",
+    )

--- a/backend/bunk_logs/api/tests/test_counselor_camper_care_writes.py
+++ b/backend/bunk_logs/api/tests/test_counselor_camper_care_writes.py
@@ -1,0 +1,193 @@
+"""Tests for ``POST /api/v1/counselor/camper-care-requests/`` (Story 7)."""
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import AuditEvent
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Order
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+
+User = get_user_model()
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="CC Camp", slug="cc-camp")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org, name="CC Camp Summer 2026", slug="cc-summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1), end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def counselor_user():
+    return User.objects.create_user(email="c@cc.test", password="pw")
+
+
+@pytest.fixture
+def counselor_person(org, counselor_user):
+    return Person.all_objects.create(
+        organization=org, first_name="Lee", last_name="A", user=counselor_user,
+    )
+
+
+@pytest.fixture
+def counselor_membership(program, counselor_person):
+    return Membership.all_objects.create(
+        program=program, person=counselor_person, role="counselor", is_active=True,
+    )
+
+
+@pytest.fixture
+def bunk(org, program):
+    return AssignmentGroup.objects.create(
+        organization=org, program=program, name="Bunk Pine",
+        slug="bunk-pine-cc", group_type="bunk", is_active=True,
+    )
+
+
+@pytest.fixture
+def counselor_as_author(bunk, counselor_person):
+    return AssignmentGroupMembership.objects.create(
+        group=bunk, person=counselor_person, role_in_group="author", is_active=True,
+    )
+
+
+@pytest.fixture
+def camper(org, bunk):
+    p = Person.all_objects.create(organization=org, first_name="Avi", last_name="L")
+    AssignmentGroupMembership.objects.create(
+        group=bunk, person=p, role_in_group="subject", is_active=True,
+    )
+    return p
+
+
+def _client(user, org):
+    c = APIClient()
+    c.force_authenticate(user=user)
+    c.credentials(HTTP_X_ORGANIZATION_SLUG=org.slug)
+    return c
+
+
+@pytest.mark.django_db
+def test_create_camper_care_request_201(
+    org, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author, camper,
+):
+    c = _client(counselor_user, org)
+    payload = {
+        "subject_id": camper.id,
+        "item": "Toothbrush",
+        "item_note": "purple please",
+        "client_submission_id": str(uuid.uuid4()),
+    }
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/counselor/camper-care-requests/", payload, format="json",
+        )
+    assert resp.status_code == 201, resp.data
+    assert resp.data["item"] == "Toothbrush"
+    order = Order.all_objects.get(id=resp.data["id"])
+    assert order.subject == camper
+    assert order.submitted_by == counselor_membership
+    assert order.status == "new"
+
+
+@pytest.mark.django_db
+def test_camper_care_request_idempotent(
+    org, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author, camper,
+):
+    c = _client(counselor_user, org)
+    csid = str(uuid.uuid4())
+    payload = {
+        "subject_id": camper.id, "item": "Toothpaste",
+        "client_submission_id": csid,
+    }
+    with organization_context(org):
+        first = c.post(
+            "/api/v1/counselor/camper-care-requests/", payload, format="json",
+        )
+        second = c.post(
+            "/api/v1/counselor/camper-care-requests/", payload, format="json",
+        )
+    assert first.status_code == 201
+    assert second.status_code == 200
+    assert first.data["id"] == second.data["id"]
+    assert Order.all_objects.filter(client_submission_id=csid).count() == 1
+
+
+@pytest.mark.django_db
+def test_camper_care_emits_audit(
+    org, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author, camper,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        c.post(
+            "/api/v1/counselor/camper-care-requests/",
+            {"subject_id": camper.id, "item": "Sunscreen",
+             "client_submission_id": str(uuid.uuid4())}, format="json",
+        )
+    assert AuditEvent.all_objects.filter(
+        event_type=AuditEvent.EventType.CREATED, content_type="order",
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_camper_care_subject_must_be_on_viewer_bunk(
+    org, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author,
+):
+    other_camper = Person.all_objects.create(
+        organization=org, first_name="Off", last_name="Roster",
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/counselor/camper-care-requests/",
+            {"subject_id": other_camper.id, "item": "X",
+             "client_submission_id": str(uuid.uuid4())}, format="json",
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_camper_care_no_subject_allowed(
+    org, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author,
+):
+    """Bunk-scoped requests (no subject) are allowed for general bunk needs."""
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/counselor/camper-care-requests/",
+            {"item": "Bug spray", "item_note": "Whole bunk",
+             "client_submission_id": str(uuid.uuid4())}, format="json",
+        )
+    assert resp.status_code == 201, resp.data
+    assert resp.data["subject_id"] is None

--- a/backend/bunk_logs/api/tests/test_counselor_camper_reflection_writes.py
+++ b/backend/bunk_logs/api/tests/test_counselor_camper_reflection_writes.py
@@ -1,0 +1,413 @@
+"""Tests for counselor camper reflection write endpoints (Step 7_6c).
+
+Covers ``POST /api/v1/counselor/camper-reflections/`` and
+``PATCH /api/v1/counselor/camper-reflections/<id>/`` against Story 3 + 4
+acceptance criteria: idempotency, off-camp gating, cross-counselor edit
+permission, audit emission, edit window enforcement.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import AuditEvent
+from bunk_logs.core.models import CamperDayState
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+
+User = get_user_model()
+
+CAMPER_SCHEMA = {
+    "fields": [
+        {"key": "note", "type": "textarea", "required": False, "prompts": {"en": "Notes"}},
+    ],
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="CW Camp", slug="cw-camp")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="CW Camp Summer 2026",
+        slug="cw-summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def counselor_user():
+    return User.objects.create_user(email="counselor@cw.test", password="pw")
+
+
+@pytest.fixture
+def counselor_person(org, counselor_user):
+    return Person.all_objects.create(
+        organization=org, first_name="Mira", last_name="Silver", user=counselor_user,
+    )
+
+
+@pytest.fixture
+def counselor_membership(program, counselor_person):
+    return Membership.all_objects.create(
+        program=program, person=counselor_person, role="counselor", is_active=True,
+    )
+
+
+@pytest.fixture
+def bunk(org, program):
+    return AssignmentGroup.objects.create(
+        organization=org, program=program, name="Bunk Birch",
+        slug="bunk-birch-cw", group_type="bunk", is_active=True,
+    )
+
+
+@pytest.fixture
+def counselor_as_author(bunk, counselor_person):
+    return AssignmentGroupMembership.objects.create(
+        group=bunk, person=counselor_person, role_in_group="author", is_active=True,
+    )
+
+
+@pytest.fixture
+def campers(org, bunk):
+    persons = []
+    for first, last in [("Sarah", "Levin"), ("Maya", "Cohen")]:
+        p = Person.all_objects.create(organization=org, first_name=first, last_name=last)
+        AssignmentGroupMembership.objects.create(
+            group=bunk, person=p, role_in_group="subject", is_active=True,
+        )
+        persons.append(p)
+    return persons
+
+
+@pytest.fixture
+def camper_template(org):
+    return ReflectionTemplate.all_objects.create(
+        organization=org, name="Bunk Log", slug="bunk-log-cw",
+        cadence="daily", subject_mode="single_subject",
+        assignment_scope="per_subject_in_group",
+        assignment_group_types=["bunk"], schema=CAMPER_SCHEMA,
+        languages=["en"], is_active=True, program_type="summer_camp",
+        author_role_filter=["counselor"], supports_privacy=True,
+    )
+
+
+def _client(user, org):
+    c = APIClient()
+    c.force_authenticate(user=user)
+    c.credentials(HTTP_X_ORGANIZATION_SLUG=org.slug)
+    return c
+
+
+def _post_payload(*, subject, bunk, csid=None):
+    return {
+        "subject_id": subject.id,
+        "assignment_group_id": bunk.id,
+        "answers": {"note": "Great day"},
+        "language": "en",
+        "client_submission_id": str(csid or uuid.uuid4()),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Auth / context
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_post_requires_authentication():
+    c = APIClient()
+    resp = c.post("/api/v1/counselor/camper-reflections/", {}, format="json")
+    assert resp.status_code in {401, 403}
+
+
+@pytest.mark.django_db
+def test_post_requires_org_context(counselor_user):
+    c = APIClient()
+    c.force_authenticate(user=counselor_user)
+    resp = c.post("/api/v1/counselor/camper-reflections/", {}, format="json")
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Successful create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_camper_reflection_201_and_persists(
+    org, program, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author, campers, camper_template,
+):
+    sarah = campers[0]
+    c = _client(counselor_user, org)
+    payload = _post_payload(subject=sarah, bunk=bunk)
+    with organization_context(org):
+        resp = c.post("/api/v1/counselor/camper-reflections/", payload, format="json")
+    assert resp.status_code == 201, resp.data
+    assert resp.data["subject_id"] == sarah.id
+    assert resp.data["assignment_group_id"] == bunk.id
+    assert resp.data["template"]["slug"] == "bunk-log-cw"
+    assert resp.data["client_submission_id"] == payload["client_submission_id"]
+    assert resp.data["audience"]  # AudienceDisclosure roles surfaced
+    assert "Counselor" in resp.data["audience"]
+    row = Reflection.all_objects.get(id=resp.data["id"])
+    assert row.author == counselor_person
+    assert row.is_complete is True
+
+
+@pytest.mark.django_db
+def test_create_emits_audit_created(
+    org, program, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author, campers, camper_template,
+):
+    sarah = campers[0]
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        c.post(
+            "/api/v1/counselor/camper-reflections/",
+            _post_payload(subject=sarah, bunk=bunk),
+            format="json",
+        )
+    events = AuditEvent.all_objects.filter(content_type="reflection")
+    assert events.filter(event_type=AuditEvent.EventType.CREATED).exists()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_is_idempotent_on_client_submission_id(
+    org, program, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author, campers, camper_template,
+):
+    sarah = campers[0]
+    c = _client(counselor_user, org)
+    csid = uuid.uuid4()
+    payload = _post_payload(subject=sarah, bunk=bunk, csid=csid)
+    with organization_context(org):
+        first = c.post("/api/v1/counselor/camper-reflections/", payload, format="json")
+        second = c.post("/api/v1/counselor/camper-reflections/", payload, format="json")
+    assert first.status_code == 201
+    assert second.status_code == 200
+    assert first.data["id"] == second.data["id"]
+    assert Reflection.all_objects.filter(client_submission_id=csid).count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Authorization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_non_author_on_bunk_cannot_post(
+    org, program, counselor_user, counselor_person, counselor_membership,
+    bunk, campers, camper_template,
+):
+    # No counselor_as_author fixture pulled in => viewer is not an author.
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/counselor/camper-reflections/",
+            _post_payload(subject=campers[0], bunk=bunk),
+            format="json",
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_subject_must_be_on_bunk(
+    org, program, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author, campers, camper_template,
+):
+    stranger = Person.all_objects.create(
+        organization=org, first_name="Off", last_name="Roster",
+    )
+    c = _client(counselor_user, org)
+    payload = _post_payload(subject=stranger, bunk=bunk)
+    with organization_context(org):
+        resp = c.post("/api/v1/counselor/camper-reflections/", payload, format="json")
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_off_camp_camper_rejected(
+    org, program, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author, campers, camper_template,
+):
+    sarah = campers[0]
+    CamperDayState.all_objects.create(
+        organization=org, program=program, camper=sarah,
+        date=date.today(), is_off_camp=True,
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/counselor/camper-reflections/",
+            _post_payload(subject=sarah, bunk=bunk),
+            format="json",
+        )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# PATCH / edit window / cross-counselor permission
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def existing_reflection(
+    org, program, counselor_person, bunk, counselor_as_author, campers, camper_template,
+):
+    today = date.today()
+    return Reflection.all_objects.create(
+        organization=org, program=program, subject=campers[0],
+        author=counselor_person, assignment_group=bunk, template=camper_template,
+        period_start=today, period_end=today,
+        answers={"note": "initial"}, language="en", is_complete=True,
+        client_submission_id=uuid.uuid4(),
+    )
+
+
+@pytest.mark.django_db
+def test_patch_updates_answers_and_emits_audit(
+    org, counselor_user, counselor_membership, existing_reflection,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.patch(
+            f"/api/v1/counselor/camper-reflections/{existing_reflection.id}/",
+            {"answers": {"note": "updated"}}, format="json",
+        )
+    assert resp.status_code == 200, resp.data
+    existing_reflection.refresh_from_db()
+    assert existing_reflection.answers == {"note": "updated"}
+    assert AuditEvent.all_objects.filter(
+        content_type="reflection",
+        event_type=AuditEvent.EventType.EDITED,
+        content_id=str(existing_reflection.id),
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_co_counselor_on_same_bunk_can_edit(
+    org, program, bunk, counselor_person, existing_reflection, camper_template,
+):
+    """Story 4 criterion 2: any active bunk author can edit, not just author."""
+    co_user = User.objects.create_user(email="co@cw.test", password="pw")
+    co_person = Person.all_objects.create(
+        organization=org, first_name="Jordan", last_name="Patel", user=co_user,
+    )
+    Membership.all_objects.create(
+        program=program, person=co_person, role="counselor", is_active=True,
+    )
+    AssignmentGroupMembership.objects.create(
+        group=bunk, person=co_person, role_in_group="author", is_active=True,
+    )
+    c = _client(co_user, org)
+    with organization_context(org):
+        resp = c.patch(
+            f"/api/v1/counselor/camper-reflections/{existing_reflection.id}/",
+            {"answers": {"note": "co edited"}}, format="json",
+        )
+    assert resp.status_code == 200, resp.data
+    existing_reflection.refresh_from_db()
+    assert existing_reflection.answers == {"note": "co edited"}
+
+
+@pytest.mark.django_db
+def test_unrelated_counselor_cannot_edit(
+    org, program, bunk, existing_reflection,
+):
+    """A counselor not on the bunk gets 403."""
+    stranger_user = User.objects.create_user(email="stranger@cw.test", password="pw")
+    stranger_person = Person.all_objects.create(
+        organization=org, first_name="Stranger", last_name="X", user=stranger_user,
+    )
+    Membership.all_objects.create(
+        program=program, person=stranger_person, role="counselor", is_active=True,
+    )
+    c = _client(stranger_user, org)
+    with organization_context(org):
+        resp = c.patch(
+            f"/api/v1/counselor/camper-reflections/{existing_reflection.id}/",
+            {"answers": {"note": "no"}}, format="json",
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_patch_outside_edit_window_returns_403(
+    org, program, counselor_person, counselor_user, counselor_membership,
+    bunk, counselor_as_author, campers, camper_template,
+):
+    yesterday = date.today() - timedelta(days=1)
+    old = Reflection.all_objects.create(
+        organization=org, program=program, subject=campers[0],
+        author=counselor_person, assignment_group=bunk, template=camper_template,
+        period_start=yesterday, period_end=yesterday,
+        answers={"note": "old"}, language="en", is_complete=True,
+        client_submission_id=uuid.uuid4(),
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.patch(
+            f"/api/v1/counselor/camper-reflections/{old.id}/",
+            {"answers": {"note": "late"}}, format="json",
+        )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_post_invalidates_dashboard_cache(
+    org, program, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author, campers, camper_template,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        # Prime the cache by hitting the dashboard.
+        c.get("/api/v1/counselor/dashboard/")
+        # Submit a reflection — should invalidate the prior cache.
+        c.post(
+            "/api/v1/counselor/camper-reflections/",
+            _post_payload(subject=campers[0], bunk=bunk),
+            format="json",
+        )
+        # Fresh GET should reflect the new submission in covered count.
+        resp = c.get("/api/v1/counselor/dashboard/")
+    section = resp.data["sections"]["camper_reflections"]
+    assert section["covered"] == 1

--- a/backend/bunk_logs/api/tests/test_counselor_dashboard.py
+++ b/backend/bunk_logs/api/tests/test_counselor_dashboard.py
@@ -479,6 +479,14 @@ def test_dashboard_self_section_day_off_counts_as_complete(
 def test_dashboard_self_section_none_when_no_template(
     org, counselor_user, counselor_person, counselor_membership,
 ):
+    # Strip the global counselor self-reflection template seeded by
+    # migration 0029 so this scenario can exercise the "no template
+    # configured at all" path. Org-scoped tenants without any
+    # applicable template still hit the same branch in production
+    # (e.g. a religious-school program with no counselors).
+    ReflectionTemplate.all_objects.filter(
+        organization__isnull=True, slug="counselor-self-reflection",
+    ).delete()
     c = _client(counselor_user, org)
     with organization_context(org):
         resp = c.get("/api/v1/counselor/dashboard/?nocache=1")

--- a/backend/bunk_logs/api/tests/test_counselor_maintenance_writes.py
+++ b/backend/bunk_logs/api/tests/test_counselor_maintenance_writes.py
@@ -1,0 +1,253 @@
+"""Tests for counselor maintenance ticket write endpoints (Story 8)."""
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.core.files.uploadedfile import SimpleUploadedFile
+from rest_framework.test import APIClient
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import AuditEvent
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import TicketPhoto
+
+User = get_user_model()
+
+
+# 1x1 white PNG generated via PIL; passes ImageField's image-content
+# verification. Inlined as bytes so the test doesn't depend on PIL at runtime.
+PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\xff\xff"
+    b"?\x00\x05\xfe\x02\xfe\r\xefF\xb8\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="MT Camp", slug="mt-camp")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org, name="MT Camp Summer 2026", slug="mt-summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1), end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def counselor_user():
+    return User.objects.create_user(email="c@mt.test", password="pw")
+
+
+@pytest.fixture
+def counselor_person(org, counselor_user):
+    return Person.all_objects.create(
+        organization=org, first_name="Lior", last_name="K", user=counselor_user,
+    )
+
+
+@pytest.fixture
+def counselor_membership(program, counselor_person):
+    return Membership.all_objects.create(
+        program=program, person=counselor_person, role="counselor", is_active=True,
+    )
+
+
+def _client(user, org):
+    c = APIClient()
+    c.force_authenticate(user=user)
+    c.credentials(HTTP_X_ORGANIZATION_SLUG=org.slug)
+    return c
+
+
+def _png_upload(name="photo.png"):
+    return SimpleUploadedFile(name, PNG_BYTES, content_type="image/png")
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_ticket_201(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    c = _client(counselor_user, org)
+    payload = {
+        "location": "Bunk Maple — sink",
+        "category": "plumbing",
+        "description": "Drain runs slow",
+        "urgency": "normal",
+        "client_submission_id": str(uuid.uuid4()),
+    }
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/counselor/maintenance-tickets/", payload, format="json",
+        )
+    assert resp.status_code == 201, resp.data
+    ticket = MaintenanceTicket.all_objects.get(id=resp.data["id"])
+    assert ticket.location == "Bunk Maple — sink"
+    assert ticket.category == "plumbing"
+    assert ticket.submitted_by == counselor_membership
+
+
+@pytest.mark.django_db
+def test_urgent_requires_reason(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    c = _client(counselor_user, org)
+    payload = {
+        "location": "Bunk Maple",
+        "category": "leak",
+        "description": "Major leak",
+        "urgency": "urgent",
+        "client_submission_id": str(uuid.uuid4()),
+    }
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/counselor/maintenance-tickets/", payload, format="json",
+        )
+    assert resp.status_code == 400
+    assert "urgent_reason" in (resp.data or {})
+
+
+@pytest.mark.django_db
+def test_create_ticket_idempotent(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    c = _client(counselor_user, org)
+    csid = str(uuid.uuid4())
+    payload = {
+        "location": "Pool deck", "category": "broken_light",
+        "description": "Floodlight out", "urgency": "normal",
+        "client_submission_id": csid,
+    }
+    with organization_context(org):
+        first = c.post(
+            "/api/v1/counselor/maintenance-tickets/", payload, format="json",
+        )
+        second = c.post(
+            "/api/v1/counselor/maintenance-tickets/", payload, format="json",
+        )
+    assert first.status_code == 201
+    assert second.status_code == 200
+    assert first.data["id"] == second.data["id"]
+    assert MaintenanceTicket.all_objects.filter(client_submission_id=csid).count() == 1
+
+
+@pytest.mark.django_db
+def test_create_ticket_emits_audit(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        c.post(
+            "/api/v1/counselor/maintenance-tickets/",
+            {"location": "Loc", "category": "other", "urgency": "low",
+             "client_submission_id": str(uuid.uuid4())},
+            format="json",
+        )
+    assert AuditEvent.all_objects.filter(
+        event_type=AuditEvent.EventType.CREATED, content_type="maintenance_ticket",
+    ).exists()
+
+
+# ---------------------------------------------------------------------------
+# Photo upload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_ticket_with_photos(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    c = _client(counselor_user, org)
+    data = {
+        "location": "Bunk Maple",
+        "category": "pest",
+        "description": "Wasp nest",
+        "urgency": "normal",
+        "client_submission_id": str(uuid.uuid4()),
+        "photos": [_png_upload("a.png"), _png_upload("b.png")],
+    }
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/counselor/maintenance-tickets/", data, format="multipart",
+        )
+    assert resp.status_code == 201, resp.data
+    assert len(resp.data["photos"]) == 2
+    assert all(p["is_followup"] is False for p in resp.data["photos"])
+
+
+@pytest.mark.django_db
+def test_followup_photo_endpoint(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        create_resp = c.post(
+            "/api/v1/counselor/maintenance-tickets/",
+            {"location": "Loc", "category": "other", "urgency": "low",
+             "client_submission_id": str(uuid.uuid4())},
+            format="json",
+        )
+        ticket_id = create_resp.data["id"]
+        upload_resp = c.post(
+            f"/api/v1/counselor/maintenance-tickets/{ticket_id}/photos/",
+            {"image": _png_upload("followup.png"), "caption": "after"},
+            format="multipart",
+        )
+    assert upload_resp.status_code == 201, upload_resp.data
+    assert upload_resp.data["is_followup"] is True
+    assert TicketPhoto.objects.filter(
+        ticket_id=ticket_id, is_followup=True,
+    ).count() == 1
+
+
+@pytest.mark.django_db
+def test_followup_photo_403_on_other_submitter(
+    org, program, counselor_user, counselor_person, counselor_membership,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        create_resp = c.post(
+            "/api/v1/counselor/maintenance-tickets/",
+            {"location": "Loc", "category": "other", "urgency": "low",
+             "client_submission_id": str(uuid.uuid4())},
+            format="json",
+        )
+        ticket_id = create_resp.data["id"]
+
+    other_user = User.objects.create_user(email="other@mt.test", password="pw")
+    other_person = Person.all_objects.create(
+        organization=org, first_name="X", last_name="Y", user=other_user,
+    )
+    Membership.all_objects.create(
+        program=program, person=other_person, role="counselor", is_active=True,
+    )
+    c2 = _client(other_user, org)
+    with organization_context(org):
+        resp = c2.post(
+            f"/api/v1/counselor/maintenance-tickets/{ticket_id}/photos/",
+            {"image": _png_upload("nope.png")}, format="multipart",
+        )
+    assert resp.status_code == 403

--- a/backend/bunk_logs/api/tests/test_counselor_self_reflection_history.py
+++ b/backend/bunk_logs/api/tests/test_counselor_self_reflection_history.py
@@ -112,6 +112,12 @@ def _submit(organization, program, person, template, target_date, answers):
 def test_history_empty_when_no_template(
     org, counselor_user, counselor_person, counselor_membership,
 ):
+    # See test_counselor_dashboard.py for rationale — drop the seeded
+    # global template so this exercises the "no template configured"
+    # path rather than the always-available global path.
+    ReflectionTemplate.all_objects.filter(
+        organization__isnull=True, slug="counselor-self-reflection",
+    ).delete()
     c = _client(counselor_user, org)
     with organization_context(org):
         resp = c.get("/api/v1/counselor/self-reflection/history/")

--- a/backend/bunk_logs/api/tests/test_counselor_self_reflection_writes.py
+++ b/backend/bunk_logs/api/tests/test_counselor_self_reflection_writes.py
@@ -1,0 +1,251 @@
+"""Tests for counselor self-reflection write endpoints (Step 7_6c).
+
+Covers ``POST /api/v1/counselor/self-reflection/`` and
+``PATCH /api/v1/counselor/self-reflection/<id>/`` against Story 5 + 6
+acceptance criteria including the ``day_off`` shortcut.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+from bunk_logs.api.counselor.common import counselor_self_template
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import AuditEvent
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+
+User = get_user_model()
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="SR Camp", slug="sr-camp")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org, name="SR Camp Summer 2026", slug="sr-summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1), end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def counselor_user():
+    return User.objects.create_user(email="counselor@sr.test", password="pw")
+
+
+@pytest.fixture
+def counselor_person(org, counselor_user):
+    return Person.all_objects.create(
+        organization=org, first_name="Aviv", last_name="Lev", user=counselor_user,
+    )
+
+
+@pytest.fixture
+def counselor_membership(program, counselor_person):
+    return Membership.all_objects.create(
+        program=program, person=counselor_person, role="counselor", is_active=True,
+    )
+
+
+def _client(user, org):
+    c = APIClient()
+    c.force_authenticate(user=user)
+    c.credentials(HTTP_X_ORGANIZATION_SLUG=org.slug)
+    return c
+
+
+# ---------------------------------------------------------------------------
+# day_off shortcut (Story 5 criterion 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_day_off_shortcut_creates_minimal_reflection(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    c = _client(counselor_user, org)
+    payload = {"day_off": True, "client_submission_id": str(uuid.uuid4())}
+    with organization_context(org):
+        resp = c.post("/api/v1/counselor/self-reflection/", payload, format="json")
+    assert resp.status_code == 201, resp.data
+    assert resp.data["answers"] == {"day_off": True}
+    row = Reflection.all_objects.get(id=resp.data["id"])
+    assert row.is_complete is True
+    assert row.author == counselor_person
+    assert row.subject == counselor_person
+
+
+@pytest.mark.django_db
+def test_full_answers_create_validates_against_schema(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    c = _client(counselor_user, org)
+    payload = {
+        "answers": {
+            "day_off": False,
+            "overall_day": 4,
+            "wins": ["Helped a camper through homesickness"],
+            "improvements": ["More water during free swim"],
+            "concern": "Camper Eden seemed quiet today.",
+        },
+        "language": "en",
+        "client_submission_id": str(uuid.uuid4()),
+    }
+    with organization_context(org):
+        resp = c.post("/api/v1/counselor/self-reflection/", payload, format="json")
+    assert resp.status_code == 201, resp.data
+    assert resp.data["answers"]["overall_day"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Idempotency + audit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_self_reflection_idempotent(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    c = _client(counselor_user, org)
+    csid = str(uuid.uuid4())
+    payload = {"day_off": True, "client_submission_id": csid}
+    with organization_context(org):
+        first = c.post("/api/v1/counselor/self-reflection/", payload, format="json")
+        second = c.post("/api/v1/counselor/self-reflection/", payload, format="json")
+    assert first.status_code == 201
+    assert second.status_code == 200
+    assert first.data["id"] == second.data["id"]
+    assert Reflection.all_objects.filter(
+        client_submission_id=uuid.UUID(csid),
+    ).count() == 1
+
+
+@pytest.mark.django_db
+def test_self_reflection_emits_audit(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        c.post(
+            "/api/v1/counselor/self-reflection/",
+            {"day_off": True, "client_submission_id": str(uuid.uuid4())},
+            format="json",
+        )
+    assert AuditEvent.all_objects.filter(
+        event_type=AuditEvent.EventType.CREATED, content_type="reflection",
+    ).exists()
+
+
+# ---------------------------------------------------------------------------
+# PATCH / edit window / permission
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def existing_self(org, counselor_person, counselor_membership, db):
+    # We rely on the migration-seeded global template. The resolver uses
+    # the org-scoped Membership manager so it must run inside the org
+    # context to find the viewer's active memberships.
+    with organization_context(org):
+        template = counselor_self_template(
+            counselor_person, org, counselor_membership.program,
+        )
+    today = date.today()
+    return Reflection.all_objects.create(
+        organization=org, program=counselor_membership.program,
+        author=counselor_person, subject=counselor_person, template=template,
+        period_start=today, period_end=today,
+        answers={"day_off": True}, language="en", is_complete=True,
+        client_submission_id=uuid.uuid4(),
+    )
+
+
+@pytest.mark.django_db
+def test_patch_self_reflection_updates_and_audits(
+    org, counselor_user, existing_self,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.patch(
+            f"/api/v1/counselor/self-reflection/{existing_self.id}/",
+            {"day_off": False, "answers": {
+                "day_off": False, "overall_day": 5,
+                "wins": [], "improvements": [], "concern": "",
+            }}, format="json",
+        )
+    assert resp.status_code == 200, resp.data
+    existing_self.refresh_from_db()
+    assert existing_self.answers["overall_day"] == 5
+    assert AuditEvent.all_objects.filter(
+        event_type=AuditEvent.EventType.EDITED, content_type="reflection",
+        content_id=str(existing_self.id),
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_patch_other_users_self_reflection_403(
+    org, program, counselor_user, existing_self,
+):
+    other_user = User.objects.create_user(email="other@sr.test", password="pw")
+    other_person = Person.all_objects.create(
+        organization=org, first_name="Other", last_name="P", user=other_user,
+    )
+    Membership.all_objects.create(
+        program=program, person=other_person, role="counselor", is_active=True,
+    )
+    c = _client(other_user, org)
+    with organization_context(org):
+        resp = c.patch(
+            f"/api/v1/counselor/self-reflection/{existing_self.id}/",
+            {"day_off": False, "answers": {"day_off": False, "overall_day": 3,
+                "wins": [], "improvements": [], "concern": ""}},
+            format="json",
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_patch_outside_edit_window_403(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    with organization_context(org):
+        template = counselor_self_template(
+            counselor_person, org, counselor_membership.program,
+        )
+    yesterday = date.today() - timedelta(days=1)
+    row = Reflection.all_objects.create(
+        organization=org, program=counselor_membership.program,
+        author=counselor_person, subject=counselor_person, template=template,
+        period_start=yesterday, period_end=yesterday,
+        answers={"day_off": True}, language="en", is_complete=True,
+        client_submission_id=uuid.uuid4(),
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.patch(
+            f"/api/v1/counselor/self-reflection/{row.id}/",
+            {"day_off": False, "answers": {"day_off": False, "overall_day": 3,
+                "wins": [], "improvements": [], "concern": ""}},
+            format="json",
+        )
+    assert resp.status_code == 403

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -14,8 +14,10 @@ from . import reflections
 from . import supervisions as supervisions_api
 from . import templates as templates_api
 from . import views
+from .counselor import camper_care_requests as counselor_camper_care_requests
 from .counselor import camper_reflections as counselor_camper_reflections
 from .counselor import dashboard as counselor_dashboard
+from .counselor import maintenance_tickets as counselor_maintenance_tickets
 from .counselor import requests as counselor_requests
 from .counselor import self_reflection as counselor_self_reflection
 from .dashboards import authors as authors_dashboard
@@ -191,6 +193,38 @@ urlpatterns = [
         "counselor/requests/",
         counselor_requests.CounselorRequestsListView.as_view(),
         name="counselor-requests",
+    ),
+
+    # Counselor flow write endpoints (Step 7_6c)
+    path(
+        "counselor/camper-reflections/<int:reflection_id>/",
+        counselor_camper_reflections.CamperReflectionDetailView.as_view(),
+        name="counselor-camper-reflection-detail",
+    ),
+    path(
+        "counselor/self-reflection/",
+        counselor_self_reflection.SelfReflectionCreateView.as_view(),
+        name="counselor-self-reflection-create",
+    ),
+    path(
+        "counselor/self-reflection/<int:reflection_id>/",
+        counselor_self_reflection.SelfReflectionDetailView.as_view(),
+        name="counselor-self-reflection-detail",
+    ),
+    path(
+        "counselor/camper-care-requests/",
+        counselor_camper_care_requests.CamperCareRequestCreateView.as_view(),
+        name="counselor-camper-care-create",
+    ),
+    path(
+        "counselor/maintenance-tickets/",
+        counselor_maintenance_tickets.MaintenanceTicketCreateView.as_view(),
+        name="counselor-maintenance-ticket-create",
+    ),
+    path(
+        "counselor/maintenance-tickets/<uuid:ticket_id>/photos/",
+        counselor_maintenance_tickets.MaintenanceTicketPhotoCreateView.as_view(),
+        name="counselor-maintenance-ticket-photo-create",
     ),
 ]
 

--- a/backend/bunk_logs/core/migrations/0029_seed_counselor_self_reflection_template.py
+++ b/backend/bunk_logs/core/migrations/0029_seed_counselor_self_reflection_template.py
@@ -1,0 +1,133 @@
+"""Seed the global counselor self-reflection ReflectionTemplate (Step 7_6c).
+
+A single ``organization IS NULL`` template that applies to both ``counselor``
+and ``junior_counselor`` Memberships. Org-scoped templates may shadow it via
+the resolution helper in ``api/counselor/common.py``; this seed only lights
+up tenants that haven't authored their own.
+
+Schema design (Story 5):
+1. ``day_off`` (yes_no) — the shortcut described in Story 5 criterion 3.
+2. ``overall_day`` (single_rating) — the primary dashboard score.
+3. ``wins`` (text_list) — what went well.
+4. ``improvements`` (text_list) — what could be different.
+5. ``concern`` (textarea) — open-ended flag to supervisors.
+
+All fields are ``required: false`` so the ``day_off`` shortcut payload
+``{"day_off": true}`` validates without the other fields needing values.
+English + Spanish are seeded; additional languages can be backfilled by a
+later migration without touching this row's ``version``.
+
+The migration is idempotent: re-applying ``get_or_create`` keyed on
+``(organization=None, slug, version)`` does not create a duplicate row,
+and ``reverse_code`` only removes the row we created.
+"""
+
+from django.db import migrations
+
+SLUG = "counselor-self-reflection"
+NAME = "Counselor Self-Reflection"
+LANGUAGES = ["en", "es"]
+
+
+def _schema() -> dict:
+    return {
+        "fields": [
+            {
+                "key": "day_off",
+                "type": "yes_no",
+                "required": False,
+                "prompts": {
+                    "en": "Are you taking a day off today?",
+                    "es": "¿Estás tomando un día libre hoy?",
+                },
+            },
+            {
+                "key": "overall_day",
+                "type": "single_rating",
+                "required": False,
+                "scale": [1, 5],
+                "scale_labels": {
+                    "en": ["Difficult", "Tough", "OK", "Good", "Great"],
+                    "es": ["Difícil", "Duro", "Regular", "Bueno", "Excelente"],
+                },
+                "dashboard_role": "primary_rating",
+            },
+            {
+                "key": "wins",
+                "type": "text_list",
+                "required": False,
+                "prompts": {
+                    "en": "What went well today?",
+                    "es": "¿Qué salió bien hoy?",
+                },
+                "dashboard_role": "wins",
+            },
+            {
+                "key": "improvements",
+                "type": "text_list",
+                "required": False,
+                "prompts": {
+                    "en": "What could you do differently tomorrow?",
+                    "es": "¿Qué podrías hacer diferente mañana?",
+                },
+                "dashboard_role": "improvements",
+            },
+            {
+                "key": "concern",
+                "type": "textarea",
+                "required": False,
+                "prompts": {
+                    "en": "Anything you want to flag for your team?",
+                    "es": "¿Algo que quieras compartir con tu equipo?",
+                },
+                "dashboard_role": "open_concern",
+            },
+        ],
+    }
+
+
+def _seed_template(apps, schema_editor):
+    ReflectionTemplate = apps.get_model("core", "ReflectionTemplate")
+    ReflectionTemplate.objects.update_or_create(
+        organization=None,
+        slug=SLUG,
+        version=1,
+        defaults={
+            "name": NAME,
+            "description": (
+                "Daily self-reflection for counselors. Includes a 'day off' "
+                "shortcut that records a complete-but-empty submission."
+            ),
+            "cadence": "daily",
+            "schema": _schema(),
+            "languages": LANGUAGES,
+            "is_active": True,
+            "subject_mode": "self",
+            "assignment_scope": "none",
+            "assignment_group_types": [],
+            "author_role_filter": ["counselor", "junior_counselor"],
+            "subject_role_filter": [],
+            "required_per_subject_per_period": 1,
+            "subject_visible": False,
+            "supports_privacy": False,
+            "role": "counselor",
+            "program_type": None,
+        },
+    )
+
+
+def _remove_template(apps, schema_editor):
+    ReflectionTemplate = apps.get_model("core", "ReflectionTemplate")
+    ReflectionTemplate.objects.filter(
+        organization__isnull=True, slug=SLUG, version=1,
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0028_camperdaystate_orderitemsuggestion_ticketphoto_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(_seed_template, reverse_code=_remove_template),
+    ]

--- a/backend/bunk_logs/core/test_multitenancy.py
+++ b/backend/bunk_logs/core/test_multitenancy.py
@@ -127,7 +127,13 @@ def test_reflection_template_includes_global_for_org(org_alpha):
         schema={"fields": [_field_schema("x")]},
     )
     with organization_context(org_alpha):
-        ids = set(ReflectionTemplate.objects.values_list("id", flat=True))
+        # The seeded global counselor-self-reflection template (migration
+        # 0029) is always present; assert subset rather than equality so
+        # this test stays focused on the org/global scoping behavior.
+        ids = set(
+            ReflectionTemplate.objects.exclude(slug="counselor-self-reflection")
+            .values_list("id", flat=True),
+        )
         assert ids == {global_t.id, org_t.id}
 
 

--- a/backend/bunk_logs/core/test_my_tasks_api.py
+++ b/backend/bunk_logs/core/test_my_tasks_api.py
@@ -186,10 +186,23 @@ def _authed_client(user, org):
 # ---------------------------------------------------------------------------
 
 
+def _drop_seeded_counselor_self_template():
+    """Strip the seeded global counselor self-reflection template.
+
+    These tests pre-date the migration 0029 seed and assert specific task
+    counts / templates by index; the global template adds an extra row that
+    isn't relevant to my-tasks behavior under test.
+    """
+    ReflectionTemplate.all_objects.filter(
+        organization__isnull=True, slug="counselor-self-reflection",
+    ).delete()
+
+
 @pytest.mark.django_db
 def test_my_tasks_self_reflection_appears(
     org, program, counselor_user, counselor_person, counselor_membership, self_template,
 ):
+    _drop_seeded_counselor_self_template()
     with organization_context(org):
         client = _authed_client(counselor_user, org)
         resp = client.get("/api/v1/reflections/my-tasks/")
@@ -209,6 +222,7 @@ def test_my_tasks_self_reflection_appears(
 def test_my_tasks_self_reflection_shows_submitted(
     org, program, counselor_user, counselor_person, counselor_membership, self_template,
 ):
+    _drop_seeded_counselor_self_template()
     today = date.today()
     with organization_context(org):
         Reflection.all_objects.create(
@@ -262,6 +276,7 @@ def test_my_tasks_roster_shows_subjects(
     camper_person,
     camper_person2,
 ):
+    _drop_seeded_counselor_self_template()
     with organization_context(org):
         client = _authed_client(counselor_user, org)
         resp = client.get("/api/v1/reflections/my-tasks/")
@@ -339,6 +354,7 @@ def test_my_tasks_covered_by_me_flag_accurate(
     camper_person,
 ):
     """covered_by_me is False when another counselor logged the camper."""
+    _drop_seeded_counselor_self_template()
     other_user = User.objects.create_user(email="other_counselor@test.com", password="pw")
     other_person = Person.all_objects.create(
         organization=org, first_name="Other", last_name="Counselor", user=other_user,
@@ -383,6 +399,7 @@ def test_my_tasks_multi_bunk_counselor_sees_both_bunks(
     counselor_as_author,
     camper_in_bunk,
 ):
+    _drop_seeded_counselor_self_template()
     bunk2 = AssignmentGroup.objects.create(
         organization=org,
         program=program,

--- a/backend/bunk_logs/core/test_seed_role_template.py
+++ b/backend/bunk_logs/core/test_seed_role_template.py
@@ -98,7 +98,9 @@ class TestSeedRoleTemplateCommand:
             stdout=StringIO(),
         )
         first_pk = ReflectionTemplate.all_objects.get(organization=org).pk
-        assert ReflectionTemplate.all_objects.count() == 1
+        # Filter to this org's template (the global counselor-self-reflection
+        # template seeded by migration 0029 lives at organization=None).
+        assert ReflectionTemplate.all_objects.filter(organization=org).count() == 1
         out2 = StringIO()
         call_command(
             "seed_role_template",
@@ -107,7 +109,7 @@ class TestSeedRoleTemplateCommand:
             template_file=str(path),
             stdout=out2,
         )
-        assert ReflectionTemplate.all_objects.count() == 1
+        assert ReflectionTemplate.all_objects.filter(organization=org).count() == 1
         second_pk = ReflectionTemplate.all_objects.get(organization=org).pk
         assert first_pk == second_pk
         assert "Updated" in out2.getvalue()


### PR DESCRIPTION
## Summary

Adds the four write endpoints for the counselor mobile flow on top of `7_6b`'s read surface. All endpoints are idempotent on `client_submission_id`, enforce the today-only edit window with a 403 + clear error, emit `AuditEvent` rows on every write, and bust the per-viewer/per-co-counselor dashboard cache.

Endpoints (all under `/api/v1/counselor/`):
- `POST camper-reflections/` and `PATCH camper-reflections/<id>/` — Story 3 + 4. Cross-counselor edit permission (any current bunk author can edit, not just original author).
- `POST self-reflection/` and `PATCH self-reflection/<id>/` — Story 5 + 6. Includes the ``day_off`` shortcut that records ``{"day_off": true}`` and counts as ""complete"" for all-set.
- `POST camper-care-requests/` — Story 7. Subject must be on viewer's bunk; bunk-scoped requests (no subject) are allowed.
- `POST maintenance-tickets/` and `POST maintenance-tickets/<uuid>/photos/` — Story 8 + decision C5. Multipart photo upload via `request.FILES`; follow-up endpoint for additional photos on tickets the viewer submitted.

Other changes:
- Adds the global counselor self-reflection `ReflectionTemplate` (migration `0029`) with en + es prompts.
- Refactors response shaping into `api/counselor/responses.py` so list, create, and patch payloads agree. Includes the `AudienceDisclosure` role list per Step 7_6 item 11.
- Moves the dashboard cache key into `common.py` and exposes `invalidate_dashboard_for_viewers` so write endpoints can target the viewer + all co-counselors on the relevant bunk.
- Updates pre-existing tests (`test_my_tasks_api`, `test_multitenancy`, `test_seed_role_template`, the two `_no_template` cases in counselor read tests) to either filter by slug or drop the seeded global template — they predated the seed.

Stacked on `feat/7_6b_read_endpoints`.

## Test plan

- [x] 857 backend tests pass (32 new in `test_counselor_*_writes.py`).
- [x] `ruff check` clean for all touched files.
- [x] Migration `0029` applies cleanly locally; `update_or_create` keyed on `(organization=None, slug, version)` is idempotent.
- [ ] Manual smoke: submit camper reflection → confirm dashboard reflects coverage; PATCH same row → confirm `AuditEvent` recorded.
- [ ] Manual smoke: upload a maintenance ticket with a photo on a preview env → confirm S3 storage backend serves the image URL.


Made with [Cursor](https://cursor.com)