### PR TITLE
7_6e: counselor self-reflection form + history

### DIFF
--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -50,6 +50,8 @@ import AppLayout from './layouts/AppLayout';
 import CounselorMobileDashboard from './pages/counselor/CounselorMobileDashboard';
 import CamperReflectionListPage from './pages/counselor/CamperReflectionListPage';
 import CamperReflectionFormPage from './pages/counselor/CamperReflectionFormPage';
+import CounselorSelfReflectionPage from './pages/counselor/CounselorSelfReflectionPage';
+import CounselorSelfReflectionHistoryPage from './pages/counselor/CounselorSelfReflectionHistoryPage';
 import { useBunk } from './contexts/BunkContext';
 
 // Protected route component
@@ -354,6 +356,23 @@ function Router() {
           <Route
             path="/counselor/camper-reflections/:reflectionId/edit"
             element={<CamperReflectionFormPage />}
+          />
+          {/* 7_6e: Counselor self-reflection. ``/self-reflection`` auto-routes
+              to today's edit URL if a submission already exists, otherwise
+              renders the create form. ``/history`` is a dedicated paginated
+              view (Story 6 criterion 6); gap days are rendered as
+              "No submission" rows by the server. */}
+          <Route
+            path="/counselor/self-reflection"
+            element={<CounselorSelfReflectionPage />}
+          />
+          <Route
+            path="/counselor/self-reflection/history"
+            element={<CounselorSelfReflectionHistoryPage />}
+          />
+          <Route
+            path="/counselor/self-reflection/:reflectionId/edit"
+            element={<CounselorSelfReflectionPage />}
           />
         </Route>
 

--- a/frontend/src/api/__tests__/counselor.test.js
+++ b/frontend/src/api/__tests__/counselor.test.js
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   CAMPER_REFLECTION_AUDIENCE,
+  COUNSELOR_SELF_REFLECTION_AUDIENCE,
   createCamperReflection,
+  createSelfReflection,
   fetchCamperReflections,
   fetchCounselorDashboard,
   fetchReflection,
+  fetchSelfReflectionHistory,
   fetchTemplateById,
   newClientSubmissionId,
   patchCamperReflection,
+  patchSelfReflection,
 } from '../counselor';
 
 const getMock = vi.fn();
@@ -109,5 +113,66 @@ describe('counselor API helpers', () => {
     getMock.mockResolvedValue({ data: { id: 1 } });
     await fetchReflection(42);
     expect(getMock.mock.calls[0][0]).toBe('/api/v1/reflections/42/');
+  });
+
+  it('exports the canonical self-reflection audience set', () => {
+    expect(COUNSELOR_SELF_REFLECTION_AUDIENCE).toEqual([
+      'Admin',
+      'Counselor',
+      'Leadership Team',
+      'Unit Head',
+    ]);
+  });
+
+  it('createSelfReflection day-off shortcut omits answers', async () => {
+    postMock.mockResolvedValue({ data: { id: 1 }, status: 201 });
+    await createSelfReflection({
+      dayOff: true,
+      language: 'en',
+      clientSubmissionId: '11111111-1111-4111-8111-111111111111',
+    });
+    expect(postMock.mock.calls[0][0]).toBe('/api/v1/counselor/self-reflection/');
+    const body = postMock.mock.calls[0][1];
+    expect(body).toEqual({
+      day_off: true,
+      language: 'en',
+      client_submission_id: '11111111-1111-4111-8111-111111111111',
+    });
+    expect(body).not.toHaveProperty('answers');
+  });
+
+  it('createSelfReflection sends the full answers payload otherwise', async () => {
+    postMock.mockResolvedValue({ data: { id: 2 }, status: 201 });
+    await createSelfReflection({
+      dayOff: false,
+      answers: { overall_day: 4 },
+      language: 'es',
+      clientSubmissionId: '22222222-2222-4222-8222-222222222222',
+    });
+    const body = postMock.mock.calls[0][1];
+    expect(body).toEqual({
+      day_off: false,
+      language: 'es',
+      client_submission_id: '22222222-2222-4222-8222-222222222222',
+      answers: { overall_day: 4 },
+    });
+  });
+
+  it('patchSelfReflection omits undefined fields', async () => {
+    patchMock.mockResolvedValue({ data: { id: 9 } });
+    await patchSelfReflection(9, { dayOff: true });
+    expect(patchMock.mock.calls[0]).toEqual([
+      '/api/v1/counselor/self-reflection/9/',
+      { day_off: true },
+    ]);
+  });
+
+  it('fetchSelfReflectionHistory forwards pagination params', async () => {
+    getMock.mockResolvedValue({ data: { results: [] } });
+    await fetchSelfReflectionHistory({ page: 3, pageSize: 30 });
+    expect(getMock.mock.calls[0]).toEqual([
+      '/api/v1/counselor/self-reflection/history/',
+      { params: { page: 3, page_size: 30 } },
+    ]);
   });
 });

--- a/frontend/src/api/counselor.js
+++ b/frontend/src/api/counselor.js
@@ -129,3 +129,96 @@ export const CAMPER_REFLECTION_AUDIENCE = Object.freeze([
   'Leadership Team',
   'Unit Head',
 ]);
+
+/**
+ * Static audience labels for a counselor self-reflection.
+ *
+ * Mirrors ``audience_labels(ContentType.COUNSELOR_SELF_REFLECTION)`` from
+ * ``bunk_logs/core/content_visibility.py``. No ``supports_privacy`` toggle
+ * applies to the seeded counselor template, so this set is fixed.
+ */
+export const COUNSELOR_SELF_REFLECTION_AUDIENCE = Object.freeze([
+  'Admin',
+  'Counselor',
+  'Leadership Team',
+  'Unit Head',
+]);
+
+// ---------------------------------------------------------------------------
+// Self-reflection (Stories 5 + 6)
+// ---------------------------------------------------------------------------
+
+/**
+ * Submit today's self-reflection (Story 5).
+ *
+ * Two payload shapes:
+ *
+ *   * ``{ dayOff: true }`` — shortcut. The server fills ``answers`` with
+ *     ``{"day_off": true}`` regardless of what we send, so the offline
+ *     queue can record a day off without knowing the schema.
+ *   * ``{ dayOff: false, answers: {...} }`` — full submission. ``answers``
+ *     must validate against the seeded counselor template schema.
+ *
+ * The view also accepts an explicit ``team_visibility`` but the seeded
+ * template ships ``supports_privacy=false``, so the server always stores
+ * ``team`` for self-reflections. We don't send the field to keep the
+ * payload minimal.
+ */
+export async function createSelfReflection({
+  dayOff = false,
+  answers,
+  language = 'en',
+  clientSubmissionId,
+}) {
+  const payload = {
+    day_off: !!dayOff,
+    language,
+    client_submission_id: clientSubmissionId,
+  };
+  if (!dayOff) {
+    payload.answers = answers || {};
+  }
+  const res = await api.post('/api/v1/counselor/self-reflection/', payload);
+  return { data: res.data, status: res.status };
+}
+
+/**
+ * Patch an existing self-reflection within today's edit window (Story 6).
+ *
+ * ``dayOff`` is a tri-state: ``true`` flips to the day-off shortcut and
+ * blanks the rest of the answers; ``false`` flips back to a normal entry
+ * (and requires ``answers``); ``undefined`` leaves the shortcut state
+ * untouched. The view enforces the rollover-aware edit window and returns
+ * 403 once "today" passes.
+ */
+export async function patchSelfReflection(reflectionId, {
+  dayOff,
+  answers,
+  language,
+}) {
+  const payload = {};
+  if (dayOff !== undefined) payload.day_off = !!dayOff;
+  if (answers !== undefined) payload.answers = answers;
+  if (language !== undefined) payload.language = language;
+  const { data } = await api.patch(
+    `/api/v1/counselor/self-reflection/${reflectionId}/`,
+    payload,
+  );
+  return data;
+}
+
+/**
+ * Paginated history view of the viewer's own self-reflections (Story 6).
+ *
+ * Returns one row per calendar day in the page window — including "no
+ * submission" gap rows — so the client can render Story 6 criterion 6
+ * without inferring missing dates client-side.
+ */
+export async function fetchSelfReflectionHistory({ page = 1, pageSize } = {}) {
+  const params = { page };
+  if (pageSize) params.page_size = pageSize;
+  const { data } = await api.get('/api/v1/counselor/self-reflection/history/', {
+    params,
+  });
+  return data;
+}

--- a/frontend/src/pages/counselor/CounselorSelfReflectionHistoryPage.jsx
+++ b/frontend/src/pages/counselor/CounselorSelfReflectionHistoryPage.jsx
@@ -1,0 +1,207 @@
+/**
+ * Counselor self-reflection history — Step 7_6e (Story 6).
+ *
+ * Renders one row per calendar day in the page window. The server already
+ * fills in "no submission" rows so we don't have to infer gaps client-side
+ * (Story 6 criterion 6). Three row variants:
+ *
+ *   * submitted + content → date + preview text
+ *   * submitted + day_off → "Day off" badge
+ *   * not submitted      → "No submission" placeholder
+ *
+ * Today's row also exposes a "View / edit" link that deep-links into the
+ * detail page; past rows expose a read-only "View" link (since the edit
+ * window is closed, the form will load in read-only via the 403 path).
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { fetchSelfReflectionHistory } from '../../api/counselor';
+
+function StatusBadge({ submitted, isDayOff }) {
+  if (!submitted) {
+    return (
+      <span
+        data-testid="row-badge-missing"
+        className="text-xs font-medium px-2 py-0.5 rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+      >
+        No submission
+      </span>
+    );
+  }
+  if (isDayOff) {
+    return (
+      <span
+        data-testid="row-badge-day-off"
+        className="text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
+      >
+        Day off
+      </span>
+    );
+  }
+  return (
+    <span
+      data-testid="row-badge-submitted"
+      className="text-xs font-medium px-2 py-0.5 rounded-full bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200"
+    >
+      Submitted
+    </span>
+  );
+}
+
+function HistoryRow({ row }) {
+  const { date, submitted, is_day_off: isDayOff, preview, reflection_id: reflectionId, editable } = row;
+
+  return (
+    <li
+      data-testid={`history-row-${date}`}
+      data-submitted={submitted ? 'true' : 'false'}
+      data-day-off={isDayOff ? 'true' : 'false'}
+      className="flex items-start justify-between gap-3 py-3 border-b border-gray-100 dark:border-gray-800 last:border-b-0"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <p className="text-sm font-medium text-gray-900 dark:text-white">{date}</p>
+          <StatusBadge submitted={submitted} isDayOff={isDayOff} />
+        </div>
+        {submitted && !isDayOff && preview ? (
+          <p
+            data-testid={`history-row-${date}-preview`}
+            className="text-xs text-gray-600 dark:text-gray-400 mt-1 line-clamp-2"
+          >
+            {preview}
+          </p>
+        ) : null}
+        {!submitted ? (
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            Nothing recorded for this day.
+          </p>
+        ) : null}
+      </div>
+      {submitted && reflectionId ? (
+        <Link
+          to={
+            editable
+              ? `/counselor/self-reflection/${reflectionId}/edit`
+              : `/reflections/${reflectionId}`
+          }
+          data-testid={`history-row-${date}-link`}
+          className="shrink-0 inline-flex items-center justify-center min-h-[44px] px-3 rounded-lg border border-gray-300 dark:border-gray-600 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800"
+        >
+          {editable ? 'Edit' : 'View'}
+        </Link>
+      ) : null}
+    </li>
+  );
+}
+
+export default function CounselorSelfReflectionHistoryPage() {
+  const navigate = useNavigate();
+  const [data, setData] = useState(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+
+  const load = useCallback(async (targetPage) => {
+    setLoading(true);
+    setError('');
+    try {
+      const payload = await fetchSelfReflectionHistory({ page: targetPage });
+      setData(payload);
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      setError(typeof detail === 'string' ? detail : 'Could not load your history.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load(page);
+  }, [load, page]);
+
+  return (
+    <div className="px-4 py-6 pb-24">
+      <div className="max-w-lg mx-auto space-y-4">
+        <header>
+          <button
+            type="button"
+            onClick={() => navigate('/counselor')}
+            className="text-xs text-blue-600 dark:text-blue-400 mb-1 flex items-center gap-1"
+          >
+            ← Back to dashboard
+          </button>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
+            My self-reflection history
+          </h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+            Most recent first. Empty rows mean nothing was submitted that day.
+          </p>
+        </header>
+
+        {loading && !data ? (
+          <p
+            className="text-gray-600 dark:text-gray-400"
+            data-testid="history-loading"
+          >
+            Loading history…
+          </p>
+        ) : error ? (
+          <div
+            className="rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/40 dark:border-amber-800 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+            role="alert"
+            data-testid="history-error"
+          >
+            {error}
+          </div>
+        ) : (
+          <>
+            <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-2 shadow-sm">
+              {data?.results?.length ? (
+                <ul>
+                  {data.results.map((row) => (
+                    <HistoryRow key={row.date} row={row} />
+                  ))}
+                </ul>
+              ) : (
+                <p
+                  className="text-sm text-gray-600 dark:text-gray-400 py-4"
+                  data-testid="history-empty"
+                >
+                  No history yet — submit a reflection today to start your record.
+                </p>
+              )}
+            </section>
+
+            <nav
+              data-testid="history-pagination"
+              className="flex items-center justify-between gap-2"
+            >
+              <button
+                type="button"
+                data-testid="history-prev"
+                disabled={!data?.previous || loading}
+                onClick={() => data?.previous && setPage(data.previous)}
+                className="min-h-[44px] px-4 rounded-lg border border-gray-300 dark:border-gray-600 text-sm font-medium text-gray-700 dark:text-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                ← Newer
+              </button>
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                Page {data?.page || page}
+              </span>
+              <button
+                type="button"
+                data-testid="history-next"
+                disabled={!data?.next || loading}
+                onClick={() => data?.next && setPage(data.next)}
+                className="min-h-[44px] px-4 rounded-lg border border-gray-300 dark:border-gray-600 text-sm font-medium text-gray-700 dark:text-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Older →
+              </button>
+            </nav>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/counselor/CounselorSelfReflectionPage.jsx
+++ b/frontend/src/pages/counselor/CounselorSelfReflectionPage.jsx
@@ -1,0 +1,412 @@
+/**
+ * Counselor self-reflection form — Step 7_6e (Stories 5 + 6).
+ *
+ * URL shapes:
+ *
+ *   /counselor/self-reflection
+ *     → If no submission exists for today, render a POST form.
+ *       If today's submission exists, redirect to the edit URL.
+ *
+ *   /counselor/self-reflection/:reflectionId/edit
+ *     → PATCH /api/v1/counselor/self-reflection/:reflectionId/
+ *
+ * "Day off" UX (Story 5 criterion 3):
+ *   The seeded template includes a ``day_off`` yes_no field. We render it
+ *   as a prominent toggle at the top of the form, separate from the
+ *   schema's normal field rendering. When ON, the rest of the form is
+ *   hidden and the submit button reads "Mark day off"; payload to the
+ *   server is the shortcut ``{ day_off: true }``. When OFF, normal
+ *   schema fields render.
+ *
+ * Template resolution:
+ *   We hit `GET /counselor/dashboard/` (cached 30s) to discover the
+ *   active self-reflection template ID + whether a row already exists
+ *   today, then fetch the template schema by ID. This avoids the
+ *   ambiguity in `/reflections/template-for-me/` which would pick the
+ *   wrong template if the org has both a single-subject (camper) and a
+ *   self template both keyed `role=counselor`.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import AudienceDisclosure from '../../components/AudienceDisclosure';
+import ReflectionField from '../../components/templates/ReflectionField';
+import {
+  buildDefaultAnswers,
+  validateReflectionAnswers,
+} from '../../utils/reflection/reflectionFormValidation';
+import {
+  COUNSELOR_SELF_REFLECTION_AUDIENCE,
+  createSelfReflection,
+  fetchCounselorDashboard,
+  fetchReflection,
+  fetchTemplateById,
+  newClientSubmissionId,
+  patchSelfReflection,
+} from '../../api/counselor';
+
+const DAY_OFF_FIELD_KEY = 'day_off';
+
+function flattenError(err, fallback) {
+  const body = err?.response?.data;
+  if (!body) return err?.message || fallback;
+  if (typeof body === 'string') return body;
+  if (typeof body.detail === 'string') return body.detail;
+  if (typeof body === 'object') {
+    try {
+      return JSON.stringify(body);
+    } catch (_) {
+      return fallback;
+    }
+  }
+  return fallback;
+}
+
+function withoutDayOffField(schema) {
+  if (!schema?.fields) return schema;
+  return {
+    ...schema,
+    fields: schema.fields.filter((f) => f?.key !== DAY_OFF_FIELD_KEY),
+  };
+}
+
+export default function CounselorSelfReflectionPage() {
+  const navigate = useNavigate();
+  const { reflectionId: editIdParam } = useParams();
+  const isEdit = !!editIdParam;
+  const editReflectionId = isEdit ? Number(editIdParam) : null;
+
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
+  const [schema, setSchema] = useState(null);
+  const [templateMeta, setTemplateMeta] = useState(null);
+
+  const [dayOff, setDayOff] = useState(false);
+  const [answers, setAnswers] = useState({});
+  const [language, setLanguage] = useState('en');
+
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [submitError, setSubmitError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  // Stable UUID across retries for create mode (Step 7_6c idempotency).
+  const clientSubmissionIdRef = useRef(null);
+  if (!isEdit && clientSubmissionIdRef.current === null) {
+    clientSubmissionIdRef.current = newClientSubmissionId();
+  }
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError('');
+    try {
+      if (isEdit) {
+        const reflection = await fetchReflection(editReflectionId);
+        const templateId = reflection.template || reflection.template_meta?.id;
+        if (!templateId) {
+          setLoadError('Reflection has no template attached.');
+          return;
+        }
+        const template = await fetchTemplateById(templateId);
+        setSchema(template.schema);
+        setTemplateMeta({
+          id: template.id,
+          name: template.name,
+          slug: template.slug,
+          version: template.version,
+          languages: template.languages || ['en'],
+        });
+
+        const existingAnswers = reflection.answers || {};
+        const isDayOff = !!existingAnswers[DAY_OFF_FIELD_KEY];
+        setDayOff(isDayOff);
+        const defaults = buildDefaultAnswers(template.schema);
+        // When the row is a day-off shortcut, keep the rest of the answers
+        // at their defaults so flipping the toggle reveals a clean form.
+        setAnswers(isDayOff ? defaults : { ...defaults, ...existingAnswers });
+        setLanguage(reflection.language || 'en');
+      } else {
+        const dashboard = await fetchCounselorDashboard();
+        const selfSection = dashboard?.sections?.self_reflection;
+        if (selfSection?.reflection_id) {
+          // Already submitted today — bounce to the edit URL so the user
+          // can refine, day-off-toggle, or change language. ``replace``
+          // keeps the back stack tidy.
+          navigate(
+            `/counselor/self-reflection/${selfSection.reflection_id}/edit`,
+            { replace: true },
+          );
+          return;
+        }
+        const tplMeta = selfSection?.template;
+        if (!tplMeta?.id) {
+          setLoadError('No counselor self-reflection template is configured.');
+          return;
+        }
+        const template = await fetchTemplateById(tplMeta.id);
+        setSchema(template.schema);
+        setTemplateMeta({
+          id: template.id,
+          name: template.name,
+          slug: template.slug,
+          version: template.version,
+          languages: template.languages || ['en'],
+        });
+        setAnswers(buildDefaultAnswers(template.schema));
+      }
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 403) {
+        setLoadError(
+          err?.response?.data?.detail
+          || 'You do not have permission to open this self-reflection.',
+        );
+      } else if (status === 404) {
+        setLoadError('Reflection not found.');
+      } else {
+        setLoadError(flattenError(err, 'Could not load the form.'));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [isEdit, editReflectionId, navigate]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const visibleSchema = useMemo(
+    () => (schema ? withoutDayOffField(schema) : null),
+    [schema],
+  );
+
+  const updateAnswer = (key, value) => {
+    setAnswers((prev) => ({ ...prev, [key]: value }));
+    setFieldErrors((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  };
+
+  const langChoices = useMemo(
+    () => (templateMeta?.languages?.length ? templateMeta.languages : ['en']),
+    [templateMeta],
+  );
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitError('');
+    if (!schema || !templateMeta?.id) {
+      setSubmitError('Template not loaded.');
+      return;
+    }
+
+    if (!dayOff) {
+      const { ok, errors } = validateReflectionAnswers(visibleSchema, answers);
+      setFieldErrors(errors);
+      if (!ok) return;
+    }
+
+    setSubmitting(true);
+    try {
+      if (isEdit) {
+        await patchSelfReflection(editReflectionId, {
+          dayOff,
+          answers: dayOff ? undefined : answers,
+          language,
+        });
+      } else {
+        await createSelfReflection({
+          dayOff,
+          answers: dayOff ? undefined : answers,
+          language,
+          clientSubmissionId: clientSubmissionIdRef.current,
+        });
+      }
+      navigate('/counselor', { replace: true });
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 403) {
+        setSubmitError(flattenError(err, 'You can no longer edit this reflection.'));
+      } else if (status === 400) {
+        const body = err?.response?.data;
+        if (body && typeof body === 'object' && !Array.isArray(body)) {
+          const next = {};
+          for (const k of Object.keys(body)) {
+            if (k === 'detail') continue;
+            const v = body[k];
+            next[k] = Array.isArray(v) ? v[0] : typeof v === 'string' ? v : JSON.stringify(v);
+          }
+          setFieldErrors(next);
+          setSubmitError(
+            typeof body.detail === 'string'
+              ? body.detail
+              : 'Please fix the errors and try again.',
+          );
+        } else {
+          setSubmitError(flattenError(err, 'Submit failed.'));
+        }
+      } else {
+        setSubmitError(flattenError(err, 'Submit failed.'));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const dayOffLabel = useMemo(() => {
+    if (!schema?.fields) return 'Day off today?';
+    const field = schema.fields.find((f) => f?.key === DAY_OFF_FIELD_KEY);
+    if (!field?.prompts) return 'Day off today?';
+    return field.prompts[language] || field.prompts.en || 'Day off today?';
+  }, [schema, language]);
+
+  return (
+    <div className="px-4 py-6 pb-24">
+      <div className="max-w-lg mx-auto">
+        <header className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <button
+              type="button"
+              onClick={() => navigate('/counselor')}
+              className="text-xs text-blue-600 dark:text-blue-400 mb-1 flex items-center gap-1"
+            >
+              ← Back to dashboard
+            </button>
+            <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
+              My self-reflection
+            </h1>
+            {templateMeta ? (
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                {templateMeta.name}
+              </p>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-3 shrink-0">
+            <Link
+              to="/counselor/self-reflection/history"
+              data-testid="self-reflection-history-link"
+              className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              History
+            </Link>
+            {langChoices.length > 1 ? (
+              <div
+                className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden"
+                data-testid="self-reflection-language"
+              >
+                {langChoices.map((code) => (
+                  <button
+                    key={code}
+                    type="button"
+                    aria-pressed={language === code}
+                    onClick={() => setLanguage(code)}
+                    className={`px-3 py-1.5 text-sm font-medium min-h-[44px] ${
+                      language === code
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200'
+                    }`}
+                  >
+                    {code === 'es' ? 'Español' : code === 'en' ? 'English' : code}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </header>
+
+        {loading ? (
+          <p
+            className="text-gray-600 dark:text-gray-400"
+            data-testid="self-reflection-loading"
+          >
+            Loading form…
+          </p>
+        ) : loadError ? (
+          <div
+            className="rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/40 dark:border-amber-800 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+            role="alert"
+            data-testid="self-reflection-load-error"
+          >
+            {loadError}
+          </div>
+        ) : (
+          <form
+            onSubmit={handleSubmit}
+            className="space-y-2"
+            data-testid="self-reflection-form"
+          >
+            <AudienceDisclosure audience={COUNSELOR_SELF_REFLECTION_AUDIENCE} />
+
+            <fieldset
+              className="mb-4 rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-3"
+              data-testid="self-reflection-day-off-fieldset"
+            >
+              <legend className="text-xs font-medium text-gray-600 dark:text-gray-400 px-1">
+                Quick action
+              </legend>
+              <label className="flex items-center gap-3 cursor-pointer mt-1">
+                <input
+                  type="checkbox"
+                  data-testid="self-reflection-day-off-toggle"
+                  checked={dayOff}
+                  onChange={(e) => {
+                    setDayOff(e.target.checked);
+                    if (e.target.checked) {
+                      setFieldErrors({});
+                    }
+                  }}
+                  className="h-5 w-5 text-blue-600 border-gray-300 rounded focus:ring-blue-500 dark:border-gray-600"
+                />
+                <span className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                  {dayOffLabel}
+                </span>
+              </label>
+              <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                Counts as complete for the day. You can switch back any time today.
+              </p>
+            </fieldset>
+
+            {!dayOff && (visibleSchema?.fields || []).map((field) => (
+              <ReflectionField
+                key={field.key}
+                field={field}
+                language={language}
+                answer={answers[field.key]}
+                onChange={(val) => updateAnswer(field.key, val)}
+                error={fieldErrors[field.key]}
+              />
+            ))}
+
+            {submitError ? (
+              <p
+                className="text-red-600 text-sm"
+                role="alert"
+                data-testid="self-reflection-submit-error"
+              >
+                {submitError}
+              </p>
+            ) : null}
+
+            <button
+              type="submit"
+              disabled={submitting}
+              data-testid="self-reflection-submit"
+              className="w-full sm:w-auto mt-4 min-h-[48px] px-6 rounded-lg bg-blue-600 text-white font-medium text-sm disabled:opacity-50"
+            >
+              {submitting
+                ? 'Submitting…'
+                : dayOff
+                  ? isEdit
+                    ? 'Mark day off'
+                    : 'Mark day off'
+                  : isEdit
+                    ? 'Save changes'
+                    : 'Submit reflection'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/counselor/__tests__/CounselorSelfReflectionHistoryPage.test.jsx
+++ b/frontend/src/pages/counselor/__tests__/CounselorSelfReflectionHistoryPage.test.jsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import CounselorSelfReflectionHistoryPage from '../CounselorSelfReflectionHistoryPage';
+
+const getMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+  },
+}));
+
+function payload(overrides = {}) {
+  return {
+    count: 60,
+    page: 1,
+    page_size: 14,
+    next: 2,
+    previous: null,
+    results: [
+      {
+        date: '2026-07-04',
+        submitted: true,
+        is_day_off: false,
+        reflection_id: 700,
+        submitted_at: '2026-07-04T20:00:00Z',
+        preview: 'A productive day with the bunk.',
+        editable: true,
+      },
+      {
+        date: '2026-07-03',
+        submitted: true,
+        is_day_off: true,
+        reflection_id: 699,
+        submitted_at: '2026-07-03T10:00:00Z',
+        preview: '',
+        editable: false,
+      },
+      {
+        date: '2026-07-02',
+        submitted: false,
+        is_day_off: false,
+        reflection_id: null,
+        submitted_at: null,
+        preview: '',
+        editable: false,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/counselor/self-reflection/history']}>
+      <CounselorSelfReflectionHistoryPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('CounselorSelfReflectionHistoryPage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  it('renders submitted, day-off, and missing rows distinctly', async () => {
+    getMock.mockResolvedValue({ data: payload() });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('history-row-2026-07-04')).toBeInTheDocument());
+
+    const submitted = screen.getByTestId('history-row-2026-07-04');
+    expect(submitted).toHaveAttribute('data-submitted', 'true');
+    expect(submitted).toHaveAttribute('data-day-off', 'false');
+    expect(screen.getByTestId('history-row-2026-07-04-preview')).toHaveTextContent(
+      'A productive day',
+    );
+
+    const dayOff = screen.getByTestId('history-row-2026-07-03');
+    expect(dayOff).toHaveAttribute('data-day-off', 'true');
+    expect(dayOff.querySelector('[data-testid="row-badge-day-off"]')).toBeTruthy();
+
+    const missing = screen.getByTestId('history-row-2026-07-02');
+    expect(missing).toHaveAttribute('data-submitted', 'false');
+    expect(missing.querySelector('[data-testid="row-badge-missing"]')).toBeTruthy();
+  });
+
+  it('points today (editable) at the edit URL and past rows at the read-only viewer', async () => {
+    getMock.mockResolvedValue({ data: payload() });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('history-row-2026-07-04-link')).toBeInTheDocument());
+
+    expect(screen.getByTestId('history-row-2026-07-04-link')).toHaveAttribute(
+      'href',
+      '/counselor/self-reflection/700/edit',
+    );
+    expect(screen.getByTestId('history-row-2026-07-04-link')).toHaveTextContent('Edit');
+
+    expect(screen.getByTestId('history-row-2026-07-03-link')).toHaveAttribute(
+      'href',
+      '/reflections/699',
+    );
+    expect(screen.getByTestId('history-row-2026-07-03-link')).toHaveTextContent('View');
+
+    // Missing rows shouldn't render any link.
+    expect(screen.queryByTestId('history-row-2026-07-02-link')).toBeNull();
+  });
+
+  it('paginates forward and backward via the API', async () => {
+    const user = userEvent.setup();
+    getMock.mockResolvedValueOnce({ data: payload() });
+    getMock.mockResolvedValueOnce({
+      data: payload({ page: 2, previous: 1, next: 3, results: [] }),
+    });
+    getMock.mockResolvedValueOnce({ data: payload() });
+    renderPage();
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByTestId('history-next'));
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2));
+    expect(getMock.mock.calls[1][1].params).toEqual({ page: 2 });
+
+    await user.click(screen.getByTestId('history-prev'));
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(3));
+    expect(getMock.mock.calls[2][1].params).toEqual({ page: 1 });
+  });
+
+  it('disables prev on page 1 and next on the last page', async () => {
+    getMock.mockResolvedValue({
+      data: payload({ next: null, previous: null }),
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('history-prev')).toBeInTheDocument());
+    expect(screen.getByTestId('history-prev')).toBeDisabled();
+    expect(screen.getByTestId('history-next')).toBeDisabled();
+  });
+
+  it('renders the empty state when results are empty', async () => {
+    getMock.mockResolvedValue({
+      data: { count: 0, page: 1, page_size: 14, next: null, previous: null, results: [] },
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('history-empty')).toBeInTheDocument());
+  });
+
+  it('shows an error banner on API failure', async () => {
+    getMock.mockRejectedValue({ response: { status: 500, data: { detail: 'boom' } } });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('history-error')).toBeInTheDocument());
+    expect(screen.getByTestId('history-error')).toHaveTextContent('boom');
+  });
+});

--- a/frontend/src/pages/counselor/__tests__/CounselorSelfReflectionPage.test.jsx
+++ b/frontend/src/pages/counselor/__tests__/CounselorSelfReflectionPage.test.jsx
@@ -1,0 +1,382 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import CounselorSelfReflectionPage from '../CounselorSelfReflectionPage';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+const patchMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: (...args) => postMock(...args),
+    patch: (...args) => patchMock(...args),
+  },
+}));
+
+function PathProbe() {
+  const loc = useLocation();
+  return (
+    <div data-testid="path-probe" data-pathname={loc.pathname}>
+      probe: {loc.pathname}
+    </div>
+  );
+}
+
+const selfTemplate = {
+  id: 9,
+  name: 'Counselor Self-Reflection',
+  slug: 'counselor-self-reflection',
+  version: 1,
+  languages: ['en', 'es'],
+  supports_privacy: false,
+  schema: {
+    fields: [
+      {
+        key: 'day_off',
+        type: 'yes_no',
+        required: false,
+        prompts: { en: 'Are you taking a day off today?' },
+      },
+      {
+        key: 'overall_day',
+        type: 'single_rating',
+        required: false,
+        scale: [1, 5],
+        scale_labels: { en: ['Difficult', 'Tough', 'OK', 'Good', 'Great'] },
+        prompts: { en: 'How was today overall?' },
+      },
+      {
+        key: 'wins',
+        type: 'text_list',
+        required: false,
+        min_items: 1,
+        max_items: 3,
+        prompts: { en: 'What went well?' },
+      },
+      {
+        key: 'concern',
+        type: 'textarea',
+        required: false,
+        prompts: { en: 'Anything to flag?' },
+      },
+    ],
+  },
+};
+
+const dashboardNoSubmission = {
+  today: '2026-07-04',
+  sections: {
+    self_reflection: {
+      state: 'none',
+      submitted: false,
+      reflection_id: null,
+      template: {
+        id: 9,
+        slug: 'counselor-self-reflection',
+        name: 'Counselor Self-Reflection',
+        version: 1,
+      },
+    },
+  },
+};
+
+function renderCreate() {
+  return render(
+    <MemoryRouter initialEntries={['/counselor/self-reflection']}>
+      <Routes>
+        <Route path="/counselor/self-reflection" element={<CounselorSelfReflectionPage />} />
+        <Route
+          path="/counselor/self-reflection/:reflectionId/edit"
+          element={<CounselorSelfReflectionPage />}
+        />
+        <Route path="/counselor" element={<PathProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function renderEdit(reflectionId = 501) {
+  return render(
+    <MemoryRouter initialEntries={[`/counselor/self-reflection/${reflectionId}/edit`]}>
+      <Routes>
+        <Route
+          path="/counselor/self-reflection/:reflectionId/edit"
+          element={<CounselorSelfReflectionPage />}
+        />
+        <Route path="/counselor" element={<PathProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('CounselorSelfReflectionPage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    postMock.mockReset();
+    patchMock.mockReset();
+  });
+
+  describe('create mode', () => {
+    function arrangeCreate() {
+      // First call: dashboard fetch (to discover the template + existing reflection)
+      getMock.mockResolvedValueOnce({ data: dashboardNoSubmission });
+      // Second call: template-by-id fetch
+      getMock.mockResolvedValueOnce({ data: selfTemplate });
+    }
+
+    it('loads the template via dashboard + template-by-id and renders the schema', async () => {
+      arrangeCreate();
+      renderCreate();
+      await waitFor(() => expect(screen.getByText('How was today overall?')).toBeInTheDocument());
+      expect(screen.getByText('What went well?')).toBeInTheDocument();
+      expect(screen.getByText('Anything to flag?')).toBeInTheDocument();
+
+      // The day_off field should NOT render inside the schema area;
+      // it's elevated to the prominent toggle at top.
+      const schemaArea = screen.queryByTestId('reflect-input-day_off');
+      expect(schemaArea).toBeNull();
+      expect(screen.getByTestId('self-reflection-day-off-toggle')).toBeInTheDocument();
+    });
+
+    it('shows the audience disclosure with the canonical self-reflection labels', async () => {
+      arrangeCreate();
+      renderCreate();
+      await waitFor(() => expect(screen.getByTestId('audience-disclosure')).toBeInTheDocument());
+      expect(screen.getByTestId('audience-disclosure-labels')).toHaveTextContent(
+        'Admin, Counselor, Leadership Team, Unit Head',
+      );
+    });
+
+    it('toggling day-off hides the schema fields and changes the submit label', async () => {
+      const user = userEvent.setup();
+      arrangeCreate();
+      renderCreate();
+      await waitFor(() => expect(screen.getByText('How was today overall?')).toBeInTheDocument());
+
+      await user.click(screen.getByTestId('self-reflection-day-off-toggle'));
+
+      expect(screen.queryByText('How was today overall?')).toBeNull();
+      expect(screen.queryByText('What went well?')).toBeNull();
+      expect(screen.getByTestId('self-reflection-submit')).toHaveTextContent(/Mark day off/i);
+    });
+
+    it('POSTs the day-off shortcut payload when toggle is on', async () => {
+      const user = userEvent.setup();
+      arrangeCreate();
+      postMock.mockResolvedValue({ data: { id: 600 }, status: 201 });
+      renderCreate();
+      await waitFor(() => expect(screen.getByText('How was today overall?')).toBeInTheDocument());
+
+      await user.click(screen.getByTestId('self-reflection-day-off-toggle'));
+      await user.click(screen.getByTestId('self-reflection-submit'));
+
+      await waitFor(() => expect(postMock).toHaveBeenCalled());
+      const [url, body] = postMock.mock.calls[0];
+      expect(url).toBe('/api/v1/counselor/self-reflection/');
+      expect(body.day_off).toBe(true);
+      expect(body).not.toHaveProperty('answers');
+      expect(typeof body.client_submission_id).toBe('string');
+
+      await waitFor(() => expect(screen.getByTestId('path-probe')).toHaveAttribute(
+        'data-pathname',
+        '/counselor',
+      ));
+    });
+
+    it('POSTs a full payload when day-off is off and fields are filled', async () => {
+      const user = userEvent.setup();
+      arrangeCreate();
+      postMock.mockResolvedValue({ data: { id: 601 }, status: 201 });
+      renderCreate();
+      await waitFor(() => expect(screen.getByText('How was today overall?')).toBeInTheDocument());
+
+      // Pick a rating
+      const ratingButtons = screen.getAllByRole('button', { name: '4' });
+      await user.click(ratingButtons[0]);
+
+      // Fill at least one win
+      const wins = screen.getAllByRole('textbox');
+      await user.type(wins[0], 'lunchtime activity');
+
+      await user.click(screen.getByTestId('self-reflection-submit'));
+      await waitFor(() => expect(postMock).toHaveBeenCalled());
+
+      const body = postMock.mock.calls[0][1];
+      expect(body.day_off).toBe(false);
+      expect(body.answers.overall_day).toBe(4);
+      expect(body.answers.wins).toEqual(expect.arrayContaining(['lunchtime activity']));
+    });
+
+    it('redirects to the edit URL when a reflection already exists for today', async () => {
+      // Dashboard reports a submitted reflection for today.
+      getMock.mockResolvedValueOnce({
+        data: {
+          today: '2026-07-04',
+          sections: {
+            self_reflection: {
+              state: 'complete',
+              submitted: true,
+              reflection_id: 777,
+              template: {
+                id: 9,
+                slug: 'counselor-self-reflection',
+                name: 'Counselor Self-Reflection',
+                version: 1,
+              },
+            },
+          },
+        },
+      });
+      // After redirect, the edit branch loads the reflection + template.
+      getMock.mockResolvedValueOnce({
+        data: {
+          id: 777,
+          template: 9,
+          subject: 1,
+          author: 1,
+          answers: { overall_day: 3 },
+          language: 'en',
+          team_visibility: 'team',
+        },
+      });
+      getMock.mockResolvedValueOnce({ data: selfTemplate });
+
+      renderCreate();
+
+      await waitFor(() => expect(getMock).toHaveBeenCalledTimes(3));
+      // Final page renders edit form
+      await waitFor(() => expect(screen.getByTestId('self-reflection-submit')).toBeInTheDocument());
+      expect(screen.getByTestId('self-reflection-submit')).toHaveTextContent(/Save changes/i);
+    });
+
+    it('shows a load error when no self template is configured', async () => {
+      getMock.mockResolvedValueOnce({
+        data: {
+          today: '2026-07-04',
+          sections: {
+            self_reflection: {
+              state: 'complete',
+              submitted: false,
+              reflection_id: null,
+              template: null,
+            },
+          },
+        },
+      });
+      renderCreate();
+      await waitFor(() =>
+        expect(screen.getByTestId('self-reflection-load-error')).toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe('edit mode', () => {
+    const existing = {
+      id: 501,
+      template: 9,
+      template_meta: { id: 9, slug: 'counselor-self-reflection', name: 'Counselor Self-Reflection', version: 1 },
+      answers: { overall_day: 3, wins: ['nice morning'], concern: '' },
+      language: 'en',
+      subject: 1,
+      author: 1,
+      team_visibility: 'team',
+    };
+
+    function arrangeEdit(reflection = existing, template = selfTemplate) {
+      getMock.mockResolvedValueOnce({ data: reflection });
+      getMock.mockResolvedValueOnce({ data: template });
+    }
+
+    it('prefills existing answers and language', async () => {
+      arrangeEdit();
+      renderEdit();
+      await waitFor(() => expect(screen.getByText('How was today overall?')).toBeInTheDocument());
+      const wins = screen.getAllByRole('textbox');
+      expect(wins[0]).toHaveValue('nice morning');
+    });
+
+    it('detects day-off state in an existing reflection and pre-toggles', async () => {
+      arrangeEdit({
+        ...existing,
+        answers: { day_off: true },
+      });
+      renderEdit();
+      await waitFor(() => expect(screen.getByTestId('self-reflection-day-off-toggle')).toBeChecked());
+      expect(screen.queryByText('How was today overall?')).toBeNull();
+    });
+
+    it('PATCHes the day-off flip when the user toggles it on', async () => {
+      const user = userEvent.setup();
+      arrangeEdit();
+      patchMock.mockResolvedValue({ data: { id: 501 } });
+      renderEdit();
+      await waitFor(() => expect(screen.getByText('How was today overall?')).toBeInTheDocument());
+
+      await user.click(screen.getByTestId('self-reflection-day-off-toggle'));
+      await user.click(screen.getByTestId('self-reflection-submit'));
+
+      await waitFor(() => expect(patchMock).toHaveBeenCalled());
+      const [url, body] = patchMock.mock.calls[0];
+      expect(url).toBe('/api/v1/counselor/self-reflection/501/');
+      expect(body.day_off).toBe(true);
+      expect(body).not.toHaveProperty('answers');
+    });
+
+    it('PATCHes answers + language when the user edits without toggling day-off', async () => {
+      const user = userEvent.setup();
+      arrangeEdit();
+      patchMock.mockResolvedValue({ data: { id: 501 } });
+      renderEdit();
+      await waitFor(() => expect(screen.getByText('How was today overall?')).toBeInTheDocument());
+
+      const wins = screen.getAllByRole('textbox');
+      await user.clear(wins[0]);
+      await user.type(wins[0], 'updated win');
+
+      await user.click(screen.getByTestId('self-reflection-submit'));
+      await waitFor(() => expect(patchMock).toHaveBeenCalled());
+      const body = patchMock.mock.calls[0][1];
+      expect(body.day_off).toBe(false);
+      expect(body.answers.wins).toEqual(expect.arrayContaining(['updated win']));
+      expect(body.language).toBe('en');
+    });
+
+    it('surfaces a 403 edit-window-closed response verbatim', async () => {
+      const user = userEvent.setup();
+      arrangeEdit();
+      patchMock.mockRejectedValue({
+        response: {
+          status: 403,
+          data: {
+            detail: 'This reflection can no longer be edited (the edit window has closed).',
+          },
+        },
+      });
+      renderEdit();
+      await waitFor(() => expect(screen.getByText('How was today overall?')).toBeInTheDocument());
+
+      const wins = screen.getAllByRole('textbox');
+      await user.clear(wins[0]);
+      await user.type(wins[0], 'too late');
+      await user.click(screen.getByTestId('self-reflection-submit'));
+      await waitFor(() => expect(screen.getByTestId('self-reflection-submit-error')).toBeInTheDocument());
+      expect(screen.getByTestId('self-reflection-submit-error')).toHaveTextContent(
+        /edit window has closed/i,
+      );
+    });
+
+    it('renders 404 friendly text when the reflection is gone', async () => {
+      getMock.mockRejectedValueOnce({ response: { status: 404, data: { detail: 'not found' } } });
+      renderEdit();
+      await waitFor(() =>
+        expect(screen.getByTestId('self-reflection-load-error')).toBeInTheDocument(),
+      );
+      expect(screen.getByTestId('self-reflection-load-error')).toHaveTextContent(
+        /Reflection not found/i,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Stacks on top of `feat/7_6d_counselor_frontend` (PR #76). Adds the counselor self-reflection surfaces on top of the 7_6c write endpoints:

- `/counselor/self-reflection` — POST today's reflection (auto-redirects to edit URL if already submitted)
- `/counselor/self-reflection/<id>/edit` — PATCH within the edit window (Story 6)
- `/counselor/self-reflection/history` — paginated history with day-off and gap indicators (Story 6 criterion 6)

## Highlights

- **Day-off shortcut elevated to UX-prominent toggle** (Story 5 criterion 3). The seeded template ships a `day_off` yes/no field — we filter that field out of the normal schema render and surface it as a checkbox at the top of the form. Toggling on hides the rest of the form and switches the submit button to "Mark day off"; payload reduces to `{ day_off: true }`. The backend fills `answers = {"day_off": true}` regardless of what we send, so this is safe for offline replay.

- **Auto-redirect on already-submitted**. Visiting the bare URL fetches the cached dashboard payload — same call the dashboard makes, so it's free — and if `self_reflection.reflection_id` exists, `navigate(replace=true)` bounces to the edit URL.

- **Template resolution via dashboard**. `/template-for-me` resolves by role alone, which would return the wrong template if an org has both a single-subject (camper) and a self template both keyed `role=counselor`. The dashboard's `self_section.template` already filters by `subject_mode='self'`, so we use that as the source of truth.

- **Edit detects existing day-off state**. If `answers.day_off === true` on load, the toggle pre-checks and the schema fields stay hidden. Flipping back to normal entry blanks defaults so the user doesn't see stale data.

- **History page renders gap rows**. The server already materializes one row per calendar day in the page window (submitted / day-off / missing variants); the client just renders. Today's editable row deep-links to the edit URL; past submitted rows deep-link to `/reflections/<id>` (the read-only viewer).

## Test plan

- [x] 24 new Vitest tests across 3 files
- [x] Full frontend suite: 391/391 green (up from 367/367 on 7_6d)
- [x] Production `vite build` clean
- [x] 0 lint errors on new files
- [ ] Manual QA (recommend before merging):
  - Sign in as a counselor with no submission for today → `/counselor/self-reflection` renders the create form
  - Submit a normal reflection → land back on `/counselor`, see "Done" in the self section, click "Edit" → land on the edit URL
  - Toggle day off in edit mode, save → dashboard self section says "Day off recorded"
  - Toggle day off back to off, fill answers, save → dashboard shows "Your self-reflection is in"
  - Visit `/counselor/self-reflection/history` → see the recent days with status badges; click "Edit" on today; click "View" on a past day → routes to `/reflections/<id>`

## Notes for reviewers

- This PR does NOT touch the legacy `/counselor-dashboard` route. The dashboard from 7_6d already routes self-reflection CTAs to the new URLs, so the legacy CounselorDashboard.jsx is reachable only via direct URL until 7_6g deprecates it.
- I deliberately picked the dashboard payload (cached 30s) as the template-resolution source rather than adding a new dedicated `/api/v1/counselor/self-reflection/template/` endpoint. Less backend surface and the call is free in steady state.


Made with [Cursor](https://cursor.com)