### PR TITLE
7_6d: counselor mobile dashboard + camper reflection flow

### DIFF
--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -47,6 +47,9 @@ import ConcernsInboxPage from './pages/dashboards/ConcernsInboxPage';
 import DashboardsHub from './pages/dashboards/DashboardsHub';
 import AdminLayout from './layouts/AdminLayout';
 import AppLayout from './layouts/AppLayout';
+import CounselorMobileDashboard from './pages/counselor/CounselorMobileDashboard';
+import CamperReflectionListPage from './pages/counselor/CamperReflectionListPage';
+import CamperReflectionFormPage from './pages/counselor/CamperReflectionFormPage';
 import { useBunk } from './contexts/BunkContext';
 
 // Protected route component
@@ -329,6 +332,29 @@ function Router() {
           <Route path="/reflect/summary" element={<ReflectionSummaryPage />} />
           <Route path="/tasks" element={<TasksPage />} />
           <Route path="/supervisor/coverage" element={<SupervisorCoveragePage />} />
+          {/* 7_6d: Counselor mobile flow. Lives under AppLayout so the
+              sidebar/header chrome (3.32 / 3.33) stays available on the
+              dashboard, roster, and form screens. The legacy
+              `/counselor-dashboard` route still serves the old
+              CounselorDashboard.jsx self-reflection surface and is
+              untouched while 7_6d/e migrate counselors over. */}
+          <Route path="/counselor" element={<CounselorMobileDashboard />} />
+          <Route
+            path="/counselor/camper-reflections"
+            element={<CamperReflectionListPage />}
+          />
+          <Route
+            path="/counselor/camper-reflections/:date"
+            element={<CamperReflectionListPage />}
+          />
+          <Route
+            path="/counselor/camper-reflections/new"
+            element={<CamperReflectionFormPage />}
+          />
+          <Route
+            path="/counselor/camper-reflections/:reflectionId/edit"
+            element={<CamperReflectionFormPage />}
+          />
         </Route>
 
         <Route

--- a/frontend/src/api/__tests__/counselor.test.js
+++ b/frontend/src/api/__tests__/counselor.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  CAMPER_REFLECTION_AUDIENCE,
+  createCamperReflection,
+  fetchCamperReflections,
+  fetchCounselorDashboard,
+  fetchReflection,
+  fetchTemplateById,
+  newClientSubmissionId,
+  patchCamperReflection,
+} from '../counselor';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+const patchMock = vi.fn();
+
+vi.mock('../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: (...args) => postMock(...args),
+    patch: (...args) => patchMock(...args),
+  },
+}));
+
+describe('counselor API helpers', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    postMock.mockReset();
+    patchMock.mockReset();
+  });
+
+  it('exports the canonical camper-reflection audience set', () => {
+    expect(CAMPER_REFLECTION_AUDIENCE).toEqual([
+      'Admin',
+      'Camper Care',
+      'Counselor',
+      'Leadership Team',
+      'Unit Head',
+    ]);
+  });
+
+  it('newClientSubmissionId returns a UUID-shaped string', () => {
+    const id = newClientSubmissionId();
+    expect(id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+    expect(newClientSubmissionId()).not.toBe(id);
+  });
+
+  it('fetchCounselorDashboard hits the v1 endpoint with optional nocache param', async () => {
+    getMock.mockResolvedValue({ data: { ok: true } });
+    await fetchCounselorDashboard();
+    expect(getMock.mock.calls[0][0]).toBe('/api/v1/counselor/dashboard/');
+    expect(getMock.mock.calls[0][1]).toEqual({ params: {} });
+
+    await fetchCounselorDashboard({ noCache: true });
+    expect(getMock.mock.calls[1][1]).toEqual({ params: { nocache: '1' } });
+  });
+
+  it('fetchCamperReflections forwards the date param', async () => {
+    getMock.mockResolvedValue({ data: {} });
+    await fetchCamperReflections({ date: '2026-07-04' });
+    expect(getMock.mock.calls[0]).toEqual([
+      '/api/v1/counselor/camper-reflections/',
+      { params: { date: '2026-07-04' } },
+    ]);
+  });
+
+  it('createCamperReflection sends the camel→snake payload', async () => {
+    postMock.mockResolvedValue({ data: { id: 1 }, status: 201 });
+    const result = await createCamperReflection({
+      subjectId: 7,
+      assignmentGroupId: 100,
+      answers: { note: 'hi' },
+      language: 'es',
+      teamVisibility: 'supervisors_only',
+      clientSubmissionId: '11111111-1111-4111-8111-111111111111',
+    });
+    expect(postMock.mock.calls[0]).toEqual([
+      '/api/v1/counselor/camper-reflections/',
+      {
+        subject_id: 7,
+        assignment_group_id: 100,
+        answers: { note: 'hi' },
+        language: 'es',
+        team_visibility: 'supervisors_only',
+        client_submission_id: '11111111-1111-4111-8111-111111111111',
+      },
+    ]);
+    expect(result.status).toBe(201);
+  });
+
+  it('patchCamperReflection omits undefined fields', async () => {
+    patchMock.mockResolvedValue({ data: { id: 1 } });
+    await patchCamperReflection(99, { answers: { note: 'edited' } });
+    expect(patchMock.mock.calls[0]).toEqual([
+      '/api/v1/counselor/camper-reflections/99/',
+      { answers: { note: 'edited' } },
+    ]);
+  });
+
+  it('fetchTemplateById uses the templates viewset', async () => {
+    getMock.mockResolvedValue({ data: { id: 7 } });
+    await fetchTemplateById(7);
+    expect(getMock.mock.calls[0][0]).toBe('/api/v1/templates/7/');
+  });
+
+  it('fetchReflection uses the reflection viewset', async () => {
+    getMock.mockResolvedValue({ data: { id: 1 } });
+    await fetchReflection(42);
+    expect(getMock.mock.calls[0][0]).toBe('/api/v1/reflections/42/');
+  });
+});

--- a/frontend/src/api/counselor.js
+++ b/frontend/src/api/counselor.js
@@ -1,0 +1,131 @@
+/**
+ * Counselor flow API client (Step 7_6).
+ *
+ * Thin wrappers around the `/api/v1/counselor/*` endpoints built in
+ * `7_6b` (reads) and `7_6c` (writes). Centralized so each page doesn't
+ * hand-roll URLs / payloads and so the offline-queue work in 7_6e can
+ * intercept submission paths in one place.
+ *
+ * Convention: every write helper takes (or generates) a
+ * `client_submission_id` UUID for backend idempotency. Callers should
+ * persist the UUID until the server confirms the write so retries land
+ * on the same row instead of duplicating data.
+ */
+
+import api from '../api';
+
+/**
+ * Generate a UUIDv4 for `client_submission_id`.
+ *
+ * Browsers running on `https://` (or localhost) expose `crypto.randomUUID`.
+ * We fall back to a Math.random()-based polyfill for very old runtimes /
+ * jsdom in test mode so unit tests don't have to stub `globalThis.crypto`.
+ */
+export function newClientSubmissionId() {
+  if (typeof globalThis !== 'undefined'
+      && globalThis.crypto
+      && typeof globalThis.crypto.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+  // RFC4122 v4 fallback. Not cryptographically strong; only used in
+  // environments where Web Crypto is missing.
+  const r = () => Math.floor(Math.random() * 0xffff).toString(16).padStart(4, '0');
+  const time = Date.now().toString(16).padStart(12, '0');
+  return `${time.slice(0, 8)}-${time.slice(8, 12)}-4${r().slice(0, 3)}-${
+    ((Math.floor(Math.random() * 4) + 8).toString(16))}${r().slice(0, 3)}-${r()}${r()}${r()}`;
+}
+
+/** Counselor dashboard payload (Story 2 + 9). */
+export async function fetchCounselorDashboard({ noCache = false } = {}) {
+  const params = noCache ? { nocache: '1' } : {};
+  const { data } = await api.get('/api/v1/counselor/dashboard/', { params });
+  return data;
+}
+
+/**
+ * Camper reflection roster for `date` (defaults to org "today").
+ * Returns `{ date, editable, template, bunks: [{ id, name, covered, total, campers, off_camp }] }`.
+ */
+export async function fetchCamperReflections({ date } = {}) {
+  const params = date ? { date } : {};
+  const { data } = await api.get('/api/v1/counselor/camper-reflections/', { params });
+  return data;
+}
+
+/** Submit a new camper reflection (Story 3). */
+export async function createCamperReflection({
+  subjectId,
+  assignmentGroupId,
+  answers,
+  language = 'en',
+  teamVisibility = 'team',
+  clientSubmissionId,
+}) {
+  const payload = {
+    subject_id: subjectId,
+    assignment_group_id: assignmentGroupId,
+    answers,
+    language,
+    team_visibility: teamVisibility,
+    client_submission_id: clientSubmissionId,
+  };
+  const res = await api.post('/api/v1/counselor/camper-reflections/', payload);
+  return { data: res.data, status: res.status };
+}
+
+/** Edit a camper reflection within today's window (Story 4). */
+export async function patchCamperReflection(reflectionId, {
+  answers,
+  language,
+  teamVisibility,
+}) {
+  const payload = {};
+  if (answers !== undefined) payload.answers = answers;
+  if (language !== undefined) payload.language = language;
+  if (teamVisibility !== undefined) payload.team_visibility = teamVisibility;
+  const { data } = await api.patch(
+    `/api/v1/counselor/camper-reflections/${reflectionId}/`,
+    payload,
+  );
+  return data;
+}
+
+/**
+ * Fetch a template by ID — used to load the full schema once the camper
+ * reflection list endpoint has handed us back ``template.id``. We don't
+ * hit ``template-for-me`` for camper reflections because that resolver
+ * uses ``subject_mode='self'`` semantics; the camper bunk-roster template
+ * is selected server-side by ``CamperReflectionListView`` and we just
+ * need its ``schema`` to render the form.
+ */
+export async function fetchTemplateById(templateId) {
+  const { data } = await api.get(`/api/v1/templates/${templateId}/`);
+  return data;
+}
+
+/** Read a single reflection (for prefilling the edit form). */
+export async function fetchReflection(reflectionId) {
+  const { data } = await api.get(`/api/v1/reflections/${reflectionId}/`);
+  return data;
+}
+
+/**
+ * Static audience labels for a camper reflection (write-time disclosure).
+ *
+ * The backend computes the canonical list from
+ * ``audience_labels(ContentType.CAMPER_REFLECTION, ...)`` and returns it
+ * on each write response, but at form-render time we don't yet have a
+ * server-computed value. The set is constant for camper reflections
+ * regardless of ``team_visibility`` (no sensitive override is configured
+ * in ``_SENSITIVE_AUDIENCES`` for this content type), so we mirror the
+ * default list here in alphabetical order to match the server output.
+ *
+ * Keep in sync with ``bunk_logs/core/content_visibility.py``.
+ */
+export const CAMPER_REFLECTION_AUDIENCE = Object.freeze([
+  'Admin',
+  'Camper Care',
+  'Counselor',
+  'Leadership Team',
+  'Unit Head',
+]);

--- a/frontend/src/pages/counselor/CamperReflectionFormPage.jsx
+++ b/frontend/src/pages/counselor/CamperReflectionFormPage.jsx
@@ -1,0 +1,373 @@
+/**
+ * Camper reflection form — Step 7_6d (Stories 3 + 4).
+ *
+ * Two URL shapes:
+ *
+ *   /counselor/camper-reflections/new?subject=<id>&bunk=<id>&name=...
+ *     → POST /api/v1/counselor/camper-reflections/  (new submission)
+ *
+ *   /counselor/camper-reflections/:reflectionId/edit
+ *     → PATCH /api/v1/counselor/camper-reflections/:reflectionId/
+ *
+ * Both modes load the template schema (via /api/v1/templates/:id/) so the
+ * form fields render from server-side config. Idempotency: a single
+ * `client_submission_id` UUID is generated once on mount in create mode
+ * and reused across retries so the backend's
+ * ``find_existing_by_client_submission_id`` collapses duplicate submits
+ * into a 200 (existing row) instead of a 201 (new row).
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import AudienceDisclosure from '../../components/AudienceDisclosure';
+import ReflectionField from '../../components/templates/ReflectionField';
+import {
+  buildDefaultAnswers,
+  validateReflectionAnswers,
+} from '../../utils/reflection/reflectionFormValidation';
+import {
+  CAMPER_REFLECTION_AUDIENCE,
+  createCamperReflection,
+  fetchCamperReflections,
+  fetchReflection,
+  fetchTemplateById,
+  newClientSubmissionId,
+  patchCamperReflection,
+} from '../../api/counselor';
+
+function flattenError(err, fallback) {
+  const body = err?.response?.data;
+  if (!body) return err?.message || fallback;
+  if (typeof body === 'string') return body;
+  if (typeof body.detail === 'string') return body.detail;
+  if (typeof body === 'object') {
+    try {
+      return JSON.stringify(body);
+    } catch (_) {
+      return fallback;
+    }
+  }
+  return fallback;
+}
+
+export default function CamperReflectionFormPage() {
+  const navigate = useNavigate();
+  const { reflectionId: editIdParam } = useParams();
+  const [searchParams] = useSearchParams();
+
+  const isEdit = !!editIdParam;
+  const editReflectionId = isEdit ? Number(editIdParam) : null;
+  const subjectIdParam = isEdit ? null : Number(searchParams.get('subject'));
+  const bunkIdParam = isEdit ? null : Number(searchParams.get('bunk'));
+  const subjectNameParam = searchParams.get('name') || '';
+
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
+  const [schema, setSchema] = useState(null);
+  const [templateMeta, setTemplateMeta] = useState(null);
+  const [supportsPrivacy, setSupportsPrivacy] = useState(false);
+
+  const [answers, setAnswers] = useState({});
+  const [language, setLanguage] = useState('en');
+  const [teamVisibility, setTeamVisibility] = useState('team');
+  const [subjectName, setSubjectName] = useState(subjectNameParam);
+  const [resolvedSubjectId, setResolvedSubjectId] = useState(subjectIdParam);
+  const [resolvedBunkId, setResolvedBunkId] = useState(bunkIdParam);
+
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [submitError, setSubmitError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  // Persist a single client_submission_id across retries for new submissions.
+  // ``useRef`` keeps the UUID stable even if the component re-renders mid-submit.
+  const clientSubmissionIdRef = useRef(null);
+  if (!isEdit && clientSubmissionIdRef.current === null) {
+    clientSubmissionIdRef.current = newClientSubmissionId();
+  }
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError('');
+    try {
+      if (isEdit) {
+        const reflection = await fetchReflection(editReflectionId);
+        const templateId = reflection.template || reflection.template_meta?.id;
+        if (!templateId) {
+          setLoadError('Reflection has no template attached.');
+          return;
+        }
+        const template = await fetchTemplateById(templateId);
+        setSchema(template.schema);
+        setTemplateMeta({
+          id: template.id,
+          name: template.name,
+          slug: template.slug,
+          version: template.version,
+          languages: template.languages || ['en'],
+        });
+        setSupportsPrivacy(!!template.supports_privacy);
+        const defaults = buildDefaultAnswers(template.schema);
+        setAnswers({ ...defaults, ...(reflection.answers || {}) });
+        setLanguage(reflection.language || 'en');
+        setTeamVisibility(reflection.team_visibility || 'team');
+        setResolvedSubjectId(reflection.subject || null);
+        setResolvedBunkId(reflection.assignment_group || null);
+      } else {
+        // Pull today's roster to discover the active template id + verify
+        // the camper is on a bunk the viewer authors. Cheaper than another
+        // template-by-program endpoint for this v1 flow.
+        const roster = await fetchCamperReflections();
+        const templateRef = roster.template;
+        if (!templateRef?.id) {
+          setLoadError('No camper reflection template is configured for your program.');
+          return;
+        }
+        const template = await fetchTemplateById(templateRef.id);
+        setSchema(template.schema);
+        setTemplateMeta({
+          id: template.id,
+          name: template.name,
+          slug: template.slug,
+          version: template.version,
+          languages: template.languages || ['en'],
+        });
+        setSupportsPrivacy(!!template.supports_privacy);
+        setAnswers(buildDefaultAnswers(template.schema));
+
+        // Best-effort camper-name display from the roster if the link
+        // didn't pass `?name=...`; non-fatal if missing.
+        if (!subjectNameParam && subjectIdParam) {
+          const bunk = roster.bunks?.find((b) => b.id === bunkIdParam);
+          const row = bunk?.campers?.find((c) => c.id === subjectIdParam);
+          if (row?.name) setSubjectName(row.name);
+        }
+      }
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 403) {
+        setLoadError('You do not have permission to open this reflection.');
+      } else if (status === 404) {
+        setLoadError('Reflection not found.');
+      } else {
+        setLoadError(flattenError(err, 'Could not load the form.'));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [isEdit, editReflectionId, subjectIdParam, bunkIdParam, subjectNameParam]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const updateAnswer = (key, value) => {
+    setAnswers((prev) => ({ ...prev, [key]: value }));
+    setFieldErrors((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  };
+
+  const langChoices = useMemo(
+    () => (templateMeta?.languages?.length ? templateMeta.languages : ['en']),
+    [templateMeta],
+  );
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitError('');
+    if (!schema || !templateMeta?.id) {
+      setSubmitError('Template not loaded.');
+      return;
+    }
+
+    const { ok, errors } = validateReflectionAnswers(schema, answers);
+    setFieldErrors(errors);
+    if (!ok) return;
+
+    setSubmitting(true);
+    try {
+      if (isEdit) {
+        await patchCamperReflection(editReflectionId, {
+          answers,
+          language,
+          teamVisibility: supportsPrivacy ? teamVisibility : undefined,
+        });
+      } else {
+        if (!resolvedSubjectId || !resolvedBunkId) {
+          setSubmitError('Missing camper or bunk reference.');
+          setSubmitting(false);
+          return;
+        }
+        await createCamperReflection({
+          subjectId: resolvedSubjectId,
+          assignmentGroupId: resolvedBunkId,
+          answers,
+          language,
+          teamVisibility: supportsPrivacy ? teamVisibility : 'team',
+          clientSubmissionId: clientSubmissionIdRef.current,
+        });
+      }
+      navigate('/counselor/camper-reflections', { replace: true });
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 403) {
+        setSubmitError(flattenError(err, 'You can no longer edit this reflection.'));
+      } else if (status === 400) {
+        // Validation errors — try to surface field-level messages.
+        const body = err?.response?.data;
+        if (body && typeof body === 'object' && !Array.isArray(body)) {
+          const fieldKeys = Object.keys(body).filter((k) => k !== 'detail');
+          const next = {};
+          for (const k of fieldKeys) {
+            const v = body[k];
+            next[k] = Array.isArray(v) ? v[0] : typeof v === 'string' ? v : JSON.stringify(v);
+          }
+          setFieldErrors(next);
+          setSubmitError(typeof body.detail === 'string' ? body.detail : 'Please fix the errors and try again.');
+        } else {
+          setSubmitError(flattenError(err, 'Submit failed.'));
+        }
+      } else {
+        setSubmitError(flattenError(err, 'Submit failed.'));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="px-4 py-6 pb-24">
+      <div className="max-w-lg mx-auto">
+        <header className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <button
+              type="button"
+              onClick={() => navigate('/counselor/camper-reflections')}
+              className="text-xs text-blue-600 dark:text-blue-400 mb-1 flex items-center gap-1"
+            >
+              ← Back to roster
+            </button>
+            <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
+              {subjectName ? `About ${subjectName}` : 'Camper reflection'}
+            </h1>
+            {templateMeta ? (
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                {templateMeta.name}
+              </p>
+            ) : null}
+          </div>
+          {langChoices.length > 1 ? (
+            <div className="flex items-center gap-2 shrink-0">
+              <span className="text-xs text-gray-500 uppercase tracking-wide">Language</span>
+              <div
+                className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden"
+                data-testid="camper-reflection-language"
+              >
+                {langChoices.map((code) => (
+                  <button
+                    key={code}
+                    type="button"
+                    onClick={() => setLanguage(code)}
+                    aria-pressed={language === code}
+                    className={`px-3 py-1.5 text-sm font-medium min-h-[44px] ${
+                      language === code
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200'
+                    }`}
+                  >
+                    {code === 'es' ? 'Español' : code === 'en' ? 'English' : code}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </header>
+
+        {loading ? (
+          <p
+            className="text-gray-600 dark:text-gray-400"
+            data-testid="camper-reflection-loading"
+          >
+            Loading form…
+          </p>
+        ) : loadError ? (
+          <div
+            className="rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/40 dark:border-amber-800 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+            role="alert"
+            data-testid="camper-reflection-load-error"
+          >
+            {loadError}
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-2" data-testid="camper-reflection-form">
+            <AudienceDisclosure audience={CAMPER_REFLECTION_AUDIENCE} />
+
+            {supportsPrivacy ? (
+              <fieldset
+                className="mb-4 rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-3"
+                data-testid="camper-reflection-visibility"
+              >
+                <legend className="text-xs font-medium text-gray-600 dark:text-gray-400 px-1">
+                  Visible to
+                </legend>
+                <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden mt-1">
+                  {[
+                    { value: 'team', label: 'My team' },
+                    { value: 'supervisors_only', label: 'Supervisors only' },
+                  ].map((opt) => (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      aria-pressed={teamVisibility === opt.value}
+                      data-testid={`camper-reflection-visibility-${opt.value}`}
+                      onClick={() => setTeamVisibility(opt.value)}
+                      className={`flex-1 px-3 py-2 text-sm font-medium min-h-[44px] ${
+                        teamVisibility === opt.value
+                          ? 'bg-blue-600 text-white'
+                          : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200'
+                      }`}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              </fieldset>
+            ) : null}
+
+            {(schema?.fields || []).map((field) => (
+              <ReflectionField
+                key={field.key}
+                field={field}
+                language={language}
+                answer={answers[field.key]}
+                onChange={(val) => updateAnswer(field.key, val)}
+                error={fieldErrors[field.key]}
+              />
+            ))}
+
+            {submitError ? (
+              <p
+                className="text-red-600 text-sm"
+                role="alert"
+                data-testid="camper-reflection-submit-error"
+              >
+                {submitError}
+              </p>
+            ) : null}
+
+            <button
+              type="submit"
+              disabled={submitting}
+              data-testid="camper-reflection-submit"
+              className="w-full sm:w-auto mt-4 min-h-[48px] px-6 rounded-lg bg-blue-600 text-white font-medium text-sm disabled:opacity-50"
+            >
+              {submitting ? 'Submitting…' : isEdit ? 'Save changes' : 'Submit reflection'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/counselor/CamperReflectionListPage.jsx
+++ b/frontend/src/pages/counselor/CamperReflectionListPage.jsx
@@ -1,0 +1,246 @@
+/**
+ * Camper reflection roster — Step 7_6d (Story 3).
+ *
+ * Lists each bunk the counselor authors on with per-camper submission
+ * state for a given date. Two URL shapes:
+ *
+ *   /counselor/camper-reflections        → today's roster
+ *   /counselor/camper-reflections/:date  → historical (read-only) view
+ *
+ * The endpoint already differentiates editable from read-only via the
+ * `editable` flag on each row and on the response root. Today's view
+ * shows "Add reflection" CTAs for missing campers and "Edit" for
+ * submitted ones; past dates show submitted-only rows with no CTAs.
+ *
+ * Off-camp campers are rendered in a dedicated subsection per bunk and
+ * are not actionable.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { fetchCamperReflections } from '../../api/counselor';
+
+function CamperRow({ camper, bunkId, editable, dateIsToday }) {
+  const submitted = !!camper.submitted;
+  const submitter = camper.submitter;
+  const wasMine = submitter?.is_self;
+  const submitterName = submitter && !wasMine ? submitter.name : null;
+
+  return (
+    <li
+      data-testid={`camper-row-${camper.id}`}
+      data-submitted={submitted ? 'true' : 'false'}
+      className="flex items-center justify-between gap-3 py-3 border-b border-gray-100 dark:border-gray-800 last:border-b-0"
+    >
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+          {camper.name}
+        </p>
+        {submitted ? (
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            {wasMine ? 'Submitted by you' : submitterName ? `Submitted by ${submitterName}` : 'Submitted'}
+          </p>
+        ) : (
+          <p className="text-xs text-amber-700 dark:text-amber-300 mt-0.5">
+            Needs reflection
+          </p>
+        )}
+      </div>
+      {submitted && camper.editable && dateIsToday ? (
+        <Link
+          data-testid={`camper-row-${camper.id}-edit`}
+          to={`/counselor/camper-reflections/${camper.reflection_id}/edit`}
+          className="shrink-0 inline-flex items-center justify-center min-h-[44px] px-3 rounded-lg border border-gray-300 dark:border-gray-600 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800"
+        >
+          Edit
+        </Link>
+      ) : !submitted && editable ? (
+        <Link
+          data-testid={`camper-row-${camper.id}-new`}
+          to={`/counselor/camper-reflections/new?subject=${camper.id}&bunk=${bunkId}&name=${encodeURIComponent(camper.name || '')}`}
+          className="shrink-0 inline-flex items-center justify-center min-h-[44px] px-3 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
+        >
+          Add
+        </Link>
+      ) : (
+        <span
+          data-testid={`camper-row-${camper.id}-readonly`}
+          className="shrink-0 text-xs text-gray-400 dark:text-gray-500"
+        >
+          Read-only
+        </span>
+      )}
+    </li>
+  );
+}
+
+function OffCampList({ rows }) {
+  if (!rows?.length) return null;
+  return (
+    <div className="mt-4 pt-3 border-t border-dashed border-gray-200 dark:border-gray-700">
+      <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+        Off-camp today
+      </p>
+      <ul className="space-y-1">
+        {rows.map((row) => (
+          <li
+            key={row.id}
+            data-testid={`off-camp-row-${row.id}`}
+            className="text-sm text-gray-700 dark:text-gray-300"
+          >
+            {row.name}
+            <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">(not counted)</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function BunkCard({ bunk, editable, dateIsToday }) {
+  return (
+    <section
+      data-testid={`bunk-card-${bunk.id}`}
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-4 shadow-sm"
+    >
+      <header className="flex items-center justify-between mb-2">
+        <div>
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+            {bunk.name}
+          </h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            {bunk.covered}/{bunk.total} covered
+          </p>
+        </div>
+        <span
+          data-testid={`bunk-card-${bunk.id}-state`}
+          className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+            bunk.total === 0 || bunk.covered >= bunk.total
+              ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200'
+              : 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200'
+          }`}
+        >
+          {bunk.total === 0 ? 'No campers' : bunk.covered >= bunk.total ? 'Done' : 'In progress'}
+        </span>
+      </header>
+
+      {bunk.campers?.length ? (
+        <ul>
+          {bunk.campers.map((camper) => (
+            <CamperRow
+              key={camper.id}
+              camper={camper}
+              bunkId={bunk.id}
+              editable={editable}
+              dateIsToday={dateIsToday}
+            />
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          No campers on roster.
+        </p>
+      )}
+
+      <OffCampList rows={bunk.off_camp} />
+    </section>
+  );
+}
+
+export default function CamperReflectionListPage() {
+  const { date: dateParam } = useParams();
+  const navigate = useNavigate();
+  const [data, setData] = useState(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const payload = await fetchCamperReflections({ date: dateParam });
+      setData(payload);
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      const status = err?.response?.status;
+      if (status === 400) {
+        setError(typeof detail === 'string' ? detail : 'Invalid date.');
+      } else if (status === 403) {
+        setError(typeof detail === 'string' ? detail : 'You do not have access to camper reflections.');
+      } else {
+        setError(typeof detail === 'string' ? detail : 'Could not load the roster.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [dateParam]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <div className="px-4 py-6 pb-24">
+      <div className="max-w-lg mx-auto space-y-4">
+        <header>
+          <button
+            type="button"
+            onClick={() => navigate('/counselor')}
+            className="text-xs text-blue-600 dark:text-blue-400 mb-1 flex items-center gap-1"
+          >
+            ← Back to dashboard
+          </button>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
+            Camper reflections
+          </h1>
+          {data?.date ? (
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {data.date}
+              {!data.editable ? (
+                <span
+                  data-testid="camper-roster-readonly-banner"
+                  className="ml-2 inline-flex items-center text-xs font-medium px-2 py-0.5 rounded-full bg-gray-200 text-gray-700 dark:bg-gray-800 dark:text-gray-200"
+                >
+                  Read-only
+                </span>
+              ) : null}
+            </p>
+          ) : null}
+        </header>
+
+        {loading ? (
+          <p
+            className="text-gray-600 dark:text-gray-400"
+            data-testid="camper-roster-loading"
+          >
+            Loading roster…
+          </p>
+        ) : error ? (
+          <div
+            className="rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/40 dark:border-amber-800 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+            role="alert"
+            data-testid="camper-roster-error"
+          >
+            {error}
+          </div>
+        ) : data?.bunks?.length ? (
+          data.bunks.map((bunk) => (
+            <BunkCard
+              key={bunk.id}
+              bunk={bunk}
+              editable={data.editable}
+              dateIsToday={data.editable}
+            />
+          ))
+        ) : (
+          <p
+            className="text-gray-600 dark:text-gray-400"
+            data-testid="camper-roster-empty"
+          >
+            You aren&apos;t assigned to any bunks.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/counselor/CounselorMobileDashboard.jsx
+++ b/frontend/src/pages/counselor/CounselorMobileDashboard.jsx
@@ -1,0 +1,304 @@
+/**
+ * Counselor mobile dashboard — Step 7_6d (Stories 2 + 9).
+ *
+ * Renders the three-section payload from
+ * `GET /api/v1/counselor/dashboard/`:
+ *
+ *   1. Camper reflections — covered / total, off-camp count, deep link
+ *      into the roster page.
+ *   2. Self-reflection — submitted/missing state, day-off badge, edit
+ *      link.
+ *   3. Open requests — combined camper-care + maintenance count from
+ *      the viewer + co-counselors (decision C4).
+ *
+ * "All set" banner appears when the first two sections are complete.
+ * The Requests section never blocks all-set (Story 9 criterion 2).
+ *
+ * Auto-refresh on a 60-second interval so co-counselor submissions
+ * surface without a manual reload (matches dashboard cache TTL of 30s
+ * with one round-trip of buffer).
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchCounselorDashboard } from '../../api/counselor';
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+function SectionCard({ title, state, children, actionLabel, actionTo, dataTestid }) {
+  const stateBadge = (() => {
+    switch (state) {
+      case 'complete':
+        return { label: 'Done', className: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200' };
+      case 'in_progress':
+        return { label: 'In progress', className: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200' };
+      case 'none':
+      default:
+        return { label: 'Not started', className: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200' };
+    }
+  })();
+
+  return (
+    <section
+      data-testid={dataTestid}
+      data-state={state}
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-4 shadow-sm"
+    >
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white">{title}</h2>
+        <span
+          className={`text-xs font-medium px-2 py-0.5 rounded-full ${stateBadge.className}`}
+          data-testid={`${dataTestid}-state`}
+        >
+          {stateBadge.label}
+        </span>
+      </div>
+      <div className="text-sm text-gray-700 dark:text-gray-300">{children}</div>
+      {actionTo ? (
+        <div className="mt-3">
+          <Link
+            to={actionTo}
+            data-testid={`${dataTestid}-action`}
+            className="inline-flex items-center justify-center min-h-[44px] px-4 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
+          >
+            {actionLabel}
+          </Link>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function CamperSection({ section }) {
+  const { covered = 0, total = 0, off_camp: offCamp = 0, state } = section || {};
+  const remaining = Math.max(total - covered, 0);
+
+  let summary;
+  if (total === 0) {
+    summary = (
+      <p className="text-gray-600 dark:text-gray-400">
+        No campers on roster today.
+      </p>
+    );
+  } else if (state === 'complete') {
+    summary = (
+      <p>
+        All <span className="font-medium">{total}</span> campers covered.
+      </p>
+    );
+  } else {
+    summary = (
+      <p>
+        <span className="font-medium">{remaining}</span> camper{remaining === 1 ? '' : 's'} still need{remaining === 1 ? 's' : ''} a reflection.
+        {' '}
+        <span className="text-gray-500 dark:text-gray-400">
+          ({covered}/{total})
+        </span>
+      </p>
+    );
+  }
+
+  return (
+    <SectionCard
+      title="Camper reflections"
+      state={state}
+      actionLabel={state === 'complete' ? 'Review' : 'Start reflections'}
+      actionTo="/counselor/camper-reflections"
+      dataTestid="counselor-section-campers"
+    >
+      {summary}
+      {offCamp > 0 ? (
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          {offCamp} camper{offCamp === 1 ? '' : 's'} off-camp today (not counted).
+        </p>
+      ) : null}
+    </SectionCard>
+  );
+}
+
+function SelfSection({ section }) {
+  const { state, submitted, is_day_off: isDayOff, template, reflection_id: reflectionId } = section || {};
+  let summary;
+  let actionLabel;
+  let actionTo;
+  if (template === null) {
+    summary = (
+      <p className="text-gray-600 dark:text-gray-400">
+        No self-reflection template is configured for your role.
+      </p>
+    );
+  } else if (state === 'complete') {
+    summary = isDayOff ? (
+      <p>Day off recorded — nothing else to do here.</p>
+    ) : (
+      <p>Your self-reflection is in.</p>
+    );
+    if (reflectionId) {
+      actionLabel = 'Edit';
+      actionTo = `/counselor/self-reflection/${reflectionId}/edit`;
+    }
+  } else {
+    summary = <p>You haven&apos;t submitted your self-reflection yet.</p>;
+    actionLabel = 'Open self-reflection';
+    actionTo = '/counselor/self-reflection';
+  }
+
+  return (
+    <SectionCard
+      title="My self-reflection"
+      state={state}
+      actionLabel={actionLabel}
+      actionTo={actionTo}
+      dataTestid="counselor-section-self"
+    >
+      {summary}
+    </SectionCard>
+  );
+}
+
+function RequestsSection({ section }) {
+  const { open_count: openCount = 0, by_type: byType = {}, state } = section || {};
+  const camperCare = byType.camper_care || 0;
+  const maintenance = byType.maintenance || 0;
+
+  const summary = openCount === 0 ? (
+    <p className="text-gray-600 dark:text-gray-400">
+      No open requests on your bunks right now.
+    </p>
+  ) : (
+    <p>
+      <span className="font-medium">{openCount}</span> open request{openCount === 1 ? '' : 's'} — {camperCare} camper care, {maintenance} maintenance.
+    </p>
+  );
+
+  return (
+    <SectionCard
+      title="Open requests"
+      state={state}
+      actionLabel="View requests"
+      actionTo="/counselor/requests"
+      dataTestid="counselor-section-requests"
+    >
+      {summary}
+    </SectionCard>
+  );
+}
+
+export default function CounselorMobileDashboard() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(async ({ background = false } = {}) => {
+    if (background) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
+    }
+    setError('');
+    try {
+      const payload = await fetchCounselorDashboard({ noCache: background });
+      setData(payload);
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      const status = err?.response?.status;
+      if (status === 403) {
+        setError(typeof detail === 'string' ? detail : 'You do not have access to the counselor dashboard.');
+      } else {
+        setError(typeof detail === 'string' ? detail : 'Could not load your dashboard.');
+      }
+    } finally {
+      if (background) {
+        setRefreshing(false);
+      } else {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!data) return undefined;
+    const id = setInterval(() => {
+      load({ background: true });
+    }, REFRESH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [data, load]);
+
+  if (loading) {
+    return (
+      <div className="px-4 py-6">
+        <div className="max-w-lg mx-auto" data-testid="counselor-dashboard-loading">
+          <p className="text-gray-600 dark:text-gray-400">Loading your dashboard…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="px-4 py-6">
+        <div
+          className="max-w-lg mx-auto rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/40 dark:border-amber-800 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+          role="alert"
+          data-testid="counselor-dashboard-error"
+        >
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const { today, all_set: allSet, sections, program } = data;
+  const camperSection = sections?.camper_reflections;
+  const selfSection = sections?.self_reflection;
+  const requestsSection = sections?.requests;
+
+  return (
+    <div className="px-4 py-6 pb-24">
+      <div className="max-w-lg mx-auto space-y-4">
+        <header className="mb-2">
+          <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            {program?.name ? `${program.name} · ` : ''}Today
+          </p>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
+            {today}
+          </h1>
+          {refreshing ? (
+            <p
+              className="text-xs text-gray-400 dark:text-gray-500 mt-1"
+              data-testid="counselor-dashboard-refreshing"
+            >
+              Refreshing…
+            </p>
+          ) : null}
+        </header>
+
+        {allSet ? (
+          <div
+            className="rounded-xl border border-green-200 bg-green-50 dark:bg-green-950/40 dark:border-green-800 px-4 py-3"
+            data-testid="counselor-all-set"
+            role="status"
+          >
+            <p className="text-sm font-medium text-green-900 dark:text-green-100">
+              You&apos;re all set for today — nice work.
+            </p>
+            <p className="text-xs text-green-800 dark:text-green-200 mt-1">
+              Edits stay open until the day rolls over.
+            </p>
+          </div>
+        ) : null}
+
+        <CamperSection section={camperSection} />
+        <SelfSection section={selfSection} />
+        <RequestsSection section={requestsSection} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/counselor/__tests__/CamperReflectionFormPage.test.jsx
+++ b/frontend/src/pages/counselor/__tests__/CamperReflectionFormPage.test.jsx
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import CamperReflectionFormPage from '../CamperReflectionFormPage';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+const patchMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: (...args) => postMock(...args),
+    patch: (...args) => patchMock(...args),
+  },
+}));
+
+function ListProbe() {
+  const loc = useLocation();
+  return (
+    <div data-testid="list-probe" data-pathname={loc.pathname}>
+      list
+    </div>
+  );
+}
+
+const templateSchema = {
+  fields: [
+    { key: 'note', type: 'text', prompts: { en: 'Note?' } },
+    {
+      key: 'r',
+      type: 'rating_group',
+      prompts: { en: 'Ratings?' },
+      scale_labels: { en: ['1', '2', '3', '4'] },
+      categories: [{ key: 'effort', labels: { en: 'Effort' } }],
+    },
+  ],
+};
+
+const templatePayload = {
+  id: 7,
+  name: 'Camper daily',
+  slug: 'camper-daily',
+  version: 1,
+  languages: ['en', 'es'],
+  supports_privacy: true,
+  schema: templateSchema,
+};
+
+const rosterPayload = {
+  date: '2026-07-04',
+  editable: true,
+  template: { id: 7, slug: 'camper-daily', name: 'Camper daily', version: 1 },
+  bunks: [
+    {
+      id: 100,
+      slug: 'bunk-a',
+      name: 'Bunk A',
+      covered: 0,
+      total: 1,
+      campers: [
+        {
+          id: 11,
+          name: 'Diana W.',
+          preferred_name: 'Diana',
+          first_name: 'Diana',
+          last_initial: 'W',
+          submitted: false,
+          reflection_id: null,
+          submitted_at: null,
+          submitter: null,
+          editable: false,
+        },
+      ],
+      off_camp: [],
+    },
+  ],
+};
+
+function renderCreate(query = '?subject=11&bunk=100&name=Diana%20W.') {
+  return render(
+    <MemoryRouter initialEntries={[`/counselor/camper-reflections/new${query}`]}>
+      <Routes>
+        <Route
+          path="/counselor/camper-reflections/new"
+          element={<CamperReflectionFormPage />}
+        />
+        <Route path="/counselor/camper-reflections" element={<ListProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function renderEdit(reflectionId = 501) {
+  return render(
+    <MemoryRouter initialEntries={[`/counselor/camper-reflections/${reflectionId}/edit`]}>
+      <Routes>
+        <Route
+          path="/counselor/camper-reflections/:reflectionId/edit"
+          element={<CamperReflectionFormPage />}
+        />
+        <Route path="/counselor/camper-reflections" element={<ListProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function arrangeCreateRoute() {
+  // First call: roster fetch (for template id).
+  getMock.mockResolvedValueOnce({ data: rosterPayload });
+  // Second call: template-by-id fetch (for schema).
+  getMock.mockResolvedValueOnce({ data: templatePayload });
+}
+
+describe('CamperReflectionFormPage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    postMock.mockReset();
+    patchMock.mockReset();
+  });
+
+  describe('create mode', () => {
+    it('loads the active template schema and renders fields', async () => {
+      arrangeCreateRoute();
+      renderCreate();
+      await waitFor(() => expect(screen.getByText('Note?')).toBeInTheDocument());
+      expect(screen.getByText('Ratings?')).toBeInTheDocument();
+      expect(screen.getByText(/About Diana W\./i)).toBeInTheDocument();
+    });
+
+    it('shows the audience disclosure with the camper-reflection labels', async () => {
+      arrangeCreateRoute();
+      renderCreate();
+      await waitFor(() => expect(screen.getByTestId('audience-disclosure')).toBeInTheDocument());
+      expect(screen.getByTestId('audience-disclosure-labels')).toHaveTextContent(
+        'Admin, Camper Care, Counselor, Leadership Team, Unit Head',
+      );
+    });
+
+    it('blocks submit while required fields are missing', async () => {
+      const user = userEvent.setup();
+      arrangeCreateRoute();
+      renderCreate();
+      await waitFor(() => expect(screen.getByText('Note?')).toBeInTheDocument());
+      await user.click(screen.getByTestId('camper-reflection-submit'));
+      expect(postMock).not.toHaveBeenCalled();
+      expect(screen.getByText(/Rate every category/i)).toBeInTheDocument();
+    });
+
+    it('POSTs with subject + bunk + a UUID client_submission_id, then navigates back to the list', async () => {
+      const user = userEvent.setup();
+      arrangeCreateRoute();
+      postMock.mockResolvedValue({ data: { id: 999 }, status: 201 });
+      renderCreate();
+      await waitFor(() => expect(screen.getByText('Note?')).toBeInTheDocument());
+
+      await user.type(screen.getByTestId('reflect-input-note'), 'great day');
+      const ratingButtons = screen.getAllByRole('button', { name: '3' });
+      await user.click(ratingButtons[0]);
+
+      await user.click(screen.getByTestId('camper-reflection-submit'));
+      await waitFor(() => expect(postMock).toHaveBeenCalled());
+
+      expect(postMock.mock.calls[0][0]).toBe('/api/v1/counselor/camper-reflections/');
+      const body = postMock.mock.calls[0][1];
+      expect(body.subject_id).toBe(11);
+      expect(body.assignment_group_id).toBe(100);
+      expect(body.answers.note).toBe('great day');
+      expect(body.answers.r).toEqual({ effort: 3 });
+      expect(body.team_visibility).toBe('team');
+      expect(typeof body.client_submission_id).toBe('string');
+      expect(body.client_submission_id.length).toBeGreaterThanOrEqual(36);
+
+      await waitFor(() => expect(screen.getByTestId('list-probe')).toBeInTheDocument());
+    });
+
+    it('reuses the same client_submission_id on retry after a failed submit', async () => {
+      const user = userEvent.setup();
+      arrangeCreateRoute();
+      postMock
+        .mockRejectedValueOnce({ response: { status: 500, data: { detail: 'oops' } } })
+        .mockResolvedValueOnce({ data: { id: 1000 }, status: 201 });
+      renderCreate();
+      await waitFor(() => expect(screen.getByText('Note?')).toBeInTheDocument());
+      await user.type(screen.getByTestId('reflect-input-note'), 'retry note');
+      const ratingButtons = screen.getAllByRole('button', { name: '3' });
+      await user.click(ratingButtons[0]);
+
+      await user.click(screen.getByTestId('camper-reflection-submit'));
+      await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+      expect(await screen.findByTestId('camper-reflection-submit-error')).toBeInTheDocument();
+
+      await user.click(screen.getByTestId('camper-reflection-submit'));
+      await waitFor(() => expect(postMock).toHaveBeenCalledTimes(2));
+
+      const firstUuid = postMock.mock.calls[0][1].client_submission_id;
+      const secondUuid = postMock.mock.calls[1][1].client_submission_id;
+      expect(firstUuid).toBe(secondUuid);
+    });
+
+    it('surfaces a 403 from the server on closed edit window', async () => {
+      const user = userEvent.setup();
+      arrangeCreateRoute();
+      postMock.mockRejectedValue({
+        response: {
+          status: 403,
+          data: { detail: 'Camper is marked off-camp today.' },
+        },
+      });
+      renderCreate();
+      await waitFor(() => expect(screen.getByText('Note?')).toBeInTheDocument());
+      await user.type(screen.getByTestId('reflect-input-note'), 'late');
+      const ratingButtons = screen.getAllByRole('button', { name: '3' });
+      await user.click(ratingButtons[0]);
+      await user.click(screen.getByTestId('camper-reflection-submit'));
+      await waitFor(() => expect(screen.getByTestId('camper-reflection-submit-error')).toBeInTheDocument());
+      expect(screen.getByTestId('camper-reflection-submit-error')).toHaveTextContent(
+        /Camper is marked off-camp today/i,
+      );
+    });
+
+    it('renders the load error when no template is configured', async () => {
+      getMock.mockResolvedValueOnce({
+        data: { date: '2026-07-04', editable: true, template: null, bunks: [] },
+      });
+      renderCreate();
+      await waitFor(() =>
+        expect(screen.getByTestId('camper-reflection-load-error')).toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe('edit mode', () => {
+    const existingReflection = {
+      id: 501,
+      subject: 11,
+      assignment_group: 100,
+      template: 7,
+      template_meta: { id: 7, slug: 'camper-daily', name: 'Camper daily', version: 1 },
+      answers: { note: 'already filled', r: { effort: 4 } },
+      language: 'en',
+      team_visibility: 'team',
+    };
+
+    function arrangeEditRoute() {
+      // First call: GET /api/v1/reflections/501/
+      getMock.mockResolvedValueOnce({ data: existingReflection });
+      // Second call: GET /api/v1/templates/7/
+      getMock.mockResolvedValueOnce({ data: templatePayload });
+    }
+
+    it('pre-fills existing answers, language, and visibility', async () => {
+      arrangeEditRoute();
+      renderEdit();
+      await waitFor(() => expect(screen.getByText('Note?')).toBeInTheDocument());
+      expect(screen.getByTestId('reflect-input-note')).toHaveValue('already filled');
+      expect(screen.getByTestId('camper-reflection-visibility-team')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+    });
+
+    it('PATCHes only the changed fields', async () => {
+      const user = userEvent.setup();
+      arrangeEditRoute();
+      patchMock.mockResolvedValue({ data: { id: 501 } });
+      renderEdit();
+      await waitFor(() => expect(screen.getByText('Note?')).toBeInTheDocument());
+
+      const noteInput = screen.getByTestId('reflect-input-note');
+      await user.clear(noteInput);
+      await user.type(noteInput, 'edited note');
+
+      await user.click(screen.getByTestId('camper-reflection-submit'));
+      await waitFor(() => expect(patchMock).toHaveBeenCalled());
+
+      expect(patchMock.mock.calls[0][0]).toBe('/api/v1/counselor/camper-reflections/501/');
+      const body = patchMock.mock.calls[0][1];
+      expect(body.answers.note).toBe('edited note');
+      expect(body.team_visibility).toBe('team');
+      expect(body).not.toHaveProperty('client_submission_id');
+      await waitFor(() => expect(screen.getByTestId('list-probe')).toBeInTheDocument());
+    });
+
+    it('surfaces a 403 edit-window-closed response', async () => {
+      const user = userEvent.setup();
+      arrangeEditRoute();
+      patchMock.mockRejectedValue({
+        response: {
+          status: 403,
+          data: {
+            detail: 'This reflection can no longer be edited (the edit window has closed).',
+          },
+        },
+      });
+      renderEdit();
+      await waitFor(() => expect(screen.getByText('Note?')).toBeInTheDocument());
+      const noteInput = screen.getByTestId('reflect-input-note');
+      await user.clear(noteInput);
+      await user.type(noteInput, 'too late');
+      await user.click(screen.getByTestId('camper-reflection-submit'));
+      await waitFor(() => expect(screen.getByTestId('camper-reflection-submit-error')).toBeInTheDocument());
+      expect(screen.getByTestId('camper-reflection-submit-error')).toHaveTextContent(
+        /edit window has closed/i,
+      );
+    });
+
+    it('renders 404 friendly text when the reflection is gone', async () => {
+      getMock.mockRejectedValueOnce({ response: { status: 404, data: { detail: 'not found' } } });
+      renderEdit();
+      await waitFor(() => expect(screen.getByTestId('camper-reflection-load-error')).toBeInTheDocument());
+      expect(screen.getByTestId('camper-reflection-load-error')).toHaveTextContent(/Reflection not found/i);
+    });
+  });
+});

--- a/frontend/src/pages/counselor/__tests__/CamperReflectionListPage.test.jsx
+++ b/frontend/src/pages/counselor/__tests__/CamperReflectionListPage.test.jsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import CamperReflectionListPage from '../CamperReflectionListPage';
+
+const getMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+  },
+}));
+
+function makeRoster(overrides = {}) {
+  return {
+    date: '2026-07-04',
+    editable: true,
+    template: { id: 7, slug: 'camper-daily', name: 'Camper Daily', version: 1 },
+    bunks: [
+      {
+        id: 100,
+        slug: 'bunk-a',
+        name: 'Bunk A',
+        covered: 1,
+        total: 2,
+        campers: [
+          {
+            id: 1,
+            name: 'Alice S.',
+            preferred_name: 'Alice',
+            first_name: 'Alice',
+            last_initial: 'S',
+            submitted: true,
+            reflection_id: 501,
+            submitted_at: '2026-07-04T15:00:00Z',
+            submitter: { is_self: true, name: null },
+            editable: true,
+          },
+          {
+            id: 2,
+            name: 'Bob T.',
+            preferred_name: 'Bob',
+            first_name: 'Bob',
+            last_initial: 'T',
+            submitted: false,
+            reflection_id: null,
+            submitted_at: null,
+            submitter: null,
+            editable: false,
+          },
+        ],
+        off_camp: [
+          { id: 3, name: 'Charlie U.', preferred_name: 'Charlie', first_name: 'Charlie', last_initial: 'U' },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderPage({ url = '/counselor/camper-reflections' } = {}) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <Routes>
+        <Route path="/counselor/camper-reflections" element={<CamperReflectionListPage />} />
+        <Route path="/counselor/camper-reflections/:date" element={<CamperReflectionListPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('CamperReflectionListPage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  it('renders the bunk roster with submitted and not-submitted rows', async () => {
+    getMock.mockResolvedValue({ data: makeRoster() });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Bunk A')).toBeInTheDocument());
+
+    const alice = screen.getByTestId('camper-row-1');
+    expect(alice).toHaveAttribute('data-submitted', 'true');
+    expect(alice).toHaveTextContent('Alice S.');
+    expect(alice).toHaveTextContent('Submitted by you');
+
+    const bob = screen.getByTestId('camper-row-2');
+    expect(bob).toHaveAttribute('data-submitted', 'false');
+    expect(bob).toHaveTextContent('Bob T.');
+    expect(bob).toHaveTextContent('Needs reflection');
+  });
+
+  it('shows submitter attribution for co-counselor submissions', async () => {
+    getMock.mockResolvedValue({
+      data: makeRoster({
+        bunks: [
+          {
+            id: 100,
+            slug: 'bunk-a',
+            name: 'Bunk A',
+            covered: 1,
+            total: 1,
+            campers: [
+              {
+                id: 1,
+                name: 'Alice S.',
+                preferred_name: 'Alice',
+                first_name: 'Alice',
+                last_initial: 'S',
+                submitted: true,
+                reflection_id: 501,
+                submitted_at: '2026-07-04T15:00:00Z',
+                submitter: { is_self: false, name: 'Casey C.' },
+                editable: true,
+              },
+            ],
+            off_camp: [],
+          },
+        ],
+      }),
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('camper-row-1')).toBeInTheDocument());
+    expect(screen.getByText('Submitted by Casey C.')).toBeInTheDocument();
+  });
+
+  it('renders off-camp campers in their own subsection', async () => {
+    getMock.mockResolvedValue({ data: makeRoster() });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('off-camp-row-3')).toBeInTheDocument());
+    expect(screen.getByText(/Off-camp today/i)).toBeInTheDocument();
+    expect(screen.getByText(/Charlie U\./)).toBeInTheDocument();
+  });
+
+  it('renders Add and Edit CTAs for editable today rows', async () => {
+    getMock.mockResolvedValue({ data: makeRoster() });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('camper-row-1-edit')).toBeInTheDocument());
+    expect(screen.getByTestId('camper-row-1-edit')).toHaveAttribute(
+      'href',
+      '/counselor/camper-reflections/501/edit',
+    );
+    expect(screen.getByTestId('camper-row-2-new')).toHaveAttribute(
+      'href',
+      expect.stringContaining('/counselor/camper-reflections/new?subject=2&bunk=100'),
+    );
+  });
+
+  it('hides Add/Edit affordances when the roster is read-only (past date)', async () => {
+    getMock.mockResolvedValue({
+      data: makeRoster({
+        date: '2026-07-01',
+        editable: false,
+        bunks: [
+          {
+            id: 100,
+            slug: 'bunk-a',
+            name: 'Bunk A',
+            covered: 1,
+            total: 1,
+            campers: [
+              {
+                id: 1,
+                name: 'Alice S.',
+                preferred_name: 'Alice',
+                first_name: 'Alice',
+                last_initial: 'S',
+                submitted: true,
+                reflection_id: 501,
+                submitted_at: '2026-07-01T15:00:00Z',
+                submitter: { is_self: true, name: null },
+                editable: false,
+              },
+            ],
+            off_camp: [],
+          },
+        ],
+      }),
+    });
+    renderPage({ url: '/counselor/camper-reflections/2026-07-01' });
+    await waitFor(() => expect(screen.getByTestId('camper-row-1')).toBeInTheDocument());
+    expect(screen.getByTestId('camper-roster-readonly-banner')).toBeInTheDocument();
+    expect(screen.queryByTestId('camper-row-1-edit')).toBeNull();
+    expect(screen.getByTestId('camper-row-1-readonly')).toBeInTheDocument();
+  });
+
+  it('passes the date param to the API', async () => {
+    getMock.mockResolvedValue({ data: makeRoster({ date: '2026-07-01' }) });
+    renderPage({ url: '/counselor/camper-reflections/2026-07-01' });
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    const lastCall = getMock.mock.calls[0];
+    expect(lastCall[0]).toBe('/api/v1/counselor/camper-reflections/');
+    expect(lastCall[1].params).toEqual({ date: '2026-07-01' });
+  });
+
+  it('renders the empty state when the viewer has no bunks', async () => {
+    getMock.mockResolvedValue({
+      data: { date: '2026-07-04', editable: true, template: null, bunks: [] },
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-roster-empty')).toBeInTheDocument(),
+    );
+  });
+
+  it('shows the error banner on 400 invalid date', async () => {
+    getMock.mockRejectedValue({
+      response: { status: 400, data: { detail: "Invalid 'date' query parameter; expected YYYY-MM-DD." } },
+    });
+    renderPage({ url: '/counselor/camper-reflections/garbage' });
+    await waitFor(() => expect(screen.getByTestId('camper-roster-error')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/pages/counselor/__tests__/CounselorMobileDashboard.test.jsx
+++ b/frontend/src/pages/counselor/__tests__/CounselorMobileDashboard.test.jsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import CounselorMobileDashboard from '../CounselorMobileDashboard';
+
+const getMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+  },
+}));
+
+function makePayload(overrides = {}) {
+  return {
+    today: '2026-07-04',
+    rollover_hour: 4,
+    timezone: 'America/New_York',
+    program: { id: 1, slug: 'clc-summer-2026', name: 'CLC Summer 2026' },
+    all_set: false,
+    sections: {
+      camper_reflections: {
+        state: 'in_progress',
+        covered: 2,
+        total: 5,
+        off_camp: 1,
+        bunk_count: 1,
+      },
+      self_reflection: {
+        state: 'none',
+        submitted: false,
+        reflection_id: null,
+        submitted_at: null,
+        is_day_off: false,
+        editable: false,
+        template: { id: 9, slug: 'counselor-self-reflection', name: 'Counselor self', version: 1 },
+      },
+      requests: {
+        state: 'in_progress',
+        open_count: 2,
+        by_type: { camper_care: 1, maintenance: 1 },
+      },
+      ...overrides.sections,
+    },
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/counselor']}>
+      <CounselorMobileDashboard />
+    </MemoryRouter>,
+  );
+}
+
+describe('CounselorMobileDashboard', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  it('renders the three sections from the dashboard payload', async () => {
+    getMock.mockResolvedValue({ data: makePayload() });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('2026-07-04')).toBeInTheDocument());
+
+    expect(screen.getByTestId('counselor-section-campers')).toBeInTheDocument();
+    expect(screen.getByTestId('counselor-section-self')).toBeInTheDocument();
+    expect(screen.getByTestId('counselor-section-requests')).toBeInTheDocument();
+
+    expect(screen.getByTestId('counselor-section-campers-state')).toHaveTextContent('In progress');
+    expect(screen.getByTestId('counselor-section-campers')).toHaveTextContent(
+      /3\s*campers? still need/i,
+    );
+    expect(screen.getByTestId('counselor-section-campers')).toHaveTextContent(
+      /1 camper off-camp today/i,
+    );
+  });
+
+  it('shows the all-set banner when both required sections are complete', async () => {
+    getMock.mockResolvedValue({
+      data: makePayload({
+        all_set: true,
+        sections: {
+          camper_reflections: { state: 'complete', covered: 5, total: 5, off_camp: 0, bunk_count: 1 },
+          self_reflection: {
+            state: 'complete',
+            submitted: true,
+            reflection_id: 42,
+            submitted_at: '2026-07-04T13:00:00Z',
+            is_day_off: false,
+            editable: true,
+            template: { id: 9, slug: 'counselor-self-reflection', name: 'Counselor self', version: 1 },
+          },
+          requests: { state: 'none', open_count: 0, by_type: { camper_care: 0, maintenance: 0 } },
+        },
+      }),
+    });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId('counselor-all-set')).toBeInTheDocument());
+    expect(screen.getByText(/you're all set for today/i)).toBeInTheDocument();
+  });
+
+  it('shows day-off summary when self_reflection.is_day_off is true', async () => {
+    getMock.mockResolvedValue({
+      data: makePayload({
+        sections: {
+          camper_reflections: { state: 'complete', covered: 0, total: 0, off_camp: 0, bunk_count: 0 },
+          self_reflection: {
+            state: 'complete',
+            submitted: true,
+            reflection_id: 50,
+            submitted_at: '2026-07-04T13:00:00Z',
+            is_day_off: true,
+            editable: true,
+            template: { id: 9, slug: 'counselor-self-reflection', name: 'Counselor self', version: 1 },
+          },
+          requests: { state: 'none', open_count: 0, by_type: { camper_care: 0, maintenance: 0 } },
+        },
+      }),
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/Day off recorded/i)).toBeInTheDocument());
+  });
+
+  it('renders an error banner on API failure', async () => {
+    getMock.mockRejectedValue({ response: { status: 500, data: { detail: 'boom' } } });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('counselor-dashboard-error')).toBeInTheDocument());
+    expect(screen.getByTestId('counselor-dashboard-error')).toHaveTextContent('boom');
+  });
+
+  it('shows a friendly message for 403 without organization context', async () => {
+    getMock.mockRejectedValue({ response: { status: 403, data: { detail: 'Organization context required.' } } });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('counselor-dashboard-error')).toBeInTheDocument());
+    expect(screen.getByTestId('counselor-dashboard-error')).toHaveTextContent('Organization context required.');
+  });
+
+  it('points the campers CTA at /counselor/camper-reflections', async () => {
+    getMock.mockResolvedValue({ data: makePayload() });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('counselor-section-campers-action')).toBeInTheDocument());
+    expect(screen.getByTestId('counselor-section-campers-action')).toHaveAttribute(
+      'href',
+      '/counselor/camper-reflections',
+    );
+  });
+
+  it('renders a complete-no-action self section when template is null', async () => {
+    getMock.mockResolvedValue({
+      data: makePayload({
+        sections: {
+          camper_reflections: { state: 'complete', covered: 0, total: 0, off_camp: 0, bunk_count: 0 },
+          self_reflection: {
+            state: 'complete',
+            submitted: false,
+            reflection_id: null,
+            submitted_at: null,
+            is_day_off: false,
+            editable: false,
+            template: null,
+          },
+          requests: { state: 'none', open_count: 0, by_type: { camper_care: 0, maintenance: 0 } },
+        },
+      }),
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('counselor-section-self')).toBeInTheDocument());
+    expect(screen.getByText(/No self-reflection template is configured/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('counselor-section-self-action')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Builds the counselor-facing mobile UI on top of the `7_6b` read endpoints (PR #74) and `7_6c` write endpoints (PR #75). Stacked on top of `feat/7_6c_write_endpoints` — re-target to `main` after that one merges.

**Scope of this PR (out of the 7_6 series):**
- `/counselor` — three-section mobile dashboard (Stories 2 + 9)
- `/counselor/camper-reflections[/<date>]` — bunk roster with today/past distinction (Story 3)
- `/counselor/camper-reflections/new` — create camper reflection (Story 3)
- `/counselor/camper-reflections/<id>/edit` — edit within today's window (Story 4)
- `frontend/src/api/counselor.js` — typed-shaped API client + `client_submission_id` UUID generator

**Out of scope (next PRs):**
- 7_6e: refactor existing self-reflection form (Stories 5 + 6) + camper-care/maintenance request submission (Stories 7 + 8)
- 7_6f: dual-write + backfill from legacy `CounselorLog` model, e2e tests, docs

## Highlights

- **Idempotency wired through end-to-end.** Each new-reflection submission generates one UUID via `crypto.randomUUID()` (with a Math.random fallback for jsdom) and stores it in a `useRef` so retries after a flaky network hit the backend's `find_existing_by_client_submission_id` shortcut — duplicates collapse into a 200 instead of creating duplicate rows. Tested explicitly.
- **Schema-driven form.** Reuses `ReflectionField` + `validateReflectionAnswers` so all 12 template field types render without bespoke code. Template loaded via `/api/v1/templates/<id>/`.
- **Audience disclosure on every form.** `AudienceDisclosure` wired with the static camper-reflection audience set (mirrors `audience_labels(CAMPER_REFLECTION)` in core). Safe to hard-code because that content type has no sensitive override.
- **Auto-refresh.** Dashboard polls in the background every 60s (`?nocache=1`) so a co-counselor's submission shows up on your dashboard within seconds of the 30s server-side TTL clearing.
- **Read-only past dates.** `/counselor/camper-reflections/<date>` strips Add/Edit CTAs and surfaces a "Read-only" banner. The backend already returns `editable: false` on every camper row for past dates — frontend just honors it.

## Test plan

- [x] 34 new Vitest tests across 4 files, api mocked via `vi.mock('../../api')`. All pass.
- [x] Full frontend suite (`vitest run`): 367 tests across 48 files green.
- [x] Production `vite build` clean.
- [x] No lint errors on new files (warnings limited to `i18next/no-literal-string`, consistent with other pages and addressed incrementally as the rest of the app is migrated to i18n).
- [ ] Manual QA against the local backend stack (recommend before merging to `feat/7_6c_write_endpoints`):
  - Sign in as a counselor with at least one bunk.
  - Visit `/counselor` — verify all three sections render and "All set" banner appears when both required sections are complete.
  - Visit `/counselor/camper-reflections` — verify roster shows submitted vs. not submitted, co-counselor attribution, off-camp grouping.
  - Submit a reflection for one camper, return to roster — verify row flips to "Submitted by you" and CTA changes to Edit.
  - Edit the reflection — verify PATCH succeeds and roster still shows it submitted.
  - Past date URL (e.g. yesterday) — verify read-only banner and no CTAs.
  - Network panel — verify `client_submission_id` is sent on POST and stays the same across a manual retry.

## Notes for reviewers

- Legacy `/counselor-dashboard` route is intentionally left alone — that surface is still the source of truth for the old counselor self-reflection until 7_6e refactors it onto the new endpoints. Once 7_6e ships we can redirect `/counselor-dashboard → /counselor` and delete `CounselorDashboard.jsx`.
- The dashboard's auto-refresh interval (60s) is buffered above the backend's 30s cache TTL on purpose. If we want a tighter "live" feel later, that's the dial.
- New routes live under `AppLayout` so the 3.32/3.33 sidebar chrome stays available on the mobile surface. Each page also has its own narrow column (`max-w-lg`) so it still feels mobile-first inside the shell.


Made with [Cursor](https://cursor.com)