### PR TITLE
7_6f: counselor Camper Care + Maintenance request flow

### DIFF
--- a/backend/bunk_logs/api/counselor/camper_care_requests.py
+++ b/backend/bunk_logs/api/counselor/camper_care_requests.py
@@ -18,6 +18,7 @@ from bunk_logs.core import audit as audit_module
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Order
+from bunk_logs.core.models import OrderItemSuggestion
 
 from .common import co_counselor_person_ids
 from .common import find_existing_by_client_submission_id
@@ -26,6 +27,47 @@ from .common import viewer_bunk_groups
 from .common import viewer_or_403
 from .responses import order_response
 from .serializers import CamperCareRequestCreateSerializer
+
+
+class CamperCareItemSuggestionListView(APIView):
+    """``GET /api/v1/counselor/camper-care-item-suggestions/`` — Story 7 criterion 2.ii.
+
+    Returns the curated camper-care item list for the viewer's primary
+    program (decision C6). The form uses this for autocomplete; counselors
+    can still submit any free-text label, so an empty list (e.g. for a
+    program that hasn't been seeded yet) just disables autocomplete on
+    the client without blocking submission.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer = ctx.person
+
+        primary_membership = (
+            Membership.objects.filter(person=viewer, is_active=True)
+            .select_related("program")
+            .order_by("-created_at")
+            .first()
+        )
+        if primary_membership is None or primary_membership.program is None:
+            return Response({"suggestions": []})
+
+        program = primary_membership.program
+        rows = (
+            OrderItemSuggestion.all_objects.filter(program=program, is_active=True)
+            .order_by("sort_order", "label")
+            .values("id", "label", "sort_order")
+        )
+        # Stringify the id to match the convention used elsewhere in the
+        # counselor surface (Order/MaintenanceTicket also return string IDs).
+        return Response({
+            "suggestions": [
+                {"id": str(r["id"]), "label": r["label"], "sort_order": r["sort_order"]}
+                for r in rows
+            ],
+        })
 
 
 class CamperCareRequestCreateView(APIView):

--- a/backend/bunk_logs/api/tests/test_counselor_camper_care_writes.py
+++ b/backend/bunk_logs/api/tests/test_counselor_camper_care_writes.py
@@ -15,6 +15,7 @@ from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import AuditEvent
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Order
+from bunk_logs.core.models import OrderItemSuggestion
 from bunk_logs.core.models import Organization
 from bunk_logs.core.models import Person
 from bunk_logs.core.models import Program
@@ -174,6 +175,37 @@ def test_camper_care_subject_must_be_on_viewer_bunk(
              "client_submission_id": str(uuid.uuid4())}, format="json",
         )
     assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_item_suggestions_returns_active_rows_in_sort_order(
+    org, counselor_user, counselor_person, counselor_membership,
+    program,
+):
+    OrderItemSuggestion.objects.create(program=program, label="Toothpaste", sort_order=2)
+    OrderItemSuggestion.objects.create(program=program, label="Bug spray", sort_order=1)
+    OrderItemSuggestion.objects.create(
+        program=program, label="Hidden", sort_order=0, is_active=False,
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/camper-care-item-suggestions/")
+    assert resp.status_code == 200, resp.data
+    labels = [s["label"] for s in resp.data["suggestions"]]
+    assert labels == ["Bug spray", "Toothpaste"]
+    assert all("id" in s and "sort_order" in s for s in resp.data["suggestions"])
+
+
+@pytest.mark.django_db
+def test_item_suggestions_empty_when_no_program(
+    org, counselor_user, counselor_person,
+):
+    """A viewer without a program membership gets an empty list, not a 500."""
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/camper-care-item-suggestions/")
+    assert resp.status_code == 200
+    assert resp.data == {"suggestions": []}
 
 
 @pytest.mark.django_db

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -217,6 +217,11 @@ urlpatterns = [
         name="counselor-camper-care-create",
     ),
     path(
+        "counselor/camper-care-item-suggestions/",
+        counselor_camper_care_requests.CamperCareItemSuggestionListView.as_view(),
+        name="counselor-camper-care-item-suggestions",
+    ),
+    path(
         "counselor/maintenance-tickets/",
         counselor_maintenance_tickets.MaintenanceTicketCreateView.as_view(),
         name="counselor-maintenance-ticket-create",

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -52,6 +52,9 @@ import CamperReflectionListPage from './pages/counselor/CamperReflectionListPage
 import CamperReflectionFormPage from './pages/counselor/CamperReflectionFormPage';
 import CounselorSelfReflectionPage from './pages/counselor/CounselorSelfReflectionPage';
 import CounselorSelfReflectionHistoryPage from './pages/counselor/CounselorSelfReflectionHistoryPage';
+import CounselorRequestsListPage from './pages/counselor/CounselorRequestsListPage';
+import CamperCareRequestFormPage from './pages/counselor/CamperCareRequestFormPage';
+import MaintenanceTicketFormPage from './pages/counselor/MaintenanceTicketFormPage';
 import { useBunk } from './contexts/BunkContext';
 
 // Protected route component
@@ -373,6 +376,23 @@ function Router() {
           <Route
             path="/counselor/self-reflection/:reflectionId/edit"
             element={<CounselorSelfReflectionPage />}
+          />
+          {/* 7_6f: Camper Care + Maintenance request flow. The list view
+              accepts ``?status=open|all`` so counselors can confirm a
+              request closed without leaving the surface. Both per-type
+              forms have a stable client_submission_id ref so an offline
+              replay POSTs the same row instead of duplicating. */}
+          <Route
+            path="/counselor/requests"
+            element={<CounselorRequestsListPage />}
+          />
+          <Route
+            path="/counselor/requests/camper-care/new"
+            element={<CamperCareRequestFormPage />}
+          />
+          <Route
+            path="/counselor/requests/maintenance/new"
+            element={<MaintenanceTicketFormPage />}
           />
         </Route>
 

--- a/frontend/src/api/__tests__/counselor.test.js
+++ b/frontend/src/api/__tests__/counselor.test.js
@@ -2,16 +2,23 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   CAMPER_REFLECTION_AUDIENCE,
   COUNSELOR_SELF_REFLECTION_AUDIENCE,
+  MAINTENANCE_CATEGORIES,
+  MAINTENANCE_URGENCY_CHOICES,
+  createCamperCareRequest,
   createCamperReflection,
+  createMaintenanceTicket,
   createSelfReflection,
+  fetchCamperCareItemSuggestions,
   fetchCamperReflections,
   fetchCounselorDashboard,
+  fetchCounselorRequests,
   fetchReflection,
   fetchSelfReflectionHistory,
   fetchTemplateById,
   newClientSubmissionId,
   patchCamperReflection,
   patchSelfReflection,
+  uploadMaintenanceTicketPhoto,
 } from '../counselor';
 
 const getMock = vi.fn();
@@ -173,6 +180,136 @@ describe('counselor API helpers', () => {
     expect(getMock.mock.calls[0]).toEqual([
       '/api/v1/counselor/self-reflection/history/',
       { params: { page: 3, page_size: 30 } },
+    ]);
+  });
+
+  it('fetchCounselorRequests defaults status=open', async () => {
+    getMock.mockResolvedValue({ data: { requests: [] } });
+    await fetchCounselorRequests();
+    expect(getMock.mock.calls[0]).toEqual([
+      '/api/v1/counselor/requests/',
+      { params: { status: 'open' } },
+    ]);
+  });
+
+  it('fetchCounselorRequests forwards status filter', async () => {
+    getMock.mockResolvedValue({ data: { requests: [] } });
+    await fetchCounselorRequests({ status: 'all' });
+    expect(getMock.mock.calls[0][1].params.status).toBe('all');
+  });
+
+  it('fetchCamperCareItemSuggestions calls the suggestions endpoint', async () => {
+    getMock.mockResolvedValue({ data: { suggestions: [] } });
+    await fetchCamperCareItemSuggestions();
+    expect(getMock.mock.calls[0][0]).toBe(
+      '/api/v1/counselor/camper-care-item-suggestions/',
+    );
+  });
+
+  it('createCamperCareRequest sends the trimmed payload', async () => {
+    postMock.mockResolvedValue({ data: { id: 'order-1' }, status: 201 });
+    await createCamperCareRequest({
+      subjectId: 42,
+      item: 'Toothbrush',
+      itemNote: 'purple',
+      description: 'after lights out',
+      clientSubmissionId: '33333333-3333-4333-8333-333333333333',
+    });
+    expect(postMock.mock.calls[0][0]).toBe('/api/v1/counselor/camper-care-requests/');
+    expect(postMock.mock.calls[0][1]).toEqual({
+      subject_id: 42,
+      item: 'Toothbrush',
+      item_note: 'purple',
+      description: 'after lights out',
+      client_submission_id: '33333333-3333-4333-8333-333333333333',
+    });
+  });
+
+  it('createCamperCareRequest omits subject_id when null/undefined', async () => {
+    postMock.mockResolvedValue({ data: { id: 'order-2' }, status: 201 });
+    await createCamperCareRequest({
+      subjectId: null,
+      item: 'Bug spray',
+      clientSubmissionId: '44444444-4444-4444-8444-444444444444',
+    });
+    const body = postMock.mock.calls[0][1];
+    expect(body).not.toHaveProperty('subject_id');
+    expect(body.item).toBe('Bug spray');
+  });
+
+  it('createMaintenanceTicket builds a multipart FormData with photos', async () => {
+    postMock.mockResolvedValue({ data: { id: 'mt-1' }, status: 201 });
+    const photo1 = new File(['fake-image-1'], 'photo1.jpg', { type: 'image/jpeg' });
+    const photo2 = new File(['fake-image-2'], 'photo2.jpg', { type: 'image/jpeg' });
+    await createMaintenanceTicket({
+      location: 'Bunk Pine',
+      category: 'leak',
+      description: 'under sink',
+      urgency: 'urgent',
+      urgentReason: 'flooding',
+      photos: [photo1, photo2],
+      clientSubmissionId: '55555555-5555-4555-8555-555555555555',
+    });
+    expect(postMock.mock.calls[0][0]).toBe('/api/v1/counselor/maintenance-tickets/');
+    const body = postMock.mock.calls[0][1];
+    expect(body).toBeInstanceOf(FormData);
+    expect(body.get('location')).toBe('Bunk Pine');
+    expect(body.get('category')).toBe('leak');
+    expect(body.get('urgency')).toBe('urgent');
+    expect(body.get('urgent_reason')).toBe('flooding');
+    expect(body.get('client_submission_id')).toBe(
+      '55555555-5555-4555-8555-555555555555',
+    );
+    expect(body.getAll('photos')).toHaveLength(2);
+
+    // ``Content-Type: undefined`` so the browser sets the multipart boundary.
+    expect(postMock.mock.calls[0][2]).toEqual({
+      headers: { 'Content-Type': undefined },
+    });
+  });
+
+  it('createMaintenanceTicket skips urgent_reason when urgency is normal', async () => {
+    postMock.mockResolvedValue({ data: { id: 'mt-2' }, status: 201 });
+    await createMaintenanceTicket({
+      location: 'Dining hall',
+      category: 'broken_light',
+      photos: [],
+      urgency: 'normal',
+      urgentReason: 'should be ignored',
+      clientSubmissionId: '66666666-6666-4666-8666-666666666666',
+    });
+    const body = postMock.mock.calls[0][1];
+    expect(body.get('urgent_reason')).toBeNull();
+    expect(body.getAll('photos')).toHaveLength(0);
+  });
+
+  it('uploadMaintenanceTicketPhoto posts to the follow-up endpoint', async () => {
+    postMock.mockResolvedValue({ data: { id: 'photo-1' } });
+    const photo = new File(['data'], 'extra.jpg', { type: 'image/jpeg' });
+    await uploadMaintenanceTicketPhoto('abc-123', {
+      image: photo,
+      caption: 'cracked',
+    });
+    expect(postMock.mock.calls[0][0]).toBe(
+      '/api/v1/counselor/maintenance-tickets/abc-123/photos/',
+    );
+    const body = postMock.mock.calls[0][1];
+    expect(body).toBeInstanceOf(FormData);
+    expect(body.get('caption')).toBe('cracked');
+    expect(body.get('image')).toBeInstanceOf(File);
+  });
+
+  it('exports stable maintenance categories + urgencies', () => {
+    expect(MAINTENANCE_CATEGORIES.map((c) => c.value)).toEqual([
+      'plumbing',
+      'broken_light',
+      'pest',
+      'leak',
+      'other',
+    ]);
+    expect(MAINTENANCE_URGENCY_CHOICES.map((u) => u.value)).toEqual([
+      'normal',
+      'urgent',
     ]);
   });
 });

--- a/frontend/src/api/counselor.js
+++ b/frontend/src/api/counselor.js
@@ -222,3 +222,157 @@ export async function fetchSelfReflectionHistory({ page = 1, pageSize } = {}) {
   });
   return data;
 }
+
+// ---------------------------------------------------------------------------
+// Camper-care + maintenance requests (Stories 7 + 8)
+// ---------------------------------------------------------------------------
+
+/**
+ * Combined open-requests list for the dashboard's request pane.
+ *
+ * Returns Orders + MaintenanceTickets the viewer + their co-counselors
+ * submitted on the viewer's bunks. Default ``status=open`` filters to
+ * NEW + IN_PROGRESS; pass ``status='all'`` for the historical view.
+ */
+export async function fetchCounselorRequests({ status = 'open' } = {}) {
+  const { data } = await api.get('/api/v1/counselor/requests/', {
+    params: { status },
+  });
+  return data;
+}
+
+/**
+ * Fetch the curated camper-care item suggestion list for the viewer's
+ * program (Story 7 criterion 2.ii). Used as autocomplete options on the
+ * camper-care request form. An empty list just disables autocomplete
+ * (a counselor can still submit any free-text label).
+ */
+export async function fetchCamperCareItemSuggestions() {
+  const { data } = await api.get(
+    '/api/v1/counselor/camper-care-item-suggestions/',
+  );
+  return data;
+}
+
+/**
+ * Submit a camper-care request (Story 7).
+ *
+ * ``subjectId`` is optional: counselors can file a bunk-scoped request
+ * (no subject) for "the whole bunk" needs. ``item`` is free text; the
+ * client surfaces an autocomplete from
+ * :func:`fetchCamperCareItemSuggestions` but never blocks on it.
+ */
+export async function createCamperCareRequest({
+  subjectId,
+  item,
+  itemNote = '',
+  description = '',
+  clientSubmissionId,
+}) {
+  const payload = {
+    item,
+    item_note: itemNote,
+    description,
+    client_submission_id: clientSubmissionId,
+  };
+  if (subjectId !== undefined && subjectId !== null) {
+    payload.subject_id = subjectId;
+  }
+  const res = await api.post(
+    '/api/v1/counselor/camper-care-requests/', payload,
+  );
+  return { data: res.data, status: res.status };
+}
+
+/**
+ * Submit a maintenance ticket (Story 8) with optional photos.
+ *
+ * Photos must be supplied as an array of ``File`` instances so we can
+ * stream them through ``FormData`` with repeated ``photos`` keys, which
+ * is the only multipart shape DRF's serializer + view actually accept
+ * (see ``MaintenanceTicketCreateSerializer`` docstring for why the
+ * serializer can't validate the list directly — the view pulls from
+ * ``request.FILES.getlist('photos')`` instead).
+ *
+ * When ``urgency === 'urgent'`` the server requires ``urgent_reason``
+ * (Story 8 criterion 2); the form already enforces this client-side so
+ * a 400 here is a genuine server-side validation surface.
+ */
+export async function createMaintenanceTicket({
+  location,
+  category,
+  description = '',
+  urgency = 'normal',
+  urgentReason = '',
+  photos = [],
+  clientSubmissionId,
+}) {
+  const form = new FormData();
+  form.append('location', location);
+  form.append('category', category);
+  form.append('description', description);
+  form.append('urgency', urgency);
+  if (urgency === 'urgent' && urgentReason) {
+    form.append('urgent_reason', urgentReason);
+  }
+  form.append('client_submission_id', clientSubmissionId);
+  for (const file of photos) {
+    if (file) form.append('photos', file);
+  }
+  // Let the browser set the multipart boundary by NOT setting
+  // Content-Type explicitly. Passing ``Content-Type: undefined`` here
+  // unsets the JSON default baked into the axios instance defaults.
+  const res = await api.post(
+    '/api/v1/counselor/maintenance-tickets/',
+    form,
+    { headers: { 'Content-Type': undefined } },
+  );
+  return { data: res.data, status: res.status };
+}
+
+/**
+ * Add a follow-up photo to a maintenance ticket the viewer submitted
+ * (decision C5). Only counselors who submitted the original ticket can
+ * call this; cross-counselor follow-ups are out of scope until bunk-team
+ * co-ownership lands.
+ */
+export async function uploadMaintenanceTicketPhoto(ticketId, { image, caption = '' }) {
+  const form = new FormData();
+  form.append('image', image);
+  if (caption) form.append('caption', caption);
+  const { data } = await api.post(
+    `/api/v1/counselor/maintenance-tickets/${ticketId}/photos/`,
+    form,
+    { headers: { 'Content-Type': undefined } },
+  );
+  return data;
+}
+
+/**
+ * Frozen list of maintenance ticket categories. Mirrors
+ * ``MaintenanceTicket.Category.choices`` in the backend model. Kept
+ * client-side because the form's category picker can't wait on a round
+ * trip to render, and because the list is stable across releases —
+ * adding a new category is a coordinated backend + frontend change.
+ *
+ * Keep in sync with ``bunk_logs/core/models.py``.
+ */
+export const MAINTENANCE_CATEGORIES = Object.freeze([
+  { value: 'plumbing', label: 'Clogged plumbing' },
+  { value: 'broken_light', label: 'Broken light' },
+  { value: 'pest', label: 'Pest / Insect' },
+  { value: 'leak', label: 'Leak' },
+  { value: 'other', label: 'Other' },
+]);
+
+/**
+ * Frozen list of maintenance urgency levels. Mirrors
+ * ``OrderableContent.Urgency`` choices. ``low`` is hidden from the
+ * counselor form: counselors only pick between ``normal`` (default) and
+ * ``urgent`` (which unlocks ``urgent_reason``). Admins on the ops side
+ * can re-grade to ``low`` if needed.
+ */
+export const MAINTENANCE_URGENCY_CHOICES = Object.freeze([
+  { value: 'normal', label: 'Normal' },
+  { value: 'urgent', label: 'Urgent' },
+]);

--- a/frontend/src/pages/counselor/CamperCareRequestFormPage.jsx
+++ b/frontend/src/pages/counselor/CamperCareRequestFormPage.jsx
@@ -1,0 +1,337 @@
+/**
+ * Camper Care request form — Step 7_6f (Story 7).
+ *
+ * URL:  /counselor/requests/camper-care/new
+ *
+ * Two pickers up top:
+ *   * camper (optional) — populated from the dashboard's bunk roster.
+ *     Counselors can leave this blank to file a bunk-scoped request.
+ *   * item — free text with a datalist of curated suggestions
+ *     (Story 7 criterion 2.ii, decision C6). An empty suggestion list
+ *     just disables autocomplete; the field stays free-text.
+ *
+ * On submit POSTs ``/api/v1/counselor/camper-care-requests/`` with a
+ * stable ``client_submission_id`` so the offline queue can replay
+ * safely. On success we land back on the requests list (the dashboard's
+ * "Open Requests" section also picks up the row within 60s via the
+ * existing auto-refresh).
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  createCamperCareRequest,
+  fetchCamperCareItemSuggestions,
+  fetchCamperReflections,
+  newClientSubmissionId,
+} from '../../api/counselor';
+
+function flattenError(err, fallback) {
+  const body = err?.response?.data;
+  if (!body) return err?.message || fallback;
+  if (typeof body === 'string') return body;
+  if (typeof body.detail === 'string') return body.detail;
+  if (typeof body === 'object') {
+    try {
+      return JSON.stringify(body);
+    } catch (_) {
+      return fallback;
+    }
+  }
+  return fallback;
+}
+
+function flattenCamperRoster(camperReflections) {
+  // The roster source is the camper-reflections endpoint — same data the
+  // dashboard counts but with per-camper records (the dashboard's
+  // sections.campers only returns aggregates). Including off-camp campers
+  // here is intentional: it's fine to file a Camper Care request for an
+  // off-camp camper since the need (toiletries, supplies) often spans
+  // their entire stay.
+  const bunks = camperReflections?.bunks || [];
+  const seen = new Set();
+  const rows = [];
+  for (const bunk of bunks) {
+    const onCamp = bunk.campers || [];
+    const offCamp = bunk.off_camp || [];
+    for (const camper of [...onCamp, ...offCamp]) {
+      if (seen.has(camper.id)) continue;
+      seen.add(camper.id);
+      rows.push({
+        id: camper.id,
+        name: camper.name,
+        bunkName: bunk.name,
+        bunkId: bunk.id,
+      });
+    }
+  }
+  rows.sort((a, b) => {
+    if (a.bunkName !== b.bunkName) return a.bunkName.localeCompare(b.bunkName);
+    return a.name.localeCompare(b.name);
+  });
+  return rows;
+}
+
+export default function CamperCareRequestFormPage() {
+  const navigate = useNavigate();
+
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
+  const [campers, setCampers] = useState([]);
+  const [suggestions, setSuggestions] = useState([]);
+
+  const [subjectId, setSubjectId] = useState('');
+  const [item, setItem] = useState('');
+  const [itemNote, setItemNote] = useState('');
+  const [description, setDescription] = useState('');
+
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [submitError, setSubmitError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const clientSubmissionIdRef = useRef(null);
+  if (clientSubmissionIdRef.current === null) {
+    clientSubmissionIdRef.current = newClientSubmissionId();
+  }
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError('');
+    try {
+      const [camperReflections, suggestionPayload] = await Promise.all([
+        fetchCamperReflections(),
+        fetchCamperCareItemSuggestions().catch((err) => {
+          // Suggestions endpoint failure is non-fatal — the form still
+          // works as free text. Log but don't block.
+          // eslint-disable-next-line no-console
+          console.warn('camper-care suggestions failed:', err);
+          return { suggestions: [] };
+        }),
+      ]);
+      setCampers(flattenCamperRoster(camperReflections));
+      setSuggestions(suggestionPayload?.suggestions || []);
+    } catch (err) {
+      setLoadError(flattenError(err, 'Could not load the form.'));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const datalistOptions = useMemo(
+    () => suggestions.map((s) => s.label).filter(Boolean),
+    [suggestions],
+  );
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitError('');
+    const errs = {};
+    if (!item.trim()) errs.item = 'An item is required.';
+    setFieldErrors(errs);
+    if (Object.keys(errs).length) return;
+
+    setSubmitting(true);
+    try {
+      await createCamperCareRequest({
+        subjectId: subjectId ? Number(subjectId) : null,
+        item: item.trim(),
+        itemNote: itemNote.trim(),
+        description: description.trim(),
+        clientSubmissionId: clientSubmissionIdRef.current,
+      });
+      navigate('/counselor/requests', { replace: true });
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 403) {
+        setSubmitError(
+          flattenError(err, 'You can only file a request for a camper on your bunk.'),
+        );
+      } else if (status === 400) {
+        const body = err?.response?.data;
+        if (body && typeof body === 'object' && !Array.isArray(body)) {
+          const next = {};
+          for (const k of Object.keys(body)) {
+            if (k === 'detail') continue;
+            const v = body[k];
+            next[k] = Array.isArray(v) ? v[0] : typeof v === 'string' ? v : JSON.stringify(v);
+          }
+          setFieldErrors(next);
+          setSubmitError(
+            typeof body.detail === 'string'
+              ? body.detail
+              : 'Please fix the errors and try again.',
+          );
+        } else {
+          setSubmitError(flattenError(err, 'Submit failed.'));
+        }
+      } else {
+        setSubmitError(flattenError(err, 'Submit failed.'));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="px-4 py-6 pb-24">
+      <div className="max-w-lg mx-auto">
+        <header className="mb-6">
+          <button
+            type="button"
+            onClick={() => navigate('/counselor')}
+            className="text-xs text-blue-600 dark:text-blue-400 mb-1 flex items-center gap-1"
+          >
+            ← Back to dashboard
+          </button>
+          <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
+            New Camper Care request
+          </h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+            Goes to the Camper Care team. They'll see who it's for and what's
+            needed; you can leave the camper blank for a bunk-wide need.
+          </p>
+        </header>
+
+        {loading ? (
+          <p
+            className="text-gray-600 dark:text-gray-400"
+            data-testid="camper-care-loading"
+          >
+            Loading…
+          </p>
+        ) : loadError ? (
+          <div
+            className="rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/40 dark:border-amber-800 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+            role="alert"
+            data-testid="camper-care-load-error"
+          >
+            {loadError}
+          </div>
+        ) : (
+          <form
+            onSubmit={handleSubmit}
+            className="space-y-4"
+            data-testid="camper-care-form"
+          >
+            <div>
+              <label
+                htmlFor="cc-subject"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
+              >
+                Camper (optional)
+              </label>
+              <select
+                id="cc-subject"
+                data-testid="camper-care-subject"
+                value={subjectId}
+                onChange={(e) => setSubjectId(e.target.value)}
+                className="block w-full min-h-[44px] rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+              >
+                <option value="">— bunk-wide / no specific camper —</option>
+                {campers.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name} ({c.bunkName})
+                  </option>
+                ))}
+              </select>
+              {fieldErrors.subject_id ? (
+                <p className="mt-1 text-xs text-red-600" role="alert">
+                  {fieldErrors.subject_id}
+                </p>
+              ) : null}
+            </div>
+
+            <div>
+              <label
+                htmlFor="cc-item"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
+              >
+                Item *
+              </label>
+              <input
+                id="cc-item"
+                data-testid="camper-care-item"
+                value={item}
+                onChange={(e) => setItem(e.target.value)}
+                list={datalistOptions.length ? 'camper-care-item-options' : undefined}
+                required
+                placeholder="Toothpaste, sunscreen, …"
+                className="block w-full min-h-[44px] rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+              />
+              {datalistOptions.length ? (
+                <datalist id="camper-care-item-options">
+                  {datalistOptions.map((label) => (
+                    <option key={label} value={label} />
+                  ))}
+                </datalist>
+              ) : null}
+              {fieldErrors.item ? (
+                <p className="mt-1 text-xs text-red-600" role="alert">
+                  {fieldErrors.item}
+                </p>
+              ) : null}
+            </div>
+
+            <div>
+              <label
+                htmlFor="cc-item-note"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
+              >
+                Item note
+              </label>
+              <input
+                id="cc-item-note"
+                data-testid="camper-care-item-note"
+                value={itemNote}
+                onChange={(e) => setItemNote(e.target.value)}
+                placeholder="e.g. unscented, size 8…"
+                className="block w-full min-h-[44px] rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="cc-description"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
+              >
+                Notes for Camper Care
+              </label>
+              <textarea
+                id="cc-description"
+                data-testid="camper-care-description"
+                rows={4}
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Anything Camper Care should know to help."
+                className="block w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+              />
+            </div>
+
+            {submitError ? (
+              <p
+                className="text-red-600 text-sm"
+                role="alert"
+                data-testid="camper-care-submit-error"
+              >
+                {submitError}
+              </p>
+            ) : null}
+
+            <button
+              type="submit"
+              disabled={submitting}
+              data-testid="camper-care-submit"
+              className="w-full sm:w-auto mt-4 min-h-[48px] px-6 rounded-lg bg-blue-600 text-white font-medium text-sm disabled:opacity-50"
+            >
+              {submitting ? 'Sending…' : 'Send request'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/counselor/CounselorRequestsListPage.jsx
+++ b/frontend/src/pages/counselor/CounselorRequestsListPage.jsx
@@ -1,0 +1,276 @@
+/**
+ * Counselor requests list — Step 7_6f (Stories 7 + 8).
+ *
+ * URL:  /counselor/requests[?status=open|all]
+ *
+ * Renders the combined open camper-care + maintenance request roster
+ * that the dashboard's "Open Requests" tile teases (Story 7 + 8 list
+ * view). Two CTA buttons up top take the counselor to the per-resource
+ * "New request" forms. A status filter (open ↔ all) flips the API call
+ * so counselors can confirm a request has been closed without leaving
+ * the surface.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { fetchCounselorRequests } from '../../api/counselor';
+
+function TypeBadge({ type }) {
+  if (type === 'camper_care') {
+    return (
+      <span
+        data-testid="request-type-badge"
+        className="text-xs font-medium px-2 py-0.5 rounded-full bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200"
+      >
+        Camper Care
+      </span>
+    );
+  }
+  if (type === 'maintenance') {
+    return (
+      <span
+        data-testid="request-type-badge"
+        className="text-xs font-medium px-2 py-0.5 rounded-full bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-200"
+      >
+        Maintenance
+      </span>
+    );
+  }
+  return null;
+}
+
+function StatusBadge({ status, statusLabel }) {
+  // Map the OrderStateMachine status to a tailwind colour palette.
+  // Keep this loose; new statuses fall back to the neutral pill.
+  const palette = {
+    new: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
+    in_progress: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+    completed: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
+    closed: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200',
+    cancelled: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200',
+  };
+  const cls = palette[status] || palette.closed;
+  return (
+    <span
+      data-testid="request-status-badge"
+      data-status={status}
+      className={`text-xs font-medium px-2 py-0.5 rounded-full ${cls}`}
+    >
+      {statusLabel || status}
+    </span>
+  );
+}
+
+function UrgencyBadge({ urgency, urgencyLabel }) {
+  if (urgency !== 'urgent') return null;
+  return (
+    <span
+      data-testid="request-urgency-badge"
+      className="text-xs font-medium px-2 py-0.5 rounded-full bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200"
+    >
+      {urgencyLabel || 'Urgent'}
+    </span>
+  );
+}
+
+function formatRelative(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  const now = new Date();
+  const diffMs = now - d;
+  const diffMin = Math.round(diffMs / 60000);
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffH = Math.round(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+  const diffD = Math.round(diffH / 24);
+  return `${diffD}d ago`;
+}
+
+function RequestRow({ row }) {
+  const isCamperCare = row.type === 'camper_care';
+  const title = isCamperCare
+    ? row.item || 'Camper Care request'
+    : (row.category_label || row.location || 'Maintenance ticket');
+  const subtitle = isCamperCare
+    ? (row.subject?.name
+        ? `For ${row.subject.name}`
+        : 'Bunk-wide request')
+    : (row.location ? `Location: ${row.location}` : '');
+
+  const submitter = row.submitter?.is_self
+    ? 'you'
+    : row.submitter?.name || 'a co-counselor';
+
+  return (
+    <li
+      data-testid={`request-row-${row.type}-${row.id}`}
+      data-type={row.type}
+      data-status={row.status}
+      className="py-3 border-b border-gray-100 dark:border-gray-800 last:border-b-0 flex flex-col gap-1"
+    >
+      <div className="flex items-center gap-2 flex-wrap">
+        <TypeBadge type={row.type} />
+        <StatusBadge status={row.status} statusLabel={row.status_label} />
+        <UrgencyBadge urgency={row.urgency} urgencyLabel={row.urgency_label} />
+      </div>
+      <p className="text-sm font-medium text-gray-900 dark:text-white">{title}</p>
+      {subtitle ? (
+        <p className="text-xs text-gray-600 dark:text-gray-400">{subtitle}</p>
+      ) : null}
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        Sent by {submitter}
+        {row.submitted_at ? ` · ${formatRelative(row.submitted_at)}` : ''}
+        {row.type === 'maintenance' && row.photo_count
+          ? ` · ${row.photo_count} photo${row.photo_count === 1 ? '' : 's'}`
+          : ''}
+      </p>
+    </li>
+  );
+}
+
+export default function CounselorRequestsListPage() {
+  const navigate = useNavigate();
+  const [params, setParams] = useSearchParams();
+  const statusParam = (params.get('status') === 'all' ? 'all' : 'open');
+
+  const [rows, setRows] = useState(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async (filterStatus) => {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await fetchCounselorRequests({ status: filterStatus });
+      setRows(data?.requests || []);
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      setError(typeof detail === 'string' ? detail : 'Could not load requests.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load(statusParam);
+  }, [load, statusParam]);
+
+  const changeFilter = (next) => {
+    // Drop the param entirely on the "open" default so URLs stay clean.
+    if (next === 'open') {
+      params.delete('status');
+    } else {
+      params.set('status', next);
+    }
+    setParams(params, { replace: true });
+  };
+
+  return (
+    <div className="px-4 py-6 pb-24">
+      <div className="max-w-lg mx-auto space-y-4">
+        <header className="flex items-start justify-between gap-3">
+          <div>
+            <button
+              type="button"
+              onClick={() => navigate('/counselor')}
+              className="text-xs text-blue-600 dark:text-blue-400 mb-1 flex items-center gap-1"
+            >
+              ← Back to dashboard
+            </button>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
+              Open requests
+            </h1>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+              Yours and your co-counselors' active requests.
+            </p>
+          </div>
+          <div
+            data-testid="requests-status-filter"
+            className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden shrink-0"
+          >
+            <button
+              type="button"
+              data-testid="requests-filter-open"
+              aria-pressed={statusParam === 'open'}
+              onClick={() => changeFilter('open')}
+              className={`px-3 py-1.5 text-sm min-h-[36px] ${
+                statusParam === 'open'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200'
+              }`}
+            >
+              Open
+            </button>
+            <button
+              type="button"
+              data-testid="requests-filter-all"
+              aria-pressed={statusParam === 'all'}
+              onClick={() => changeFilter('all')}
+              className={`px-3 py-1.5 text-sm min-h-[36px] ${
+                statusParam === 'all'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200'
+              }`}
+            >
+              All
+            </button>
+          </div>
+        </header>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Link
+            to="/counselor/requests/camper-care/new"
+            data-testid="requests-new-camper-care"
+            className="min-h-[44px] flex items-center justify-center rounded-lg bg-purple-600 text-white text-sm font-medium px-4"
+          >
+            + Camper Care
+          </Link>
+          <Link
+            to="/counselor/requests/maintenance/new"
+            data-testid="requests-new-maintenance"
+            className="min-h-[44px] flex items-center justify-center rounded-lg bg-orange-600 text-white text-sm font-medium px-4"
+          >
+            + Maintenance
+          </Link>
+        </div>
+
+        {loading && rows === null ? (
+          <p
+            className="text-gray-600 dark:text-gray-400"
+            data-testid="requests-loading"
+          >
+            Loading requests…
+          </p>
+        ) : error ? (
+          <div
+            className="rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/40 dark:border-amber-800 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+            role="alert"
+            data-testid="requests-error"
+          >
+            {error}
+          </div>
+        ) : (
+          <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-2 shadow-sm">
+            {rows && rows.length ? (
+              <ul>
+                {rows.map((row) => (
+                  <RequestRow key={`${row.type}-${row.id}`} row={row} />
+                ))}
+              </ul>
+            ) : (
+              <p
+                className="text-sm text-gray-600 dark:text-gray-400 py-4"
+                data-testid="requests-empty"
+              >
+                {statusParam === 'open'
+                  ? 'No open requests right now. Tap "+ Camper Care" or "+ Maintenance" to file a new one.'
+                  : 'Nothing to show yet.'}
+              </p>
+            )}
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/counselor/MaintenanceTicketFormPage.jsx
+++ b/frontend/src/pages/counselor/MaintenanceTicketFormPage.jsx
@@ -1,0 +1,360 @@
+/**
+ * Maintenance ticket form — Step 7_6f (Story 8).
+ *
+ * URL:  /counselor/requests/maintenance/new
+ *
+ * Submission is multipart/form-data so we can attach photos in the same
+ * round-trip (Story 8 criterion 1.iv). ``urgency=urgent`` unlocks an
+ * ``urgent_reason`` textarea which the server enforces via
+ * ``MaintenanceTicket.clean()`` (Story 8 criterion 2); we mirror that
+ * client-side so the user sees the requirement before hitting submit.
+ *
+ * Photo handling notes:
+ *   * We add a small per-file preview tile so it's obvious which photos
+ *     the form is about to send. Each tile has a "Remove" affordance.
+ *   * No client-side resize (keeping scope tight for 7_6f). Modern
+ *     mobile cameras land around 3-6MB per HEIC/JPEG which the API
+ *     accepts; if it ends up being a problem we can add resize in a
+ *     follow-up.
+ *   * Object URLs are revoked when files change so we don't leak.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  MAINTENANCE_CATEGORIES,
+  MAINTENANCE_URGENCY_CHOICES,
+  createMaintenanceTicket,
+  newClientSubmissionId,
+} from '../../api/counselor';
+
+function flattenError(err, fallback) {
+  const body = err?.response?.data;
+  if (!body) return err?.message || fallback;
+  if (typeof body === 'string') return body;
+  if (typeof body.detail === 'string') return body.detail;
+  if (typeof body === 'object') {
+    try {
+      return JSON.stringify(body);
+    } catch (_) {
+      return fallback;
+    }
+  }
+  return fallback;
+}
+
+function PhotoTile({ file, onRemove }) {
+  const url = useMemo(() => URL.createObjectURL(file), [file]);
+  useEffect(() => () => URL.revokeObjectURL(url), [url]);
+  return (
+    <div
+      data-testid="maintenance-photo-tile"
+      className="relative w-20 h-20 rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700"
+    >
+      <img
+        src={url}
+        alt={file.name}
+        className="w-full h-full object-cover"
+      />
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Remove ${file.name}`}
+        data-testid="maintenance-photo-remove"
+        className="absolute top-0 right-0 bg-black/60 text-white text-xs px-1.5 py-0.5 rounded-bl-md"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+
+export default function MaintenanceTicketFormPage() {
+  const navigate = useNavigate();
+
+  const [location, setLocation] = useState('');
+  const [category, setCategory] = useState('');
+  const [description, setDescription] = useState('');
+  const [urgency, setUrgency] = useState('normal');
+  const [urgentReason, setUrgentReason] = useState('');
+  const [photos, setPhotos] = useState([]);
+
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [submitError, setSubmitError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const clientSubmissionIdRef = useRef(null);
+  if (clientSubmissionIdRef.current === null) {
+    clientSubmissionIdRef.current = newClientSubmissionId();
+  }
+  const fileInputRef = useRef(null);
+
+  const handlePhotosChosen = (e) => {
+    const next = Array.from(e.target.files || []);
+    if (next.length === 0) return;
+    setPhotos((prev) => [...prev, ...next]);
+    // Reset the input value so the user can pick the same file twice if
+    // they want; otherwise the change event won't fire on re-select.
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const removePhoto = (index) => {
+    setPhotos((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitError('');
+    const errs = {};
+    if (!location.trim()) errs.location = 'Location is required.';
+    if (!category) errs.category = 'Pick a category.';
+    if (urgency === 'urgent' && !urgentReason.trim()) {
+      // Mirror MaintenanceTicket.clean() (Story 8 criterion 2).
+      errs.urgent_reason = 'Required when this is urgent.';
+    }
+    setFieldErrors(errs);
+    if (Object.keys(errs).length) return;
+
+    setSubmitting(true);
+    try {
+      await createMaintenanceTicket({
+        location: location.trim(),
+        category,
+        description: description.trim(),
+        urgency,
+        urgentReason: urgency === 'urgent' ? urgentReason.trim() : '',
+        photos,
+        clientSubmissionId: clientSubmissionIdRef.current,
+      });
+      navigate('/counselor/requests', { replace: true });
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 400) {
+        const body = err?.response?.data;
+        if (body && typeof body === 'object' && !Array.isArray(body)) {
+          const next = {};
+          for (const k of Object.keys(body)) {
+            if (k === 'detail') continue;
+            const v = body[k];
+            next[k] = Array.isArray(v) ? v[0] : typeof v === 'string' ? v : JSON.stringify(v);
+          }
+          setFieldErrors(next);
+          setSubmitError(
+            typeof body.detail === 'string'
+              ? body.detail
+              : 'Please fix the errors and try again.',
+          );
+        } else {
+          setSubmitError(flattenError(err, 'Submit failed.'));
+        }
+      } else {
+        setSubmitError(flattenError(err, 'Submit failed.'));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="px-4 py-6 pb-24">
+      <div className="max-w-lg mx-auto">
+        <header className="mb-6">
+          <button
+            type="button"
+            onClick={() => navigate('/counselor')}
+            className="text-xs text-blue-600 dark:text-blue-400 mb-1 flex items-center gap-1"
+          >
+            ← Back to dashboard
+          </button>
+          <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
+            New Maintenance ticket
+          </h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+            Goes to the Maintenance team. Photos help triage faster.
+          </p>
+        </header>
+
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-4"
+          data-testid="maintenance-form"
+          encType="multipart/form-data"
+        >
+          <div>
+            <label
+              htmlFor="mt-location"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
+            >
+              Location *
+            </label>
+            <input
+              id="mt-location"
+              data-testid="maintenance-location"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              placeholder="Bunk Pine, dining hall, …"
+              required
+              className="block w-full min-h-[44px] rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+            />
+            {fieldErrors.location ? (
+              <p className="mt-1 text-xs text-red-600" role="alert">
+                {fieldErrors.location}
+              </p>
+            ) : null}
+          </div>
+
+          <div>
+            <label
+              htmlFor="mt-category"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
+            >
+              Category *
+            </label>
+            <select
+              id="mt-category"
+              data-testid="maintenance-category"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              required
+              className="block w-full min-h-[44px] rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+            >
+              <option value="">— pick one —</option>
+              {MAINTENANCE_CATEGORIES.map((c) => (
+                <option key={c.value} value={c.value}>{c.label}</option>
+              ))}
+            </select>
+            {fieldErrors.category ? (
+              <p className="mt-1 text-xs text-red-600" role="alert">
+                {fieldErrors.category}
+              </p>
+            ) : null}
+          </div>
+
+          <fieldset
+            data-testid="maintenance-urgency-group"
+            className="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-3"
+          >
+            <legend className="text-xs font-medium text-gray-600 dark:text-gray-400 px-1">
+              Urgency
+            </legend>
+            <div className="flex gap-3 mt-1">
+              {MAINTENANCE_URGENCY_CHOICES.map((u) => (
+                <label
+                  key={u.value}
+                  className="flex items-center gap-2 cursor-pointer text-sm text-gray-800 dark:text-gray-200"
+                >
+                  <input
+                    type="radio"
+                    name="urgency"
+                    value={u.value}
+                    checked={urgency === u.value}
+                    onChange={() => setUrgency(u.value)}
+                    data-testid={`maintenance-urgency-${u.value}`}
+                    className="h-4 w-4 text-blue-600 focus:ring-blue-500"
+                  />
+                  {u.label}
+                </label>
+              ))}
+            </div>
+            {urgency === 'urgent' ? (
+              <div className="mt-3">
+                <label
+                  htmlFor="mt-urgent-reason"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
+                >
+                  Why is this urgent? *
+                </label>
+                <textarea
+                  id="mt-urgent-reason"
+                  data-testid="maintenance-urgent-reason"
+                  rows={3}
+                  value={urgentReason}
+                  onChange={(e) => setUrgentReason(e.target.value)}
+                  placeholder="What's at stake if this waits?"
+                  className="block w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+                />
+                {fieldErrors.urgent_reason ? (
+                  <p className="mt-1 text-xs text-red-600" role="alert">
+                    {fieldErrors.urgent_reason}
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+          </fieldset>
+
+          <div>
+            <label
+              htmlFor="mt-description"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
+            >
+              Description
+            </label>
+            <textarea
+              id="mt-description"
+              data-testid="maintenance-description"
+              rows={4}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What's broken, where to look, anything Maintenance needs to know."
+              className="block w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+            />
+          </div>
+
+          <div>
+            <span className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+              Photos
+            </span>
+            <div className="flex flex-wrap items-center gap-2">
+              {photos.map((file, index) => (
+                <PhotoTile
+                  key={`${file.name}-${file.lastModified}-${index}`}
+                  file={file}
+                  onRemove={() => removePhoto(index)}
+                />
+              ))}
+              <label
+                htmlFor="mt-photo-input"
+                data-testid="maintenance-photo-add"
+                className="w-20 h-20 rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-600 flex items-center justify-center text-xs text-gray-500 dark:text-gray-400 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800"
+              >
+                + Photo
+              </label>
+              <input
+                id="mt-photo-input"
+                data-testid="maintenance-photo-input"
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                onChange={handlePhotosChosen}
+                className="sr-only"
+              />
+            </div>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              Tap to add — you can pick multiple at once.
+            </p>
+          </div>
+
+          {submitError ? (
+            <p
+              className="text-red-600 text-sm"
+              role="alert"
+              data-testid="maintenance-submit-error"
+            >
+              {submitError}
+            </p>
+          ) : null}
+
+          <button
+            type="submit"
+            disabled={submitting}
+            data-testid="maintenance-submit"
+            className="w-full sm:w-auto mt-4 min-h-[48px] px-6 rounded-lg bg-blue-600 text-white font-medium text-sm disabled:opacity-50"
+          >
+            {submitting ? 'Submitting…' : 'Submit ticket'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/counselor/__tests__/CamperCareRequestFormPage.test.jsx
+++ b/frontend/src/pages/counselor/__tests__/CamperCareRequestFormPage.test.jsx
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import CamperCareRequestFormPage from '../CamperCareRequestFormPage';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: (...args) => postMock(...args),
+  },
+}));
+
+function PathProbe() {
+  const loc = useLocation();
+  return <div data-testid="path-probe" data-pathname={loc.pathname} />;
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/counselor/requests/camper-care/new']}>
+      <Routes>
+        <Route
+          path="/counselor/requests/camper-care/new"
+          element={<CamperCareRequestFormPage />}
+        />
+        <Route path="/counselor/requests" element={<PathProbe />} />
+        <Route path="/counselor" element={<PathProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const rosterPayload = {
+  date: '2026-07-04',
+  editable: true,
+  template: { id: 9, slug: 'camper', name: 'Camper', version: 1 },
+  bunks: [
+    {
+      id: 1,
+      slug: 'pine',
+      name: 'Pine',
+      covered: 0,
+      total: 2,
+      campers: [
+        { id: 100, name: 'Avi L', preferred_name: 'Avi', first_name: 'Avi', last_initial: 'L', submitted: false, reflection_id: null, submitter: null, editable: false },
+        { id: 101, name: 'Beth M', preferred_name: 'Beth', first_name: 'Beth', last_initial: 'M', submitted: false, reflection_id: null, submitter: null, editable: false },
+      ],
+      off_camp: [
+        { id: 102, name: 'Carl N', preferred_name: 'Carl', first_name: 'Carl', last_initial: 'N' },
+      ],
+    },
+    {
+      id: 2,
+      slug: 'oak',
+      name: 'Oak',
+      covered: 0,
+      total: 1,
+      campers: [
+        { id: 200, name: 'Dana O', preferred_name: 'Dana', first_name: 'Dana', last_initial: 'O', submitted: false, reflection_id: null, submitter: null, editable: false },
+      ],
+      off_camp: [],
+    },
+  ],
+};
+
+const suggestionPayload = {
+  suggestions: [
+    { id: 'sug-1', label: 'Toothpaste', sort_order: 1 },
+    { id: 'sug-2', label: 'Sunscreen', sort_order: 2 },
+  ],
+};
+
+describe('CamperCareRequestFormPage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    postMock.mockReset();
+  });
+
+  function arrange(suggestions = suggestionPayload) {
+    getMock.mockImplementation((url) => {
+      if (url === '/api/v1/counselor/camper-reflections/') {
+        return Promise.resolve({ data: rosterPayload });
+      }
+      if (url === '/api/v1/counselor/camper-care-item-suggestions/') {
+        return Promise.resolve({ data: suggestions });
+      }
+      return Promise.reject(new Error(`Unmocked: ${url}`));
+    });
+  }
+
+  it('flattens the roster across bunks (including off-camp) into the picker', async () => {
+    arrange();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+    const options = Array.from(
+      screen.getByTestId('camper-care-subject').querySelectorAll('option'),
+    );
+    const labels = options.map((o) => o.textContent);
+    // Empty option + Avi/Beth/Carl in Pine + Dana in Oak. Alphabetical
+    // by bunk then by name; Pine comes before Oak in alpha, no — Oak
+    // < Pine. So Oak's Dana first.
+    expect(labels[0]).toMatch(/— bunk-wide/);
+    expect(labels.slice(1)).toEqual([
+      'Dana O (Oak)',
+      'Avi L (Pine)',
+      'Beth M (Pine)',
+      'Carl N (Pine)',
+    ]);
+  });
+
+  it('renders a datalist with the curated suggestions', async () => {
+    arrange();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+    const dl = document.getElementById('camper-care-item-options');
+    expect(dl).toBeTruthy();
+    const values = Array.from(dl.querySelectorAll('option')).map((o) => o.value);
+    expect(values).toEqual(['Toothpaste', 'Sunscreen']);
+  });
+
+  it('skips the datalist when no suggestions exist (free text only)', async () => {
+    arrange({ suggestions: [] });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+    expect(document.getElementById('camper-care-item-options')).toBeNull();
+    expect(screen.getByTestId('camper-care-item').hasAttribute('list')).toBe(false);
+  });
+
+  it('survives a suggestions endpoint error gracefully', async () => {
+    getMock.mockImplementation((url) => {
+      if (url === '/api/v1/counselor/camper-reflections/') {
+        return Promise.resolve({ data: rosterPayload });
+      }
+      return Promise.reject(new Error('boom'));
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+    expect(document.getElementById('camper-care-item-options')).toBeNull();
+  });
+
+  it('requires an item before submit', async () => {
+    arrange();
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+    // userEvent honors the `required` attr; remove it so we can test our
+    // own validation message.
+    const input = screen.getByTestId('camper-care-item');
+    input.removeAttribute('required');
+    await user.click(screen.getByTestId('camper-care-submit'));
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it('POSTs with stable client_submission_id and routes to the list', async () => {
+    arrange();
+    postMock.mockResolvedValue({ data: { id: 'order-1' }, status: 201 });
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+
+    await user.selectOptions(screen.getByTestId('camper-care-subject'), '100');
+    await user.type(screen.getByTestId('camper-care-item'), 'Toothpaste');
+    await user.type(screen.getByTestId('camper-care-item-note'), 'mint please');
+    await user.type(screen.getByTestId('camper-care-description'), 'whole bunk is out');
+    await user.click(screen.getByTestId('camper-care-submit'));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    const [url, body] = postMock.mock.calls[0];
+    expect(url).toBe('/api/v1/counselor/camper-care-requests/');
+    expect(body.subject_id).toBe(100);
+    expect(body.item).toBe('Toothpaste');
+    expect(body.item_note).toBe('mint please');
+    expect(body.description).toBe('whole bunk is out');
+    expect(typeof body.client_submission_id).toBe('string');
+    expect(body.client_submission_id.length).toBeGreaterThan(20);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('path-probe')).toHaveAttribute(
+        'data-pathname',
+        '/counselor/requests',
+      ),
+    );
+  });
+
+  it('omits subject_id for bunk-scoped requests', async () => {
+    arrange();
+    postMock.mockResolvedValue({ data: { id: 'order-2' }, status: 201 });
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+
+    await user.type(screen.getByTestId('camper-care-item'), 'Bug spray');
+    await user.click(screen.getByTestId('camper-care-submit'));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    const body = postMock.mock.calls[0][1];
+    expect(body).not.toHaveProperty('subject_id');
+  });
+
+  it('shows a 403 server message verbatim', async () => {
+    arrange();
+    postMock.mockRejectedValue({
+      response: { status: 403, data: { detail: 'Camper is not on any of your bunks.' } },
+    });
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+
+    await user.type(screen.getByTestId('camper-care-item'), 'X');
+    await user.click(screen.getByTestId('camper-care-submit'));
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-submit-error')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('camper-care-submit-error')).toHaveTextContent(
+      'Camper is not on any of your bunks.',
+    );
+  });
+
+  it('surfaces 400 field errors per-field', async () => {
+    arrange();
+    postMock.mockRejectedValue({
+      response: { status: 400, data: { item: ['This field is required.'] } },
+    });
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+    await user.type(screen.getByTestId('camper-care-item'), 'X');
+    await user.click(screen.getByTestId('camper-care-submit'));
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-submit-error')).toBeInTheDocument(),
+    );
+    expect(screen.getByText('This field is required.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/counselor/__tests__/CounselorRequestsListPage.test.jsx
+++ b/frontend/src/pages/counselor/__tests__/CounselorRequestsListPage.test.jsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import CounselorRequestsListPage from '../CounselorRequestsListPage';
+
+const getMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+  },
+}));
+
+const samplePayload = {
+  requests: [
+    {
+      type: 'maintenance',
+      id: 'mt-1',
+      status: 'new',
+      status_label: 'New',
+      location: 'Bunk Pine',
+      category: 'leak',
+      category_label: 'Leak',
+      urgency: 'urgent',
+      urgency_label: 'Urgent',
+      description: 'under sink',
+      photo_count: 2,
+      submitter: { is_self: true, name: null },
+      submitted_at: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+    },
+    {
+      type: 'camper_care',
+      id: 'order-1',
+      status: 'in_progress',
+      status_label: 'In progress',
+      subject: { id: 100, name: 'Avi L' },
+      item: 'Toothpaste',
+      item_note: 'mint',
+      submitter: { is_self: false, name: 'Casey Q' },
+      submitted_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    },
+    {
+      type: 'camper_care',
+      id: 'order-2',
+      status: 'new',
+      status_label: 'New',
+      subject: null,
+      item: 'Bug spray',
+      item_note: '',
+      submitter: { is_self: true, name: null },
+      submitted_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+    },
+  ],
+};
+
+function renderPage(initialEntry = '/counselor/requests') {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <CounselorRequestsListPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('CounselorRequestsListPage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  it('fetches with status=open by default', async () => {
+    getMock.mockResolvedValue({ data: samplePayload });
+    renderPage();
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    expect(getMock.mock.calls[0]).toEqual([
+      '/api/v1/counselor/requests/',
+      { params: { status: 'open' } },
+    ]);
+  });
+
+  it('renders each request with type, status, and submitter info', async () => {
+    getMock.mockResolvedValue({ data: samplePayload });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('request-row-maintenance-mt-1')).toBeInTheDocument(),
+    );
+
+    const mt = screen.getByTestId('request-row-maintenance-mt-1');
+    expect(mt).toHaveAttribute('data-status', 'new');
+    expect(mt).toHaveAttribute('data-type', 'maintenance');
+    expect(mt.querySelector('[data-testid="request-urgency-badge"]')).toBeTruthy();
+    expect(mt).toHaveTextContent('Leak');
+    expect(mt).toHaveTextContent('Sent by you');
+    expect(mt).toHaveTextContent('2 photos');
+
+    const cc1 = screen.getByTestId('request-row-camper_care-order-1');
+    expect(cc1).toHaveTextContent('Toothpaste');
+    expect(cc1).toHaveTextContent('For Avi L');
+    expect(cc1).toHaveTextContent('Casey Q');
+    expect(cc1.querySelector('[data-testid="request-status-badge"]')).toHaveAttribute(
+      'data-status',
+      'in_progress',
+    );
+
+    const cc2 = screen.getByTestId('request-row-camper_care-order-2');
+    expect(cc2).toHaveTextContent('Bunk-wide request');
+  });
+
+  it('flips to status=all when the All filter is clicked', async () => {
+    const user = userEvent.setup();
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    getMock.mockResolvedValueOnce({ data: { requests: [] } });
+    renderPage();
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByTestId('requests-filter-all'));
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2));
+    expect(getMock.mock.calls[1][1].params.status).toBe('all');
+  });
+
+  it('seeds the filter from the URL ?status=all', async () => {
+    getMock.mockResolvedValue({ data: samplePayload });
+    renderPage('/counselor/requests?status=all');
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    expect(getMock.mock.calls[0][1].params.status).toBe('all');
+    expect(screen.getByTestId('requests-filter-all')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('renders empty-state copy when no rows', async () => {
+    getMock.mockResolvedValue({ data: { requests: [] } });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('requests-empty')).toBeInTheDocument());
+    expect(screen.getByTestId('requests-empty')).toHaveTextContent(/No open requests/i);
+  });
+
+  it('renders an error banner when fetch fails', async () => {
+    getMock.mockRejectedValue({ response: { status: 500, data: { detail: 'boom' } } });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('requests-error')).toBeInTheDocument());
+    expect(screen.getByTestId('requests-error')).toHaveTextContent('boom');
+  });
+
+  it('always exposes both new-request CTAs', async () => {
+    getMock.mockResolvedValue({ data: samplePayload });
+    renderPage();
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    expect(screen.getByTestId('requests-new-camper-care')).toHaveAttribute(
+      'href',
+      '/counselor/requests/camper-care/new',
+    );
+    expect(screen.getByTestId('requests-new-maintenance')).toHaveAttribute(
+      'href',
+      '/counselor/requests/maintenance/new',
+    );
+  });
+});

--- a/frontend/src/pages/counselor/__tests__/MaintenanceTicketFormPage.test.jsx
+++ b/frontend/src/pages/counselor/__tests__/MaintenanceTicketFormPage.test.jsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import MaintenanceTicketFormPage from '../MaintenanceTicketFormPage';
+
+const postMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    post: (...args) => postMock(...args),
+  },
+}));
+
+function PathProbe() {
+  const loc = useLocation();
+  return <div data-testid="path-probe" data-pathname={loc.pathname} />;
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/counselor/requests/maintenance/new']}>
+      <Routes>
+        <Route
+          path="/counselor/requests/maintenance/new"
+          element={<MaintenanceTicketFormPage />}
+        />
+        <Route path="/counselor/requests" element={<PathProbe />} />
+        <Route path="/counselor" element={<PathProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// jsdom's URL doesn't ship createObjectURL out of the box.
+beforeEach(() => {
+  if (!URL.createObjectURL) {
+    URL.createObjectURL = vi.fn(() => 'blob:mocked');
+  } else {
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mocked');
+  }
+  if (!URL.revokeObjectURL) {
+    URL.revokeObjectURL = vi.fn();
+  } else {
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+  }
+});
+
+describe('MaintenanceTicketFormPage', () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it('renders the category options and defaults urgency to normal', () => {
+    renderPage();
+    const categoryOptions = Array.from(
+      screen.getByTestId('maintenance-category').querySelectorAll('option'),
+    ).map((o) => o.value);
+    expect(categoryOptions).toEqual([
+      '', 'plumbing', 'broken_light', 'pest', 'leak', 'other',
+    ]);
+    expect(screen.getByTestId('maintenance-urgency-normal')).toBeChecked();
+    expect(screen.getByTestId('maintenance-urgency-urgent')).not.toBeChecked();
+    // Urgent reason field is hidden initially.
+    expect(screen.queryByTestId('maintenance-urgent-reason')).toBeNull();
+  });
+
+  it('reveals the urgent_reason textarea when urgency flips to urgent', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByTestId('maintenance-urgency-urgent'));
+    expect(screen.getByTestId('maintenance-urgent-reason')).toBeInTheDocument();
+  });
+
+  it('blocks submit when urgent_reason missing on an urgent ticket', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    // Bypass HTML `required` so we can hit our own validation path.
+    screen.getByTestId('maintenance-location').removeAttribute('required');
+    screen.getByTestId('maintenance-category').removeAttribute('required');
+
+    await user.type(screen.getByTestId('maintenance-location'), 'Bunk Pine');
+    await user.selectOptions(screen.getByTestId('maintenance-category'), 'leak');
+    await user.click(screen.getByTestId('maintenance-urgency-urgent'));
+    await user.click(screen.getByTestId('maintenance-submit'));
+
+    expect(postMock).not.toHaveBeenCalled();
+    expect(screen.getByText('Required when this is urgent.')).toBeInTheDocument();
+  });
+
+  it('attaches photos and previews them with remove affordance', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const file = new File(['data'], 'shower.jpg', { type: 'image/jpeg' });
+    const input = screen.getByTestId('maintenance-photo-input');
+    await user.upload(input, file);
+
+    expect(screen.getAllByTestId('maintenance-photo-tile')).toHaveLength(1);
+    await user.click(screen.getByTestId('maintenance-photo-remove'));
+    expect(screen.queryByTestId('maintenance-photo-tile')).toBeNull();
+  });
+
+  it('POSTs multipart with photos + urgent_reason and routes to the list', async () => {
+    postMock.mockResolvedValue({ data: { id: 'mt-1' }, status: 201 });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByTestId('maintenance-location'), 'Bunk Pine');
+    await user.selectOptions(screen.getByTestId('maintenance-category'), 'leak');
+    await user.click(screen.getByTestId('maintenance-urgency-urgent'));
+    await user.type(screen.getByTestId('maintenance-urgent-reason'), 'flooding');
+    await user.type(screen.getByTestId('maintenance-description'), 'under sink');
+
+    const file1 = new File(['x'], 'p1.jpg', { type: 'image/jpeg' });
+    const file2 = new File(['y'], 'p2.jpg', { type: 'image/jpeg' });
+    await user.upload(screen.getByTestId('maintenance-photo-input'), [file1, file2]);
+
+    await user.click(screen.getByTestId('maintenance-submit'));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    const [url, body, config] = postMock.mock.calls[0];
+    expect(url).toBe('/api/v1/counselor/maintenance-tickets/');
+    expect(body).toBeInstanceOf(FormData);
+    expect(body.get('location')).toBe('Bunk Pine');
+    expect(body.get('category')).toBe('leak');
+    expect(body.get('urgency')).toBe('urgent');
+    expect(body.get('urgent_reason')).toBe('flooding');
+    expect(body.get('description')).toBe('under sink');
+    expect(body.getAll('photos')).toHaveLength(2);
+    expect(typeof body.get('client_submission_id')).toBe('string');
+    expect(config).toEqual({ headers: { 'Content-Type': undefined } });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('path-probe')).toHaveAttribute(
+        'data-pathname',
+        '/counselor/requests',
+      ),
+    );
+  });
+
+  it('surfaces a 400 field error from the server', async () => {
+    postMock.mockRejectedValue({
+      response: { status: 400, data: { urgent_reason: ['Required when urgency is urgent.'] } },
+    });
+    const user = userEvent.setup();
+    renderPage();
+    await user.type(screen.getByTestId('maintenance-location'), 'X');
+    await user.selectOptions(screen.getByTestId('maintenance-category'), 'leak');
+    await user.click(screen.getByTestId('maintenance-urgency-urgent'));
+    await user.type(screen.getByTestId('maintenance-urgent-reason'), 'something');
+    await user.click(screen.getByTestId('maintenance-submit'));
+    await waitFor(() =>
+      expect(screen.getByTestId('maintenance-submit-error')).toBeInTheDocument(),
+    );
+    expect(screen.getByText('Required when urgency is urgent.')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on `feat/7_6e_counselor_self_reflection` (PR #77). Closes Stories 7 + 8 from the 7_6 counselor flow roadmap, layered on top of the 7_6c write endpoints.

**New surfaces**
- `/counselor/requests` — combined open camper-care + maintenance request list with `?status=open|all` filter
- `/counselor/requests/camper-care/new` — Camper Care request form with autocomplete
- `/counselor/requests/maintenance/new` — Maintenance ticket form with multi-photo upload + conditional urgent reason

**New backend surface**
- `GET /api/v1/counselor/camper-care-item-suggestions/` — curated item autocomplete list, program-scoped (decision C6)

## Highlights

- **Multipart photo upload**. `createMaintenanceTicket()` builds a `FormData` with repeated `photos` keys (the only shape the view's `request.FILES.getlist('photos')` accepts; the serializer can't handle lists directly per its own docstring), and passes `Content-Type: undefined` so axios lets the browser set the multipart boundary. Photo tiles use `URL.createObjectURL` with revoke-on-cleanup.

- **Urgency reveals reason field**. Picking "Urgent" unlocks the `urgent_reason` textarea and mirrors `MaintenanceTicket.clean()` client-side, so the user sees the requirement before submit (Story 8 criterion 2).

- **Roster reuse**. Camper Care form pulls the roster from `fetchCamperReflections()` (the dashboard's `sections.campers` is aggregate-only). Off-camp campers are included since toiletries/supplies often span the full stay.

- **Suggestions degrade gracefully**. If `camper-care-item-suggestions/` fails or returns empty, the form drops the `<datalist>` and stays free-text — matching Story 7 criterion 2.ii.

- **URL-driven filter state** on the requests list (`?status=open|all`). Empty/error states + always-visible new-request CTAs keep the surface useful in degraded conditions.

- Idempotency via `useRef`-stable `client_submission_id` from 7_6d/e — verified by api helper unit tests.

## Test plan

- [x] **Backend** 859 / 859 pytest green (added 2 new tests for the suggestions endpoint).
- [x] **Frontend** 422 / 422 vitest green (up from 391 on 7_6e — 31 new tests across 4 files).
- [x] `vite build` clean.
- [x] 0 lint errors on new code.
- [ ] Manual QA (recommend before merging):
  - Sign in as a counselor. Open `/counselor/requests` — empty state copy points at the CTAs.
  - Tap "+ Camper Care" → pick a camper + item from the datalist → send. Lands on requests list with the new row.
  - Tap "+ Maintenance" → set urgency=urgent without filling reason → submit blocked with inline error.
  - Fill the reason, add 2 photos, submit → lands on requests list with a maintenance row showing `🟠 Urgent` badge + "2 photos".
  - Flip filter to All → URL becomes `?status=all`, completed rows appear.
  - As a co-counselor, send a request → original viewer sees it on the list within ~60s (dashboard auto-refresh).

## Notes for reviewers

- Maintenance category + urgency choice lists are frozen in `counselor.js`. Adding a new option is a coordinated backend + frontend change; alternative is a round-trip on every form mount for a pre-baked list, which I don't think pulls its weight.
- No legacy `CounselorLog` touchpoints here. The dual-write / backfill from `CounselorLog → Reflection + Order + MaintenanceTicket` lives in 7_6g.
- The dashboard's "View requests" CTA (added in 7_6d) is now functional instead of 404-ing.


Made with [Cursor](https://cursor.com)