### PR TITLE
7_6g: dual-write + backfill legacy CounselorLog ↔ core.Reflection

### DIFF
--- a/backend/bunk_logs/api/counselor/camper_care_requests.py
+++ b/backend/bunk_logs/api/counselor/camper_care_requests.py
@@ -18,6 +18,7 @@ from bunk_logs.core import audit as audit_module
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Order
+from bunk_logs.core.models import OrderItemSuggestion
 
 from .common import co_counselor_person_ids
 from .common import find_existing_by_client_submission_id
@@ -26,6 +27,47 @@ from .common import viewer_bunk_groups
 from .common import viewer_or_403
 from .responses import order_response
 from .serializers import CamperCareRequestCreateSerializer
+
+
+class CamperCareItemSuggestionListView(APIView):
+    """``GET /api/v1/counselor/camper-care-item-suggestions/`` — Story 7 criterion 2.ii.
+
+    Returns the curated camper-care item list for the viewer's primary
+    program (decision C6). The form uses this for autocomplete; counselors
+    can still submit any free-text label, so an empty list (e.g. for a
+    program that hasn't been seeded yet) just disables autocomplete on
+    the client without blocking submission.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer = ctx.person
+
+        primary_membership = (
+            Membership.objects.filter(person=viewer, is_active=True)
+            .select_related("program")
+            .order_by("-created_at")
+            .first()
+        )
+        if primary_membership is None or primary_membership.program is None:
+            return Response({"suggestions": []})
+
+        program = primary_membership.program
+        rows = (
+            OrderItemSuggestion.all_objects.filter(program=program, is_active=True)
+            .order_by("sort_order", "label")
+            .values("id", "label", "sort_order")
+        )
+        # Stringify the id to match the convention used elsewhere in the
+        # counselor surface (Order/MaintenanceTicket also return string IDs).
+        return Response({
+            "suggestions": [
+                {"id": str(r["id"]), "label": r["label"], "sort_order": r["sort_order"]}
+                for r in rows
+            ],
+        })
 
 
 class CamperCareRequestCreateView(APIView):

--- a/backend/bunk_logs/api/counselor/legacy_mapping.py
+++ b/backend/bunk_logs/api/counselor/legacy_mapping.py
@@ -1,0 +1,310 @@
+"""Legacy ``CounselorLog`` (a.k.a. ``StaffLog``) → ``core.Reflection`` mapping.
+
+Step 7_6g shipping checklist item 1: dual-write + backfill. The legacy
+``bunklogs.StaffLog`` table is Crane Lake's existing self-reflection
+storage. The new multi-tenant counselor flow (steps 7_6a — 7_6f) writes
+to ``core.Reflection`` with the seeded ``counselor-self-reflection``
+template (migration 0029). Until the legacy admin/UI is fully retired
+we want both stores in sync so:
+
+  * the new dashboards (``/counselor`` and the role dashboards) see
+    today's submission even when a counselor still writes via the
+    legacy admin or an in-flight branch of the old form, and
+  * Crane Lake's pre-7_6 history is queryable via the new
+    ``GET /counselor/self-reflection/history/`` view from day one.
+
+Both directions converge on the same helper below so the deterministic
+``client_submission_id`` UUID5 derivation is shared. That key is what
+gives us idempotency across re-runs of the backfill and across signal
+firings caused by ``StaffLog.save()`` happening more than once
+(e.g. when the legacy admin re-saves the same row).
+
+Field mapping decisions
+-----------------------
+
+The seeded counselor-self-reflection schema only declares five fields
+(``day_off``, ``overall_day``, ``wins``, ``improvements``, ``concern``)
+while the legacy ``StaffLog`` row carries eight (the five core ones plus
+``support_level_score``, ``values_reflection``, ``staff_care_support_needed``).
+The validator only checks fields that appear in the schema; extra keys
+in ``answers`` are kept on the row. We exploit that to lossy-map without
+data loss:
+
+  ``day_off``                  → ``answers.day_off`` (direct bool)
+  ``day_quality_score``        → ``answers.overall_day`` (direct int 1-5)
+  ``elaboration``              → ``answers.concern`` (free text)
+  ``wins``, ``improvements``   → empty lists (legacy form didn't ask)
+  ``support_level_score``      → ``answers.support_level_score`` (extra key)
+  ``values_reflection``        → ``answers.values_reflection`` (extra key)
+  ``staff_care_support_needed``→ ``answers.staff_care_support_needed`` (extra key)
+  ``staff_log_id``             → ``answers._legacy_staff_log_id`` (provenance)
+
+The "extra key" surfaces are NOT rendered by the new mobile form
+(``ReflectionField`` only iterates schema fields) but they ARE preserved
+in storage, exported by the admin/audit JSON, and recoverable by the
+backfill itself for inspection. That mirrors the "deprecate, don't
+delete" pattern we used in earlier migrations (see 6_1).
+
+Skip semantics
+--------------
+
+We skip without raising when:
+
+  * ``staff_member`` has no ``Person`` row (unmigrated staff member).
+  * The viewer has no active ``counselor``/``junior_counselor``
+    Membership (kitchen / leadership logs are handled by future steps).
+  * The org doesn't have a counselor-self-reflection template resolved
+    by ``counselor_self_template()`` (test fixtures often skip the
+    seed migration; production always has it).
+
+Skip-with-reason is logged at INFO so an operator running the backfill
+can see why a row was passed over without crashing the bulk run.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from django.db import transaction
+
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import reflection_snapshot
+
+from .common import counselor_self_template
+
+if TYPE_CHECKING:
+    from bunk_logs.bunklogs.models import StaffLog
+    from bunk_logs.core.models import ReflectionTemplate
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic client_submission_id derivation
+# ---------------------------------------------------------------------------
+
+# Fixed namespace UUID — only used as the seed for ``uuid.uuid5()`` to
+# produce stable derived UUIDs. Choosing a hand-picked UUID rather than
+# ``uuid.NAMESPACE_OID`` is intentional: anyone grepping the codebase
+# for this constant will land here and understand its purpose.
+_BACKFILL_NAMESPACE = uuid.UUID("7e1f0007-0000-0000-0000-000000000007")
+
+
+def client_submission_id_for_staff_log(staff_log_id: int) -> uuid.UUID:
+    """Return the stable ``client_submission_id`` for a legacy log row.
+
+    The same ``staff_log_id`` always yields the same UUID, so backfill
+    re-runs (or a backfill followed by a stray ``StaffLog.save()`` that
+    fires the dual-write signal) deduplicate via the existing
+    ``(program, client_submission_id)`` unique constraint instead of
+    creating a duplicate Reflection.
+    """
+    return uuid.uuid5(_BACKFILL_NAMESPACE, f"stafflog:{int(staff_log_id)}")
+
+
+# ---------------------------------------------------------------------------
+# Mapping shape + result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    """What happened when we tried to sync a single ``StaffLog``.
+
+    * ``action`` is the user-facing summary verb: ``"created"``,
+      ``"updated"``, ``"unchanged"``, or ``"skipped"``.
+    * ``reason`` is set only on ``"skipped"`` so operators have a hint
+      in the management-command summary.
+    * ``reflection_id`` is the matching ``Reflection.id`` when known
+      (always present on created/updated/unchanged).
+    """
+
+    action: str
+    reason: str = ""
+    reflection_id: int | None = None
+
+
+def _answers_from_staff_log(log_row: StaffLog) -> dict:
+    """Project ``StaffLog`` fields onto the seeded counselor template answers."""
+    return {
+        # Schema-recognised keys: rendered by the new mobile form.
+        "day_off": bool(log_row.day_off),
+        "overall_day": int(log_row.day_quality_score)
+        if log_row.day_quality_score is not None else 0,
+        "wins": [],
+        "improvements": [],
+        "concern": log_row.elaboration or "",
+        # Extra keys: not rendered, but preserved for audit + recovery.
+        "support_level_score": int(log_row.support_level_score)
+        if log_row.support_level_score is not None else None,
+        "values_reflection": log_row.values_reflection or "",
+        "staff_care_support_needed": bool(log_row.staff_care_support_needed),
+        # Provenance.
+        "_legacy_staff_log_id": int(log_row.id),
+    }
+
+
+def _resolve_person_and_membership(
+    user_id: int,
+) -> tuple[Person | None, Membership | None]:
+    """Return the viewer's ``Person`` + best counselor ``Membership`` if any.
+
+    "Best" = active ``counselor`` or ``junior_counselor`` Membership,
+    newest-first. We do NOT scope by organization slug — legacy
+    StaffLog rows don't carry an org, and Crane Lake is the only
+    Reflection-emitting tenant for now. If a person ever ends up with
+    multiple counselor memberships across orgs, we'd need to revisit.
+    """
+    person = Person.all_objects.filter(user_id=user_id).first()
+    if person is None:
+        return None, None
+    membership = (
+        Membership.all_objects.filter(
+            person=person,
+            role__in=("counselor", "junior_counselor"),
+            is_active=True,
+        )
+        .select_related("program", "person", "program__organization")
+        .order_by("-created_at")
+        .first()
+    )
+    return person, membership
+
+
+def _resolve_template(
+    person: Person, membership: Membership,
+) -> ReflectionTemplate | None:
+    """Look up the counselor self-reflection template for this person.
+
+    Delegates to :func:`counselor_self_template` so the same resolver
+    rules (org-scoped shadowing the global seed) apply. The helper
+    internally hits ``Membership.objects`` which is org-scoped via
+    :class:`MembershipScopedManager`; the legacy bridge runs outside
+    of a request context, so we set the organization explicitly to
+    make the scoped manager return real rows. Returns ``None`` when no
+    template is configured at all.
+    """
+    org = membership.program.organization
+    program = membership.program
+    with organization_context(org):
+        return counselor_self_template(person, org, program)
+
+
+# ---------------------------------------------------------------------------
+# Main entry point: idempotent upsert
+# ---------------------------------------------------------------------------
+
+
+def sync_staff_log_to_reflection(
+    log_row: StaffLog, *, emit_audit: bool = True,
+) -> SyncResult:
+    """Idempotently mirror a ``StaffLog`` row onto a ``core.Reflection``.
+
+    Returns a :class:`SyncResult` describing the outcome:
+
+      * **created**: no prior Reflection — inserted a new row.
+      * **updated**: a prior Reflection existed (matched by deterministic
+        ``client_submission_id``) and its answers/day-off state differed;
+        the row was rewritten in place with the new payload.
+      * **unchanged**: a prior Reflection existed and was already in
+        sync; no DB write.
+      * **skipped**: pre-conditions weren't met (see the ``reason``
+        field). Common in test fixtures that don't seed Person rows for
+        legacy User accounts.
+
+    ``emit_audit=True`` (default) logs the edit through the existing
+    audit pipeline so the dashboard's "Edited by" attribution stays
+    accurate. The signal path also defaults to True so any spurious
+    background write shows up as audited.
+    """
+    person, membership = _resolve_person_and_membership(log_row.staff_member_id)
+    if person is None:
+        return SyncResult(
+            action="skipped", reason="no_person_for_user",
+        )
+    if membership is None or membership.program is None:
+        return SyncResult(
+            action="skipped", reason="no_active_counselor_membership",
+        )
+
+    template = _resolve_template(person, membership)
+    if template is None:
+        return SyncResult(
+            action="skipped", reason="no_counselor_template_configured",
+        )
+
+    csid = client_submission_id_for_staff_log(log_row.id)
+    answers = _answers_from_staff_log(log_row)
+    org = membership.program.organization
+    program = membership.program
+
+    with transaction.atomic():
+        existing = (
+            Reflection.all_objects.select_for_update()
+            .filter(program=program, client_submission_id=csid)
+            .first()
+        )
+        if existing is not None:
+            # Same payload? Bail without a write so we don't churn the
+            # ``updated_at`` timestamp on every backfill re-run.
+            if (
+                existing.answers == answers
+                and existing.period_start == log_row.date
+                and existing.period_end == log_row.date
+                and existing.language == "en"
+            ):
+                return SyncResult(
+                    action="unchanged", reflection_id=existing.id,
+                )
+            before = reflection_snapshot(existing)
+            existing.answers = answers
+            existing.period_start = log_row.date
+            existing.period_end = log_row.date
+            existing.language = "en"
+            existing.team_visibility = Reflection.TeamVisibility.TEAM
+            existing.is_complete = True
+            existing.save()
+            after = reflection_snapshot(existing)
+            if emit_audit and before != after:
+                audit_module.edited(
+                    membership, existing, before, after,
+                    content_type="reflection",
+                )
+            return SyncResult(
+                action="updated", reflection_id=existing.id,
+            )
+
+        # Brand-new mirror — emit a "created" audit event so the new
+        # dashboards show the row with proper attribution.
+        reflection = Reflection.all_objects.create(
+            organization=org,
+            program=program,
+            subject=person,
+            author=person,
+            assignment_group=None,
+            template=template,
+            submitted_by=log_row.staff_member,
+            period_start=log_row.date,
+            period_end=log_row.date,
+            answers=answers,
+            language="en",
+            team_visibility=Reflection.TeamVisibility.TEAM,
+            is_complete=True,
+            client_submission_id=csid,
+        )
+        if emit_audit:
+            audit_module.created(
+                membership, reflection,
+                after_state=reflection_snapshot(reflection),
+                content_type="reflection",
+            )
+        return SyncResult(
+            action="created", reflection_id=reflection.id,
+        )

--- a/backend/bunk_logs/api/tests/conftest.py
+++ b/backend/bunk_logs/api/tests/conftest.py
@@ -1,0 +1,79 @@
+"""Shared pytest fixtures for the ``bunk_logs.api`` test package.
+
+Why this lives here
+-------------------
+
+The counselor-flow tests in step 7_6 depend on the seeded
+``counselor-self-reflection`` ReflectionTemplate that migration
+``core/0029`` adds to the DB. That works fine for ordinary
+``@pytest.mark.django_db`` tests because pytest-django wraps each one
+in a transaction that's rolled back at teardown — the seeded row
+survives.
+
+But the dual-write signal tests in step 7_6g need
+``@pytest.mark.django_db(transaction=True)`` so that
+``transaction.on_commit`` callbacks actually fire. ``transaction=True``
+uses ``TransactionTestCase`` semantics, which **flushes every table**
+between tests to reset state. That flush removes the seeded
+ReflectionTemplate, and any subsequent ordinary test that expected to
+find it 403s out (Story 5 endpoints) or hits a NOT-NULL violation when
+constructing a Reflection without a template FK.
+
+Re-seeding the template at the start of every test fixes both:
+
+- transactional tests get a fresh seed after the flush;
+- ordinary tests still see a seeded template even if a transactional
+  test ran earlier in the same session.
+
+Keeping the fixture as ``autouse=True`` here (rather than in each test
+file) means new test modules pick up the protection automatically.
+"""
+from __future__ import annotations
+
+import pytest
+
+from bunk_logs.core.models import ReflectionTemplate
+
+_COUNSELOR_SELF_REFLECTION_SCHEMA = {
+    "fields": [
+        {"key": "day_off", "type": "yes_no", "required": False},
+        {"key": "overall_day", "type": "single_rating", "required": False, "scale": [1, 5]},
+        {"key": "wins", "type": "text_list", "required": False},
+        {"key": "improvements", "type": "text_list", "required": False},
+        {"key": "concern", "type": "textarea", "required": False},
+    ],
+}
+
+
+@pytest.fixture(autouse=True)
+def _ensure_counselor_self_reflection_template(db):
+    """Re-seed the counselor self-reflection template before every test.
+
+    Mirrors the production seed (migration ``core/0029``) but is
+    explicit about it so a single failing test surfaces immediately
+    rather than cascading into 'no template configured' 403s in
+    seemingly unrelated tests.
+    """
+    ReflectionTemplate.all_objects.update_or_create(
+        organization=None,
+        slug="counselor-self-reflection",
+        version=1,
+        defaults={
+            "name": "Counselor Self-Reflection",
+            "description": "Auto-seeded for tests via api/tests/conftest.py.",
+            "cadence": "daily",
+            "schema": _COUNSELOR_SELF_REFLECTION_SCHEMA,
+            "languages": ["en", "es"],
+            "is_active": True,
+            "subject_mode": "self",
+            "assignment_scope": "none",
+            "assignment_group_types": [],
+            "author_role_filter": ["counselor", "junior_counselor"],
+            "subject_role_filter": [],
+            "required_per_subject_per_period": 1,
+            "subject_visible": False,
+            "supports_privacy": False,
+            "role": "counselor",
+            "program_type": None,
+        },
+    )

--- a/backend/bunk_logs/api/tests/test_counselor_camper_care_writes.py
+++ b/backend/bunk_logs/api/tests/test_counselor_camper_care_writes.py
@@ -15,6 +15,7 @@ from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import AuditEvent
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Order
+from bunk_logs.core.models import OrderItemSuggestion
 from bunk_logs.core.models import Organization
 from bunk_logs.core.models import Person
 from bunk_logs.core.models import Program
@@ -174,6 +175,37 @@ def test_camper_care_subject_must_be_on_viewer_bunk(
              "client_submission_id": str(uuid.uuid4())}, format="json",
         )
     assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_item_suggestions_returns_active_rows_in_sort_order(
+    org, counselor_user, counselor_person, counselor_membership,
+    program,
+):
+    OrderItemSuggestion.objects.create(program=program, label="Toothpaste", sort_order=2)
+    OrderItemSuggestion.objects.create(program=program, label="Bug spray", sort_order=1)
+    OrderItemSuggestion.objects.create(
+        program=program, label="Hidden", sort_order=0, is_active=False,
+    )
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/camper-care-item-suggestions/")
+    assert resp.status_code == 200, resp.data
+    labels = [s["label"] for s in resp.data["suggestions"]]
+    assert labels == ["Bug spray", "Toothpaste"]
+    assert all("id" in s and "sort_order" in s for s in resp.data["suggestions"])
+
+
+@pytest.mark.django_db
+def test_item_suggestions_empty_when_no_program(
+    org, counselor_user, counselor_person,
+):
+    """A viewer without a program membership gets an empty list, not a 500."""
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/camper-care-item-suggestions/")
+    assert resp.status_code == 200
+    assert resp.data == {"suggestions": []}
 
 
 @pytest.mark.django_db

--- a/backend/bunk_logs/api/tests/test_counselor_legacy_bridge.py
+++ b/backend/bunk_logs/api/tests/test_counselor_legacy_bridge.py
@@ -1,0 +1,433 @@
+"""Step 7_6g: backfill + dual-write tests for legacy ``StaffLog`` rows.
+
+Covers:
+
+* :func:`sync_staff_log_to_reflection` idempotency, skip semantics, and
+  field mapping.
+* ``backfill_counselor_logs`` management command in dry-run and apply
+  modes, including the deterministic ``client_submission_id``.
+* The ``post_save`` signal that dual-writes new StaffLog rows into
+  Reflection on commit, including the kill-switch setting.
+
+These tests treat the seeded ``counselor-self-reflection`` template
+(migration 0029) as the resolution target. The seed is a global
+``organization IS NULL`` row so any org we create in fixtures resolves
+to it without further setup.
+"""
+from __future__ import annotations
+
+from datetime import date
+from datetime import timedelta
+from io import StringIO
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.core.management import call_command
+from django.db import transaction
+from django.test.utils import override_settings
+from django.utils import timezone
+
+
+def _today() -> date:
+    """Real "today" — must match what ``StaffLog.clean()`` checks against.
+
+    Hard-coding a future date breaks the legacy validator (no future
+    dates), so we anchor all test rows around the actual system date.
+    """
+    return timezone.localtime().date()
+
+from bunk_logs.api.counselor.legacy_mapping import client_submission_id_for_staff_log
+from bunk_logs.api.counselor.legacy_mapping import sync_staff_log_to_reflection
+from bunk_logs.bunklogs.models import StaffLog
+from bunk_logs.core.models import AuditEvent
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+
+User = get_user_model()
+
+# The seeded ``counselor-self-reflection`` template is restored before
+# every test by the autouse fixture in ``api/tests/conftest.py``; see
+# that file for the rationale (TransactionTestCase flush would wipe it).
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="Bridge Camp", slug="bridge-camp")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="Bridge Camp Summer 2026",
+        slug="bridge-summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def counselor_user():
+    return User.objects.create_user(email="bridge-counselor@bridge.test", password="pw")
+
+
+@pytest.fixture
+def counselor_person(org, counselor_user):
+    return Person.all_objects.create(
+        organization=org,
+        first_name="Lee",
+        last_name="Bridge",
+        user=counselor_user,
+    )
+
+
+@pytest.fixture
+def counselor_membership(program, counselor_person):
+    return Membership.all_objects.create(
+        program=program,
+        person=counselor_person,
+        role="counselor",
+        is_active=True,
+    )
+
+
+def _staff_log(user, **overrides):
+    # Default to "yesterday" so we sit safely inside the legacy
+    # validator's allowed window (no future, no older than 30 days).
+    defaults = {
+        "staff_member": user,
+        "date": _today() - timedelta(days=1),
+        "day_quality_score": 4,
+        "support_level_score": 5,
+        "elaboration": "Good day; bunk hike went great.",
+        "day_off": False,
+        "staff_care_support_needed": False,
+        "values_reflection": "Modeled curiosity and kindness today.",
+    }
+    defaults.update(overrides)
+    return StaffLog.objects.create(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# sync_staff_log_to_reflection — direct mapper tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_sync_maps_fields_onto_seeded_schema_keys(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    log = _staff_log(counselor_user)
+
+    result = sync_staff_log_to_reflection(log)
+    assert result.action == "created", result.reason
+
+    reflection = Reflection.all_objects.get(id=result.reflection_id)
+    assert reflection.author == counselor_person
+    assert reflection.subject == counselor_person
+    assert reflection.period_start == log.date
+    assert reflection.period_end == log.date
+    assert reflection.is_complete is True
+    assert reflection.team_visibility == Reflection.TeamVisibility.TEAM
+
+    answers = reflection.answers
+    # Schema-mapped keys
+    assert answers["day_off"] is False
+    assert answers["overall_day"] == 4
+    assert answers["concern"] == "Good day; bunk hike went great."
+    assert answers["wins"] == []
+    assert answers["improvements"] == []
+    # Provenance + lossless legacy fields
+    assert answers["_legacy_staff_log_id"] == log.id
+    assert answers["support_level_score"] == 5
+    assert answers["values_reflection"] == "Modeled curiosity and kindness today."
+    assert answers["staff_care_support_needed"] is False
+
+
+@pytest.mark.django_db
+def test_sync_preserves_day_off_flag(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    # ``day_off=True`` short-circuits the elaboration/values *clean()*
+    # requirement in ``StaffLog`` but the field-level ``blank=False`` on
+    # CharField still applies, so we keep non-empty placeholder text.
+    # The mapper must preserve the day_off bool regardless.
+    log = _staff_log(
+        counselor_user, day_off=True,
+        elaboration="(day off)", values_reflection="(day off)",
+        day_quality_score=3, support_level_score=3,
+    )
+    result = sync_staff_log_to_reflection(log)
+    assert result.action == "created"
+    assert Reflection.all_objects.get(id=result.reflection_id).answers["day_off"] is True
+
+
+@pytest.mark.django_db
+def test_sync_is_idempotent_on_re_run(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    log = _staff_log(counselor_user)
+    first = sync_staff_log_to_reflection(log)
+    assert first.action == "created"
+
+    second = sync_staff_log_to_reflection(log)
+    assert second.action == "unchanged"
+    assert second.reflection_id == first.reflection_id
+    assert Reflection.all_objects.filter(
+        client_submission_id=client_submission_id_for_staff_log(log.id),
+    ).count() == 1
+
+
+@pytest.mark.django_db
+def test_sync_updates_when_staff_log_changes(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    log = _staff_log(counselor_user, elaboration="initial")
+    first = sync_staff_log_to_reflection(log)
+    assert first.action == "created"
+
+    log.elaboration = "edited later"
+    log.day_quality_score = 5
+    log.save()
+    second = sync_staff_log_to_reflection(log)
+    assert second.action == "updated"
+    assert second.reflection_id == first.reflection_id
+
+    refreshed = Reflection.all_objects.get(id=first.reflection_id)
+    assert refreshed.answers["concern"] == "edited later"
+    assert refreshed.answers["overall_day"] == 5
+
+
+@pytest.mark.django_db
+def test_sync_emits_audit_event_on_create(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    log = _staff_log(counselor_user)
+    sync_staff_log_to_reflection(log)
+    assert AuditEvent.all_objects.filter(
+        event_type=AuditEvent.EventType.CREATED,
+        content_type="reflection",
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_sync_skips_when_no_person_for_user(db, counselor_user):
+    """A User with no Person row is silently skipped (unmigrated staff)."""
+    log = _staff_log(counselor_user)
+    result = sync_staff_log_to_reflection(log)
+    assert result.action == "skipped"
+    assert result.reason == "no_person_for_user"
+    assert Reflection.all_objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_sync_skips_when_no_counselor_membership(
+    org, counselor_user, counselor_person,
+):
+    """A Person without a counselor Membership is skipped (e.g. kitchen)."""
+    log = _staff_log(counselor_user)
+    result = sync_staff_log_to_reflection(log)
+    assert result.action == "skipped"
+    assert result.reason == "no_active_counselor_membership"
+
+
+@pytest.mark.django_db
+def test_sync_picks_junior_counselor_role_too(
+    org, program, counselor_user, counselor_person,
+):
+    """``junior_counselor`` is treated as a counselor for the bridge."""
+    Membership.all_objects.create(
+        program=program, person=counselor_person,
+        role="junior_counselor", is_active=True,
+    )
+    log = _staff_log(counselor_user)
+    result = sync_staff_log_to_reflection(log)
+    assert result.action == "created", result.reason
+
+
+# ---------------------------------------------------------------------------
+# Management command tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_backfill_command_dry_run_makes_no_writes(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    _staff_log(counselor_user)
+    _staff_log(counselor_user, date=_today() - timedelta(days=2))
+    assert Reflection.all_objects.count() == 0
+
+    out = StringIO()
+    call_command("backfill_counselor_logs", stdout=out)
+    text = out.getvalue()
+    assert "Dry run only" in text
+    assert "created: 2" in text
+    # Nothing actually persisted.
+    assert Reflection.all_objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_backfill_command_apply_persists_writes(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    log1 = _staff_log(counselor_user)
+    log2 = _staff_log(counselor_user, date=_today() - timedelta(days=2))
+
+    out = StringIO()
+    call_command("backfill_counselor_logs", "--apply", stdout=out)
+    assert "created: 2" in out.getvalue()
+
+    csids = {
+        client_submission_id_for_staff_log(log1.id),
+        client_submission_id_for_staff_log(log2.id),
+    }
+    assert (
+        set(Reflection.all_objects.values_list("client_submission_id", flat=True))
+        == csids
+    )
+
+
+@pytest.mark.django_db
+def test_backfill_command_replay_marks_rows_unchanged(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    _staff_log(counselor_user)
+    call_command("backfill_counselor_logs", "--apply", stdout=StringIO())
+    assert Reflection.all_objects.count() == 1
+
+    out = StringIO()
+    call_command("backfill_counselor_logs", "--apply", stdout=out)
+    text = out.getvalue()
+    assert "unchanged: 1" in text
+    assert "created: 0" in text
+    # No duplicates introduced.
+    assert Reflection.all_objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_backfill_command_date_range_filter(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    today = _today()
+    _staff_log(counselor_user, date=today - timedelta(days=10))
+    _staff_log(counselor_user, date=today - timedelta(days=5))
+    _staff_log(counselor_user, date=today - timedelta(days=1))
+
+    target = today - timedelta(days=5)
+    out = StringIO()
+    call_command(
+        "backfill_counselor_logs", "--apply",
+        "--since", (target - timedelta(days=1)).isoformat(),
+        "--until", (target + timedelta(days=1)).isoformat(),
+        stdout=out,
+    )
+    assert "created: 1" in out.getvalue()
+    assert Reflection.all_objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_backfill_command_reports_skip_reasons(
+    db, counselor_user,
+):
+    """A run with mostly orphan StaffLog rows surfaces skip reasons in the summary."""
+    _staff_log(counselor_user)
+    out = StringIO()
+    call_command("backfill_counselor_logs", "--apply", stdout=out)
+    text = out.getvalue()
+    assert "skipped: 1" in text
+    assert "no_person_for_user: 1" in text
+
+
+# ---------------------------------------------------------------------------
+# Dual-write signal tests
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Dual-write signal tests
+# ---------------------------------------------------------------------------
+#
+# The signal uses ``transaction.on_commit`` so the mirror only fires after
+# the outer transaction wrapping the StaffLog save commits. Pytest's
+# ``@django_db(transaction=True)`` mode runs in autocommit BUT fixture
+# setup still runs inside an implicit transaction — so the callback
+# never fires before the test body exits. We work around that by
+# explicitly wrapping the saves in our own ``transaction.atomic()``
+# block so we control the commit boundary precisely.
+
+
+@pytest.mark.django_db(transaction=True)
+def test_dual_write_signal_mirrors_on_commit(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    """Saving a StaffLog through the ORM triggers a Reflection mirror."""
+    assert Reflection.all_objects.count() == 0
+    with transaction.atomic():
+        log = _staff_log(counselor_user)
+    # post_save → on_commit fires on transaction exit.
+    reflections = Reflection.all_objects.filter(
+        client_submission_id=client_submission_id_for_staff_log(log.id),
+    )
+    assert reflections.count() == 1, list(reflections.values())
+    mirrored = reflections.get()
+    assert mirrored.answers["_legacy_staff_log_id"] == log.id
+    assert mirrored.answers["overall_day"] == log.day_quality_score
+
+
+@pytest.mark.django_db(transaction=True)
+def test_dual_write_signal_updates_on_subsequent_save(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    with transaction.atomic():
+        log = _staff_log(counselor_user)
+    assert Reflection.all_objects.count() == 1
+
+    with transaction.atomic():
+        log.elaboration = "now updated"
+        log.day_quality_score = 5
+        log.save()
+
+    reflection = Reflection.all_objects.get(
+        client_submission_id=client_submission_id_for_staff_log(log.id),
+    )
+    assert reflection.answers["concern"] == "now updated"
+    assert reflection.answers["overall_day"] == 5
+    assert Reflection.all_objects.count() == 1
+
+
+@pytest.mark.django_db(transaction=True)
+@override_settings(BUNKLOGS_DUAL_WRITE_REFLECTION=False)
+def test_dual_write_signal_respects_kill_switch(
+    org, counselor_user, counselor_person, counselor_membership,
+):
+    """``BUNKLOGS_DUAL_WRITE_REFLECTION=False`` disables the mirror entirely."""
+    with transaction.atomic():
+        _staff_log(counselor_user)
+    assert Reflection.all_objects.count() == 0
+
+
+@pytest.mark.django_db(transaction=True)
+def test_dual_write_signal_swallows_mapper_errors(
+    db, counselor_user,
+):
+    """A StaffLog without prerequisites does NOT block legacy persistence."""
+    # No Person, no Membership — the mapper will skip cleanly. Verify
+    # that the StaffLog row still persisted (i.e. the signal didn't
+    # break the implicit transaction commit).
+    with transaction.atomic():
+        log = _staff_log(counselor_user)
+    assert StaffLog.objects.filter(id=log.id).exists()
+    assert Reflection.all_objects.count() == 0

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -217,6 +217,11 @@ urlpatterns = [
         name="counselor-camper-care-create",
     ),
     path(
+        "counselor/camper-care-item-suggestions/",
+        counselor_camper_care_requests.CamperCareItemSuggestionListView.as_view(),
+        name="counselor-camper-care-item-suggestions",
+    ),
+    path(
         "counselor/maintenance-tickets/",
         counselor_maintenance_tickets.MaintenanceTicketCreateView.as_view(),
         name="counselor-maintenance-ticket-create",

--- a/backend/bunk_logs/bunklogs/apps.py
+++ b/backend/bunk_logs/bunklogs/apps.py
@@ -4,3 +4,9 @@ from django.apps import AppConfig
 class BunklogsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "bunk_logs.bunklogs"
+
+    def ready(self):
+        # Wire up the StaffLog → core.Reflection dual-write signal
+        # (Step 7_6g). The receiver is registered via @receiver decorator
+        # so the import side-effect is what attaches the handler.
+        from bunk_logs.bunklogs import signals  # noqa: F401

--- a/backend/bunk_logs/bunklogs/signals.py
+++ b/backend/bunk_logs/bunklogs/signals.py
@@ -1,0 +1,78 @@
+"""Cross-app signals for the legacy ``bunklogs`` app.
+
+Step 7_6g item 2: dual-write each ``StaffLog`` save into ``core.Reflection``.
+
+We hang the dual-write off ``post_save`` rather than overriding
+``StaffLog.save()`` so the legacy model stays untouched (per the
+"deprecate, don't delete" policy in the migration prompts). The handler:
+
+  * runs in the same transaction as the original save via
+    ``transaction.on_commit`` so failures in the mapper never partially
+    commit Reflection state for a save that itself rolled back;
+  * is best-effort — any exception from the helper is logged at WARNING
+    and swallowed so a missing template or membership doesn't break
+    counselor-log writes (which Crane Lake operations depend on today);
+  * is opt-out via ``settings.BUNKLOGS_DUAL_WRITE_REFLECTION = False``
+    for environments where we want to disable the bridge (e.g. data
+    migration scripts that import StaffLog rows but already populated
+    Reflection directly).
+
+Wiring lives in :mod:`bunk_logs.bunklogs.apps`. Don't import this module
+from anywhere else.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.conf import settings
+from django.db import transaction
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from bunk_logs.bunklogs.models import StaffLog
+
+log = logging.getLogger(__name__)
+
+
+def _dual_write_enabled() -> bool:
+    """Honour the kill-switch setting; default ON."""
+    return getattr(settings, "BUNKLOGS_DUAL_WRITE_REFLECTION", True)
+
+
+@receiver(post_save, sender=StaffLog, dispatch_uid="bunklogs.dual_write_reflection")
+def dual_write_staff_log_to_reflection(sender, instance, **kwargs):
+    """Mirror an inserted/updated ``StaffLog`` onto ``core.Reflection``.
+
+    Note the importer-side guard: when an existing ``StaffLog`` is saved
+    by the backfill command itself we don't want the signal to fire a
+    second time. The backfill uses
+    ``sync_staff_log_to_reflection`` directly without calling
+    ``StaffLog.save()``, so that case is naturally avoided. If a future
+    code path saves StaffLog inside the mapper, we'd need to wire a
+    thread-local skip flag here.
+    """
+    if not _dual_write_enabled():
+        return
+    if instance is None or instance.pk is None:
+        return
+
+    # Import lazily so app loading doesn't import core.* before its app
+    # registry is populated. ``ready()`` connects this receiver after
+    # apps are loaded but the function body still executes lazily.
+    from bunk_logs.api.counselor.legacy_mapping import sync_staff_log_to_reflection
+
+    def _go():
+        try:
+            sync_staff_log_to_reflection(instance, emit_audit=True)
+        except Exception:
+            log.warning(
+                "Dual-write StaffLog->Reflection failed for staff_log_id=%s",
+                instance.pk,
+                exc_info=True,
+            )
+
+    # Run on commit so a rolled-back StaffLog.save() doesn't leave a
+    # mirrored Reflection behind. ``on_commit`` is a no-op outside of a
+    # transaction (e.g. raw script use), which is also what we want.
+    transaction.on_commit(_go)

--- a/backend/bunk_logs/core/management/commands/backfill_counselor_logs.py
+++ b/backend/bunk_logs/core/management/commands/backfill_counselor_logs.py
@@ -1,0 +1,168 @@
+"""Backfill legacy ``CounselorLog`` rows into ``core.Reflection``.
+
+Step 7_6g: ship the new mobile counselor flow on top of the existing
+StaffLog history Crane Lake has accumulated since 2024. Re-runs are
+safe — the mapping uses a deterministic ``client_submission_id`` UUID5
+keyed on ``staff_log.id`` so each legacy row maps to exactly one
+Reflection across any number of replays.
+
+Usage::
+
+    # Default: dry-run, prints summary
+    python manage.py backfill_counselor_logs
+
+    # Apply changes
+    python manage.py backfill_counselor_logs --apply
+
+    # Limit scope (useful while iterating on a prod snapshot)
+    python manage.py backfill_counselor_logs --apply \
+        --since 2026-06-01 --until 2026-08-31
+
+    # Run for a single counselor (e.g. while debugging)
+    python manage.py backfill_counselor_logs --apply --user-id 42
+
+The default to dry-run is deliberate: this command touches the
+``core.Reflection`` table that the new dashboards read from, so an
+operator should see the planned counts before letting it write. The
+``--apply`` flag flips it to a real write run.
+"""
+
+from __future__ import annotations
+
+from datetime import date as date_type
+from datetime import datetime
+
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+from django.db import transaction
+
+from bunk_logs.api.counselor.legacy_mapping import sync_staff_log_to_reflection
+from bunk_logs.bunklogs.models import StaffLog
+
+
+def _parse_iso_date(s: str | None) -> date_type | None:
+    if not s:
+        return None
+    try:
+        return datetime.strptime(s, "%Y-%m-%d").date()
+    except ValueError as e:
+        msg = f"Invalid date '{s}'. Expected YYYY-MM-DD."
+        raise CommandError(msg) from e
+
+
+class Command(BaseCommand):
+    help = "Backfill legacy CounselorLog/StaffLog rows into core.Reflection."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Persist the writes. Without this flag the command is a dry run.",
+        )
+        parser.add_argument(
+            "--since",
+            type=str,
+            default=None,
+            help="Only consider StaffLog rows on or after this date (YYYY-MM-DD).",
+        )
+        parser.add_argument(
+            "--until",
+            type=str,
+            default=None,
+            help="Only consider StaffLog rows on or before this date (YYYY-MM-DD).",
+        )
+        parser.add_argument(
+            "--user-id",
+            type=int,
+            default=None,
+            help="Restrict to one staff_member User ID (debugging shortcut).",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=500,
+            help="How many StaffLog rows to process per transaction batch.",
+        )
+        parser.add_argument(
+            "--no-audit",
+            action="store_true",
+            help=(
+                "Skip emitting audit events for the synced rows. Useful when "
+                "backfilling a very large history and the audit-table noise "
+                "would dominate; the resulting Reflections still trace back "
+                "to the StaffLog via answers._legacy_staff_log_id."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        apply_writes: bool = options["apply"]
+        since = _parse_iso_date(options.get("since"))
+        until = _parse_iso_date(options.get("until"))
+        user_id = options.get("user_id")
+        batch_size = max(1, int(options.get("batch_size") or 500))
+        emit_audit = not options.get("no_audit")
+
+        qs = StaffLog.objects.all().order_by("date", "id")
+        if since:
+            qs = qs.filter(date__gte=since)
+        if until:
+            qs = qs.filter(date__lte=until)
+        if user_id is not None:
+            qs = qs.filter(staff_member_id=user_id)
+        total = qs.count()
+
+        # Counters keyed by SyncResult.action / SyncResult.reason.
+        counts: dict[str, int] = {
+            "created": 0, "updated": 0, "unchanged": 0, "skipped": 0,
+        }
+        skip_reasons: dict[str, int] = {}
+
+        if total == 0:
+            self.stdout.write(self.style.NOTICE(
+                "No StaffLog rows match the filters; nothing to do.",
+            ))
+            return
+
+        self.stdout.write(self.style.NOTICE(
+            f"Processing {total} StaffLog rows "
+            f"({'apply' if apply_writes else 'dry-run'} mode)…",
+        ))
+
+        seen = 0
+        for start in range(0, total, batch_size):
+            batch = list(qs[start:start + batch_size])
+            for row in batch:
+                # Each StaffLog gets its own atomic block so a stray
+                # validation error on one row doesn't poison the rest.
+                with transaction.atomic():
+                    result = sync_staff_log_to_reflection(
+                        row, emit_audit=emit_audit,
+                    )
+                    if not apply_writes:
+                        # Roll back inside this iteration so dry-run
+                        # counts reflect what WOULD happen.
+                        transaction.set_rollback(True)
+                counts[result.action] = counts.get(result.action, 0) + 1
+                if result.action == "skipped" and result.reason:
+                    skip_reasons[result.reason] = skip_reasons.get(
+                        result.reason, 0,
+                    ) + 1
+            seen += len(batch)
+            self.stdout.write(
+                f"  …{seen}/{total}",
+            )
+
+        # Summary
+        self.stdout.write("")
+        self.stdout.write(self.style.MIGRATE_HEADING("Summary:"))
+        for action, count in counts.items():
+            self.stdout.write(f"  {action:>9}: {count}")
+        if counts["skipped"]:
+            self.stdout.write("  skip reasons:")
+            for reason, count in sorted(skip_reasons.items()):
+                self.stdout.write(f"    {reason}: {count}")
+        if not apply_writes:
+            self.stdout.write("")
+            self.stdout.write(self.style.WARNING(
+                "Dry run only. Re-run with --apply to persist changes.",
+            ))

--- a/docs/role_flows/counselor.md
+++ b/docs/role_flows/counselor.md
@@ -1,0 +1,246 @@
+# Counselor flow — developer reference
+
+This document describes the **production counselor flow** introduced in
+migration step `7_6` and the data-bridge story that ties it back to the
+legacy `bunklogs.StaffLog` table during the cutover period.
+
+It is the canonical developer-facing reference for:
+
+- which endpoints the mobile counselor UI talks to,
+- where reflection data lives in the new `core.Reflection` model,
+- how the legacy `CounselorLog` form continues to work in parallel,
+- and how the dual-write + backfill bridge keeps both sides in sync.
+
+If you are looking for the product spec (acceptance criteria, screens,
+copy), see `docs/user_stories/01_counselor/`. Routing prompts live in
+`migration_prompts/7_6_counselor_flow.md`.
+
+---
+
+## 1. Surface area
+
+### 1.1 Backend endpoints
+
+All counselor-scoped APIs live under `/api/v1/counselor/`:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/dashboard/` | Combined home payload: bunk roster, self-reflection state, open requests, all-set state. Cached 30s. |
+| `GET` | `/camper-reflections/?date=` | Bunk roster + per-camper reflection state for a date. |
+| `POST` | `/camper-reflections/` | Submit a camper reflection. Idempotent via `client_submission_id`. |
+| `PATCH` | `/camper-reflections/<id>/` | Edit within the org's edit window (Story 4). |
+| `POST` | `/self-reflection/` | Submit a self-reflection. Supports the `day_off` shortcut. |
+| `PATCH` | `/self-reflection/<id>/` | Edit a self-reflection within the edit window. |
+| `GET` | `/self-reflection/history/` | Paginated history (including no-submission gaps and day-off rows). |
+| `POST` | `/camper-care-requests/` | Submit a camper care request (item or generic). |
+| `GET` | `/camper-care-item-suggestions/` | Active program-scoped item autocomplete labels. |
+| `POST` | `/maintenance-tickets/` | Submit a maintenance ticket (multipart, supports photos). |
+| `POST` | `/maintenance-tickets/<id>/photos/` | Attach an additional photo to an existing ticket. |
+| `GET` | `/requests/?status=open|all` | Combined list of camper-care + maintenance requests for the counselor + co-counselors. |
+
+Caching: the dashboard payload is cached in Redis for 30 seconds and
+invalidated on any reflection submission, edit, or status change. See
+`backend/bunk_logs/api/counselor/dashboard.py`.
+
+### 1.2 Frontend routes
+
+| Route | Component |
+|---|---|
+| `/counselor` | `CounselorMobileDashboard` (the home screen) |
+| `/counselor/camper-reflections` | `CamperReflectionList` |
+| `/counselor/camper-reflections/<camperId>` | `CamperReflectionForm` |
+| `/counselor/self-reflection` | `CounselorSelfReflectionPage` (create or edit-today) |
+| `/counselor/self-reflection/history` | `CounselorSelfReflectionHistoryPage` |
+| `/counselor/self-reflection/<id>/edit` | `CounselorSelfReflectionPage` (edit mode) |
+| `/counselor/requests` | `CounselorRequestsListPage` (combined feed) |
+| `/counselor/requests/camper-care/new` | `CamperCareRequestFormPage` |
+| `/counselor/requests/maintenance/new` | `MaintenanceTicketFormPage` |
+
+All routes go through `ProtectedRoute` and `AppLayout`. The API client
+is `frontend/src/api/counselor.js`; every POST in this flow sends a
+`client_submission_id` generated via `crypto.randomUUID()` so the
+offline queue can safely retry after reconnect.
+
+### 1.3 Data model
+
+The new flow writes only `core.Reflection`, `core.Order`, and
+`core.MaintenanceTicket` rows. The seeded `counselor-self-reflection`
+ReflectionTemplate (migration `core/0029`) drives both rendering and
+validation. The legacy `bunklogs.StaffLog` / `CounselorLog` model is
+**deprecated but still readable** — see §2.
+
+---
+
+## 2. Legacy bridge (Step 7_6g)
+
+Crane Lake has been running on `StaffLog` since 2024 and the legacy
+admin remains live during the rollout window. To keep both sides in
+sync we ship **two complementary mechanisms**:
+
+### 2.1 Dual-write signal
+
+`bunk_logs.bunklogs.signals` registers a `post_save` receiver on
+`StaffLog` (see `apps.BunklogsConfig.ready`). Every successful save
+queues a `transaction.on_commit` callback that mirrors the row onto a
+`core.Reflection` via `api.counselor.legacy_mapping.sync_staff_log_to_reflection`.
+
+The receiver is **best-effort**: missing template, missing membership,
+or a mid-mapper exception are logged at WARNING and swallowed so the
+legacy admin path never fails because of the bridge.
+
+A kill-switch setting `BUNKLOGS_DUAL_WRITE_REFLECTION = False`
+disables the bridge entirely — useful for bulk import scripts that
+already populate `core.Reflection` directly.
+
+### 2.2 One-off backfill
+
+`backend/bunk_logs/core/management/commands/backfill_counselor_logs.py`
+walks every existing `StaffLog` row and synchronises it through the
+same mapper. The command defaults to **dry-run**; pass `--apply` to
+actually write.
+
+```bash
+# Dry run (no writes; prints planned counts)
+python manage.py backfill_counselor_logs
+
+# Apply the backfill
+python manage.py backfill_counselor_logs --apply
+
+# Scoped re-run after fixing a single counselor's mapping
+python manage.py backfill_counselor_logs --apply --user-id 42
+
+# Backfill a date range
+python manage.py backfill_counselor_logs --apply \
+    --since 2026-06-01 --until 2026-08-31
+```
+
+Output summarises `created` / `updated` / `unchanged` / `skipped`
+counts and lists skip reasons (`no_person_for_user`,
+`no_active_counselor_membership`, `no_counselor_template_configured`).
+
+### 2.3 Idempotency
+
+The bridge uses a deterministic `client_submission_id` derived as
+`uuid5(NAMESPACE, "stafflog:{id}")` — see
+`api.counselor.legacy_mapping.client_submission_id_for_staff_log`.
+
+This means:
+
+1. Re-running the backfill command never produces duplicates.
+2. The dual-write signal upserts the same row each save fires; multiple
+   saves of the same `StaffLog` result in exactly one Reflection.
+3. A backfill followed by a stray legacy save (or vice versa) converges
+   on the same Reflection without operator intervention.
+
+### 2.4 Field mapping
+
+The seeded counselor template declares five fields; `StaffLog` carries
+eight. Mapping decisions live next to `sync_staff_log_to_reflection`
+and are repeated here for searchability:
+
+| `StaffLog` field | `Reflection.answers[...]` key | Notes |
+|---|---|---|
+| `day_off` (bool) | `day_off` | direct |
+| `day_quality_score` (1-5) | `overall_day` | direct |
+| `elaboration` (text) | `concern` | direct |
+| — (new key) | `wins` | empty list (legacy form did not collect) |
+| — (new key) | `improvements` | empty list |
+| `support_level_score` (1-5) | `support_level_score` | extra key, preserved for audit |
+| `values_reflection` (text) | `values_reflection` | extra key, preserved for audit |
+| `staff_care_support_needed` (bool) | `staff_care_support_needed` | extra key, preserved for audit |
+| `id` (int) | `_legacy_staff_log_id` | provenance pointer |
+
+`Reflection.answers` is a `JSONField` — extra keys are silently kept by
+the schema validator (it only checks fields declared in the schema).
+The new mobile form never *renders* the extra keys, but they are
+exported in admin / audit JSON.
+
+---
+
+## 3. Rollout plan
+
+The bridge is designed to ship in three phases. The current branch
+(`feat/7_6g_counselor_dual_write`) covers phases 1 and 2. Phase 3 is
+explicitly **out of scope** for this PR and is tracked separately.
+
+### Phase 1: dual-write on (this PR)
+
+- Merge step 7_6g.
+- Backend deploy auto-applies the bridge. `BUNKLOGS_DUAL_WRITE_REFLECTION`
+  defaults to `True`. No frontend changes ride with this phase.
+- Verify in production by saving a `CounselorLog` via the legacy admin
+  and confirming a corresponding `core.Reflection` appears within a
+  few seconds.
+
+### Phase 2: backfill historical data
+
+- On Render, open a one-off shell against `bunklogs-backend`:
+  ```bash
+  python manage.py backfill_counselor_logs --apply --batch-size 200
+  ```
+- The run prints incremental progress every 200 rows. Expected runtime
+  for Crane Lake's ~6 months of history is < 10 minutes.
+- Re-running is safe — the deterministic `client_submission_id` makes
+  the second pass a no-op (`unchanged: N`).
+
+### Phase 3: deprecate the legacy form (future PR — out of scope here)
+
+When the new mobile flow has been live for at least one camp session
+and supports all the legacy fields counselors used to fill in:
+
+1. Mark `bunklogs.StaffLog.save()` with a `DeprecationWarning`.
+2. Hide the legacy `CounselorLog` admin pages behind a feature flag.
+3. After one more session of cooldown, drop the dual-write signal and
+   schedule a follow-up PR to move `StaffLog` to read-only.
+
+---
+
+## 4. Testing
+
+Backend coverage lives in
+`backend/bunk_logs/api/tests/test_counselor_legacy_bridge.py`:
+
+- Field mapping (incl. day-off shortcut and `junior_counselor` role).
+- Mapper idempotency (re-run produces `unchanged`).
+- Update path on `StaffLog` edits.
+- Skip reasons (`no_person_for_user`, `no_active_counselor_membership`,
+  `no_counselor_template_configured`).
+- Management command dry-run vs `--apply`, date-range filter, replay,
+  skip-reason reporting.
+- Signal: on-commit mirror, update-on-resave, kill-switch,
+  best-effort skip.
+
+Frontend coverage for the new counselor flow lives across the per-page
+test files in `frontend/src/pages/counselor/__tests__/`.
+
+---
+
+## 5. Troubleshooting
+
+**The mirror Reflection is missing for a recent StaffLog row.**
+
+Check the Django log for `Dual-write StaffLog->Reflection failed for
+staff_log_id=...`. Common causes:
+
+- The user has no `Person` row in the new model (run the staff import
+  command, then re-save the StaffLog or run a scoped backfill via
+  `--user-id`).
+- The user has no active `counselor` / `junior_counselor` Membership in
+  any program. Confirm in the admin.
+- No counselor self-reflection template is configured for the org. The
+  global seed (`organization IS NULL`, slug `counselor-self-reflection`)
+  is sufficient — re-run migration `core/0029` if it's missing.
+
+**Backfill skips everything with `no_counselor_template_configured`.**
+
+The seeded template migration didn't run on this database. Run
+`python manage.py migrate core` to re-apply.
+
+**Duplicate rows in `core.Reflection` for a single StaffLog.**
+
+Shouldn't be possible with the deterministic `client_submission_id`
+constraint. If you see it, check that the `Reflection.program` FK is
+the same on both rows; the unique constraint is keyed
+`(program, client_submission_id)`. A counselor with active memberships
+across multiple programs would resolve to the *newest* membership —
+keep an eye on that during the multi-tenant expansion.

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -52,6 +52,9 @@ import CamperReflectionListPage from './pages/counselor/CamperReflectionListPage
 import CamperReflectionFormPage from './pages/counselor/CamperReflectionFormPage';
 import CounselorSelfReflectionPage from './pages/counselor/CounselorSelfReflectionPage';
 import CounselorSelfReflectionHistoryPage from './pages/counselor/CounselorSelfReflectionHistoryPage';
+import CounselorRequestsListPage from './pages/counselor/CounselorRequestsListPage';
+import CamperCareRequestFormPage from './pages/counselor/CamperCareRequestFormPage';
+import MaintenanceTicketFormPage from './pages/counselor/MaintenanceTicketFormPage';
 import { useBunk } from './contexts/BunkContext';
 
 // Protected route component
@@ -373,6 +376,23 @@ function Router() {
           <Route
             path="/counselor/self-reflection/:reflectionId/edit"
             element={<CounselorSelfReflectionPage />}
+          />
+          {/* 7_6f: Camper Care + Maintenance request flow. The list view
+              accepts ``?status=open|all`` so counselors can confirm a
+              request closed without leaving the surface. Both per-type
+              forms have a stable client_submission_id ref so an offline
+              replay POSTs the same row instead of duplicating. */}
+          <Route
+            path="/counselor/requests"
+            element={<CounselorRequestsListPage />}
+          />
+          <Route
+            path="/counselor/requests/camper-care/new"
+            element={<CamperCareRequestFormPage />}
+          />
+          <Route
+            path="/counselor/requests/maintenance/new"
+            element={<MaintenanceTicketFormPage />}
           />
         </Route>
 

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -50,6 +50,8 @@ import AppLayout from './layouts/AppLayout';
 import CounselorMobileDashboard from './pages/counselor/CounselorMobileDashboard';
 import CamperReflectionListPage from './pages/counselor/CamperReflectionListPage';
 import CamperReflectionFormPage from './pages/counselor/CamperReflectionFormPage';
+import CounselorSelfReflectionPage from './pages/counselor/CounselorSelfReflectionPage';
+import CounselorSelfReflectionHistoryPage from './pages/counselor/CounselorSelfReflectionHistoryPage';
 import { useBunk } from './contexts/BunkContext';
 
 // Protected route component
@@ -354,6 +356,23 @@ function Router() {
           <Route
             path="/counselor/camper-reflections/:reflectionId/edit"
             element={<CamperReflectionFormPage />}
+          />
+          {/* 7_6e: Counselor self-reflection. ``/self-reflection`` auto-routes
+              to today's edit URL if a submission already exists, otherwise
+              renders the create form. ``/history`` is a dedicated paginated
+              view (Story 6 criterion 6); gap days are rendered as
+              "No submission" rows by the server. */}
+          <Route
+            path="/counselor/self-reflection"
+            element={<CounselorSelfReflectionPage />}
+          />
+          <Route
+            path="/counselor/self-reflection/history"
+            element={<CounselorSelfReflectionHistoryPage />}
+          />
+          <Route
+            path="/counselor/self-reflection/:reflectionId/edit"
+            element={<CounselorSelfReflectionPage />}
           />
         </Route>
 

--- a/frontend/src/api/__tests__/counselor.test.js
+++ b/frontend/src/api/__tests__/counselor.test.js
@@ -2,16 +2,23 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   CAMPER_REFLECTION_AUDIENCE,
   COUNSELOR_SELF_REFLECTION_AUDIENCE,
+  MAINTENANCE_CATEGORIES,
+  MAINTENANCE_URGENCY_CHOICES,
+  createCamperCareRequest,
   createCamperReflection,
+  createMaintenanceTicket,
   createSelfReflection,
+  fetchCamperCareItemSuggestions,
   fetchCamperReflections,
   fetchCounselorDashboard,
+  fetchCounselorRequests,
   fetchReflection,
   fetchSelfReflectionHistory,
   fetchTemplateById,
   newClientSubmissionId,
   patchCamperReflection,
   patchSelfReflection,
+  uploadMaintenanceTicketPhoto,
 } from '../counselor';
 
 const getMock = vi.fn();
@@ -173,6 +180,136 @@ describe('counselor API helpers', () => {
     expect(getMock.mock.calls[0]).toEqual([
       '/api/v1/counselor/self-reflection/history/',
       { params: { page: 3, page_size: 30 } },
+    ]);
+  });
+
+  it('fetchCounselorRequests defaults status=open', async () => {
+    getMock.mockResolvedValue({ data: { requests: [] } });
+    await fetchCounselorRequests();
+    expect(getMock.mock.calls[0]).toEqual([
+      '/api/v1/counselor/requests/',
+      { params: { status: 'open' } },
+    ]);
+  });
+
+  it('fetchCounselorRequests forwards status filter', async () => {
+    getMock.mockResolvedValue({ data: { requests: [] } });
+    await fetchCounselorRequests({ status: 'all' });
+    expect(getMock.mock.calls[0][1].params.status).toBe('all');
+  });
+
+  it('fetchCamperCareItemSuggestions calls the suggestions endpoint', async () => {
+    getMock.mockResolvedValue({ data: { suggestions: [] } });
+    await fetchCamperCareItemSuggestions();
+    expect(getMock.mock.calls[0][0]).toBe(
+      '/api/v1/counselor/camper-care-item-suggestions/',
+    );
+  });
+
+  it('createCamperCareRequest sends the trimmed payload', async () => {
+    postMock.mockResolvedValue({ data: { id: 'order-1' }, status: 201 });
+    await createCamperCareRequest({
+      subjectId: 42,
+      item: 'Toothbrush',
+      itemNote: 'purple',
+      description: 'after lights out',
+      clientSubmissionId: '33333333-3333-4333-8333-333333333333',
+    });
+    expect(postMock.mock.calls[0][0]).toBe('/api/v1/counselor/camper-care-requests/');
+    expect(postMock.mock.calls[0][1]).toEqual({
+      subject_id: 42,
+      item: 'Toothbrush',
+      item_note: 'purple',
+      description: 'after lights out',
+      client_submission_id: '33333333-3333-4333-8333-333333333333',
+    });
+  });
+
+  it('createCamperCareRequest omits subject_id when null/undefined', async () => {
+    postMock.mockResolvedValue({ data: { id: 'order-2' }, status: 201 });
+    await createCamperCareRequest({
+      subjectId: null,
+      item: 'Bug spray',
+      clientSubmissionId: '44444444-4444-4444-8444-444444444444',
+    });
+    const body = postMock.mock.calls[0][1];
+    expect(body).not.toHaveProperty('subject_id');
+    expect(body.item).toBe('Bug spray');
+  });
+
+  it('createMaintenanceTicket builds a multipart FormData with photos', async () => {
+    postMock.mockResolvedValue({ data: { id: 'mt-1' }, status: 201 });
+    const photo1 = new File(['fake-image-1'], 'photo1.jpg', { type: 'image/jpeg' });
+    const photo2 = new File(['fake-image-2'], 'photo2.jpg', { type: 'image/jpeg' });
+    await createMaintenanceTicket({
+      location: 'Bunk Pine',
+      category: 'leak',
+      description: 'under sink',
+      urgency: 'urgent',
+      urgentReason: 'flooding',
+      photos: [photo1, photo2],
+      clientSubmissionId: '55555555-5555-4555-8555-555555555555',
+    });
+    expect(postMock.mock.calls[0][0]).toBe('/api/v1/counselor/maintenance-tickets/');
+    const body = postMock.mock.calls[0][1];
+    expect(body).toBeInstanceOf(FormData);
+    expect(body.get('location')).toBe('Bunk Pine');
+    expect(body.get('category')).toBe('leak');
+    expect(body.get('urgency')).toBe('urgent');
+    expect(body.get('urgent_reason')).toBe('flooding');
+    expect(body.get('client_submission_id')).toBe(
+      '55555555-5555-4555-8555-555555555555',
+    );
+    expect(body.getAll('photos')).toHaveLength(2);
+
+    // ``Content-Type: undefined`` so the browser sets the multipart boundary.
+    expect(postMock.mock.calls[0][2]).toEqual({
+      headers: { 'Content-Type': undefined },
+    });
+  });
+
+  it('createMaintenanceTicket skips urgent_reason when urgency is normal', async () => {
+    postMock.mockResolvedValue({ data: { id: 'mt-2' }, status: 201 });
+    await createMaintenanceTicket({
+      location: 'Dining hall',
+      category: 'broken_light',
+      photos: [],
+      urgency: 'normal',
+      urgentReason: 'should be ignored',
+      clientSubmissionId: '66666666-6666-4666-8666-666666666666',
+    });
+    const body = postMock.mock.calls[0][1];
+    expect(body.get('urgent_reason')).toBeNull();
+    expect(body.getAll('photos')).toHaveLength(0);
+  });
+
+  it('uploadMaintenanceTicketPhoto posts to the follow-up endpoint', async () => {
+    postMock.mockResolvedValue({ data: { id: 'photo-1' } });
+    const photo = new File(['data'], 'extra.jpg', { type: 'image/jpeg' });
+    await uploadMaintenanceTicketPhoto('abc-123', {
+      image: photo,
+      caption: 'cracked',
+    });
+    expect(postMock.mock.calls[0][0]).toBe(
+      '/api/v1/counselor/maintenance-tickets/abc-123/photos/',
+    );
+    const body = postMock.mock.calls[0][1];
+    expect(body).toBeInstanceOf(FormData);
+    expect(body.get('caption')).toBe('cracked');
+    expect(body.get('image')).toBeInstanceOf(File);
+  });
+
+  it('exports stable maintenance categories + urgencies', () => {
+    expect(MAINTENANCE_CATEGORIES.map((c) => c.value)).toEqual([
+      'plumbing',
+      'broken_light',
+      'pest',
+      'leak',
+      'other',
+    ]);
+    expect(MAINTENANCE_URGENCY_CHOICES.map((u) => u.value)).toEqual([
+      'normal',
+      'urgent',
     ]);
   });
 });

--- a/frontend/src/api/__tests__/counselor.test.js
+++ b/frontend/src/api/__tests__/counselor.test.js
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   CAMPER_REFLECTION_AUDIENCE,
+  COUNSELOR_SELF_REFLECTION_AUDIENCE,
   createCamperReflection,
+  createSelfReflection,
   fetchCamperReflections,
   fetchCounselorDashboard,
   fetchReflection,
+  fetchSelfReflectionHistory,
   fetchTemplateById,
   newClientSubmissionId,
   patchCamperReflection,
+  patchSelfReflection,
 } from '../counselor';
 
 const getMock = vi.fn();
@@ -109,5 +113,66 @@ describe('counselor API helpers', () => {
     getMock.mockResolvedValue({ data: { id: 1 } });
     await fetchReflection(42);
     expect(getMock.mock.calls[0][0]).toBe('/api/v1/reflections/42/');
+  });
+
+  it('exports the canonical self-reflection audience set', () => {
+    expect(COUNSELOR_SELF_REFLECTION_AUDIENCE).toEqual([
+      'Admin',
+      'Counselor',
+      'Leadership Team',
+      'Unit Head',
+    ]);
+  });
+
+  it('createSelfReflection day-off shortcut omits answers', async () => {
+    postMock.mockResolvedValue({ data: { id: 1 }, status: 201 });
+    await createSelfReflection({
+      dayOff: true,
+      language: 'en',
+      clientSubmissionId: '11111111-1111-4111-8111-111111111111',
+    });
+    expect(postMock.mock.calls[0][0]).toBe('/api/v1/counselor/self-reflection/');
+    const body = postMock.mock.calls[0][1];
+    expect(body).toEqual({
+      day_off: true,
+      language: 'en',
+      client_submission_id: '11111111-1111-4111-8111-111111111111',
+    });
+    expect(body).not.toHaveProperty('answers');
+  });
+
+  it('createSelfReflection sends the full answers payload otherwise', async () => {
+    postMock.mockResolvedValue({ data: { id: 2 }, status: 201 });
+    await createSelfReflection({
+      dayOff: false,
+      answers: { overall_day: 4 },
+      language: 'es',
+      clientSubmissionId: '22222222-2222-4222-8222-222222222222',
+    });
+    const body = postMock.mock.calls[0][1];
+    expect(body).toEqual({
+      day_off: false,
+      language: 'es',
+      client_submission_id: '22222222-2222-4222-8222-222222222222',
+      answers: { overall_day: 4 },
+    });
+  });
+
+  it('patchSelfReflection omits undefined fields', async () => {
+    patchMock.mockResolvedValue({ data: { id: 9 } });
+    await patchSelfReflection(9, { dayOff: true });
+    expect(patchMock.mock.calls[0]).toEqual([
+      '/api/v1/counselor/self-reflection/9/',
+      { day_off: true },
+    ]);
+  });
+
+  it('fetchSelfReflectionHistory forwards pagination params', async () => {
+    getMock.mockResolvedValue({ data: { results: [] } });
+    await fetchSelfReflectionHistory({ page: 3, pageSize: 30 });
+    expect(getMock.mock.calls[0]).toEqual([
+      '/api/v1/counselor/self-reflection/history/',
+      { params: { page: 3, page_size: 30 } },
+    ]);
   });
 });

--- a/frontend/src/api/counselor.js
+++ b/frontend/src/api/counselor.js
@@ -129,3 +129,96 @@ export const CAMPER_REFLECTION_AUDIENCE = Object.freeze([
   'Leadership Team',
   'Unit Head',
 ]);
+
+/**
+ * Static audience labels for a counselor self-reflection.
+ *
+ * Mirrors ``audience_labels(ContentType.COUNSELOR_SELF_REFLECTION)`` from
+ * ``bunk_logs/core/content_visibility.py``. No ``supports_privacy`` toggle
+ * applies to the seeded counselor template, so this set is fixed.
+ */
+export const COUNSELOR_SELF_REFLECTION_AUDIENCE = Object.freeze([
+  'Admin',
+  'Counselor',
+  'Leadership Team',
+  'Unit Head',
+]);
+
+// ---------------------------------------------------------------------------
+// Self-reflection (Stories 5 + 6)
+// ---------------------------------------------------------------------------
+
+/**
+ * Submit today's self-reflection (Story 5).
+ *
+ * Two payload shapes:
+ *
+ *   * ``{ dayOff: true }`` — shortcut. The server fills ``answers`` with
+ *     ``{"day_off": true}`` regardless of what we send, so the offline
+ *     queue can record a day off without knowing the schema.
+ *   * ``{ dayOff: false, answers: {...} }`` — full submission. ``answers``
+ *     must validate against the seeded counselor template schema.
+ *
+ * The view also accepts an explicit ``team_visibility`` but the seeded
+ * template ships ``supports_privacy=false``, so the server always stores
+ * ``team`` for self-reflections. We don't send the field to keep the
+ * payload minimal.
+ */
+export async function createSelfReflection({
+  dayOff = false,
+  answers,
+  language = 'en',
+  clientSubmissionId,
+}) {
+  const payload = {
+    day_off: !!dayOff,
+    language,
+    client_submission_id: clientSubmissionId,
+  };
+  if (!dayOff) {
+    payload.answers = answers || {};
+  }
+  const res = await api.post('/api/v1/counselor/self-reflection/', payload);
+  return { data: res.data, status: res.status };
+}
+
+/**
+ * Patch an existing self-reflection within today's edit window (Story 6).
+ *
+ * ``dayOff`` is a tri-state: ``true`` flips to the day-off shortcut and
+ * blanks the rest of the answers; ``false`` flips back to a normal entry
+ * (and requires ``answers``); ``undefined`` leaves the shortcut state
+ * untouched. The view enforces the rollover-aware edit window and returns
+ * 403 once "today" passes.
+ */
+export async function patchSelfReflection(reflectionId, {
+  dayOff,
+  answers,
+  language,
+}) {
+  const payload = {};
+  if (dayOff !== undefined) payload.day_off = !!dayOff;
+  if (answers !== undefined) payload.answers = answers;
+  if (language !== undefined) payload.language = language;
+  const { data } = await api.patch(
+    `/api/v1/counselor/self-reflection/${reflectionId}/`,
+    payload,
+  );
+  return data;
+}
+
+/**
+ * Paginated history view of the viewer's own self-reflections (Story 6).
+ *
+ * Returns one row per calendar day in the page window — including "no
+ * submission" gap rows — so the client can render Story 6 criterion 6
+ * without inferring missing dates client-side.
+ */
+export async function fetchSelfReflectionHistory({ page = 1, pageSize } = {}) {
+  const params = { page };
+  if (pageSize) params.page_size = pageSize;
+  const { data } = await api.get('/api/v1/counselor/self-reflection/history/', {
+    params,
+  });
+  return data;
+}

--- a/frontend/src/api/counselor.js
+++ b/frontend/src/api/counselor.js
@@ -222,3 +222,157 @@ export async function fetchSelfReflectionHistory({ page = 1, pageSize } = {}) {
   });
   return data;
 }
+
+// ---------------------------------------------------------------------------
+// Camper-care + maintenance requests (Stories 7 + 8)
+// ---------------------------------------------------------------------------
+
+/**
+ * Combined open-requests list for the dashboard's request pane.
+ *
+ * Returns Orders + MaintenanceTickets the viewer + their co-counselors
+ * submitted on the viewer's bunks. Default ``status=open`` filters to
+ * NEW + IN_PROGRESS; pass ``status='all'`` for the historical view.
+ */
+export async function fetchCounselorRequests({ status = 'open' } = {}) {
+  const { data } = await api.get('/api/v1/counselor/requests/', {
+    params: { status },
+  });
+  return data;
+}
+
+/**
+ * Fetch the curated camper-care item suggestion list for the viewer's
+ * program (Story 7 criterion 2.ii). Used as autocomplete options on the
+ * camper-care request form. An empty list just disables autocomplete
+ * (a counselor can still submit any free-text label).
+ */
+export async function fetchCamperCareItemSuggestions() {
+  const { data } = await api.get(
+    '/api/v1/counselor/camper-care-item-suggestions/',
+  );
+  return data;
+}
+
+/**
+ * Submit a camper-care request (Story 7).
+ *
+ * ``subjectId`` is optional: counselors can file a bunk-scoped request
+ * (no subject) for "the whole bunk" needs. ``item`` is free text; the
+ * client surfaces an autocomplete from
+ * :func:`fetchCamperCareItemSuggestions` but never blocks on it.
+ */
+export async function createCamperCareRequest({
+  subjectId,
+  item,
+  itemNote = '',
+  description = '',
+  clientSubmissionId,
+}) {
+  const payload = {
+    item,
+    item_note: itemNote,
+    description,
+    client_submission_id: clientSubmissionId,
+  };
+  if (subjectId !== undefined && subjectId !== null) {
+    payload.subject_id = subjectId;
+  }
+  const res = await api.post(
+    '/api/v1/counselor/camper-care-requests/', payload,
+  );
+  return { data: res.data, status: res.status };
+}
+
+/**
+ * Submit a maintenance ticket (Story 8) with optional photos.
+ *
+ * Photos must be supplied as an array of ``File`` instances so we can
+ * stream them through ``FormData`` with repeated ``photos`` keys, which
+ * is the only multipart shape DRF's serializer + view actually accept
+ * (see ``MaintenanceTicketCreateSerializer`` docstring for why the
+ * serializer can't validate the list directly — the view pulls from
+ * ``request.FILES.getlist('photos')`` instead).
+ *
+ * When ``urgency === 'urgent'`` the server requires ``urgent_reason``
+ * (Story 8 criterion 2); the form already enforces this client-side so
+ * a 400 here is a genuine server-side validation surface.
+ */
+export async function createMaintenanceTicket({
+  location,
+  category,
+  description = '',
+  urgency = 'normal',
+  urgentReason = '',
+  photos = [],
+  clientSubmissionId,
+}) {
+  const form = new FormData();
+  form.append('location', location);
+  form.append('category', category);
+  form.append('description', description);
+  form.append('urgency', urgency);
+  if (urgency === 'urgent' && urgentReason) {
+    form.append('urgent_reason', urgentReason);
+  }
+  form.append('client_submission_id', clientSubmissionId);
+  for (const file of photos) {
+    if (file) form.append('photos', file);
+  }
+  // Let the browser set the multipart boundary by NOT setting
+  // Content-Type explicitly. Passing ``Content-Type: undefined`` here
+  // unsets the JSON default baked into the axios instance defaults.
+  const res = await api.post(
+    '/api/v1/counselor/maintenance-tickets/',
+    form,
+    { headers: { 'Content-Type': undefined } },
+  );
+  return { data: res.data, status: res.status };
+}
+
+/**
+ * Add a follow-up photo to a maintenance ticket the viewer submitted
+ * (decision C5). Only counselors who submitted the original ticket can
+ * call this; cross-counselor follow-ups are out of scope until bunk-team
+ * co-ownership lands.
+ */
+export async function uploadMaintenanceTicketPhoto(ticketId, { image, caption = '' }) {
+  const form = new FormData();
+  form.append('image', image);
+  if (caption) form.append('caption', caption);
+  const { data } = await api.post(
+    `/api/v1/counselor/maintenance-tickets/${ticketId}/photos/`,
+    form,
+    { headers: { 'Content-Type': undefined } },
+  );
+  return data;
+}
+
+/**
+ * Frozen list of maintenance ticket categories. Mirrors
+ * ``MaintenanceTicket.Category.choices`` in the backend model. Kept
+ * client-side because the form's category picker can't wait on a round
+ * trip to render, and because the list is stable across releases —
+ * adding a new category is a coordinated backend + frontend change.
+ *
+ * Keep in sync with ``bunk_logs/core/models.py``.
+ */
+export const MAINTENANCE_CATEGORIES = Object.freeze([
+  { value: 'plumbing', label: 'Clogged plumbing' },
+  { value: 'broken_light', label: 'Broken light' },
+  { value: 'pest', label: 'Pest / Insect' },
+  { value: 'leak', label: 'Leak' },
+  { value: 'other', label: 'Other' },
+]);
+
+/**
+ * Frozen list of maintenance urgency levels. Mirrors
+ * ``OrderableContent.Urgency`` choices. ``low`` is hidden from the
+ * counselor form: counselors only pick between ``normal`` (default) and
+ * ``urgent`` (which unlocks ``urgent_reason``). Admins on the ops side
+ * can re-grade to ``low`` if needed.
+ */
+export const MAINTENANCE_URGENCY_CHOICES = Object.freeze([
+  { value: 'normal', label: 'Normal' },
+  { value: 'urgent', label: 'Urgent' },
+]);

--- a/frontend/src/pages/counselor/CamperCareRequestFormPage.jsx
+++ b/frontend/src/pages/counselor/CamperCareRequestFormPage.jsx
@@ -1,0 +1,337 @@
+/**
+ * Camper Care request form — Step 7_6f (Story 7).
+ *
+ * URL:  /counselor/requests/camper-care/new
+ *
+ * Two pickers up top:
+ *   * camper (optional) — populated from the dashboard's bunk roster.
+ *     Counselors can leave this blank to file a bunk-scoped request.
+ *   * item — free text with a datalist of curated suggestions
+ *     (Story 7 criterion 2.ii, decision C6). An empty suggestion list
+ *     just disables autocomplete; the field stays free-text.
+ *
+ * On submit POSTs ``/api/v1/counselor/camper-care-requests/`` with a
+ * stable ``client_submission_id`` so the offline queue can replay
+ * safely. On success we land back on the requests list (the dashboard's
+ * "Open Requests" section also picks up the row within 60s via the
+ * existing auto-refresh).
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  createCamperCareRequest,
+  fetchCamperCareItemSuggestions,
+  fetchCamperReflections,
+  newClientSubmissionId,
+} from '../../api/counselor';
+
+function flattenError(err, fallback) {
+  const body = err?.response?.data;
+  if (!body) return err?.message || fallback;
+  if (typeof body === 'string') return body;
+  if (typeof body.detail === 'string') return body.detail;
+  if (typeof body === 'object') {
+    try {
+      return JSON.stringify(body);
+    } catch (_) {
+      return fallback;
+    }
+  }
+  return fallback;
+}
+
+function flattenCamperRoster(camperReflections) {
+  // The roster source is the camper-reflections endpoint — same data the
+  // dashboard counts but with per-camper records (the dashboard's
+  // sections.campers only returns aggregates). Including off-camp campers
+  // here is intentional: it's fine to file a Camper Care request for an
+  // off-camp camper since the need (toiletries, supplies) often spans
+  // their entire stay.
+  const bunks = camperReflections?.bunks || [];
+  const seen = new Set();
+  const rows = [];
+  for (const bunk of bunks) {
+    const onCamp = bunk.campers || [];
+    const offCamp = bunk.off_camp || [];
+    for (const camper of [...onCamp, ...offCamp]) {
+      if (seen.has(camper.id)) continue;
+      seen.add(camper.id);
+      rows.push({
+        id: camper.id,
+        name: camper.name,
+        bunkName: bunk.name,
+        bunkId: bunk.id,
+      });
+    }
+  }
+  rows.sort((a, b) => {
+    if (a.bunkName !== b.bunkName) return a.bunkName.localeCompare(b.bunkName);
+    return a.name.localeCompare(b.name);
+  });
+  return rows;
+}
+
+export default function CamperCareRequestFormPage() {
+  const navigate = useNavigate();
+
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
+  const [campers, setCampers] = useState([]);
+  const [suggestions, setSuggestions] = useState([]);
+
+  const [subjectId, setSubjectId] = useState('');
+  const [item, setItem] = useState('');
+  const [itemNote, setItemNote] = useState('');
+  const [description, setDescription] = useState('');
+
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [submitError, setSubmitError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const clientSubmissionIdRef = useRef(null);
+  if (clientSubmissionIdRef.current === null) {
+    clientSubmissionIdRef.current = newClientSubmissionId();
+  }
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError('');
+    try {
+      const [camperReflections, suggestionPayload] = await Promise.all([
+        fetchCamperReflections(),
+        fetchCamperCareItemSuggestions().catch((err) => {
+          // Suggestions endpoint failure is non-fatal — the form still
+          // works as free text. Log but don't block.
+          // eslint-disable-next-line no-console
+          console.warn('camper-care suggestions failed:', err);
+          return { suggestions: [] };
+        }),
+      ]);
+      setCampers(flattenCamperRoster(camperReflections));
+      setSuggestions(suggestionPayload?.suggestions || []);
+    } catch (err) {
+      setLoadError(flattenError(err, 'Could not load the form.'));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const datalistOptions = useMemo(
+    () => suggestions.map((s) => s.label).filter(Boolean),
+    [suggestions],
+  );
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitError('');
+    const errs = {};
+    if (!item.trim()) errs.item = 'An item is required.';
+    setFieldErrors(errs);
+    if (Object.keys(errs).length) return;
+
+    setSubmitting(true);
+    try {
+      await createCamperCareRequest({
+        subjectId: subjectId ? Number(subjectId) : null,
+        item: item.trim(),
+        itemNote: itemNote.trim(),
+        description: description.trim(),
+        clientSubmissionId: clientSubmissionIdRef.current,
+      });
+      navigate('/counselor/requests', { replace: true });
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 403) {
+        setSubmitError(
+          flattenError(err, 'You can only file a request for a camper on your bunk.'),
+        );
+      } else if (status === 400) {
+        const body = err?.response?.data;
+        if (body && typeof body === 'object' && !Array.isArray(body)) {
+          const next = {};
+          for (const k of Object.keys(body)) {
+            if (k === 'detail') continue;
+            const v = body[k];
+            next[k] = Array.isArray(v) ? v[0] : typeof v === 'string' ? v : JSON.stringify(v);
+          }
+          setFieldErrors(next);
+          setSubmitError(
+            typeof body.detail === 'string'
+              ? body.detail
+              : 'Please fix the errors and try again.',
+          );
+        } else {
+          setSubmitError(flattenError(err, 'Submit failed.'));
+        }
+      } else {
+        setSubmitError(flattenError(err, 'Submit failed.'));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="px-4 py-6 pb-24">
+      <div className="max-w-lg mx-auto">
+        <header className="mb-6">
+          <button
+            type="button"
+            onClick={() => navigate('/counselor')}
+            className="text-xs text-blue-600 dark:text-blue-400 mb-1 flex items-center gap-1"
+          >
+            ← Back to dashboard
+          </button>
+          <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
+            New Camper Care request
+          </h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+            Goes to the Camper Care team. They'll see who it's for and what's
+            needed; you can leave the camper blank for a bunk-wide need.
+          </p>
+        </header>
+
+        {loading ? (
+          <p
+            className="text-gray-600 dark:text-gray-400"
+            data-testid="camper-care-loading"
+          >
+            Loading…
+          </p>
+        ) : loadError ? (
+          <div
+            className="rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/40 dark:border-amber-800 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+            role="alert"
+            data-testid="camper-care-load-error"
+          >
+            {loadError}
+          </div>
+        ) : (
+          <form
+            onSubmit={handleSubmit}
+            className="space-y-4"
+            data-testid="camper-care-form"
+          >
+            <div>
+              <label
+                htmlFor="cc-subject"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
+              >
+                Camper (optional)
+              </label>
+              <select
+                id="cc-subject"
+                data-testid="camper-care-subject"
+                value={subjectId}
+                onChange={(e) => setSubjectId(e.target.value)}
+                className="block w-full min-h-[44px] rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+              >
+                <option value="">— bunk-wide / no specific camper —</option>
+                {campers.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name} ({c.bunkName})
+                  </option>
+                ))}
+              </select>
+              {fieldErrors.subject_id ? (
+                <p className="mt-1 text-xs text-red-600" role="alert">
+                  {fieldErrors.subject_id}
+                </p>
+              ) : null}
+            </div>
+
+            <div>
+              <label
+                htmlFor="cc-item"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
+              >
+                Item *
+              </label>
+              <input
+                id="cc-item"
+                data-testid="camper-care-item"
+                value={item}
+                onChange={(e) => setItem(e.target.value)}
+                list={datalistOptions.length ? 'camper-care-item-options' : undefined}
+                required
+                placeholder="Toothpaste, sunscreen, …"
+                className="block w-full min-h-[44px] rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+              />
+              {datalistOptions.length ? (
+                <datalist id="camper-care-item-options">
+                  {datalistOptions.map((label) => (
+                    <option key={label} value={label} />
+                  ))}
+                </datalist>
+              ) : null}
+              {fieldErrors.item ? (
+                <p className="mt-1 text-xs text-red-600" role="alert">
+                  {fieldErrors.item}
+                </p>
+              ) : null}
+            </div>
+
+            <div>
+              <label
+                htmlFor="cc-item-note"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
+              >
+                Item note
+              </label>
+              <input
+                id="cc-item-note"
+                data-testid="camper-care-item-note"
+                value={itemNote}
+                onChange={(e) => setItemNote(e.target.value)}
+                placeholder="e.g. unscented, size 8…"
+                className="block w-full min-h-[44px] rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="cc-description"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
+              >
+                Notes for Camper Care
+              </label>
+              <textarea
+                id="cc-description"
+                data-testid="camper-care-description"
+                rows={4}
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Anything Camper Care should know to help."
+                className="block w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+              />
+            </div>
+
+            {submitError ? (
+              <p
+                className="text-red-600 text-sm"
+                role="alert"
+                data-testid="camper-care-submit-error"
+              >
+                {submitError}
+              </p>
+            ) : null}
+
+            <button
+              type="submit"
+              disabled={submitting}
+              data-testid="camper-care-submit"
+              className="w-full sm:w-auto mt-4 min-h-[48px] px-6 rounded-lg bg-blue-600 text-white font-medium text-sm disabled:opacity-50"
+            >
+              {submitting ? 'Sending…' : 'Send request'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/counselor/CounselorRequestsListPage.jsx
+++ b/frontend/src/pages/counselor/CounselorRequestsListPage.jsx
@@ -1,0 +1,276 @@
+/**
+ * Counselor requests list — Step 7_6f (Stories 7 + 8).
+ *
+ * URL:  /counselor/requests[?status=open|all]
+ *
+ * Renders the combined open camper-care + maintenance request roster
+ * that the dashboard's "Open Requests" tile teases (Story 7 + 8 list
+ * view). Two CTA buttons up top take the counselor to the per-resource
+ * "New request" forms. A status filter (open ↔ all) flips the API call
+ * so counselors can confirm a request has been closed without leaving
+ * the surface.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { fetchCounselorRequests } from '../../api/counselor';
+
+function TypeBadge({ type }) {
+  if (type === 'camper_care') {
+    return (
+      <span
+        data-testid="request-type-badge"
+        className="text-xs font-medium px-2 py-0.5 rounded-full bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200"
+      >
+        Camper Care
+      </span>
+    );
+  }
+  if (type === 'maintenance') {
+    return (
+      <span
+        data-testid="request-type-badge"
+        className="text-xs font-medium px-2 py-0.5 rounded-full bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-200"
+      >
+        Maintenance
+      </span>
+    );
+  }
+  return null;
+}
+
+function StatusBadge({ status, statusLabel }) {
+  // Map the OrderStateMachine status to a tailwind colour palette.
+  // Keep this loose; new statuses fall back to the neutral pill.
+  const palette = {
+    new: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
+    in_progress: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+    completed: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
+    closed: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200',
+    cancelled: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200',
+  };
+  const cls = palette[status] || palette.closed;
+  return (
+    <span
+      data-testid="request-status-badge"
+      data-status={status}
+      className={`text-xs font-medium px-2 py-0.5 rounded-full ${cls}`}
+    >
+      {statusLabel || status}
+    </span>
+  );
+}
+
+function UrgencyBadge({ urgency, urgencyLabel }) {
+  if (urgency !== 'urgent') return null;
+  return (
+    <span
+      data-testid="request-urgency-badge"
+      className="text-xs font-medium px-2 py-0.5 rounded-full bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200"
+    >
+      {urgencyLabel || 'Urgent'}
+    </span>
+  );
+}
+
+function formatRelative(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  const now = new Date();
+  const diffMs = now - d;
+  const diffMin = Math.round(diffMs / 60000);
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffH = Math.round(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+  const diffD = Math.round(diffH / 24);
+  return `${diffD}d ago`;
+}
+
+function RequestRow({ row }) {
+  const isCamperCare = row.type === 'camper_care';
+  const title = isCamperCare
+    ? row.item || 'Camper Care request'
+    : (row.category_label || row.location || 'Maintenance ticket');
+  const subtitle = isCamperCare
+    ? (row.subject?.name
+        ? `For ${row.subject.name}`
+        : 'Bunk-wide request')
+    : (row.location ? `Location: ${row.location}` : '');
+
+  const submitter = row.submitter?.is_self
+    ? 'you'
+    : row.submitter?.name || 'a co-counselor';
+
+  return (
+    <li
+      data-testid={`request-row-${row.type}-${row.id}`}
+      data-type={row.type}
+      data-status={row.status}
+      className="py-3 border-b border-gray-100 dark:border-gray-800 last:border-b-0 flex flex-col gap-1"
+    >
+      <div className="flex items-center gap-2 flex-wrap">
+        <TypeBadge type={row.type} />
+        <StatusBadge status={row.status} statusLabel={row.status_label} />
+        <UrgencyBadge urgency={row.urgency} urgencyLabel={row.urgency_label} />
+      </div>
+      <p className="text-sm font-medium text-gray-900 dark:text-white">{title}</p>
+      {subtitle ? (
+        <p className="text-xs text-gray-600 dark:text-gray-400">{subtitle}</p>
+      ) : null}
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        Sent by {submitter}
+        {row.submitted_at ? ` · ${formatRelative(row.submitted_at)}` : ''}
+        {row.type === 'maintenance' && row.photo_count
+          ? ` · ${row.photo_count} photo${row.photo_count === 1 ? '' : 's'}`
+          : ''}
+      </p>
+    </li>
+  );
+}
+
+export default function CounselorRequestsListPage() {
+  const navigate = useNavigate();
+  const [params, setParams] = useSearchParams();
+  const statusParam = (params.get('status') === 'all' ? 'all' : 'open');
+
+  const [rows, setRows] = useState(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async (filterStatus) => {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await fetchCounselorRequests({ status: filterStatus });
+      setRows(data?.requests || []);
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      setError(typeof detail === 'string' ? detail : 'Could not load requests.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load(statusParam);
+  }, [load, statusParam]);
+
+  const changeFilter = (next) => {
+    // Drop the param entirely on the "open" default so URLs stay clean.
+    if (next === 'open') {
+      params.delete('status');
+    } else {
+      params.set('status', next);
+    }
+    setParams(params, { replace: true });
+  };
+
+  return (
+    <div className="px-4 py-6 pb-24">
+      <div className="max-w-lg mx-auto space-y-4">
+        <header className="flex items-start justify-between gap-3">
+          <div>
+            <button
+              type="button"
+              onClick={() => navigate('/counselor')}
+              className="text-xs text-blue-600 dark:text-blue-400 mb-1 flex items-center gap-1"
+            >
+              ← Back to dashboard
+            </button>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
+              Open requests
+            </h1>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+              Yours and your co-counselors' active requests.
+            </p>
+          </div>
+          <div
+            data-testid="requests-status-filter"
+            className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden shrink-0"
+          >
+            <button
+              type="button"
+              data-testid="requests-filter-open"
+              aria-pressed={statusParam === 'open'}
+              onClick={() => changeFilter('open')}
+              className={`px-3 py-1.5 text-sm min-h-[36px] ${
+                statusParam === 'open'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200'
+              }`}
+            >
+              Open
+            </button>
+            <button
+              type="button"
+              data-testid="requests-filter-all"
+              aria-pressed={statusParam === 'all'}
+              onClick={() => changeFilter('all')}
+              className={`px-3 py-1.5 text-sm min-h-[36px] ${
+                statusParam === 'all'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200'
+              }`}
+            >
+              All
+            </button>
+          </div>
+        </header>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Link
+            to="/counselor/requests/camper-care/new"
+            data-testid="requests-new-camper-care"
+            className="min-h-[44px] flex items-center justify-center rounded-lg bg-purple-600 text-white text-sm font-medium px-4"
+          >
+            + Camper Care
+          </Link>
+          <Link
+            to="/counselor/requests/maintenance/new"
+            data-testid="requests-new-maintenance"
+            className="min-h-[44px] flex items-center justify-center rounded-lg bg-orange-600 text-white text-sm font-medium px-4"
+          >
+            + Maintenance
+          </Link>
+        </div>
+
+        {loading && rows === null ? (
+          <p
+            className="text-gray-600 dark:text-gray-400"
+            data-testid="requests-loading"
+          >
+            Loading requests…
+          </p>
+        ) : error ? (
+          <div
+            className="rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/40 dark:border-amber-800 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+            role="alert"
+            data-testid="requests-error"
+          >
+            {error}
+          </div>
+        ) : (
+          <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-2 shadow-sm">
+            {rows && rows.length ? (
+              <ul>
+                {rows.map((row) => (
+                  <RequestRow key={`${row.type}-${row.id}`} row={row} />
+                ))}
+              </ul>
+            ) : (
+              <p
+                className="text-sm text-gray-600 dark:text-gray-400 py-4"
+                data-testid="requests-empty"
+              >
+                {statusParam === 'open'
+                  ? 'No open requests right now. Tap "+ Camper Care" or "+ Maintenance" to file a new one.'
+                  : 'Nothing to show yet.'}
+              </p>
+            )}
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/counselor/CounselorSelfReflectionHistoryPage.jsx
+++ b/frontend/src/pages/counselor/CounselorSelfReflectionHistoryPage.jsx
@@ -1,0 +1,207 @@
+/**
+ * Counselor self-reflection history — Step 7_6e (Story 6).
+ *
+ * Renders one row per calendar day in the page window. The server already
+ * fills in "no submission" rows so we don't have to infer gaps client-side
+ * (Story 6 criterion 6). Three row variants:
+ *
+ *   * submitted + content → date + preview text
+ *   * submitted + day_off → "Day off" badge
+ *   * not submitted      → "No submission" placeholder
+ *
+ * Today's row also exposes a "View / edit" link that deep-links into the
+ * detail page; past rows expose a read-only "View" link (since the edit
+ * window is closed, the form will load in read-only via the 403 path).
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { fetchSelfReflectionHistory } from '../../api/counselor';
+
+function StatusBadge({ submitted, isDayOff }) {
+  if (!submitted) {
+    return (
+      <span
+        data-testid="row-badge-missing"
+        className="text-xs font-medium px-2 py-0.5 rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+      >
+        No submission
+      </span>
+    );
+  }
+  if (isDayOff) {
+    return (
+      <span
+        data-testid="row-badge-day-off"
+        className="text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
+      >
+        Day off
+      </span>
+    );
+  }
+  return (
+    <span
+      data-testid="row-badge-submitted"
+      className="text-xs font-medium px-2 py-0.5 rounded-full bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200"
+    >
+      Submitted
+    </span>
+  );
+}
+
+function HistoryRow({ row }) {
+  const { date, submitted, is_day_off: isDayOff, preview, reflection_id: reflectionId, editable } = row;
+
+  return (
+    <li
+      data-testid={`history-row-${date}`}
+      data-submitted={submitted ? 'true' : 'false'}
+      data-day-off={isDayOff ? 'true' : 'false'}
+      className="flex items-start justify-between gap-3 py-3 border-b border-gray-100 dark:border-gray-800 last:border-b-0"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <p className="text-sm font-medium text-gray-900 dark:text-white">{date}</p>
+          <StatusBadge submitted={submitted} isDayOff={isDayOff} />
+        </div>
+        {submitted && !isDayOff && preview ? (
+          <p
+            data-testid={`history-row-${date}-preview`}
+            className="text-xs text-gray-600 dark:text-gray-400 mt-1 line-clamp-2"
+          >
+            {preview}
+          </p>
+        ) : null}
+        {!submitted ? (
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            Nothing recorded for this day.
+          </p>
+        ) : null}
+      </div>
+      {submitted && reflectionId ? (
+        <Link
+          to={
+            editable
+              ? `/counselor/self-reflection/${reflectionId}/edit`
+              : `/reflections/${reflectionId}`
+          }
+          data-testid={`history-row-${date}-link`}
+          className="shrink-0 inline-flex items-center justify-center min-h-[44px] px-3 rounded-lg border border-gray-300 dark:border-gray-600 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800"
+        >
+          {editable ? 'Edit' : 'View'}
+        </Link>
+      ) : null}
+    </li>
+  );
+}
+
+export default function CounselorSelfReflectionHistoryPage() {
+  const navigate = useNavigate();
+  const [data, setData] = useState(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+
+  const load = useCallback(async (targetPage) => {
+    setLoading(true);
+    setError('');
+    try {
+      const payload = await fetchSelfReflectionHistory({ page: targetPage });
+      setData(payload);
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      setError(typeof detail === 'string' ? detail : 'Could not load your history.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load(page);
+  }, [load, page]);
+
+  return (
+    <div className="px-4 py-6 pb-24">
+      <div className="max-w-lg mx-auto space-y-4">
+        <header>
+          <button
+            type="button"
+            onClick={() => navigate('/counselor')}
+            className="text-xs text-blue-600 dark:text-blue-400 mb-1 flex items-center gap-1"
+          >
+            ← Back to dashboard
+          </button>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
+            My self-reflection history
+          </h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+            Most recent first. Empty rows mean nothing was submitted that day.
+          </p>
+        </header>
+
+        {loading && !data ? (
+          <p
+            className="text-gray-600 dark:text-gray-400"
+            data-testid="history-loading"
+          >
+            Loading history…
+          </p>
+        ) : error ? (
+          <div
+            className="rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/40 dark:border-amber-800 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+            role="alert"
+            data-testid="history-error"
+          >
+            {error}
+          </div>
+        ) : (
+          <>
+            <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-2 shadow-sm">
+              {data?.results?.length ? (
+                <ul>
+                  {data.results.map((row) => (
+                    <HistoryRow key={row.date} row={row} />
+                  ))}
+                </ul>
+              ) : (
+                <p
+                  className="text-sm text-gray-600 dark:text-gray-400 py-4"
+                  data-testid="history-empty"
+                >
+                  No history yet — submit a reflection today to start your record.
+                </p>
+              )}
+            </section>
+
+            <nav
+              data-testid="history-pagination"
+              className="flex items-center justify-between gap-2"
+            >
+              <button
+                type="button"
+                data-testid="history-prev"
+                disabled={!data?.previous || loading}
+                onClick={() => data?.previous && setPage(data.previous)}
+                className="min-h-[44px] px-4 rounded-lg border border-gray-300 dark:border-gray-600 text-sm font-medium text-gray-700 dark:text-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                ← Newer
+              </button>
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                Page {data?.page || page}
+              </span>
+              <button
+                type="button"
+                data-testid="history-next"
+                disabled={!data?.next || loading}
+                onClick={() => data?.next && setPage(data.next)}
+                className="min-h-[44px] px-4 rounded-lg border border-gray-300 dark:border-gray-600 text-sm font-medium text-gray-700 dark:text-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Older →
+              </button>
+            </nav>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/counselor/CounselorSelfReflectionPage.jsx
+++ b/frontend/src/pages/counselor/CounselorSelfReflectionPage.jsx
@@ -1,0 +1,412 @@
+/**
+ * Counselor self-reflection form — Step 7_6e (Stories 5 + 6).
+ *
+ * URL shapes:
+ *
+ *   /counselor/self-reflection
+ *     → If no submission exists for today, render a POST form.
+ *       If today's submission exists, redirect to the edit URL.
+ *
+ *   /counselor/self-reflection/:reflectionId/edit
+ *     → PATCH /api/v1/counselor/self-reflection/:reflectionId/
+ *
+ * "Day off" UX (Story 5 criterion 3):
+ *   The seeded template includes a ``day_off`` yes_no field. We render it
+ *   as a prominent toggle at the top of the form, separate from the
+ *   schema's normal field rendering. When ON, the rest of the form is
+ *   hidden and the submit button reads "Mark day off"; payload to the
+ *   server is the shortcut ``{ day_off: true }``. When OFF, normal
+ *   schema fields render.
+ *
+ * Template resolution:
+ *   We hit `GET /counselor/dashboard/` (cached 30s) to discover the
+ *   active self-reflection template ID + whether a row already exists
+ *   today, then fetch the template schema by ID. This avoids the
+ *   ambiguity in `/reflections/template-for-me/` which would pick the
+ *   wrong template if the org has both a single-subject (camper) and a
+ *   self template both keyed `role=counselor`.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import AudienceDisclosure from '../../components/AudienceDisclosure';
+import ReflectionField from '../../components/templates/ReflectionField';
+import {
+  buildDefaultAnswers,
+  validateReflectionAnswers,
+} from '../../utils/reflection/reflectionFormValidation';
+import {
+  COUNSELOR_SELF_REFLECTION_AUDIENCE,
+  createSelfReflection,
+  fetchCounselorDashboard,
+  fetchReflection,
+  fetchTemplateById,
+  newClientSubmissionId,
+  patchSelfReflection,
+} from '../../api/counselor';
+
+const DAY_OFF_FIELD_KEY = 'day_off';
+
+function flattenError(err, fallback) {
+  const body = err?.response?.data;
+  if (!body) return err?.message || fallback;
+  if (typeof body === 'string') return body;
+  if (typeof body.detail === 'string') return body.detail;
+  if (typeof body === 'object') {
+    try {
+      return JSON.stringify(body);
+    } catch (_) {
+      return fallback;
+    }
+  }
+  return fallback;
+}
+
+function withoutDayOffField(schema) {
+  if (!schema?.fields) return schema;
+  return {
+    ...schema,
+    fields: schema.fields.filter((f) => f?.key !== DAY_OFF_FIELD_KEY),
+  };
+}
+
+export default function CounselorSelfReflectionPage() {
+  const navigate = useNavigate();
+  const { reflectionId: editIdParam } = useParams();
+  const isEdit = !!editIdParam;
+  const editReflectionId = isEdit ? Number(editIdParam) : null;
+
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
+  const [schema, setSchema] = useState(null);
+  const [templateMeta, setTemplateMeta] = useState(null);
+
+  const [dayOff, setDayOff] = useState(false);
+  const [answers, setAnswers] = useState({});
+  const [language, setLanguage] = useState('en');
+
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [submitError, setSubmitError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  // Stable UUID across retries for create mode (Step 7_6c idempotency).
+  const clientSubmissionIdRef = useRef(null);
+  if (!isEdit && clientSubmissionIdRef.current === null) {
+    clientSubmissionIdRef.current = newClientSubmissionId();
+  }
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError('');
+    try {
+      if (isEdit) {
+        const reflection = await fetchReflection(editReflectionId);
+        const templateId = reflection.template || reflection.template_meta?.id;
+        if (!templateId) {
+          setLoadError('Reflection has no template attached.');
+          return;
+        }
+        const template = await fetchTemplateById(templateId);
+        setSchema(template.schema);
+        setTemplateMeta({
+          id: template.id,
+          name: template.name,
+          slug: template.slug,
+          version: template.version,
+          languages: template.languages || ['en'],
+        });
+
+        const existingAnswers = reflection.answers || {};
+        const isDayOff = !!existingAnswers[DAY_OFF_FIELD_KEY];
+        setDayOff(isDayOff);
+        const defaults = buildDefaultAnswers(template.schema);
+        // When the row is a day-off shortcut, keep the rest of the answers
+        // at their defaults so flipping the toggle reveals a clean form.
+        setAnswers(isDayOff ? defaults : { ...defaults, ...existingAnswers });
+        setLanguage(reflection.language || 'en');
+      } else {
+        const dashboard = await fetchCounselorDashboard();
+        const selfSection = dashboard?.sections?.self_reflection;
+        if (selfSection?.reflection_id) {
+          // Already submitted today — bounce to the edit URL so the user
+          // can refine, day-off-toggle, or change language. ``replace``
+          // keeps the back stack tidy.
+          navigate(
+            `/counselor/self-reflection/${selfSection.reflection_id}/edit`,
+            { replace: true },
+          );
+          return;
+        }
+        const tplMeta = selfSection?.template;
+        if (!tplMeta?.id) {
+          setLoadError('No counselor self-reflection template is configured.');
+          return;
+        }
+        const template = await fetchTemplateById(tplMeta.id);
+        setSchema(template.schema);
+        setTemplateMeta({
+          id: template.id,
+          name: template.name,
+          slug: template.slug,
+          version: template.version,
+          languages: template.languages || ['en'],
+        });
+        setAnswers(buildDefaultAnswers(template.schema));
+      }
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 403) {
+        setLoadError(
+          err?.response?.data?.detail
+          || 'You do not have permission to open this self-reflection.',
+        );
+      } else if (status === 404) {
+        setLoadError('Reflection not found.');
+      } else {
+        setLoadError(flattenError(err, 'Could not load the form.'));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [isEdit, editReflectionId, navigate]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const visibleSchema = useMemo(
+    () => (schema ? withoutDayOffField(schema) : null),
+    [schema],
+  );
+
+  const updateAnswer = (key, value) => {
+    setAnswers((prev) => ({ ...prev, [key]: value }));
+    setFieldErrors((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  };
+
+  const langChoices = useMemo(
+    () => (templateMeta?.languages?.length ? templateMeta.languages : ['en']),
+    [templateMeta],
+  );
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitError('');
+    if (!schema || !templateMeta?.id) {
+      setSubmitError('Template not loaded.');
+      return;
+    }
+
+    if (!dayOff) {
+      const { ok, errors } = validateReflectionAnswers(visibleSchema, answers);
+      setFieldErrors(errors);
+      if (!ok) return;
+    }
+
+    setSubmitting(true);
+    try {
+      if (isEdit) {
+        await patchSelfReflection(editReflectionId, {
+          dayOff,
+          answers: dayOff ? undefined : answers,
+          language,
+        });
+      } else {
+        await createSelfReflection({
+          dayOff,
+          answers: dayOff ? undefined : answers,
+          language,
+          clientSubmissionId: clientSubmissionIdRef.current,
+        });
+      }
+      navigate('/counselor', { replace: true });
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 403) {
+        setSubmitError(flattenError(err, 'You can no longer edit this reflection.'));
+      } else if (status === 400) {
+        const body = err?.response?.data;
+        if (body && typeof body === 'object' && !Array.isArray(body)) {
+          const next = {};
+          for (const k of Object.keys(body)) {
+            if (k === 'detail') continue;
+            const v = body[k];
+            next[k] = Array.isArray(v) ? v[0] : typeof v === 'string' ? v : JSON.stringify(v);
+          }
+          setFieldErrors(next);
+          setSubmitError(
+            typeof body.detail === 'string'
+              ? body.detail
+              : 'Please fix the errors and try again.',
+          );
+        } else {
+          setSubmitError(flattenError(err, 'Submit failed.'));
+        }
+      } else {
+        setSubmitError(flattenError(err, 'Submit failed.'));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const dayOffLabel = useMemo(() => {
+    if (!schema?.fields) return 'Day off today?';
+    const field = schema.fields.find((f) => f?.key === DAY_OFF_FIELD_KEY);
+    if (!field?.prompts) return 'Day off today?';
+    return field.prompts[language] || field.prompts.en || 'Day off today?';
+  }, [schema, language]);
+
+  return (
+    <div className="px-4 py-6 pb-24">
+      <div className="max-w-lg mx-auto">
+        <header className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <button
+              type="button"
+              onClick={() => navigate('/counselor')}
+              className="text-xs text-blue-600 dark:text-blue-400 mb-1 flex items-center gap-1"
+            >
+              ← Back to dashboard
+            </button>
+            <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
+              My self-reflection
+            </h1>
+            {templateMeta ? (
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                {templateMeta.name}
+              </p>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-3 shrink-0">
+            <Link
+              to="/counselor/self-reflection/history"
+              data-testid="self-reflection-history-link"
+              className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              History
+            </Link>
+            {langChoices.length > 1 ? (
+              <div
+                className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden"
+                data-testid="self-reflection-language"
+              >
+                {langChoices.map((code) => (
+                  <button
+                    key={code}
+                    type="button"
+                    aria-pressed={language === code}
+                    onClick={() => setLanguage(code)}
+                    className={`px-3 py-1.5 text-sm font-medium min-h-[44px] ${
+                      language === code
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200'
+                    }`}
+                  >
+                    {code === 'es' ? 'Español' : code === 'en' ? 'English' : code}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </header>
+
+        {loading ? (
+          <p
+            className="text-gray-600 dark:text-gray-400"
+            data-testid="self-reflection-loading"
+          >
+            Loading form…
+          </p>
+        ) : loadError ? (
+          <div
+            className="rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/40 dark:border-amber-800 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+            role="alert"
+            data-testid="self-reflection-load-error"
+          >
+            {loadError}
+          </div>
+        ) : (
+          <form
+            onSubmit={handleSubmit}
+            className="space-y-2"
+            data-testid="self-reflection-form"
+          >
+            <AudienceDisclosure audience={COUNSELOR_SELF_REFLECTION_AUDIENCE} />
+
+            <fieldset
+              className="mb-4 rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-3"
+              data-testid="self-reflection-day-off-fieldset"
+            >
+              <legend className="text-xs font-medium text-gray-600 dark:text-gray-400 px-1">
+                Quick action
+              </legend>
+              <label className="flex items-center gap-3 cursor-pointer mt-1">
+                <input
+                  type="checkbox"
+                  data-testid="self-reflection-day-off-toggle"
+                  checked={dayOff}
+                  onChange={(e) => {
+                    setDayOff(e.target.checked);
+                    if (e.target.checked) {
+                      setFieldErrors({});
+                    }
+                  }}
+                  className="h-5 w-5 text-blue-600 border-gray-300 rounded focus:ring-blue-500 dark:border-gray-600"
+                />
+                <span className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                  {dayOffLabel}
+                </span>
+              </label>
+              <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                Counts as complete for the day. You can switch back any time today.
+              </p>
+            </fieldset>
+
+            {!dayOff && (visibleSchema?.fields || []).map((field) => (
+              <ReflectionField
+                key={field.key}
+                field={field}
+                language={language}
+                answer={answers[field.key]}
+                onChange={(val) => updateAnswer(field.key, val)}
+                error={fieldErrors[field.key]}
+              />
+            ))}
+
+            {submitError ? (
+              <p
+                className="text-red-600 text-sm"
+                role="alert"
+                data-testid="self-reflection-submit-error"
+              >
+                {submitError}
+              </p>
+            ) : null}
+
+            <button
+              type="submit"
+              disabled={submitting}
+              data-testid="self-reflection-submit"
+              className="w-full sm:w-auto mt-4 min-h-[48px] px-6 rounded-lg bg-blue-600 text-white font-medium text-sm disabled:opacity-50"
+            >
+              {submitting
+                ? 'Submitting…'
+                : dayOff
+                  ? isEdit
+                    ? 'Mark day off'
+                    : 'Mark day off'
+                  : isEdit
+                    ? 'Save changes'
+                    : 'Submit reflection'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/counselor/MaintenanceTicketFormPage.jsx
+++ b/frontend/src/pages/counselor/MaintenanceTicketFormPage.jsx
@@ -1,0 +1,360 @@
+/**
+ * Maintenance ticket form — Step 7_6f (Story 8).
+ *
+ * URL:  /counselor/requests/maintenance/new
+ *
+ * Submission is multipart/form-data so we can attach photos in the same
+ * round-trip (Story 8 criterion 1.iv). ``urgency=urgent`` unlocks an
+ * ``urgent_reason`` textarea which the server enforces via
+ * ``MaintenanceTicket.clean()`` (Story 8 criterion 2); we mirror that
+ * client-side so the user sees the requirement before hitting submit.
+ *
+ * Photo handling notes:
+ *   * We add a small per-file preview tile so it's obvious which photos
+ *     the form is about to send. Each tile has a "Remove" affordance.
+ *   * No client-side resize (keeping scope tight for 7_6f). Modern
+ *     mobile cameras land around 3-6MB per HEIC/JPEG which the API
+ *     accepts; if it ends up being a problem we can add resize in a
+ *     follow-up.
+ *   * Object URLs are revoked when files change so we don't leak.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  MAINTENANCE_CATEGORIES,
+  MAINTENANCE_URGENCY_CHOICES,
+  createMaintenanceTicket,
+  newClientSubmissionId,
+} from '../../api/counselor';
+
+function flattenError(err, fallback) {
+  const body = err?.response?.data;
+  if (!body) return err?.message || fallback;
+  if (typeof body === 'string') return body;
+  if (typeof body.detail === 'string') return body.detail;
+  if (typeof body === 'object') {
+    try {
+      return JSON.stringify(body);
+    } catch (_) {
+      return fallback;
+    }
+  }
+  return fallback;
+}
+
+function PhotoTile({ file, onRemove }) {
+  const url = useMemo(() => URL.createObjectURL(file), [file]);
+  useEffect(() => () => URL.revokeObjectURL(url), [url]);
+  return (
+    <div
+      data-testid="maintenance-photo-tile"
+      className="relative w-20 h-20 rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700"
+    >
+      <img
+        src={url}
+        alt={file.name}
+        className="w-full h-full object-cover"
+      />
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Remove ${file.name}`}
+        data-testid="maintenance-photo-remove"
+        className="absolute top-0 right-0 bg-black/60 text-white text-xs px-1.5 py-0.5 rounded-bl-md"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+
+export default function MaintenanceTicketFormPage() {
+  const navigate = useNavigate();
+
+  const [location, setLocation] = useState('');
+  const [category, setCategory] = useState('');
+  const [description, setDescription] = useState('');
+  const [urgency, setUrgency] = useState('normal');
+  const [urgentReason, setUrgentReason] = useState('');
+  const [photos, setPhotos] = useState([]);
+
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [submitError, setSubmitError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const clientSubmissionIdRef = useRef(null);
+  if (clientSubmissionIdRef.current === null) {
+    clientSubmissionIdRef.current = newClientSubmissionId();
+  }
+  const fileInputRef = useRef(null);
+
+  const handlePhotosChosen = (e) => {
+    const next = Array.from(e.target.files || []);
+    if (next.length === 0) return;
+    setPhotos((prev) => [...prev, ...next]);
+    // Reset the input value so the user can pick the same file twice if
+    // they want; otherwise the change event won't fire on re-select.
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const removePhoto = (index) => {
+    setPhotos((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitError('');
+    const errs = {};
+    if (!location.trim()) errs.location = 'Location is required.';
+    if (!category) errs.category = 'Pick a category.';
+    if (urgency === 'urgent' && !urgentReason.trim()) {
+      // Mirror MaintenanceTicket.clean() (Story 8 criterion 2).
+      errs.urgent_reason = 'Required when this is urgent.';
+    }
+    setFieldErrors(errs);
+    if (Object.keys(errs).length) return;
+
+    setSubmitting(true);
+    try {
+      await createMaintenanceTicket({
+        location: location.trim(),
+        category,
+        description: description.trim(),
+        urgency,
+        urgentReason: urgency === 'urgent' ? urgentReason.trim() : '',
+        photos,
+        clientSubmissionId: clientSubmissionIdRef.current,
+      });
+      navigate('/counselor/requests', { replace: true });
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 400) {
+        const body = err?.response?.data;
+        if (body && typeof body === 'object' && !Array.isArray(body)) {
+          const next = {};
+          for (const k of Object.keys(body)) {
+            if (k === 'detail') continue;
+            const v = body[k];
+            next[k] = Array.isArray(v) ? v[0] : typeof v === 'string' ? v : JSON.stringify(v);
+          }
+          setFieldErrors(next);
+          setSubmitError(
+            typeof body.detail === 'string'
+              ? body.detail
+              : 'Please fix the errors and try again.',
+          );
+        } else {
+          setSubmitError(flattenError(err, 'Submit failed.'));
+        }
+      } else {
+        setSubmitError(flattenError(err, 'Submit failed.'));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="px-4 py-6 pb-24">
+      <div className="max-w-lg mx-auto">
+        <header className="mb-6">
+          <button
+            type="button"
+            onClick={() => navigate('/counselor')}
+            className="text-xs text-blue-600 dark:text-blue-400 mb-1 flex items-center gap-1"
+          >
+            ← Back to dashboard
+          </button>
+          <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
+            New Maintenance ticket
+          </h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+            Goes to the Maintenance team. Photos help triage faster.
+          </p>
+        </header>
+
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-4"
+          data-testid="maintenance-form"
+          encType="multipart/form-data"
+        >
+          <div>
+            <label
+              htmlFor="mt-location"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
+            >
+              Location *
+            </label>
+            <input
+              id="mt-location"
+              data-testid="maintenance-location"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              placeholder="Bunk Pine, dining hall, …"
+              required
+              className="block w-full min-h-[44px] rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+            />
+            {fieldErrors.location ? (
+              <p className="mt-1 text-xs text-red-600" role="alert">
+                {fieldErrors.location}
+              </p>
+            ) : null}
+          </div>
+
+          <div>
+            <label
+              htmlFor="mt-category"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
+            >
+              Category *
+            </label>
+            <select
+              id="mt-category"
+              data-testid="maintenance-category"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              required
+              className="block w-full min-h-[44px] rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+            >
+              <option value="">— pick one —</option>
+              {MAINTENANCE_CATEGORIES.map((c) => (
+                <option key={c.value} value={c.value}>{c.label}</option>
+              ))}
+            </select>
+            {fieldErrors.category ? (
+              <p className="mt-1 text-xs text-red-600" role="alert">
+                {fieldErrors.category}
+              </p>
+            ) : null}
+          </div>
+
+          <fieldset
+            data-testid="maintenance-urgency-group"
+            className="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-3"
+          >
+            <legend className="text-xs font-medium text-gray-600 dark:text-gray-400 px-1">
+              Urgency
+            </legend>
+            <div className="flex gap-3 mt-1">
+              {MAINTENANCE_URGENCY_CHOICES.map((u) => (
+                <label
+                  key={u.value}
+                  className="flex items-center gap-2 cursor-pointer text-sm text-gray-800 dark:text-gray-200"
+                >
+                  <input
+                    type="radio"
+                    name="urgency"
+                    value={u.value}
+                    checked={urgency === u.value}
+                    onChange={() => setUrgency(u.value)}
+                    data-testid={`maintenance-urgency-${u.value}`}
+                    className="h-4 w-4 text-blue-600 focus:ring-blue-500"
+                  />
+                  {u.label}
+                </label>
+              ))}
+            </div>
+            {urgency === 'urgent' ? (
+              <div className="mt-3">
+                <label
+                  htmlFor="mt-urgent-reason"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
+                >
+                  Why is this urgent? *
+                </label>
+                <textarea
+                  id="mt-urgent-reason"
+                  data-testid="maintenance-urgent-reason"
+                  rows={3}
+                  value={urgentReason}
+                  onChange={(e) => setUrgentReason(e.target.value)}
+                  placeholder="What's at stake if this waits?"
+                  className="block w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+                />
+                {fieldErrors.urgent_reason ? (
+                  <p className="mt-1 text-xs text-red-600" role="alert">
+                    {fieldErrors.urgent_reason}
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+          </fieldset>
+
+          <div>
+            <label
+              htmlFor="mt-description"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1"
+            >
+              Description
+            </label>
+            <textarea
+              id="mt-description"
+              data-testid="maintenance-description"
+              rows={4}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What's broken, where to look, anything Maintenance needs to know."
+              className="block w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+            />
+          </div>
+
+          <div>
+            <span className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+              Photos
+            </span>
+            <div className="flex flex-wrap items-center gap-2">
+              {photos.map((file, index) => (
+                <PhotoTile
+                  key={`${file.name}-${file.lastModified}-${index}`}
+                  file={file}
+                  onRemove={() => removePhoto(index)}
+                />
+              ))}
+              <label
+                htmlFor="mt-photo-input"
+                data-testid="maintenance-photo-add"
+                className="w-20 h-20 rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-600 flex items-center justify-center text-xs text-gray-500 dark:text-gray-400 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800"
+              >
+                + Photo
+              </label>
+              <input
+                id="mt-photo-input"
+                data-testid="maintenance-photo-input"
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                onChange={handlePhotosChosen}
+                className="sr-only"
+              />
+            </div>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              Tap to add — you can pick multiple at once.
+            </p>
+          </div>
+
+          {submitError ? (
+            <p
+              className="text-red-600 text-sm"
+              role="alert"
+              data-testid="maintenance-submit-error"
+            >
+              {submitError}
+            </p>
+          ) : null}
+
+          <button
+            type="submit"
+            disabled={submitting}
+            data-testid="maintenance-submit"
+            className="w-full sm:w-auto mt-4 min-h-[48px] px-6 rounded-lg bg-blue-600 text-white font-medium text-sm disabled:opacity-50"
+          >
+            {submitting ? 'Submitting…' : 'Submit ticket'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/counselor/__tests__/CamperCareRequestFormPage.test.jsx
+++ b/frontend/src/pages/counselor/__tests__/CamperCareRequestFormPage.test.jsx
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import CamperCareRequestFormPage from '../CamperCareRequestFormPage';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: (...args) => postMock(...args),
+  },
+}));
+
+function PathProbe() {
+  const loc = useLocation();
+  return <div data-testid="path-probe" data-pathname={loc.pathname} />;
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/counselor/requests/camper-care/new']}>
+      <Routes>
+        <Route
+          path="/counselor/requests/camper-care/new"
+          element={<CamperCareRequestFormPage />}
+        />
+        <Route path="/counselor/requests" element={<PathProbe />} />
+        <Route path="/counselor" element={<PathProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const rosterPayload = {
+  date: '2026-07-04',
+  editable: true,
+  template: { id: 9, slug: 'camper', name: 'Camper', version: 1 },
+  bunks: [
+    {
+      id: 1,
+      slug: 'pine',
+      name: 'Pine',
+      covered: 0,
+      total: 2,
+      campers: [
+        { id: 100, name: 'Avi L', preferred_name: 'Avi', first_name: 'Avi', last_initial: 'L', submitted: false, reflection_id: null, submitter: null, editable: false },
+        { id: 101, name: 'Beth M', preferred_name: 'Beth', first_name: 'Beth', last_initial: 'M', submitted: false, reflection_id: null, submitter: null, editable: false },
+      ],
+      off_camp: [
+        { id: 102, name: 'Carl N', preferred_name: 'Carl', first_name: 'Carl', last_initial: 'N' },
+      ],
+    },
+    {
+      id: 2,
+      slug: 'oak',
+      name: 'Oak',
+      covered: 0,
+      total: 1,
+      campers: [
+        { id: 200, name: 'Dana O', preferred_name: 'Dana', first_name: 'Dana', last_initial: 'O', submitted: false, reflection_id: null, submitter: null, editable: false },
+      ],
+      off_camp: [],
+    },
+  ],
+};
+
+const suggestionPayload = {
+  suggestions: [
+    { id: 'sug-1', label: 'Toothpaste', sort_order: 1 },
+    { id: 'sug-2', label: 'Sunscreen', sort_order: 2 },
+  ],
+};
+
+describe('CamperCareRequestFormPage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    postMock.mockReset();
+  });
+
+  function arrange(suggestions = suggestionPayload) {
+    getMock.mockImplementation((url) => {
+      if (url === '/api/v1/counselor/camper-reflections/') {
+        return Promise.resolve({ data: rosterPayload });
+      }
+      if (url === '/api/v1/counselor/camper-care-item-suggestions/') {
+        return Promise.resolve({ data: suggestions });
+      }
+      return Promise.reject(new Error(`Unmocked: ${url}`));
+    });
+  }
+
+  it('flattens the roster across bunks (including off-camp) into the picker', async () => {
+    arrange();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+    const options = Array.from(
+      screen.getByTestId('camper-care-subject').querySelectorAll('option'),
+    );
+    const labels = options.map((o) => o.textContent);
+    // Empty option + Avi/Beth/Carl in Pine + Dana in Oak. Alphabetical
+    // by bunk then by name; Pine comes before Oak in alpha, no — Oak
+    // < Pine. So Oak's Dana first.
+    expect(labels[0]).toMatch(/— bunk-wide/);
+    expect(labels.slice(1)).toEqual([
+      'Dana O (Oak)',
+      'Avi L (Pine)',
+      'Beth M (Pine)',
+      'Carl N (Pine)',
+    ]);
+  });
+
+  it('renders a datalist with the curated suggestions', async () => {
+    arrange();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+    const dl = document.getElementById('camper-care-item-options');
+    expect(dl).toBeTruthy();
+    const values = Array.from(dl.querySelectorAll('option')).map((o) => o.value);
+    expect(values).toEqual(['Toothpaste', 'Sunscreen']);
+  });
+
+  it('skips the datalist when no suggestions exist (free text only)', async () => {
+    arrange({ suggestions: [] });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+    expect(document.getElementById('camper-care-item-options')).toBeNull();
+    expect(screen.getByTestId('camper-care-item').hasAttribute('list')).toBe(false);
+  });
+
+  it('survives a suggestions endpoint error gracefully', async () => {
+    getMock.mockImplementation((url) => {
+      if (url === '/api/v1/counselor/camper-reflections/') {
+        return Promise.resolve({ data: rosterPayload });
+      }
+      return Promise.reject(new Error('boom'));
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+    expect(document.getElementById('camper-care-item-options')).toBeNull();
+  });
+
+  it('requires an item before submit', async () => {
+    arrange();
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+    // userEvent honors the `required` attr; remove it so we can test our
+    // own validation message.
+    const input = screen.getByTestId('camper-care-item');
+    input.removeAttribute('required');
+    await user.click(screen.getByTestId('camper-care-submit'));
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it('POSTs with stable client_submission_id and routes to the list', async () => {
+    arrange();
+    postMock.mockResolvedValue({ data: { id: 'order-1' }, status: 201 });
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+
+    await user.selectOptions(screen.getByTestId('camper-care-subject'), '100');
+    await user.type(screen.getByTestId('camper-care-item'), 'Toothpaste');
+    await user.type(screen.getByTestId('camper-care-item-note'), 'mint please');
+    await user.type(screen.getByTestId('camper-care-description'), 'whole bunk is out');
+    await user.click(screen.getByTestId('camper-care-submit'));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    const [url, body] = postMock.mock.calls[0];
+    expect(url).toBe('/api/v1/counselor/camper-care-requests/');
+    expect(body.subject_id).toBe(100);
+    expect(body.item).toBe('Toothpaste');
+    expect(body.item_note).toBe('mint please');
+    expect(body.description).toBe('whole bunk is out');
+    expect(typeof body.client_submission_id).toBe('string');
+    expect(body.client_submission_id.length).toBeGreaterThan(20);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('path-probe')).toHaveAttribute(
+        'data-pathname',
+        '/counselor/requests',
+      ),
+    );
+  });
+
+  it('omits subject_id for bunk-scoped requests', async () => {
+    arrange();
+    postMock.mockResolvedValue({ data: { id: 'order-2' }, status: 201 });
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+
+    await user.type(screen.getByTestId('camper-care-item'), 'Bug spray');
+    await user.click(screen.getByTestId('camper-care-submit'));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    const body = postMock.mock.calls[0][1];
+    expect(body).not.toHaveProperty('subject_id');
+  });
+
+  it('shows a 403 server message verbatim', async () => {
+    arrange();
+    postMock.mockRejectedValue({
+      response: { status: 403, data: { detail: 'Camper is not on any of your bunks.' } },
+    });
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+
+    await user.type(screen.getByTestId('camper-care-item'), 'X');
+    await user.click(screen.getByTestId('camper-care-submit'));
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-submit-error')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('camper-care-submit-error')).toHaveTextContent(
+      'Camper is not on any of your bunks.',
+    );
+  });
+
+  it('surfaces 400 field errors per-field', async () => {
+    arrange();
+    postMock.mockRejectedValue({
+      response: { status: 400, data: { item: ['This field is required.'] } },
+    });
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-form')).toBeInTheDocument(),
+    );
+    await user.type(screen.getByTestId('camper-care-item'), 'X');
+    await user.click(screen.getByTestId('camper-care-submit'));
+    await waitFor(() =>
+      expect(screen.getByTestId('camper-care-submit-error')).toBeInTheDocument(),
+    );
+    expect(screen.getByText('This field is required.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/counselor/__tests__/CounselorRequestsListPage.test.jsx
+++ b/frontend/src/pages/counselor/__tests__/CounselorRequestsListPage.test.jsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import CounselorRequestsListPage from '../CounselorRequestsListPage';
+
+const getMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+  },
+}));
+
+const samplePayload = {
+  requests: [
+    {
+      type: 'maintenance',
+      id: 'mt-1',
+      status: 'new',
+      status_label: 'New',
+      location: 'Bunk Pine',
+      category: 'leak',
+      category_label: 'Leak',
+      urgency: 'urgent',
+      urgency_label: 'Urgent',
+      description: 'under sink',
+      photo_count: 2,
+      submitter: { is_self: true, name: null },
+      submitted_at: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+    },
+    {
+      type: 'camper_care',
+      id: 'order-1',
+      status: 'in_progress',
+      status_label: 'In progress',
+      subject: { id: 100, name: 'Avi L' },
+      item: 'Toothpaste',
+      item_note: 'mint',
+      submitter: { is_self: false, name: 'Casey Q' },
+      submitted_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    },
+    {
+      type: 'camper_care',
+      id: 'order-2',
+      status: 'new',
+      status_label: 'New',
+      subject: null,
+      item: 'Bug spray',
+      item_note: '',
+      submitter: { is_self: true, name: null },
+      submitted_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+    },
+  ],
+};
+
+function renderPage(initialEntry = '/counselor/requests') {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <CounselorRequestsListPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('CounselorRequestsListPage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  it('fetches with status=open by default', async () => {
+    getMock.mockResolvedValue({ data: samplePayload });
+    renderPage();
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    expect(getMock.mock.calls[0]).toEqual([
+      '/api/v1/counselor/requests/',
+      { params: { status: 'open' } },
+    ]);
+  });
+
+  it('renders each request with type, status, and submitter info', async () => {
+    getMock.mockResolvedValue({ data: samplePayload });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('request-row-maintenance-mt-1')).toBeInTheDocument(),
+    );
+
+    const mt = screen.getByTestId('request-row-maintenance-mt-1');
+    expect(mt).toHaveAttribute('data-status', 'new');
+    expect(mt).toHaveAttribute('data-type', 'maintenance');
+    expect(mt.querySelector('[data-testid="request-urgency-badge"]')).toBeTruthy();
+    expect(mt).toHaveTextContent('Leak');
+    expect(mt).toHaveTextContent('Sent by you');
+    expect(mt).toHaveTextContent('2 photos');
+
+    const cc1 = screen.getByTestId('request-row-camper_care-order-1');
+    expect(cc1).toHaveTextContent('Toothpaste');
+    expect(cc1).toHaveTextContent('For Avi L');
+    expect(cc1).toHaveTextContent('Casey Q');
+    expect(cc1.querySelector('[data-testid="request-status-badge"]')).toHaveAttribute(
+      'data-status',
+      'in_progress',
+    );
+
+    const cc2 = screen.getByTestId('request-row-camper_care-order-2');
+    expect(cc2).toHaveTextContent('Bunk-wide request');
+  });
+
+  it('flips to status=all when the All filter is clicked', async () => {
+    const user = userEvent.setup();
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    getMock.mockResolvedValueOnce({ data: { requests: [] } });
+    renderPage();
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByTestId('requests-filter-all'));
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2));
+    expect(getMock.mock.calls[1][1].params.status).toBe('all');
+  });
+
+  it('seeds the filter from the URL ?status=all', async () => {
+    getMock.mockResolvedValue({ data: samplePayload });
+    renderPage('/counselor/requests?status=all');
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    expect(getMock.mock.calls[0][1].params.status).toBe('all');
+    expect(screen.getByTestId('requests-filter-all')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('renders empty-state copy when no rows', async () => {
+    getMock.mockResolvedValue({ data: { requests: [] } });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('requests-empty')).toBeInTheDocument());
+    expect(screen.getByTestId('requests-empty')).toHaveTextContent(/No open requests/i);
+  });
+
+  it('renders an error banner when fetch fails', async () => {
+    getMock.mockRejectedValue({ response: { status: 500, data: { detail: 'boom' } } });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('requests-error')).toBeInTheDocument());
+    expect(screen.getByTestId('requests-error')).toHaveTextContent('boom');
+  });
+
+  it('always exposes both new-request CTAs', async () => {
+    getMock.mockResolvedValue({ data: samplePayload });
+    renderPage();
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    expect(screen.getByTestId('requests-new-camper-care')).toHaveAttribute(
+      'href',
+      '/counselor/requests/camper-care/new',
+    );
+    expect(screen.getByTestId('requests-new-maintenance')).toHaveAttribute(
+      'href',
+      '/counselor/requests/maintenance/new',
+    );
+  });
+});

--- a/frontend/src/pages/counselor/__tests__/CounselorSelfReflectionHistoryPage.test.jsx
+++ b/frontend/src/pages/counselor/__tests__/CounselorSelfReflectionHistoryPage.test.jsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import CounselorSelfReflectionHistoryPage from '../CounselorSelfReflectionHistoryPage';
+
+const getMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+  },
+}));
+
+function payload(overrides = {}) {
+  return {
+    count: 60,
+    page: 1,
+    page_size: 14,
+    next: 2,
+    previous: null,
+    results: [
+      {
+        date: '2026-07-04',
+        submitted: true,
+        is_day_off: false,
+        reflection_id: 700,
+        submitted_at: '2026-07-04T20:00:00Z',
+        preview: 'A productive day with the bunk.',
+        editable: true,
+      },
+      {
+        date: '2026-07-03',
+        submitted: true,
+        is_day_off: true,
+        reflection_id: 699,
+        submitted_at: '2026-07-03T10:00:00Z',
+        preview: '',
+        editable: false,
+      },
+      {
+        date: '2026-07-02',
+        submitted: false,
+        is_day_off: false,
+        reflection_id: null,
+        submitted_at: null,
+        preview: '',
+        editable: false,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/counselor/self-reflection/history']}>
+      <CounselorSelfReflectionHistoryPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('CounselorSelfReflectionHistoryPage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  it('renders submitted, day-off, and missing rows distinctly', async () => {
+    getMock.mockResolvedValue({ data: payload() });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('history-row-2026-07-04')).toBeInTheDocument());
+
+    const submitted = screen.getByTestId('history-row-2026-07-04');
+    expect(submitted).toHaveAttribute('data-submitted', 'true');
+    expect(submitted).toHaveAttribute('data-day-off', 'false');
+    expect(screen.getByTestId('history-row-2026-07-04-preview')).toHaveTextContent(
+      'A productive day',
+    );
+
+    const dayOff = screen.getByTestId('history-row-2026-07-03');
+    expect(dayOff).toHaveAttribute('data-day-off', 'true');
+    expect(dayOff.querySelector('[data-testid="row-badge-day-off"]')).toBeTruthy();
+
+    const missing = screen.getByTestId('history-row-2026-07-02');
+    expect(missing).toHaveAttribute('data-submitted', 'false');
+    expect(missing.querySelector('[data-testid="row-badge-missing"]')).toBeTruthy();
+  });
+
+  it('points today (editable) at the edit URL and past rows at the read-only viewer', async () => {
+    getMock.mockResolvedValue({ data: payload() });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('history-row-2026-07-04-link')).toBeInTheDocument());
+
+    expect(screen.getByTestId('history-row-2026-07-04-link')).toHaveAttribute(
+      'href',
+      '/counselor/self-reflection/700/edit',
+    );
+    expect(screen.getByTestId('history-row-2026-07-04-link')).toHaveTextContent('Edit');
+
+    expect(screen.getByTestId('history-row-2026-07-03-link')).toHaveAttribute(
+      'href',
+      '/reflections/699',
+    );
+    expect(screen.getByTestId('history-row-2026-07-03-link')).toHaveTextContent('View');
+
+    // Missing rows shouldn't render any link.
+    expect(screen.queryByTestId('history-row-2026-07-02-link')).toBeNull();
+  });
+
+  it('paginates forward and backward via the API', async () => {
+    const user = userEvent.setup();
+    getMock.mockResolvedValueOnce({ data: payload() });
+    getMock.mockResolvedValueOnce({
+      data: payload({ page: 2, previous: 1, next: 3, results: [] }),
+    });
+    getMock.mockResolvedValueOnce({ data: payload() });
+    renderPage();
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByTestId('history-next'));
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2));
+    expect(getMock.mock.calls[1][1].params).toEqual({ page: 2 });
+
+    await user.click(screen.getByTestId('history-prev'));
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(3));
+    expect(getMock.mock.calls[2][1].params).toEqual({ page: 1 });
+  });
+
+  it('disables prev on page 1 and next on the last page', async () => {
+    getMock.mockResolvedValue({
+      data: payload({ next: null, previous: null }),
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('history-prev')).toBeInTheDocument());
+    expect(screen.getByTestId('history-prev')).toBeDisabled();
+    expect(screen.getByTestId('history-next')).toBeDisabled();
+  });
+
+  it('renders the empty state when results are empty', async () => {
+    getMock.mockResolvedValue({
+      data: { count: 0, page: 1, page_size: 14, next: null, previous: null, results: [] },
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('history-empty')).toBeInTheDocument());
+  });
+
+  it('shows an error banner on API failure', async () => {
+    getMock.mockRejectedValue({ response: { status: 500, data: { detail: 'boom' } } });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('history-error')).toBeInTheDocument());
+    expect(screen.getByTestId('history-error')).toHaveTextContent('boom');
+  });
+});

--- a/frontend/src/pages/counselor/__tests__/CounselorSelfReflectionPage.test.jsx
+++ b/frontend/src/pages/counselor/__tests__/CounselorSelfReflectionPage.test.jsx
@@ -1,0 +1,382 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import CounselorSelfReflectionPage from '../CounselorSelfReflectionPage';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+const patchMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: (...args) => postMock(...args),
+    patch: (...args) => patchMock(...args),
+  },
+}));
+
+function PathProbe() {
+  const loc = useLocation();
+  return (
+    <div data-testid="path-probe" data-pathname={loc.pathname}>
+      probe: {loc.pathname}
+    </div>
+  );
+}
+
+const selfTemplate = {
+  id: 9,
+  name: 'Counselor Self-Reflection',
+  slug: 'counselor-self-reflection',
+  version: 1,
+  languages: ['en', 'es'],
+  supports_privacy: false,
+  schema: {
+    fields: [
+      {
+        key: 'day_off',
+        type: 'yes_no',
+        required: false,
+        prompts: { en: 'Are you taking a day off today?' },
+      },
+      {
+        key: 'overall_day',
+        type: 'single_rating',
+        required: false,
+        scale: [1, 5],
+        scale_labels: { en: ['Difficult', 'Tough', 'OK', 'Good', 'Great'] },
+        prompts: { en: 'How was today overall?' },
+      },
+      {
+        key: 'wins',
+        type: 'text_list',
+        required: false,
+        min_items: 1,
+        max_items: 3,
+        prompts: { en: 'What went well?' },
+      },
+      {
+        key: 'concern',
+        type: 'textarea',
+        required: false,
+        prompts: { en: 'Anything to flag?' },
+      },
+    ],
+  },
+};
+
+const dashboardNoSubmission = {
+  today: '2026-07-04',
+  sections: {
+    self_reflection: {
+      state: 'none',
+      submitted: false,
+      reflection_id: null,
+      template: {
+        id: 9,
+        slug: 'counselor-self-reflection',
+        name: 'Counselor Self-Reflection',
+        version: 1,
+      },
+    },
+  },
+};
+
+function renderCreate() {
+  return render(
+    <MemoryRouter initialEntries={['/counselor/self-reflection']}>
+      <Routes>
+        <Route path="/counselor/self-reflection" element={<CounselorSelfReflectionPage />} />
+        <Route
+          path="/counselor/self-reflection/:reflectionId/edit"
+          element={<CounselorSelfReflectionPage />}
+        />
+        <Route path="/counselor" element={<PathProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function renderEdit(reflectionId = 501) {
+  return render(
+    <MemoryRouter initialEntries={[`/counselor/self-reflection/${reflectionId}/edit`]}>
+      <Routes>
+        <Route
+          path="/counselor/self-reflection/:reflectionId/edit"
+          element={<CounselorSelfReflectionPage />}
+        />
+        <Route path="/counselor" element={<PathProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('CounselorSelfReflectionPage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    postMock.mockReset();
+    patchMock.mockReset();
+  });
+
+  describe('create mode', () => {
+    function arrangeCreate() {
+      // First call: dashboard fetch (to discover the template + existing reflection)
+      getMock.mockResolvedValueOnce({ data: dashboardNoSubmission });
+      // Second call: template-by-id fetch
+      getMock.mockResolvedValueOnce({ data: selfTemplate });
+    }
+
+    it('loads the template via dashboard + template-by-id and renders the schema', async () => {
+      arrangeCreate();
+      renderCreate();
+      await waitFor(() => expect(screen.getByText('How was today overall?')).toBeInTheDocument());
+      expect(screen.getByText('What went well?')).toBeInTheDocument();
+      expect(screen.getByText('Anything to flag?')).toBeInTheDocument();
+
+      // The day_off field should NOT render inside the schema area;
+      // it's elevated to the prominent toggle at top.
+      const schemaArea = screen.queryByTestId('reflect-input-day_off');
+      expect(schemaArea).toBeNull();
+      expect(screen.getByTestId('self-reflection-day-off-toggle')).toBeInTheDocument();
+    });
+
+    it('shows the audience disclosure with the canonical self-reflection labels', async () => {
+      arrangeCreate();
+      renderCreate();
+      await waitFor(() => expect(screen.getByTestId('audience-disclosure')).toBeInTheDocument());
+      expect(screen.getByTestId('audience-disclosure-labels')).toHaveTextContent(
+        'Admin, Counselor, Leadership Team, Unit Head',
+      );
+    });
+
+    it('toggling day-off hides the schema fields and changes the submit label', async () => {
+      const user = userEvent.setup();
+      arrangeCreate();
+      renderCreate();
+      await waitFor(() => expect(screen.getByText('How was today overall?')).toBeInTheDocument());
+
+      await user.click(screen.getByTestId('self-reflection-day-off-toggle'));
+
+      expect(screen.queryByText('How was today overall?')).toBeNull();
+      expect(screen.queryByText('What went well?')).toBeNull();
+      expect(screen.getByTestId('self-reflection-submit')).toHaveTextContent(/Mark day off/i);
+    });
+
+    it('POSTs the day-off shortcut payload when toggle is on', async () => {
+      const user = userEvent.setup();
+      arrangeCreate();
+      postMock.mockResolvedValue({ data: { id: 600 }, status: 201 });
+      renderCreate();
+      await waitFor(() => expect(screen.getByText('How was today overall?')).toBeInTheDocument());
+
+      await user.click(screen.getByTestId('self-reflection-day-off-toggle'));
+      await user.click(screen.getByTestId('self-reflection-submit'));
+
+      await waitFor(() => expect(postMock).toHaveBeenCalled());
+      const [url, body] = postMock.mock.calls[0];
+      expect(url).toBe('/api/v1/counselor/self-reflection/');
+      expect(body.day_off).toBe(true);
+      expect(body).not.toHaveProperty('answers');
+      expect(typeof body.client_submission_id).toBe('string');
+
+      await waitFor(() => expect(screen.getByTestId('path-probe')).toHaveAttribute(
+        'data-pathname',
+        '/counselor',
+      ));
+    });
+
+    it('POSTs a full payload when day-off is off and fields are filled', async () => {
+      const user = userEvent.setup();
+      arrangeCreate();
+      postMock.mockResolvedValue({ data: { id: 601 }, status: 201 });
+      renderCreate();
+      await waitFor(() => expect(screen.getByText('How was today overall?')).toBeInTheDocument());
+
+      // Pick a rating
+      const ratingButtons = screen.getAllByRole('button', { name: '4' });
+      await user.click(ratingButtons[0]);
+
+      // Fill at least one win
+      const wins = screen.getAllByRole('textbox');
+      await user.type(wins[0], 'lunchtime activity');
+
+      await user.click(screen.getByTestId('self-reflection-submit'));
+      await waitFor(() => expect(postMock).toHaveBeenCalled());
+
+      const body = postMock.mock.calls[0][1];
+      expect(body.day_off).toBe(false);
+      expect(body.answers.overall_day).toBe(4);
+      expect(body.answers.wins).toEqual(expect.arrayContaining(['lunchtime activity']));
+    });
+
+    it('redirects to the edit URL when a reflection already exists for today', async () => {
+      // Dashboard reports a submitted reflection for today.
+      getMock.mockResolvedValueOnce({
+        data: {
+          today: '2026-07-04',
+          sections: {
+            self_reflection: {
+              state: 'complete',
+              submitted: true,
+              reflection_id: 777,
+              template: {
+                id: 9,
+                slug: 'counselor-self-reflection',
+                name: 'Counselor Self-Reflection',
+                version: 1,
+              },
+            },
+          },
+        },
+      });
+      // After redirect, the edit branch loads the reflection + template.
+      getMock.mockResolvedValueOnce({
+        data: {
+          id: 777,
+          template: 9,
+          subject: 1,
+          author: 1,
+          answers: { overall_day: 3 },
+          language: 'en',
+          team_visibility: 'team',
+        },
+      });
+      getMock.mockResolvedValueOnce({ data: selfTemplate });
+
+      renderCreate();
+
+      await waitFor(() => expect(getMock).toHaveBeenCalledTimes(3));
+      // Final page renders edit form
+      await waitFor(() => expect(screen.getByTestId('self-reflection-submit')).toBeInTheDocument());
+      expect(screen.getByTestId('self-reflection-submit')).toHaveTextContent(/Save changes/i);
+    });
+
+    it('shows a load error when no self template is configured', async () => {
+      getMock.mockResolvedValueOnce({
+        data: {
+          today: '2026-07-04',
+          sections: {
+            self_reflection: {
+              state: 'complete',
+              submitted: false,
+              reflection_id: null,
+              template: null,
+            },
+          },
+        },
+      });
+      renderCreate();
+      await waitFor(() =>
+        expect(screen.getByTestId('self-reflection-load-error')).toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe('edit mode', () => {
+    const existing = {
+      id: 501,
+      template: 9,
+      template_meta: { id: 9, slug: 'counselor-self-reflection', name: 'Counselor Self-Reflection', version: 1 },
+      answers: { overall_day: 3, wins: ['nice morning'], concern: '' },
+      language: 'en',
+      subject: 1,
+      author: 1,
+      team_visibility: 'team',
+    };
+
+    function arrangeEdit(reflection = existing, template = selfTemplate) {
+      getMock.mockResolvedValueOnce({ data: reflection });
+      getMock.mockResolvedValueOnce({ data: template });
+    }
+
+    it('prefills existing answers and language', async () => {
+      arrangeEdit();
+      renderEdit();
+      await waitFor(() => expect(screen.getByText('How was today overall?')).toBeInTheDocument());
+      const wins = screen.getAllByRole('textbox');
+      expect(wins[0]).toHaveValue('nice morning');
+    });
+
+    it('detects day-off state in an existing reflection and pre-toggles', async () => {
+      arrangeEdit({
+        ...existing,
+        answers: { day_off: true },
+      });
+      renderEdit();
+      await waitFor(() => expect(screen.getByTestId('self-reflection-day-off-toggle')).toBeChecked());
+      expect(screen.queryByText('How was today overall?')).toBeNull();
+    });
+
+    it('PATCHes the day-off flip when the user toggles it on', async () => {
+      const user = userEvent.setup();
+      arrangeEdit();
+      patchMock.mockResolvedValue({ data: { id: 501 } });
+      renderEdit();
+      await waitFor(() => expect(screen.getByText('How was today overall?')).toBeInTheDocument());
+
+      await user.click(screen.getByTestId('self-reflection-day-off-toggle'));
+      await user.click(screen.getByTestId('self-reflection-submit'));
+
+      await waitFor(() => expect(patchMock).toHaveBeenCalled());
+      const [url, body] = patchMock.mock.calls[0];
+      expect(url).toBe('/api/v1/counselor/self-reflection/501/');
+      expect(body.day_off).toBe(true);
+      expect(body).not.toHaveProperty('answers');
+    });
+
+    it('PATCHes answers + language when the user edits without toggling day-off', async () => {
+      const user = userEvent.setup();
+      arrangeEdit();
+      patchMock.mockResolvedValue({ data: { id: 501 } });
+      renderEdit();
+      await waitFor(() => expect(screen.getByText('How was today overall?')).toBeInTheDocument());
+
+      const wins = screen.getAllByRole('textbox');
+      await user.clear(wins[0]);
+      await user.type(wins[0], 'updated win');
+
+      await user.click(screen.getByTestId('self-reflection-submit'));
+      await waitFor(() => expect(patchMock).toHaveBeenCalled());
+      const body = patchMock.mock.calls[0][1];
+      expect(body.day_off).toBe(false);
+      expect(body.answers.wins).toEqual(expect.arrayContaining(['updated win']));
+      expect(body.language).toBe('en');
+    });
+
+    it('surfaces a 403 edit-window-closed response verbatim', async () => {
+      const user = userEvent.setup();
+      arrangeEdit();
+      patchMock.mockRejectedValue({
+        response: {
+          status: 403,
+          data: {
+            detail: 'This reflection can no longer be edited (the edit window has closed).',
+          },
+        },
+      });
+      renderEdit();
+      await waitFor(() => expect(screen.getByText('How was today overall?')).toBeInTheDocument());
+
+      const wins = screen.getAllByRole('textbox');
+      await user.clear(wins[0]);
+      await user.type(wins[0], 'too late');
+      await user.click(screen.getByTestId('self-reflection-submit'));
+      await waitFor(() => expect(screen.getByTestId('self-reflection-submit-error')).toBeInTheDocument());
+      expect(screen.getByTestId('self-reflection-submit-error')).toHaveTextContent(
+        /edit window has closed/i,
+      );
+    });
+
+    it('renders 404 friendly text when the reflection is gone', async () => {
+      getMock.mockRejectedValueOnce({ response: { status: 404, data: { detail: 'not found' } } });
+      renderEdit();
+      await waitFor(() =>
+        expect(screen.getByTestId('self-reflection-load-error')).toBeInTheDocument(),
+      );
+      expect(screen.getByTestId('self-reflection-load-error')).toHaveTextContent(
+        /Reflection not found/i,
+      );
+    });
+  });
+});

--- a/frontend/src/pages/counselor/__tests__/MaintenanceTicketFormPage.test.jsx
+++ b/frontend/src/pages/counselor/__tests__/MaintenanceTicketFormPage.test.jsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import MaintenanceTicketFormPage from '../MaintenanceTicketFormPage';
+
+const postMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    post: (...args) => postMock(...args),
+  },
+}));
+
+function PathProbe() {
+  const loc = useLocation();
+  return <div data-testid="path-probe" data-pathname={loc.pathname} />;
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/counselor/requests/maintenance/new']}>
+      <Routes>
+        <Route
+          path="/counselor/requests/maintenance/new"
+          element={<MaintenanceTicketFormPage />}
+        />
+        <Route path="/counselor/requests" element={<PathProbe />} />
+        <Route path="/counselor" element={<PathProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// jsdom's URL doesn't ship createObjectURL out of the box.
+beforeEach(() => {
+  if (!URL.createObjectURL) {
+    URL.createObjectURL = vi.fn(() => 'blob:mocked');
+  } else {
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mocked');
+  }
+  if (!URL.revokeObjectURL) {
+    URL.revokeObjectURL = vi.fn();
+  } else {
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+  }
+});
+
+describe('MaintenanceTicketFormPage', () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it('renders the category options and defaults urgency to normal', () => {
+    renderPage();
+    const categoryOptions = Array.from(
+      screen.getByTestId('maintenance-category').querySelectorAll('option'),
+    ).map((o) => o.value);
+    expect(categoryOptions).toEqual([
+      '', 'plumbing', 'broken_light', 'pest', 'leak', 'other',
+    ]);
+    expect(screen.getByTestId('maintenance-urgency-normal')).toBeChecked();
+    expect(screen.getByTestId('maintenance-urgency-urgent')).not.toBeChecked();
+    // Urgent reason field is hidden initially.
+    expect(screen.queryByTestId('maintenance-urgent-reason')).toBeNull();
+  });
+
+  it('reveals the urgent_reason textarea when urgency flips to urgent', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByTestId('maintenance-urgency-urgent'));
+    expect(screen.getByTestId('maintenance-urgent-reason')).toBeInTheDocument();
+  });
+
+  it('blocks submit when urgent_reason missing on an urgent ticket', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    // Bypass HTML `required` so we can hit our own validation path.
+    screen.getByTestId('maintenance-location').removeAttribute('required');
+    screen.getByTestId('maintenance-category').removeAttribute('required');
+
+    await user.type(screen.getByTestId('maintenance-location'), 'Bunk Pine');
+    await user.selectOptions(screen.getByTestId('maintenance-category'), 'leak');
+    await user.click(screen.getByTestId('maintenance-urgency-urgent'));
+    await user.click(screen.getByTestId('maintenance-submit'));
+
+    expect(postMock).not.toHaveBeenCalled();
+    expect(screen.getByText('Required when this is urgent.')).toBeInTheDocument();
+  });
+
+  it('attaches photos and previews them with remove affordance', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const file = new File(['data'], 'shower.jpg', { type: 'image/jpeg' });
+    const input = screen.getByTestId('maintenance-photo-input');
+    await user.upload(input, file);
+
+    expect(screen.getAllByTestId('maintenance-photo-tile')).toHaveLength(1);
+    await user.click(screen.getByTestId('maintenance-photo-remove'));
+    expect(screen.queryByTestId('maintenance-photo-tile')).toBeNull();
+  });
+
+  it('POSTs multipart with photos + urgent_reason and routes to the list', async () => {
+    postMock.mockResolvedValue({ data: { id: 'mt-1' }, status: 201 });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByTestId('maintenance-location'), 'Bunk Pine');
+    await user.selectOptions(screen.getByTestId('maintenance-category'), 'leak');
+    await user.click(screen.getByTestId('maintenance-urgency-urgent'));
+    await user.type(screen.getByTestId('maintenance-urgent-reason'), 'flooding');
+    await user.type(screen.getByTestId('maintenance-description'), 'under sink');
+
+    const file1 = new File(['x'], 'p1.jpg', { type: 'image/jpeg' });
+    const file2 = new File(['y'], 'p2.jpg', { type: 'image/jpeg' });
+    await user.upload(screen.getByTestId('maintenance-photo-input'), [file1, file2]);
+
+    await user.click(screen.getByTestId('maintenance-submit'));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    const [url, body, config] = postMock.mock.calls[0];
+    expect(url).toBe('/api/v1/counselor/maintenance-tickets/');
+    expect(body).toBeInstanceOf(FormData);
+    expect(body.get('location')).toBe('Bunk Pine');
+    expect(body.get('category')).toBe('leak');
+    expect(body.get('urgency')).toBe('urgent');
+    expect(body.get('urgent_reason')).toBe('flooding');
+    expect(body.get('description')).toBe('under sink');
+    expect(body.getAll('photos')).toHaveLength(2);
+    expect(typeof body.get('client_submission_id')).toBe('string');
+    expect(config).toEqual({ headers: { 'Content-Type': undefined } });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('path-probe')).toHaveAttribute(
+        'data-pathname',
+        '/counselor/requests',
+      ),
+    );
+  });
+
+  it('surfaces a 400 field error from the server', async () => {
+    postMock.mockRejectedValue({
+      response: { status: 400, data: { urgent_reason: ['Required when urgency is urgent.'] } },
+    });
+    const user = userEvent.setup();
+    renderPage();
+    await user.type(screen.getByTestId('maintenance-location'), 'X');
+    await user.selectOptions(screen.getByTestId('maintenance-category'), 'leak');
+    await user.click(screen.getByTestId('maintenance-urgency-urgent'));
+    await user.type(screen.getByTestId('maintenance-urgent-reason'), 'something');
+    await user.click(screen.getByTestId('maintenance-submit'));
+    await waitFor(() =>
+      expect(screen.getByTestId('maintenance-submit-error')).toBeInTheDocument(),
+    );
+    expect(screen.getByText('Required when urgency is urgent.')).toBeInTheDocument();
+  });
+});

--- a/migration_prompts/7_6_counselor_flow.md
+++ b/migration_prompts/7_6_counselor_flow.md
@@ -33,6 +33,8 @@
     1. Backend: tests per acceptance criterion for each story. Particular attention to: cross-counselor edit accountability (Story 4 criteria 3, 5); all-set state derivation (Story 9 criterion 5).
     2. Frontend: Vitest tests for dashboard rendering, state transitions, form submissions. Playwright or Cypress end-to-end tests for the "submit camper reflection → return to list with state updated" flow.
 13. Documentation: `docs/role_flows/counselor.md` developer-facing reference.
+14. Step 7_6g (dual-write + backfill bridge): see `docs/role_flows/counselor.md` §2.
+    Ships in phases — dual-write defaults on; backfill is a one-off `python manage.py backfill_counselor_logs --apply` once the bridge is live. Both paths share the same deterministic UUID5 idempotency key, so any order of operations converges on the same Reflection rows.
 
 **Out of scope:**
 


### PR DESCRIPTION
## Summary

Step 7_6g of the counselor flow: connect the legacy ``bunklogs.StaffLog`` (a.k.a. ``CounselorLog`` proxy) store to the new ``core.Reflection`` model that powers the mobile counselor UI from 7_6a-7_6f. Both directions go through one mapper, both use a deterministic ``client_submission_id`` UUID5 derivation, so backfill replays and post_save signal firings are idempotent and converge on the same Reflection row.

This unblocks the rollout plan: ship dual-write first (this PR), one-off backfill after merge, then a future PR deprecates the legacy admin form once the new flow has been live for a session.

## What's new

### Bridge mapper (``api/counselor/legacy_mapping.py``)
- Projects the eight legacy ``StaffLog`` fields onto the five-field counselor self-reflection schema.
- Extra legacy fields (``support_level_score``, ``values_reflection``, ``staff_care_support_needed``) are stored under extra ``answers`` keys so nothing is lost; provenance via ``_legacy_staff_log_id``.
- Idempotency: ``uuid5(NAMESPACE, ""stafflog:{id}"")`` derived ``client_submission_id`` makes re-runs no-ops via the existing ``(program, client_submission_id)`` unique constraint.
- Emits audit events on create/edit so dashboards keep attribution.

### Backfill management command (``core/management/commands/backfill_counselor_logs.py``)
- Defaults to dry-run; ``--apply`` to write.
- Filters: ``--since``, ``--until``, ``--user-id``, ``--batch-size``, ``--no-audit``.
- Prints created/updated/unchanged/skipped counts and lists skip reasons (``no_person_for_user``, ``no_active_counselor_membership``, ``no_counselor_template_configured``).

### Dual-write signal (``bunklogs/signals.py``)
- ``post_save`` receiver on ``StaffLog`` fires the mapper via ``transaction.on_commit`` so failures never produce orphan Reflection rows.
- Best-effort: exceptions in the mapper are swallowed and logged at WARNING — the legacy admin path is never blocked by the bridge.
- Kill-switch: ``settings.BUNKLOGS_DUAL_WRITE_REFLECTION = False`` disables the bridge.

### Tests
- ``test_counselor_legacy_bridge.py`` (17 cases): field mapping incl. day-off & junior_counselor; idempotency on re-run; update path; skip reasons; command dry-run/apply/replay/date-range/skip-reporting; signal on-commit/update/kill-switch/best-effort.
- ``api/tests/conftest.py``: autouse fixture re-seeds the counselor self-reflection template so ``@django_db(transaction=True)`` flushes don't cascade into ""no template"" 403s in unrelated tests.

### Docs
- ``docs/role_flows/counselor.md``: developer-facing reference for the whole 7_6 surface (endpoints, frontend routes, bridge mechanics, mapping table, three-phase rollout plan, troubleshooting).
- ``migration_prompts/7_6_counselor_flow.md``: §14 pointer to the bridge story.

## Test plan

- [x] ``test_counselor_legacy_bridge.py`` — 17/17 pass
- [x] ``bunk_logs/api/tests/`` — 333/333 pass
- [x] Full backend suite — 875 passed, 1 pre-existing failure (``test_translation::TestBeatRegistration``; fails on the parent branch too — celery beat migration quirk unrelated to this PR)
- [x] ``ruff check`` clean on the new files
- [ ] Phase-2 backfill on the prod snapshot (manual; do once dual-write is verified live)
- [ ] Render shell: ``python manage.py backfill_counselor_logs --apply --batch-size 200``

## Stacked on

This PR is stacked on ``feat/7_6f_counselor_requests`` (#78). Merge that first.

## Out of scope

- Phase 3 deprecation of the legacy form (separate PR after one camp session of cooldown).
- Frontend changes — the bridge is server-side only; the new mobile UI continues to write Reflection directly.


Made with [Cursor](https://cursor.com)