### PR TITLE
7_7a: Unit Head backend (Stories 10-17) — supervision-driven dashboard, bunk + camper drill-downs, self-reflection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,3 +215,29 @@ BunkLogs is mid-way through a **Strangler Fig migration** from a single-tenant d
 **Canonical context document**: [`migration_prompts/0_0_context_prompt.md`](migration_prompts/0_0_context_prompt.md)
 
 **Ordered prompt sequence**: [`migration_prompts/`](migration_prompts/) — numbered files `1_1` through `6_3` define the full migration roadmap in execution order.
+
+## Migration step execution: lean by default
+
+Migration prompts enumerate every acceptance criterion, but **lean is the default execution mode**. Do not slice a single step into more than 1-2 PRs unless explicitly asked.
+
+**Lean mode (default):**
+- One PR per step, grouping backend + frontend + tests together. Two PRs only when the diff genuinely exceeds reviewability (~1500 lines) or when backend changes must deploy before frontend.
+- Test coverage: one happy-path, one auth/permission, one critical-edge per endpoint. Skip exhaustive per-acceptance-criterion tests unless the logic is genuinely tricky.
+- Docstrings: 5-10 lines max per module — what, why, key invariant. No long mapping tables or rationale essays in code.
+- Frontend tests: one integration-style test per page over many `vi.mock`-heavy unit tests. Skip tests that only verify "axios got called with X".
+- Skip per-role `docs/role_flows/<role>.md` files unless asked.
+- i18n: inline English for new copy. Defer `t()` wrapping to a single dedicated PR per role.
+- Don't write a backfill/dual-write bridge for new role flows that have no legacy data. Bridges are only warranted when Crane Lake's existing tables hold rows that need preserving.
+
+**Full mode (only when explicitly asked, OR when the change touches one of these):**
+- Schema migrations on tables with existing production data
+- Auth, tenancy, or `OrgScopedManager` / `organization_context` boundaries
+- Strangler-fig bridges between legacy and new models (any code that reads or writes both stores)
+- Anything that could silently corrupt Crane Lake's existing data
+
+**When ambiguous:** if a step looks like it might warrant full mode but isn't obviously in one of the trigger categories above, ask "lean or full?" before starting — don't default to full.
+
+**Don't:**
+- Re-explore the same files at the start of every sub-task. Spot-check only the files you're about to edit.
+- Add code comments that re-explain what the migration prompt already says.
+- Write tests for trivial wiring (e.g. "constants array has N entries").

--- a/backend/bunk_logs/api/dashboards/subject.py
+++ b/backend/bunk_logs/api/dashboards/subject.py
@@ -43,35 +43,11 @@ def _parse_date(s: str | None, default: date) -> date:
         return default
 
 
-def _resolve_rating(field: dict, answers: dict) -> dict[str, float | None]:
-    """Pull numeric ratings out of an answers blob for a given schema field.
-
-    Returns a flat dict ``{label: value}`` — for ``single_rating`` a single
-    entry under the field key, for ``rating_group`` one entry per category
-    keyed as ``"<field_key>__<cat_key>"``.
-    """
-    ftype = field.get("type")
-    fkey = field.get("key")
-    out: dict[str, float | None] = {}
-    if ftype == "single_rating":
-        v = answers.get(fkey)
-        if isinstance(v, (int, float)) and not isinstance(v, bool):
-            out[fkey] = float(v)
-        else:
-            out[fkey] = None
-    elif ftype == "rating_group":
-        block = answers.get(fkey) if isinstance(answers.get(fkey), dict) else {}
-        for cat in field.get("categories") or []:
-            ck = cat.get("key") if isinstance(cat, dict) else None
-            if ck is None:
-                continue
-            v = block.get(ck) if isinstance(block, dict) else None
-            label = f"{fkey}__{ck}"
-            if isinstance(v, (int, float)) and not isinstance(v, bool):
-                out[label] = float(v)
-            else:
-                out[label] = None
-    return out
+# Re-export the canonical helper from ``core.reflection_scores`` so existing
+# call sites in this module keep working without touching the rest of the
+# file. New callers should import directly from
+# ``bunk_logs.core.reflection_scores``.
+from bunk_logs.core.reflection_scores import resolve_rating_cells as _resolve_rating
 
 
 def _detect_concerning_patterns(

--- a/backend/bunk_logs/api/dashboards/trends.py
+++ b/backend/bunk_logs/api/dashboards/trends.py
@@ -42,53 +42,11 @@ def _date_range(start: date, end: date) -> list[date]:
     return [start + timedelta(days=i) for i in range(days + 1)]
 
 
-def _scale_max(field: dict) -> int:
-    scale = field.get("scale") or [1, 5]
-    try:
-        return int(scale[-1])
-    except (IndexError, ValueError, TypeError):
-        return 5
-
-
-def _find_field(template: ReflectionTemplate, role: str) -> dict | None:
-    for f in (template.schema or {}).get("fields") or []:
-        if isinstance(f, dict) and f.get("dashboard_role") == role:
-            return f
-    return None
-
-
-def _rating_from_answer(
-    answers: dict,
-    primary: dict | None,
-    category: dict | None,
-    category_key: str | None,
-) -> float | None:
-    """Resolve a single numeric rating for a reflection's answers."""
-    if primary is not None:
-        v = answers.get(primary.get("key"))
-        if isinstance(v, (int, float)) and not isinstance(v, bool):
-            return float(v)
-    if category is not None:
-        block = answers.get(category.get("key"))
-        if not isinstance(block, dict):
-            return None
-        if category_key:
-            v = block.get(category_key)
-            if isinstance(v, (int, float)) and not isinstance(v, bool):
-                return float(v)
-            return None
-        # Average across all configured categories
-        vals: list[float] = []
-        for cat in category.get("categories") or []:
-            ck = cat.get("key") if isinstance(cat, dict) else None
-            if ck is None:
-                continue
-            v = block.get(ck)
-            if isinstance(v, (int, float)) and not isinstance(v, bool):
-                vals.append(float(v))
-        if vals:
-            return sum(vals) / len(vals)
-    return None
+# Re-export from ``core.reflection_scores`` (module-local aliases keep the
+# existing call sites stable while pointing newcomers at the shared home).
+from bunk_logs.core.reflection_scores import find_field_by_dashboard_role as _find_field
+from bunk_logs.core.reflection_scores import reduce_rating as _rating_from_answer
+from bunk_logs.core.reflection_scores import scale_max as _scale_max
 
 
 class SubjectTrendGridView(APIView):

--- a/backend/bunk_logs/api/tests/conftest.py
+++ b/backend/bunk_logs/api/tests/conftest.py
@@ -41,6 +41,32 @@ _COUNSELOR_SELF_REFLECTION_SCHEMA = {
         {"key": "wins", "type": "text_list", "required": False},
         {"key": "improvements", "type": "text_list", "required": False},
         {"key": "concern", "type": "textarea", "required": False},
+        # Bunk-concerns surface (UH2 / Step 7_7). Counselors can flag
+        # specific bunks via this multi-select; the UH bunk dashboard
+        # consumes those references.
+        {
+            "key": "bunk_concerns_bunks",
+            "type": "multiple_choice",
+            "required": False,
+            "option_source": "supervised_bunks",
+        },
+    ],
+}
+
+_UNIT_HEAD_SELF_REFLECTION_SCHEMA = {
+    "fields": [
+        {"key": "day_off", "type": "yes_no", "required": False},
+        {"key": "overall_day", "type": "single_rating", "required": False, "scale": [1, 5]},
+        {"key": "wins", "type": "text_list", "required": False},
+        {"key": "improvements", "type": "text_list", "required": False},
+        {"key": "concern", "type": "textarea", "required": False},
+        {
+            "key": "bunk_concerns_bunks",
+            "type": "multiple_choice",
+            "required": False,
+            "option_source": "supervised_bunks",
+        },
+        {"key": "bunk_concerns_note", "type": "textarea", "required": False},
     ],
 }
 
@@ -74,6 +100,41 @@ def _ensure_counselor_self_reflection_template(db):
             "subject_visible": False,
             "supports_privacy": False,
             "role": "counselor",
+            "program_type": None,
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def _ensure_unit_head_self_reflection_template(db):
+    """Re-seed the UH self-reflection template before every test (Step 7_7).
+
+    Same rationale as the counselor seed; ``transaction=True`` tests
+    flush the seeded migration row otherwise. Keeping the schema list
+    aligned with the production migration ``core/0030`` is the test
+    author's responsibility — anything materially different should
+    land in BOTH places at once.
+    """
+    ReflectionTemplate.all_objects.update_or_create(
+        organization=None,
+        slug="unit-head-self-reflection",
+        version=1,
+        defaults={
+            "name": "Unit Head Self-Reflection",
+            "description": "Auto-seeded for tests via api/tests/conftest.py.",
+            "cadence": "daily",
+            "schema": _UNIT_HEAD_SELF_REFLECTION_SCHEMA,
+            "languages": ["en", "es"],
+            "is_active": True,
+            "subject_mode": "self",
+            "assignment_scope": "none",
+            "assignment_group_types": [],
+            "author_role_filter": ["unit_head"],
+            "subject_role_filter": [],
+            "required_per_subject_per_period": 1,
+            "subject_visible": False,
+            "supports_privacy": False,
+            "role": "unit_head",
             "program_type": None,
         },
     )

--- a/backend/bunk_logs/api/tests/test_unit_head_endpoints.py
+++ b/backend/bunk_logs/api/tests/test_unit_head_endpoints.py
@@ -1,0 +1,918 @@
+"""Tests for ``/api/v1/unit-head/*`` (Step 7_7, Stories 10-17).
+
+Covers supervision-driven bunk resolution, attention badges, score
+grid, bunk-concerns surfacing, camper-dashboard ranges + visibility,
+self-reflection write + history, and the supervision permission gate
+on every endpoint.
+
+Visibility specifics (sensitive note exclusion, edit-window 403s,
+template fall-back) live in their own focused module tests; here we
+focus on the UH-specific composition.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from datetime import datetime
+from datetime import timedelta
+from uuid import uuid4
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import CamperDayState
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Note
+from bunk_logs.core.models import Order
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.models import Supervision
+from bunk_logs.core.state_machine import OrderStateMachine
+
+User = get_user_model()
+
+
+CAMPER_REFLECTION_SCHEMA = {
+    "fields": [
+        {
+            "key": "overall",
+            "type": "single_rating",
+            "required": False,
+            "scale": [1, 5],
+            "scale_labels": {"en": ["1", "2", "3", "4", "5"]},
+            "dashboard_role": "primary_rating",
+        },
+        {
+            "key": "camper_scores",
+            "type": "rating_group",
+            "required": False,
+            "scale": [1, 5],
+            "scale_labels": {"en": ["1", "2", "3", "4", "5"]},
+            "dashboard_role": "category_ratings",
+            "categories": [
+                {"key": "behavior", "labels": {"en": "Behavior"}},
+                {"key": "participation", "labels": {"en": "Participation"}},
+            ],
+        },
+        {
+            "key": "request_unit_head_help",
+            "type": "yes_no",
+            "required": False,
+            "prompts": {"en": "Help requested?"},
+        },
+        {
+            "key": "notes",
+            "type": "textarea",
+            "required": False,
+            "prompts": {"en": "Notes"},
+        },
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="UH Camp", slug="uh-camp")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="UH Camp Summer 2026",
+        slug="uh-summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def uh_user():
+    return User.objects.create_user(email="uh@uh.test", password="pw")
+
+
+@pytest.fixture
+def uh_person(org, uh_user):
+    return Person.all_objects.create(
+        organization=org,
+        first_name="Avery",
+        last_name="Reeves",
+        user=uh_user,
+    )
+
+
+@pytest.fixture
+def uh_membership(program, uh_person):
+    return Membership.all_objects.create(
+        program=program, person=uh_person, role="unit_head", is_active=True,
+    )
+
+
+@pytest.fixture
+def counselor_user():
+    return User.objects.create_user(email="counselor@uh.test", password="pw")
+
+
+@pytest.fixture
+def counselor_person(org, counselor_user):
+    return Person.all_objects.create(
+        organization=org,
+        first_name="Mira",
+        last_name="Sandberg",
+        user=counselor_user,
+    )
+
+
+@pytest.fixture
+def counselor_membership(program, counselor_person):
+    return Membership.all_objects.create(
+        program=program, person=counselor_person, role="counselor", is_active=True,
+    )
+
+
+@pytest.fixture
+def bunk(org, program):
+    return AssignmentGroup.objects.create(
+        organization=org,
+        program=program,
+        name="Bunk Birch",
+        slug="bunk-birch",
+        group_type="bunk",
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def other_bunk(org, program):
+    return AssignmentGroup.objects.create(
+        organization=org,
+        program=program,
+        name="Bunk Pine",
+        slug="bunk-pine",
+        group_type="bunk",
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def counselor_authors_bunk(bunk, counselor_person):
+    return AssignmentGroupMembership.objects.create(
+        group=bunk, person=counselor_person, role_in_group="author", is_active=True,
+    )
+
+
+@pytest.fixture
+def uh_supervises_counselor(uh_membership, counselor_membership):
+    return Supervision.all_objects.create(
+        supervisor_membership=uh_membership,
+        target_type="membership",
+        target_membership=counselor_membership,
+        start_date=date(2026, 1, 1),
+    )
+
+
+@pytest.fixture
+def campers(org, bunk):
+    persons = []
+    for first, last in [("Sarah", "Levin"), ("Maya", "Cohen"), ("Eli", "Roth")]:
+        p = Person.all_objects.create(organization=org, first_name=first, last_name=last)
+        AssignmentGroupMembership.objects.create(
+            group=bunk, person=p, role_in_group="subject", is_active=True,
+        )
+        persons.append(p)
+    return persons
+
+
+@pytest.fixture
+def camper_template(org):
+    return ReflectionTemplate.all_objects.create(
+        organization=org,
+        name="Bunk Log",
+        slug="bunk-log-uh",
+        cadence="daily",
+        subject_mode="single_subject",
+        assignment_group_types=["bunk"],
+        schema=CAMPER_REFLECTION_SCHEMA,
+        languages=["en"],
+        is_active=True,
+        program_type="summer_camp",
+        author_role_filter=["counselor"],
+    )
+
+
+def _client(user, org):
+    c = APIClient()
+    c.force_authenticate(user=user)
+    c.credentials(HTTP_X_ORGANIZATION_SLUG=org.slug)
+    return c
+
+
+def _today_in_org(org):
+    """Test helper that mirrors the server's ``get_today`` result."""
+    from bunk_logs.core.time_utils import get_today
+    return get_today(org)
+
+
+# ---------------------------------------------------------------------------
+# Dashboard (Story 10)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_dashboard_requires_auth():
+    c = APIClient()
+    resp = c.get("/api/v1/unit-head/dashboard/")
+    assert resp.status_code in {401, 403}
+
+
+@pytest.mark.django_db
+def test_dashboard_requires_uh_membership(org, counselor_user, counselor_person, counselor_membership):
+    # Counselor has org + person but no UH membership — should 403.
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/unit-head/dashboard/?nocache=1")
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_dashboard_lists_supervised_bunks_only(
+    org, program, uh_user, uh_membership, bunk, other_bunk,
+    counselor_person, counselor_membership, counselor_authors_bunk,
+    uh_supervises_counselor,
+):
+    """Story 10 criterion 5: only bunks where a supervised counselor authors."""
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/unit-head/dashboard/?nocache=1")
+    assert resp.status_code == 200
+    body = resp.json()
+    names = [b["name"] for b in body["bunks"]]
+    assert names == [bunk.name]  # other_bunk has no supervised counselor
+
+
+@pytest.mark.django_db
+def test_dashboard_completion_excludes_off_camp(
+    org, program, uh_user, uh_membership, bunk,
+    counselor_person, counselor_membership, counselor_authors_bunk,
+    uh_supervises_counselor, campers, camper_template,
+):
+    """Off-camp campers are excluded from the 'expected' denominator."""
+    today = _today_in_org(org)
+    # Mark one camper off-camp
+    CamperDayState.objects.create(
+        organization=org, program=program, camper=campers[0],
+        date=today, is_off_camp=True,
+    )
+    # Submit a reflection for one of the on-camp campers
+    Reflection.all_objects.create(
+        organization=org, program=program,
+        template=camper_template, assignment_group=bunk,
+        subject=campers[1], author=counselor_person,
+        period_start=today, period_end=today,
+        answers={"overall": 5}, language="en", is_complete=True,
+    )
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/unit-head/dashboard/?nocache=1")
+    body = resp.json()
+    completion = body["bunks"][0]["completion"]
+    assert completion == {"submitted": 1, "expected": 2, "off_camp": 1}
+
+
+@pytest.mark.django_db
+def test_dashboard_attention_badges_and_sort(
+    org, program, uh_user, uh_membership, bunk, other_bunk,
+    counselor_person, counselor_membership, counselor_authors_bunk,
+    uh_supervises_counselor, campers, camper_template,
+):
+    """Help requested + off-camp + bunk-concerns badges; badged bunks sort first."""
+    today = _today_in_org(org)
+
+    # Mark a camper off-camp on Birch — triggers `off_camp` badge.
+    CamperDayState.objects.create(
+        organization=org, program=program, camper=campers[0],
+        date=today, is_off_camp=True,
+    )
+    # Help requested by another camper.
+    Reflection.all_objects.create(
+        organization=org, program=program,
+        template=camper_template, assignment_group=bunk,
+        subject=campers[1], author=counselor_person,
+        period_start=today, period_end=today,
+        answers={"request_unit_head_help": True}, is_complete=True,
+    )
+    # Pine has a supervised counselor too so it makes the list.
+    pine_counselor = Person.all_objects.create(
+        organization=org, first_name="Lior", last_name="Yarden",
+    )
+    pine_membership = Membership.all_objects.create(
+        program=program, person=pine_counselor, role="counselor", is_active=True,
+    )
+    AssignmentGroupMembership.objects.create(
+        group=other_bunk, person=pine_counselor, role_in_group="author", is_active=True,
+    )
+    Supervision.all_objects.create(
+        supervisor_membership=uh_membership,
+        target_type="membership",
+        target_membership=pine_membership,
+        start_date=date(2026, 1, 1),
+    )
+
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/unit-head/dashboard/?nocache=1")
+    body = resp.json()
+    # Birch must sort first because it has badges; Pine has none.
+    names = [b["name"] for b in body["bunks"]]
+    assert names[0] == "Bunk Birch"
+    assert names[1] == "Bunk Pine"
+    birch_badges = body["bunks"][0]["badges"]
+    assert "help_requested" in birch_badges
+    assert "off_camp" in birch_badges
+    # help_requested must precede off_camp per ATTENTION_BADGE_ORDER.
+    assert birch_badges.index("help_requested") < birch_badges.index("off_camp")
+
+
+@pytest.mark.django_db
+def test_dashboard_includes_my_reflection_state(
+    org, program, uh_user, uh_membership, bunk,
+    counselor_person, counselor_membership, counselor_authors_bunk,
+    uh_supervises_counselor, campers, uh_person,
+):
+    """Story 10 criterion 10 + Story 16: My reflection section state."""
+    c = _client(uh_user, org)
+    with organization_context(org):
+        # Missing state initially
+        resp = c.get("/api/v1/unit-head/dashboard/?nocache=1")
+    assert resp.json()["self_reflection"]["state"] == "missing"
+
+    # Create one + re-fetch
+    today = _today_in_org(org)
+    template = ReflectionTemplate.all_objects.get(slug="unit-head-self-reflection")
+    Reflection.all_objects.create(
+        organization=org, program=program,
+        template=template, subject=uh_person, author=uh_person,
+        period_start=today, period_end=today,
+        answers={"day_off": True}, is_complete=True,
+    )
+    with organization_context(org):
+        resp = c.get("/api/v1/unit-head/dashboard/?nocache=1")
+    body = resp.json()["self_reflection"]
+    assert body["state"] == "day_off"
+    assert body["editable"] is True
+
+
+# ---------------------------------------------------------------------------
+# Bunk Dashboard (Story 11) + Score Grid (Story 12)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_bunk_dashboard_requires_supervision(
+    org, program, uh_user, uh_membership, bunk, other_bunk,
+):
+    """Forbidden if the UH doesn't supervise the bunk."""
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.get(f"/api/v1/unit-head/bunks/{other_bunk.id}/")
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_bunk_dashboard_payload_shape(
+    org, program, uh_user, uh_membership, bunk,
+    counselor_person, counselor_membership, counselor_authors_bunk,
+    uh_supervises_counselor, campers, camper_template,
+):
+    """Every spec section is present in the response."""
+    today = _today_in_org(org)
+    Reflection.all_objects.create(
+        organization=org, program=program,
+        template=camper_template, assignment_group=bunk,
+        subject=campers[0], author=counselor_person,
+        period_start=today, period_end=today,
+        answers={"overall": 4, "camper_scores": {"behavior": 5, "participation": 3}},
+        is_complete=True,
+    )
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.get(f"/api/v1/unit-head/bunks/{bunk.id}/?date={today.isoformat()}")
+    assert resp.status_code == 200
+    body = resp.json()
+    expected_sections = {
+        "header", "help_requested", "off_camp", "bunk_concerns",
+        "score_grid", "orders", "specialist_reports",
+    }
+    assert expected_sections.issubset(body.keys())
+    # Score grid: 3 columns (overall, behavior, participation), 3 rows.
+    cols = [c["label"] for c in body["score_grid"]["columns"]]
+    assert cols == ["overall", "camper_scores__behavior", "camper_scores__participation"]
+    rows = body["score_grid"]["rows"]
+    assert len(rows) == 3
+    # Submitted camper has cell values; the others have None.
+    sarah_row = next(r for r in rows if r["camper"]["first_name"] == "Sarah")
+    assert sarah_row["cells"] == {
+        "overall": 4.0,
+        "camper_scores__behavior": 5.0,
+        "camper_scores__participation": 3.0,
+    }
+    maya_row = next(r for r in rows if r["camper"]["first_name"] == "Maya")
+    assert maya_row["cells"] == {
+        "overall": None,
+        "camper_scores__behavior": None,
+        "camper_scores__participation": None,
+    }
+
+
+@pytest.mark.django_db
+def test_bunk_dashboard_future_date_rejected(
+    org, uh_user, uh_membership, bunk,
+    counselor_person, counselor_membership, counselor_authors_bunk,
+    uh_supervises_counselor,
+):
+    """Story 11 criterion 3 — future dates not selectable."""
+    c = _client(uh_user, org)
+    future = (_today_in_org(org) + timedelta(days=1)).isoformat()
+    with organization_context(org):
+        resp = c.get(f"/api/v1/unit-head/bunks/{bunk.id}/?date={future}")
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_bunk_dashboard_surfaces_bunk_concerns(
+    org, program, uh_user, uh_membership, bunk,
+    counselor_user, counselor_person, counselor_membership, counselor_authors_bunk,
+    uh_supervises_counselor,
+):
+    """Counselor self-reflection referencing this bunk shows up in `bunk_concerns`."""
+    today = _today_in_org(org)
+    counselor_template = ReflectionTemplate.all_objects.get(
+        slug="counselor-self-reflection",
+    )
+    Reflection.all_objects.create(
+        organization=org, program=program,
+        template=counselor_template,
+        subject=counselor_person, author=counselor_person,
+        period_start=today, period_end=today,
+        answers={
+            "bunk_concerns_bunks": [bunk.id],
+            "concern": "Group dynamics tense today.",
+        },
+        is_complete=True,
+        team_visibility=Reflection.TeamVisibility.SUPERVISORS_ONLY,
+    )
+
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.get(f"/api/v1/unit-head/bunks/{bunk.id}/?date={today.isoformat()}")
+    body = resp.json()
+    assert len(body["bunk_concerns"]) == 1
+    assert body["bunk_concerns"][0]["open_concern"].startswith("Group dynamics")
+
+
+@pytest.mark.django_db
+def test_bunk_dashboard_orders_filter_to_bunk_counselors_only(
+    org, program, uh_user, uh_membership, bunk, other_bunk,
+    counselor_user, counselor_person, counselor_membership,
+    counselor_authors_bunk, uh_supervises_counselor, campers,
+):
+    """Story 14: only orders from THIS bunk's counselors appear."""
+    today = _today_in_org(org)
+    # Another counselor on a different bunk.
+    other_counselor = Person.all_objects.create(
+        organization=org, first_name="Tal", last_name="Stein",
+    )
+    other_membership = Membership.all_objects.create(
+        program=program, person=other_counselor, role="counselor", is_active=True,
+    )
+    AssignmentGroupMembership.objects.create(
+        group=other_bunk, person=other_counselor,
+        role_in_group="author", is_active=True,
+    )
+
+    # Order from THE bunk's counselor — should appear.
+    Order.all_objects.create(
+        organization=org, program=program,
+        submitted_by=counselor_membership,
+        subject=campers[0],
+        item="Toothpaste", status=OrderStateMachine.NEW,
+    )
+    # Order from a different bunk's counselor — must NOT appear.
+    Order.all_objects.create(
+        organization=org, program=program,
+        submitted_by=other_membership,
+        item="Soap", status=OrderStateMachine.NEW,
+    )
+    # Maintenance ticket from the bunk's counselor — should appear.
+    MaintenanceTicket.all_objects.create(
+        organization=org, program=program,
+        submitted_by=counselor_membership,
+        location="Bunk Birch", category=MaintenanceTicket.Category.LEAK,
+        status=OrderStateMachine.NEW,
+    )
+
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.get(f"/api/v1/unit-head/bunks/{bunk.id}/?date={today.isoformat()}")
+    body = resp.json()
+    today_items = body["orders"]["today"]
+    items = [(i["kind"], i.get("item") or i.get("location")) for i in today_items]
+    assert ("camper_care", "Toothpaste") in items
+    assert ("maintenance", "Bunk Birch") in items
+    assert all(i.get("item") != "Soap" for i in today_items)
+    assert body["orders"]["counts"] == {"open": 2, "in_progress": 0, "resolved": 0}
+
+
+@pytest.mark.django_db
+def test_bunk_dashboard_orders_carries_over_open(
+    org, program, uh_user, uh_membership, bunk,
+    counselor_membership, counselor_authors_bunk,
+    uh_supervises_counselor, campers,
+):
+    """Story 14 criterion 6 — carry over older still-open orders."""
+    today = _today_in_org(org)
+    old = today - timedelta(days=3)
+    order = Order.all_objects.create(
+        organization=org, program=program,
+        submitted_by=counselor_membership, subject=campers[0],
+        item="Bandages", status=OrderStateMachine.IN_PROGRESS,
+    )
+    # Manually backdate (auto_now_add doesn't allow constructor override).
+    backdate = timezone.make_aware(datetime.combine(old, datetime.min.time()))
+    Order.all_objects.filter(id=order.id).update(created_at=backdate)
+
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.get(f"/api/v1/unit-head/bunks/{bunk.id}/?date={today.isoformat()}")
+    body = resp.json()
+    assert len(body["orders"]["today"]) == 0
+    assert len(body["orders"]["carried_over"]) == 1
+    assert body["orders"]["carried_over"][0]["item"] == "Bandages"
+
+
+@pytest.mark.django_db
+def test_bunk_dashboard_specialist_reports_excludes_sensitive(
+    org, program, uh_user, uh_membership, bunk,
+    counselor_person, counselor_membership, counselor_authors_bunk,
+    uh_supervises_counselor, campers,
+):
+    """Story 15 criterion 4 — sensitive notes excluded; placeholder count emitted."""
+    today = _today_in_org(org)
+    specialist = Person.all_objects.create(
+        organization=org, first_name="Dr.", last_name="Avi",
+    )
+    Membership.all_objects.create(
+        program=program, person=specialist, role="specialist", is_active=True,
+    )
+    # Non-sensitive note: visible to UH.
+    Note.all_objects.create(
+        organization=org, program=program, subject=campers[0], author=specialist,
+        note_type=Note.NoteType.SPECIALIST,
+        body="Routine specialist observation about Sarah.",
+    )
+    # Sensitive note: NOT visible to UH (UH not in audience for SPECIALIST_NOTE sensitive variant).
+    Note.all_objects.create(
+        organization=org, program=program, subject=campers[1], author=specialist,
+        note_type=Note.NoteType.SPECIALIST,
+        body="Sensitive medical information.",
+        is_sensitive=True,
+    )
+
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.get(f"/api/v1/unit-head/bunks/{bunk.id}/?date={today.isoformat()}")
+    body = resp.json()
+    visible_bodies = [
+        n["body"] for n in (body["specialist_reports"]["today"]
+                            + body["specialist_reports"]["recent"])
+    ]
+    assert "Routine specialist observation about Sarah." in visible_bodies
+    assert all("Sensitive" not in b for b in visible_bodies)
+    counts = body["specialist_reports"]["sensitive_counts_by_camper"]
+    assert counts.get(str(campers[1].id)) == 1 or counts.get(campers[1].id) == 1
+
+
+# ---------------------------------------------------------------------------
+# Camper Dashboard (Story 13)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_camper_dashboard_requires_supervision(
+    org, program, uh_user, uh_membership, other_bunk, campers,
+):
+    """403 if the camper isn't rostered under any supervised bunk."""
+    # campers fixture rosters into `bunk`, not other_bunk; this UH supervises nothing.
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.get(f"/api/v1/unit-head/campers/{campers[0].id}/")
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_camper_dashboard_trend_gaps_as_null(
+    org, program, uh_user, uh_membership, bunk,
+    counselor_person, counselor_membership, counselor_authors_bunk,
+    uh_supervises_counselor, campers, camper_template,
+):
+    """Story 13 criterion 4 — missing days are gaps, not zeros."""
+    today = _today_in_org(org)
+    # Submit only for 2 days out of 7.
+    for d in (today - timedelta(days=6), today - timedelta(days=2)):
+        Reflection.all_objects.create(
+            organization=org, program=program,
+            template=camper_template, assignment_group=bunk,
+            subject=campers[0], author=counselor_person,
+            period_start=d, period_end=d,
+            answers={"overall": 4}, is_complete=True,
+        )
+
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.get(
+            f"/api/v1/unit-head/campers/{campers[0].id}/?range=this_week",
+        )
+    body = resp.json()
+    overall_series = next(s for s in body["trend"]["series"] if s["label"] == "overall")
+    values = [p["value"] for p in overall_series["points"]]
+    # 7 days; 2 numeric, 5 None.
+    assert values.count(4.0) == 2
+    assert values.count(None) == 5
+
+
+@pytest.mark.django_db
+def test_camper_dashboard_today_section_and_flags(
+    org, program, uh_user, uh_membership, bunk,
+    counselor_person, counselor_membership, counselor_authors_bunk,
+    uh_supervises_counselor, campers, camper_template,
+):
+    """Story 13 criterion 1: full reflection + scores + flags returned."""
+    today = _today_in_org(org)
+    Reflection.all_objects.create(
+        organization=org, program=program,
+        template=camper_template, assignment_group=bunk,
+        subject=campers[0], author=counselor_person,
+        period_start=today, period_end=today,
+        answers={
+            "overall": 2,
+            "camper_scores": {"behavior": 3, "participation": 4},
+            "request_unit_head_help": True,
+            "notes": "Talked to Sarah after lunch.",
+        },
+        is_complete=True,
+    )
+
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.get(f"/api/v1/unit-head/campers/{campers[0].id}/")
+    body = resp.json()
+    assert body["today_reflection"] is not None
+    assert body["today_reflection"]["fields"]
+    # Help-requested flag must surface as a Today flag.
+    flag_keys = {f["key"] for f in body["today_flags"]}
+    assert "request_unit_head_help" in flag_keys
+    score_labels = {s["label"] for s in body["today_scores"]}
+    assert "overall" in score_labels
+    assert "camper_scores__behavior" in score_labels
+
+
+# ---------------------------------------------------------------------------
+# Self-reflection (Stories 16, 17)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_self_reflection_day_off_post(
+    org, uh_user, uh_membership, uh_person,
+):
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/unit-head/self-reflection/",
+            data={
+                "day_off": True,
+                "language": "en",
+                "client_submission_id": str(uuid4()),
+            },
+            format="json",
+        )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["answers"] == {"day_off": True}
+
+
+@pytest.mark.django_db
+def test_self_reflection_bunk_concerns_rejects_non_supervised_bunk(
+    org, program, uh_user, uh_membership, uh_person,
+    other_bunk,
+):
+    """UH cannot flag bunks they don't supervise (UH2)."""
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/unit-head/self-reflection/",
+            data={
+                "day_off": False,
+                "answers": {
+                    "overall_day": 4,
+                    "bunk_concerns_bunks": [other_bunk.id],
+                },
+                "language": "en",
+                "client_submission_id": str(uuid4()),
+            },
+            format="json",
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_self_reflection_bunk_concerns_accepts_supervised_bunk(
+    org, program, uh_user, uh_membership, uh_person,
+    bunk, counselor_person, counselor_membership, counselor_authors_bunk,
+    uh_supervises_counselor,
+):
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/unit-head/self-reflection/",
+            data={
+                "day_off": False,
+                "answers": {
+                    "overall_day": 4,
+                    "bunk_concerns_bunks": [bunk.id],
+                    "bunk_concerns_note": "Sleep schedule rough.",
+                },
+                "language": "en",
+                "client_submission_id": str(uuid4()),
+            },
+            format="json",
+        )
+    assert resp.status_code == 201
+    refl = Reflection.all_objects.get(author=uh_person, subject=uh_person)
+    assert refl.answers["bunk_concerns_bunks"] == [bunk.id]
+
+
+@pytest.mark.django_db
+def test_self_reflection_idempotent_replay(
+    org, uh_user, uh_membership, uh_person,
+):
+    """Same client_submission_id replays the same row with HTTP 200."""
+    cid = str(uuid4())
+    c = _client(uh_user, org)
+    with organization_context(org):
+        first = c.post(
+            "/api/v1/unit-head/self-reflection/",
+            data={"day_off": True, "client_submission_id": cid},
+            format="json",
+        )
+        assert first.status_code == 201
+        replay = c.post(
+            "/api/v1/unit-head/self-reflection/",
+            data={"day_off": True, "client_submission_id": cid},
+            format="json",
+        )
+    assert replay.status_code == 200
+    assert replay.json()["id"] == first.json()["id"]
+
+
+@pytest.mark.django_db
+def test_self_reflection_patch_within_today(
+    org, program, uh_user, uh_membership, uh_person,
+):
+    today = _today_in_org(org)
+    template = ReflectionTemplate.all_objects.get(slug="unit-head-self-reflection")
+    refl = Reflection.all_objects.create(
+        organization=org, program=program, template=template,
+        subject=uh_person, author=uh_person,
+        period_start=today, period_end=today,
+        answers={"overall_day": 3}, is_complete=True,
+    )
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.patch(
+            f"/api/v1/unit-head/self-reflection/{refl.id}/",
+            data={"answers": {"overall_day": 5}},
+            format="json",
+        )
+    assert resp.status_code == 200
+    refl.refresh_from_db()
+    assert refl.answers["overall_day"] == 5
+
+
+@pytest.mark.django_db
+def test_self_reflection_patch_outside_window_403(
+    org, program, uh_user, uh_membership, uh_person,
+):
+    """Story 17 criterion 2: editable until rollover; locked after."""
+    today = _today_in_org(org)
+    template = ReflectionTemplate.all_objects.get(slug="unit-head-self-reflection")
+    # Backdate by one day so today's window doesn't include it.
+    refl = Reflection.all_objects.create(
+        organization=org, program=program, template=template,
+        subject=uh_person, author=uh_person,
+        period_start=today - timedelta(days=1),
+        period_end=today - timedelta(days=1),
+        answers={"overall_day": 3}, is_complete=True,
+    )
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.patch(
+            f"/api/v1/unit-head/self-reflection/{refl.id}/",
+            data={"answers": {"overall_day": 5}},
+            format="json",
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_self_reflection_history_shows_gaps_and_day_off(
+    org, program, uh_user, uh_membership, uh_person,
+):
+    """Story 17 criterion 5: gaps + day-off indicators in history rows."""
+    today = _today_in_org(org)
+    template = ReflectionTemplate.all_objects.get(slug="unit-head-self-reflection")
+    # Submit on day -1 (day off) and day -3 (full).
+    Reflection.all_objects.create(
+        organization=org, program=program, template=template,
+        subject=uh_person, author=uh_person,
+        period_start=today - timedelta(days=1),
+        period_end=today - timedelta(days=1),
+        answers={"day_off": True}, is_complete=True,
+    )
+    Reflection.all_objects.create(
+        organization=org, program=program, template=template,
+        subject=uh_person, author=uh_person,
+        period_start=today - timedelta(days=3),
+        period_end=today - timedelta(days=3),
+        answers={"overall_day": 4, "concern": "Long week."}, is_complete=True,
+    )
+
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/unit-head/self-reflection/history/")
+    body = resp.json()
+    rows = {r["date"]: r for r in body["results"]}
+    yesterday_row = rows[(today - timedelta(days=1)).isoformat()]
+    today_row = rows[today.isoformat()]
+    day_minus_3 = rows[(today - timedelta(days=3)).isoformat()]
+    day_minus_2 = rows[(today - timedelta(days=2)).isoformat()]
+    assert yesterday_row["is_day_off"] is True
+    assert yesterday_row["submitted"] is True
+    assert today_row["submitted"] is False  # gap on today
+    assert day_minus_3["submitted"] is True
+    assert day_minus_3["preview"]  # non-empty
+    assert day_minus_2["submitted"] is False  # gap row
+
+
+@pytest.mark.django_db
+def test_self_reflection_history_does_not_show_other_uh_rows(
+    org, program, uh_user, uh_membership, uh_person,
+):
+    """UH6: another UH's reflections aren't visible."""
+    today = _today_in_org(org)
+    template = ReflectionTemplate.all_objects.get(slug="unit-head-self-reflection")
+
+    other_uh_user = User.objects.create_user(email="other@uh.test", password="pw")
+    other_uh_person = Person.all_objects.create(
+        organization=org, first_name="Sam", last_name="Cole", user=other_uh_user,
+    )
+    Membership.all_objects.create(
+        program=program, person=other_uh_person, role="unit_head", is_active=True,
+    )
+    Reflection.all_objects.create(
+        organization=org, program=program, template=template,
+        subject=other_uh_person, author=other_uh_person,
+        period_start=today, period_end=today,
+        answers={"overall_day": 5}, is_complete=True,
+    )
+
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/unit-head/self-reflection/history/")
+    rows = {r["date"]: r for r in resp.json()["results"]}
+    today_row = rows[today.isoformat()]
+    assert today_row["submitted"] is False
+    assert today_row["reflection_id"] is None

--- a/backend/bunk_logs/api/unit_head/__init__.py
+++ b/backend/bunk_logs/api/unit_head/__init__.py
@@ -1,0 +1,13 @@
+"""Unit Head endpoints (Step 7_7).
+
+Endpoints under ``/api/v1/unit-head/`` powering the UH dashboard
+(Story 10), bunk dashboard (Story 11) with Score Grid (Story 12),
+Camper Dashboard (Story 13) with trend graph, today's orders
+(Story 14), specialist reports (Story 15), and UH self-reflection
+plus history (Stories 16, 17).
+
+The Camper Dashboard payload from this package is the canonical
+shared component used by Camper Care (Step 7_8), Leadership Team
+(Step 7_12), and Admin (Step 7_13) — visibility filtering is
+applied server-side so each role sees only what it's permitted to.
+"""

--- a/backend/bunk_logs/api/unit_head/bunk_dashboard.py
+++ b/backend/bunk_logs/api/unit_head/bunk_dashboard.py
@@ -1,0 +1,452 @@
+"""``GET /api/v1/unit-head/bunks/<bunk_id>/?date=<>`` — Story 11.
+
+Composes the bunk page payload from the per-section primitives. UH
+opens this when tapping a bunk from the dashboard; the API is
+read-only (Story 11 criterion 5).
+
+Sections returned, all key-named so the frontend can render them in
+spec order (criterion 1) and collapse them when empty (criterion 2):
+
+* ``header`` — bunk + date + counselor display names.
+* ``help_requested`` — campers who asked for UH help today.
+* ``off_camp`` — campers flagged ``is_off_camp`` today.
+* ``bunk_concerns`` — counselor / UH self-reflections that referenced
+  this bunk via ``bunk_concerns_bunks`` today.
+* ``score_grid`` — Story 12 grid (columns + per-camper cells).
+* ``orders`` — Story 14: today's Camper Care + Maintenance items
+  submitted by counselors authoring this bunk, plus "carried over".
+* ``specialist_reports`` — Story 15: visibility-filtered Notes
+  authored by Specialists about this bunk's campers.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.utils.dateparse import parse_date
+from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.api.counselor.common import bunk_camper_persons
+from bunk_logs.api.counselor.common import camper_reflection_template
+from bunk_logs.api.counselor.common import person_display_name
+from bunk_logs.core.filters import notes_visible_to
+from bunk_logs.core.filters import reflections_visible_for_user
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Note
+from bunk_logs.core.models import Order
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.state_machine import OrderStateMachine
+
+from .common import build_score_grid
+from .common import bunk_concerns_referencing
+from .common import help_requested_camper_ids_from
+from .common import off_camp_camper_ids
+from .common import supervised_bunk_ids
+from .common import viewer_or_403
+
+if TYPE_CHECKING:
+    from datetime import date
+    from datetime import datetime
+
+OPEN_STATUSES = (OrderStateMachine.NEW, OrderStateMachine.IN_PROGRESS)
+RESOLVED_STATUSES = (OrderStateMachine.FULFILLED, OrderStateMachine.UNABLE_TO_FULFILL)
+
+
+class UnitHeadBunkDashboardView(APIView):
+    """Per-bunk read payload for the Unit Head Bunk Dashboard."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, bunk_id: int, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        target_date = _parse_date_param(
+            request.query_params.get("date"), default=ctx.today,
+        )
+        # No future dates (Story 11 criterion 3).
+        if target_date > ctx.today:
+            msg = "Future dates are not selectable."
+            raise ValidationError(msg)
+
+        # Supervision gate: viewer must supervise this bunk (today —
+        # the supervision relationship is "as of today", not the
+        # selected date, since UH can browse history for bunks they
+        # supervise NOW).
+        supervised_ids = supervised_bunk_ids(ctx.membership, today=ctx.today)
+        if int(bunk_id) not in supervised_ids:
+            msg = "You do not supervise this bunk."
+            raise PermissionDenied(msg)
+
+        bunk = AssignmentGroup.all_objects.filter(
+            id=bunk_id, group_type="bunk", is_active=True,
+        ).select_related("parent").first()
+        if bunk is None:
+            msg = "Bunk not found."
+            raise NotFound(msg)
+
+        campers = bunk_camper_persons([bunk]).get(bunk.id, [])
+        camper_ids = [c.id for c in campers]
+
+        off_camp = off_camp_camper_ids(ctx.organization, target_date, camper_ids)
+        off_camp_payload = [
+            _camper_brief(c, off_camp=True) for c in campers if c.id in off_camp
+        ]
+
+        # Today's camper reflections (visibility-filtered) for help
+        # surface + score grid.
+        camper_template = camper_reflection_template(ctx.organization, ctx.program)
+        reflections_by_subject: dict[int, Reflection] = {}
+        if camper_template is not None and campers:
+            visible_qs = reflections_visible_for_user(
+                request.user,
+                Reflection.all_objects.filter(
+                    template=camper_template,
+                    assignment_group=bunk,
+                    period_start=target_date,
+                    period_end=target_date,
+                    is_complete=True,
+                ).select_related("template", "author"),
+            )
+            for r in visible_qs:
+                if r.subject_id is not None:
+                    reflections_by_subject[r.subject_id] = r
+
+        help_ids = help_requested_camper_ids_from(reflections_by_subject)
+        help_payload = [
+            _camper_brief(c) for c in campers if c.id in help_ids
+        ]
+
+        # Bunk-concerns referencing this bunk today.
+        bc_map = bunk_concerns_referencing(
+            organization=ctx.organization,
+            program=ctx.program,
+            target_date=target_date,
+        )
+        bc_payload = _serialize_bunk_concerns(bc_map.get(bunk.id, []))
+
+        # Score grid (Story 12).
+        score_grid_payload = (
+            build_score_grid(
+                template=camper_template,
+                campers=campers,
+                reflections_by_subject=reflections_by_subject,
+            ) if camper_template else {"columns": [], "rows": []}
+        )
+
+        # Orders + Maintenance Tickets for the bunk (Story 14).
+        orders_payload = _orders_for_bunk(
+            bunk=bunk, target_date=target_date, organization=ctx.organization,
+            program=ctx.program,
+        )
+
+        # Specialist reports (Story 15).
+        spec_payload = _specialist_reports_for_bunk(
+            request=request, camper_ids=camper_ids, target_date=target_date,
+        )
+
+        return Response({
+            "header": {
+                "bunk": {
+                    "id": bunk.id,
+                    "name": bunk.name,
+                    "slug": bunk.slug,
+                    "unit_name": (bunk.parent.name if bunk.parent_id else None),
+                },
+                "date": target_date.isoformat(),
+                "today": ctx.today.isoformat(),
+                "counselor_names": _counselor_names(bunk),
+            },
+            "help_requested": help_payload,
+            "off_camp": off_camp_payload,
+            "bunk_concerns": bc_payload,
+            "score_grid": score_grid_payload,
+            "orders": orders_payload,
+            "specialist_reports": spec_payload,
+        })
+
+
+# ---------------------------------------------------------------------------
+# Section helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_date_param(raw: str | None, *, default: date) -> date:
+    if not raw:
+        return default
+    parsed = parse_date(raw)
+    if parsed is None:
+        msg = "Invalid 'date' parameter; expected YYYY-MM-DD."
+        raise ValidationError(msg)
+    return parsed
+
+
+def _camper_brief(camper: Person, *, off_camp: bool = False) -> dict:
+    return {
+        "id": camper.id,
+        "first_name": camper.first_name,
+        "last_name": camper.last_name,
+        "preferred_name": camper.preferred_name,
+        "off_camp": off_camp,
+    }
+
+
+def _counselor_names(bunk: AssignmentGroup) -> list[str]:
+    rows = (
+        AssignmentGroupMembership.objects.filter(
+            group=bunk, role_in_group="author", is_active=True,
+        )
+        .select_related("person")
+        .order_by("person__last_name", "person__first_name")
+    )
+    return [person_display_name(agm.person) for agm in rows if agm.person]
+
+
+def _serialize_bunk_concerns(reflections: list[Reflection]) -> list[dict]:
+    """Compact payload for the Bunk Concerns section.
+
+    Includes the author's display name, the role binding the template
+    targets (counselor vs unit_head — informs how the section header
+    labels the source), the linked Reflection id, and the narrative
+    note when present.
+    """
+    out: list[dict] = []
+    for r in reflections:
+        answers = r.answers or {}
+        out.append({
+            "reflection_id": r.id,
+            "author": person_display_name(r.author),
+            "author_role": (r.template.role if r.template_id else None),
+            "note": answers.get("bunk_concerns_note") or "",
+            "open_concern": answers.get("concern") or "",
+            "submitted_at": r.submitted_at.isoformat() if r.submitted_at else None,
+        })
+    return out
+
+
+def _orders_for_bunk(
+    *, bunk: AssignmentGroup, target_date: date, organization, program,
+) -> dict:
+    """Combined Orders + Maintenance Tickets for the bunk.
+
+    Two sub-lists per Story 14 criterion 6: ``today`` and
+    ``carried_over``. Carried-over is anything still in an open state
+    that was submitted *before* ``target_date``. Status counts are at
+    the top so the section header can render "[n] open / [m] in
+    progress / [k] resolved" (criterion 4).
+    """
+    counselor_membership_ids = _counselor_membership_ids_for_bunk(bunk)
+    if not counselor_membership_ids:
+        return {
+            "today": [], "carried_over": [],
+            "counts": {"open": 0, "in_progress": 0, "resolved": 0},
+        }
+
+    orders = (
+        Order.all_objects.filter(
+            organization=organization,
+            program=program,
+            submitted_by_id__in=counselor_membership_ids,
+        )
+        .filter(_date_window(target_date))
+        .select_related("subject", "submitted_by", "submitted_by__person")
+        .order_by("-created_at")
+    )
+    tickets = (
+        MaintenanceTicket.all_objects.filter(
+            organization=organization,
+            program=program,
+            submitted_by_id__in=counselor_membership_ids,
+        )
+        .filter(_date_window(target_date))
+        .select_related("submitted_by", "submitted_by__person")
+        .order_by("-created_at")
+    )
+
+    today_items: list[dict] = []
+    carried_over: list[dict] = []
+    counts = {"open": 0, "in_progress": 0, "resolved": 0}
+
+    for o in orders:
+        item = _serialize_order(o)
+        _bucket_request(item, o.created_at, o.status, target_date, today_items, carried_over)
+        _bucket_count(o.status, counts)
+    for t in tickets:
+        item = _serialize_ticket(t)
+        _bucket_request(item, t.created_at, t.status, target_date, today_items, carried_over)
+        _bucket_count(t.status, counts)
+
+    today_items.sort(key=lambda r: r["submitted_at"], reverse=True)
+    carried_over.sort(key=lambda r: r["submitted_at"], reverse=True)
+    return {"today": today_items, "carried_over": carried_over, "counts": counts}
+
+
+def _date_window(target_date: date):
+    """Filter spanning ``target_date`` plus open carry-overs from before.
+
+    We need rows submitted ON ``target_date`` AND rows submitted
+    before that are still open. The simplest correct filter is "any
+    row whose date <= target_date AND (date == target_date OR status
+    is open)". We materialize both conditions in the Python loop
+    rather than at SQL level so the carried-over bucket can include
+    arbitrarily old rows without an unbounded date range.
+    """
+    from django.db.models import Q
+    return Q(created_at__date__lte=target_date)
+
+
+def _bucket_request(
+    item: dict, submitted_at: datetime, status: str, target_date: date,
+    today_items: list[dict], carried_over: list[dict],
+) -> None:
+    submitted_date = submitted_at.date() if submitted_at else target_date
+    if submitted_date == target_date:
+        today_items.append(item)
+    elif status in OPEN_STATUSES:
+        carried_over.append(item)
+    # else: resolved + submitted on a prior date — drop
+
+
+def _bucket_count(status: str, counts: dict) -> None:
+    if status == OrderStateMachine.NEW:
+        counts["open"] += 1
+    elif status == OrderStateMachine.IN_PROGRESS:
+        counts["in_progress"] += 1
+    elif status in RESOLVED_STATUSES:
+        counts["resolved"] += 1
+
+
+def _serialize_order(order: Order) -> dict:
+    subject = order.subject
+    submitter = order.submitted_by.person if order.submitted_by else None
+    return {
+        "kind": "camper_care",
+        "id": str(order.id),
+        "status": order.status,
+        "urgency": getattr(order, "urgency", None),
+        "subject": (
+            {
+                "id": subject.id,
+                "preferred_name": subject.preferred_name,
+                "first_name": subject.first_name,
+                "last_name": subject.last_name,
+            } if subject else None
+        ),
+        "item": order.item,
+        "item_note": order.item_note,
+        "submitter": person_display_name(submitter),
+        "submitted_at": order.created_at.isoformat() if order.created_at else None,
+        "photo_count": 0,  # Orders don't carry photos in 7_6.
+    }
+
+
+def _serialize_ticket(ticket: MaintenanceTicket) -> dict:
+    submitter = ticket.submitted_by.person if ticket.submitted_by else None
+    return {
+        "kind": "maintenance",
+        "id": str(ticket.id),
+        "status": ticket.status,
+        "urgency": getattr(ticket, "urgency", None),
+        "location": ticket.location,
+        "category": ticket.category,
+        "submitter": person_display_name(submitter),
+        "submitted_at": ticket.created_at.isoformat() if ticket.created_at else None,
+        "photo_count": ticket.photos.count() if hasattr(ticket, "photos") else 0,
+    }
+
+
+def _counselor_membership_ids_for_bunk(bunk: AssignmentGroup) -> list[int]:
+    """Active counselor / JC ``Membership`` IDs authoring this bunk.
+
+    We resolve via ``AssignmentGroupMembership`` (the canonical "who
+    authors this bunk" relation) then back to their counselor /
+    junior_counselor program-Memberships in the same program as the
+    bunk. This handles a counselor who has multiple program
+    memberships but whose authorship is bound to the specific
+    program-Membership that maps to THIS bunk's program.
+    """
+    person_ids = list(
+        AssignmentGroupMembership.objects.filter(
+            group=bunk, role_in_group="author", is_active=True,
+        ).values_list("person_id", flat=True),
+    )
+    if not person_ids:
+        return []
+    from bunk_logs.core.models import Membership as _Membership
+    return list(
+        _Membership.objects.filter(
+            person_id__in=person_ids,
+            program=bunk.program_id,
+            role__in=("counselor", "junior_counselor"),
+            is_active=True,
+        ).values_list("id", flat=True),
+    )
+
+
+def _specialist_reports_for_bunk(
+    *, request, camper_ids: list[int], target_date: date,
+) -> dict:
+    """Visibility-filtered specialist notes for the bunk's campers.
+
+    Story 15 splits today vs recent (14-day cap). Sensitive notes are
+    excluded by ``notes_visible_to``; the placeholder count is
+    surfaced per camper so the frontend can render "1 sensitive note"
+    (Story 15 criterion 4).
+    """
+    from datetime import timedelta
+    if not camper_ids:
+        return {"today": [], "recent": [], "sensitive_counts_by_camper": {}}
+
+    cutoff = target_date - timedelta(days=14)
+
+    base = Note.all_objects.filter(
+        note_type=Note.NoteType.SPECIALIST,
+        subject_id__in=camper_ids,
+        created_at__date__lte=target_date,
+        created_at__date__gte=cutoff,
+    ).select_related("subject", "author")
+
+    visible = notes_visible_to(request.user, base)
+    visible_ids = set(visible.values_list("id", flat=True))
+
+    today_rows: list[dict] = []
+    recent_rows: list[dict] = []
+    for n in visible.order_by("-created_at"):
+        body = n.body or ""
+        preview = body if len(body) <= 200 else (body[:200].rstrip() + "…")
+        item = {
+            "id": n.id,
+            "subject": {
+                "id": n.subject_id,
+                "first_name": n.subject.first_name if n.subject else "",
+                "last_name": n.subject.last_name if n.subject else "",
+                "preferred_name": n.subject.preferred_name if n.subject else "",
+            },
+            "author": person_display_name(n.author),
+            "created_at": n.created_at.isoformat(),
+            "body": body,
+            "preview": preview,
+            "is_long": len(body) > 200,
+            "is_sensitive": bool(n.is_sensitive),
+        }
+        if n.created_at.date() == target_date:
+            today_rows.append(item)
+        else:
+            recent_rows.append(item)
+
+    # Sensitive count per camper for the placeholder pill.
+    sensitive_counts: dict[int, int] = {}
+    for row in base.exclude(id__in=visible_ids).filter(is_sensitive=True):
+        sensitive_counts[row.subject_id] = sensitive_counts.get(row.subject_id, 0) + 1
+
+    return {
+        "today": today_rows,
+        "recent": recent_rows,
+        "sensitive_counts_by_camper": sensitive_counts,
+    }

--- a/backend/bunk_logs/api/unit_head/camper_dashboard.py
+++ b/backend/bunk_logs/api/unit_head/camper_dashboard.py
@@ -1,0 +1,498 @@
+"""``GET /api/v1/unit-head/campers/<camper_id>/?date=&range=`` — Story 13.
+
+The Camper Dashboard payload is the canonical "what does role X see
+about Camper Y on Date Z?" response. It's owned by Unit Head as the
+first consumer but the helper layer below is intentionally
+role-agnostic so Camper Care (Step 7_8), LT (Step 7_12), and Admin
+(Step 7_13) can reuse it.
+
+Visibility is enforced server-side per Story 13 criterion 7:
+
+* reflection content goes through ``reflections_visible_for_user``;
+* specialist + camper-care notes go through ``notes_visible_to`` and
+  sensitive notes excluded for the viewer are surfaced only as a
+  per-content-type count (the spec's *"1 sensitive note (Camper Care)"*
+  placeholder).
+
+Trend ranges (criterion 2):
+
+* ``this_week``      — last 7 days inclusive of ``date``.
+* ``last_4_weeks``   — last 28 days inclusive.
+* ``full_session``   — program ``start_date`` → program ``end_date``,
+                       clamped at today on the right.
+* ``custom``         — caller passes ``date_start`` / ``date_end``.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from datetime import timedelta
+from typing import Any
+
+from django.utils.dateparse import parse_date
+from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.api.counselor.common import camper_reflection_template
+from bunk_logs.api.counselor.common import person_display_name
+from bunk_logs.core.filters import notes_visible_to
+from bunk_logs.core.filters import reflections_visible_for_user
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Note
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.reflection_scores import iter_scored_fields
+from bunk_logs.core.reflection_scores import resolve_rating_cells
+
+from .common import supervised_bunks
+from .common import viewer_or_403
+
+RANGE_CHOICES: frozenset[str] = frozenset({
+    "this_week", "last_4_weeks", "full_session", "custom",
+})
+
+
+class UnitHeadCamperDashboardView(APIView):
+    """Shared Camper Dashboard payload — Unit Head entry point."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, camper_id: int, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        target_date = _parse_date_param(
+            request.query_params.get("date"), default=ctx.today,
+        )
+        if target_date > ctx.today:
+            msg = "Future dates are not selectable."
+            raise ValidationError(msg)
+
+        camper = Person.all_objects.filter(
+            id=camper_id, organization=ctx.organization,
+        ).first()
+        if camper is None:
+            msg = "Camper not found."
+            raise NotFound(msg)
+
+        # Supervision gate: viewer must supervise a bunk this camper is
+        # rostered to (today's roster — UH retains access across history).
+        if not _viewer_supervises_camper(ctx, camper):
+            msg = "You do not supervise this camper."
+            raise PermissionDenied(msg)
+
+        payload = build_camper_dashboard_payload(
+            request=request,
+            camper=camper,
+            organization=ctx.organization,
+            program=ctx.program,
+            target_date=target_date,
+            range_key=request.query_params.get("range") or "last_4_weeks",
+            date_start_raw=request.query_params.get("date_start"),
+            date_end_raw=request.query_params.get("date_end"),
+        )
+        return Response(payload)
+
+
+# ---------------------------------------------------------------------------
+# Shared payload builder (role-agnostic; reused by future role flows)
+# ---------------------------------------------------------------------------
+
+
+def build_camper_dashboard_payload(
+    *,
+    request,
+    camper: Person,
+    organization,
+    program,
+    target_date: date,
+    range_key: str = "last_4_weeks",
+    date_start_raw: str | None = None,
+    date_end_raw: str | None = None,
+) -> dict[str, Any]:
+    """Compose the Camper Dashboard payload for any role.
+
+    Pulled out of the view so future role flows (LT, Camper Care,
+    Admin) can call it with their own viewer-resolution + supervision
+    gate but share the visibility-filtered content. Visibility is
+    enforced inside the helper via ``request.user`` so the caller
+    cannot accidentally widen audience by passing a different Person.
+    """
+    if range_key not in RANGE_CHOICES:
+        msg = f"Unknown range: {range_key}."
+        raise ValidationError(msg)
+
+    period_start, period_end = _resolve_range(
+        range_key=range_key,
+        anchor=target_date,
+        program=program,
+        date_start_raw=date_start_raw,
+        date_end_raw=date_end_raw,
+    )
+
+    template = camper_reflection_template(organization, program)
+
+    # Today's full reflection (visibility-filtered for the request user).
+    today_reflection = None
+    today_payload: dict[str, Any] | None = None
+    if template is not None:
+        today_reflection = (
+            reflections_visible_for_user(
+                request.user,
+                Reflection.all_objects.filter(
+                    template=template,
+                    subject=camper,
+                    period_start=target_date,
+                    period_end=target_date,
+                    is_complete=True,
+                ).select_related("author", "template"),
+            ).order_by("-submitted_at").first()
+        )
+        if today_reflection is not None:
+            today_payload = _serialize_today_reflection(today_reflection, template)
+
+    # Trend data — one numeric per scored cell per date in the period.
+    trend_payload = (
+        _build_trend_payload(
+            request=request,
+            template=template,
+            camper=camper,
+            period_start=period_start,
+            period_end=period_end,
+        ) if template else {"series": [], "scale_max": 5}
+    )
+
+    # Specialist + camper-care notes (visibility-filtered).
+    notes_payload = _build_notes_payload(
+        request=request, camper=camper, target_date=target_date,
+    )
+
+    return {
+        "header": {
+            "camper": _camper_brief(camper),
+            "date": target_date.isoformat(),
+        },
+        "trend": trend_payload,
+        "today_reflection": today_payload,
+        "today_scores": _today_scores(today_reflection, template),
+        "today_flags": _today_flags(today_reflection, template),
+        "specialist_reports": notes_payload["specialist"],
+        "camper_care_notes": notes_payload["camper_care"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Range resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_range(
+    *,
+    range_key: str,
+    anchor: date,
+    program,
+    date_start_raw: str | None,
+    date_end_raw: str | None,
+) -> tuple[date, date]:
+    if range_key == "this_week":
+        start = anchor - timedelta(days=6)
+        return start, anchor
+    if range_key == "last_4_weeks":
+        start = anchor - timedelta(days=27)
+        return start, anchor
+    if range_key == "full_session":
+        start = program.start_date or (anchor - timedelta(days=27))
+        end = min(program.end_date or anchor, anchor)
+        if end < start:
+            start, end = end, start
+        return start, end
+    # custom
+    start = parse_date(date_start_raw or "") or (anchor - timedelta(days=27))
+    end = parse_date(date_end_raw or "") or anchor
+    if end < start:
+        start, end = end, start
+    end = min(end, anchor)
+    return start, end
+
+
+# ---------------------------------------------------------------------------
+# Trend
+# ---------------------------------------------------------------------------
+
+
+def _build_trend_payload(
+    *,
+    request,
+    template,
+    camper: Person,
+    period_start: date,
+    period_end: date,
+) -> dict[str, Any]:
+    """One series per scored cell across the period.
+
+    Missing days appear as ``None`` values rather than zeros (Story 13
+    criterion 4). The returned shape lets the frontend toggle
+    individual dimensions on/off via the legend (criterion 3) by
+    iterating ``series`` directly.
+    """
+    refs = list(
+        reflections_visible_for_user(
+            request.user,
+            Reflection.all_objects.filter(
+                template=template,
+                subject=camper,
+                period_start__gte=period_start,
+                period_end__lte=period_end,
+                is_complete=True,
+            ).order_by("period_end", "submitted_at"),
+        ),
+    )
+
+    # Most-recent-per-day collapse so a re-submission overwrites the cell.
+    per_day: dict[date, Reflection] = {}
+    for r in refs:
+        existing = per_day.get(r.period_end)
+        if existing is None or r.submitted_at > existing.submitted_at:
+            per_day[r.period_end] = r
+
+    columns = list(iter_scored_fields(template))
+    series: list[dict[str, Any]] = []
+    days = _date_range(period_start, period_end)
+    scale_max_overall = 5
+    for field, label, sm in columns:
+        scale_max_overall = max(scale_max_overall, sm)
+        points: list[dict[str, Any]] = []
+        for d in days:
+            r = per_day.get(d)
+            value: float | None = None
+            reflection_id: int | None = None
+            if r is not None:
+                cells = resolve_rating_cells(field, r.answers or {})
+                value = cells.get(label)
+                reflection_id = r.id
+            points.append({
+                "date": d.isoformat(),
+                "value": (round(value, 2) if value is not None else None),
+                "reflection_id": reflection_id,
+            })
+        series.append({
+            "label": label,
+            "field_key": field.get("key"),
+            "field_type": field.get("type"),
+            "scale_max": sm,
+            "points": points,
+        })
+
+    return {
+        "series": series,
+        "scale_max": scale_max_overall,
+        "period": {"start": period_start.isoformat(), "end": period_end.isoformat()},
+    }
+
+
+def _date_range(start: date, end: date) -> list[date]:
+    return [start + timedelta(days=i) for i in range((end - start).days + 1)]
+
+
+# ---------------------------------------------------------------------------
+# Today's reflection + scores + flags
+# ---------------------------------------------------------------------------
+
+
+def _serialize_today_reflection(reflection: Reflection, template) -> dict:
+    """Full reflection answers projected through the template field order.
+
+    Story 13 criterion 1 wants the answers shown "in template field
+    order" — the consumer renders ``fields`` directly, each carrying
+    its answer payload so the frontend doesn't have to dereference
+    schema separately.
+    """
+    answers = reflection.answers or {}
+    fields_out: list[dict[str, Any]] = []
+    for f in (template.schema or {}).get("fields") or []:
+        if not isinstance(f, dict):
+            continue
+        key = f.get("key")
+        if not isinstance(key, str):
+            continue
+        fields_out.append({
+            "key": key,
+            "type": f.get("type"),
+            "dashboard_role": f.get("dashboard_role"),
+            "prompts": f.get("prompts") or {},
+            "scale_labels": f.get("scale_labels") or {},
+            "scale": f.get("scale"),
+            "categories": f.get("categories") or [],
+            "options": f.get("options") or [],
+            "answer": answers.get(key),
+        })
+    return {
+        "id": reflection.id,
+        "author": person_display_name(reflection.author),
+        "language": reflection.language,
+        "submitted_at": reflection.submitted_at.isoformat() if reflection.submitted_at else None,
+        "team_visibility": reflection.team_visibility,
+        "fields": fields_out,
+    }
+
+
+def _today_scores(reflection: Reflection | None, template) -> list[dict]:
+    """All scored cells for today's reflection."""
+    if reflection is None or template is None:
+        return []
+    cells_out: list[dict] = []
+    answers = reflection.answers or {}
+    for f in (template.schema or {}).get("fields") or []:
+        if not isinstance(f, dict):
+            continue
+        if f.get("type") not in ("single_rating", "rating_group"):
+            continue
+        for label, value in resolve_rating_cells(f, answers).items():
+            cells_out.append({
+                "label": label,
+                "value": (round(value, 2) if value is not None else None),
+                "scale_max": _scale_max(f),
+            })
+    return cells_out
+
+
+def _today_flags(reflection: Reflection | None, template) -> list[dict]:
+    """Boolean / yes-no flags surfaced in today's reflection.
+
+    Picks up help-request fields and any ``yes_no`` whose answer is
+    truthy. Returns the field key + prompt so the frontend can show
+    them without redoing schema lookups.
+    """
+    if reflection is None or template is None:
+        return []
+    out: list[dict] = []
+    answers = reflection.answers or {}
+    for f in (template.schema or {}).get("fields") or []:
+        if not isinstance(f, dict):
+            continue
+        if f.get("type") not in ("yes_no", "single_choice", "multiple_choice"):
+            continue
+        key = f.get("key")
+        if not isinstance(key, str):
+            continue
+        v = answers.get(key)
+        if not _is_truthy_flag(v):
+            continue
+        out.append({
+            "key": key,
+            "value": v,
+            "prompts": f.get("prompts") or {},
+            "dashboard_role": f.get("dashboard_role"),
+        })
+    return out
+
+
+def _is_truthy_flag(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"yes", "true", "1"}
+    if isinstance(value, list):
+        return any(_is_truthy_flag(v) for v in value)
+    return False
+
+
+def _scale_max(field: dict) -> int:
+    from bunk_logs.core.reflection_scores import scale_max
+    return scale_max(field)
+
+
+# ---------------------------------------------------------------------------
+# Notes
+# ---------------------------------------------------------------------------
+
+
+def _build_notes_payload(
+    *, request, camper: Person, target_date: date,
+) -> dict[str, dict]:
+    """Visibility-filtered specialist + camper-care notes for one camper.
+
+    Sensitive notes that the viewer can't read are NOT serialized;
+    instead each content type returns a ``sensitive_count`` so the
+    frontend can render the placeholder per Story 13 / Story 15
+    criterion 4.
+    """
+    base = Note.all_objects.filter(subject=camper).select_related("author")
+    visible = notes_visible_to(request.user, base)
+    visible_ids = set(visible.values_list("id", flat=True))
+
+    return {
+        "specialist": _split_notes(
+            visible, base, visible_ids,
+            Note.NoteType.SPECIALIST, target_date,
+        ),
+        "camper_care": _split_notes(
+            visible, base, visible_ids,
+            Note.NoteType.CAMPER_CARE, target_date,
+        ),
+    }
+
+
+def _split_notes(
+    visible_qs, base_qs, visible_ids: set[int],
+    note_type: str, target_date: date,
+) -> dict[str, Any]:
+    filtered = visible_qs.filter(note_type=note_type).order_by("-created_at")
+    items: list[dict] = []
+    for n in filtered:
+        body = n.body or ""
+        preview = body if len(body) <= 200 else (body[:200].rstrip() + "…")
+        items.append({
+            "id": n.id,
+            "author": person_display_name(n.author),
+            "created_at": n.created_at.isoformat(),
+            "body": body,
+            "preview": preview,
+            "is_long": len(body) > 200,
+            "is_sensitive": bool(n.is_sensitive),
+            "is_today": n.created_at.date() == target_date,
+        })
+    sensitive_excluded = base_qs.exclude(id__in=visible_ids).filter(
+        note_type=note_type, is_sensitive=True,
+    ).count()
+    return {"items": items, "sensitive_excluded_count": sensitive_excluded}
+
+
+# ---------------------------------------------------------------------------
+# Misc helpers
+# ---------------------------------------------------------------------------
+
+
+def _camper_brief(camper: Person) -> dict:
+    return {
+        "id": camper.id,
+        "first_name": camper.first_name,
+        "last_name": camper.last_name,
+        "preferred_name": camper.preferred_name,
+    }
+
+
+def _viewer_supervises_camper(ctx, camper: Person) -> bool:
+    """True iff the camper is rostered on a bunk under the UH's supervision."""
+    bunks = supervised_bunks(ctx.membership, today=ctx.today)
+    if not bunks:
+        return False
+    bunk_ids = {b.id for b in bunks}
+    return AssignmentGroupMembership.objects.filter(
+        group_id__in=bunk_ids,
+        person=camper,
+        role_in_group="subject",
+        is_active=True,
+    ).exists()
+
+
+def _parse_date_param(raw: str | None, *, default: date) -> date:
+    if not raw:
+        return default
+    parsed = parse_date(raw)
+    if parsed is None:
+        msg = "Invalid 'date' parameter; expected YYYY-MM-DD."
+        raise ValidationError(msg)
+    return parsed

--- a/backend/bunk_logs/api/unit_head/common.py
+++ b/backend/bunk_logs/api/unit_head/common.py
@@ -1,0 +1,528 @@
+"""Shared helpers for Unit Head read + write endpoints.
+
+UH endpoints share a viewer-resolution contract (UH Membership + active
+counselor supervisions), a Bunk resolution path (via
+:func:`Supervision.objects.bunks_for_uh`), and a handful of Story 11/12
+projections (score grid columns, attention badges, bunk-concerns
+surfacing). They live here so the per-endpoint modules can stay focused
+on shaping the payload and the rules can be tested once.
+
+Reuse from the counselor common module is deliberate: ``get_today``,
+``is_editable_today``, ``enforce_edit_window``, ``is_day_off_answer``,
+``off_camp_camper_ids``, and ``_resolve_template`` aren't UH-specific and
+behave identically here. Importing them keeps the rollover-aware "today"
+contract and edit-window semantics consistent across role flows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from django.db.models import Q
+from rest_framework.exceptions import PermissionDenied
+
+from bunk_logs.api.counselor.common import _resolve_template
+from bunk_logs.api.counselor.common import enforce_edit_window
+from bunk_logs.api.counselor.common import is_day_off_answer
+from bunk_logs.api.counselor.common import is_editable_today
+from bunk_logs.api.counselor.common import off_camp_camper_ids
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.models import Supervision
+from bunk_logs.core.reflection_scores import iter_scored_fields
+from bunk_logs.core.reflection_scores import resolve_rating_cells
+from bunk_logs.core.time_utils import get_today
+
+if TYPE_CHECKING:
+    from datetime import date
+    from datetime import datetime
+
+    from bunk_logs.core.models import Organization
+    from bunk_logs.core.models import Program
+
+
+__all__ = [
+    "ATTENTION_BADGE_ORDER",
+    "UH_TEMPLATE_SLUG",
+    "ViewerContext",
+    "build_score_grid",
+    "bunk_camper_ids",
+    "compute_attention_badges",
+    "enforce_edit_window",
+    "is_day_off_answer",
+    "is_editable_today",
+    "off_camp_camper_ids",
+    "supervised_bunk_ids",
+    "supervised_bunks",
+    "unit_head_self_template",
+    "viewer_or_403",
+]
+
+
+UH_TEMPLATE_SLUG = "unit-head-self-reflection"
+
+# Story 10 criterion 7 sort priority: bunks with badges go first in this
+# order, then alphabetical for unbadged bunks.
+ATTENTION_BADGE_ORDER: tuple[str, ...] = (
+    "help_requested",
+    "bunk_concerns",
+    "off_camp",
+    "low_completion",
+)
+
+
+@dataclass(frozen=True)
+class ViewerContext:
+    """Resolved request context for a Unit Head endpoint."""
+
+    person: Person
+    organization: Organization
+    membership: Membership
+    program: Program
+    today: date
+
+
+def viewer_or_403(request) -> ViewerContext:
+    """Resolve viewer Person + org + active UH Membership, or raise 403.
+
+    UH endpoints require all of: authenticated user, an organization in
+    request context (set by middleware), a Person profile in that org,
+    and at least one active ``unit_head`` Membership. The "current"
+    program is the Membership's program — UHs in multiple programs hit
+    a separate program-picker (out of scope here; pick the newest).
+    """
+    org = getattr(request, "organization", None)
+    if org is None:
+        msg = "Organization context required."
+        raise PermissionDenied(msg)
+    if not request.user.is_authenticated:
+        msg = "Authentication required."
+        raise PermissionDenied(msg)
+    person = Person.objects.filter(user=request.user).first()
+    if person is None:
+        msg = "Person profile required."
+        raise PermissionDenied(msg)
+    membership = (
+        Membership.objects.filter(
+            person=person, role="unit_head", is_active=True,
+        )
+        .select_related("program", "program__organization")
+        .order_by("-created_at")
+        .first()
+    )
+    if membership is None:
+        msg = "Unit Head role required."
+        raise PermissionDenied(msg)
+    program = membership.program
+    return ViewerContext(
+        person=person,
+        organization=org,
+        membership=membership,
+        program=program,
+        today=get_today(org),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bunk resolution (Story 10 criterion 5)
+# ---------------------------------------------------------------------------
+
+
+def supervised_bunks(
+    membership: Membership, *, today: date | None = None,
+) -> list[AssignmentGroup]:
+    """Active bunk AssignmentGroups under the UH's supervision.
+
+    Wraps :func:`Supervision.objects.bunks_for_uh` so endpoints can
+    treat the result as a stable, ordered list (the manager returns a
+    distinct queryset). Order is alphabetical by group name so the
+    badge-sort in Story 10 criterion 7 has a deterministic tie-breaker.
+    """
+    qs = Supervision.objects.bunks_for_uh(membership, today=today).order_by("name")
+    return list(qs.select_related("organization"))
+
+
+def supervised_bunk_ids(
+    membership: Membership, *, today: date | None = None,
+) -> set[int]:
+    """IDs only — useful for membership / inclusion checks."""
+    return set(
+        Supervision.objects.bunks_for_uh(membership, today=today)
+        .values_list("id", flat=True),
+    )
+
+
+def bunk_camper_ids(bunk: AssignmentGroup) -> list[int]:
+    """Active camper Person IDs assigned to a bunk as ``subject``.
+
+    The unit-head dashboard never needs the full Person rows (the
+    Camper Dashboard endpoint loads those when drilled into), so we
+    return IDs to keep the bunk-list endpoint cheap.
+    """
+    return list(
+        AssignmentGroupMembership.objects.filter(
+            group=bunk, role_in_group="subject", is_active=True,
+        )
+        .order_by("person__last_name", "person__first_name")
+        .values_list("person_id", flat=True),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Template resolution
+# ---------------------------------------------------------------------------
+
+
+def unit_head_self_template(
+    organization: Organization, program: Program,
+) -> ReflectionTemplate | None:
+    """Daily self-reflection template for the UH role.
+
+    Same org-shadows-global resolver used by the counselor self
+    template. We look up by ``role='unit_head'`` OR
+    ``author_role_filter`` containing ``'unit_head'`` so a customer can
+    ship a single template targeting multiple supervisor roles by
+    listing them in ``author_role_filter``.
+    """
+    qs = ReflectionTemplate.all_objects.filter(
+        Q(role="unit_head") | Q(author_role_filter__contains=["unit_head"]),
+        subject_mode="self",
+        cadence="daily",
+    )
+    return _resolve_template(
+        qs, organization=organization, program_type=program.program_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Attention badges (Story 10 criterion 6)
+# ---------------------------------------------------------------------------
+
+
+def compute_attention_badges(
+    *,
+    bunk: AssignmentGroup,
+    bunk_camper_ids_list: list[int],
+    off_camp_ids: set[int],
+    submitted_camper_ids: set[int],
+    help_requested_camper_ids: set[int],
+    bunk_concerns_referenced_bunk_ids: set[int],
+    low_completion_threshold: float,
+    expected_by_passed: bool,
+) -> list[str]:
+    """Compute attention badges for one bunk on one date.
+
+    Returns the badge codes in dashboard-sort order
+    (``help_requested`` first, then ``bunk_concerns``, ``off_camp``,
+    ``low_completion``). The wider dashboard view applies the
+    ``ATTENTION_BADGE_ORDER`` tuple to sort BETWEEN bunks; this helper
+    is concerned only with WHICH badges apply to one bunk.
+
+    Inputs:
+
+    * ``bunk_camper_ids_list``: ordered camper IDs in the bunk.
+    * ``off_camp_ids``: set of camper IDs flagged ``is_off_camp`` today
+      (Story 10 — surfaced as the ``off_camp`` badge regardless of
+      reflection state).
+    * ``submitted_camper_ids``: campers with a ``is_complete=True``
+      reflection for today; used to compute completion ratio.
+    * ``help_requested_camper_ids``: camper IDs whose reflection asked
+      for UH help — surfaces the ``help_requested`` badge (Story 10
+      criterion 6.i).
+    * ``bunk_concerns_referenced_bunk_ids``: the union of bunk IDs
+      referenced by ANY counselor or UH bunk-concerns surface today.
+      We only check membership; the caller does the resolution.
+    * ``low_completion_threshold``: ratio (0.0-1.0) below which the
+      ``low_completion`` badge fires. Default 0.5 (Story 10 criterion
+      6.iv: "under 50%").
+    * ``expected_by_passed``: whether the org-configured "expected by"
+      time has passed (Story 58). Only check ``low_completion`` after
+      that boundary; before the boundary, low completion is normal.
+    """
+    badges: list[str] = []
+    if help_requested_camper_ids:
+        badges.append("help_requested")
+    if bunk.id in bunk_concerns_referenced_bunk_ids:
+        badges.append("bunk_concerns")
+    if off_camp_ids:
+        badges.append("off_camp")
+
+    expected = [cid for cid in bunk_camper_ids_list if cid not in off_camp_ids]
+    if expected_by_passed and expected:
+        covered = sum(1 for cid in expected if cid in submitted_camper_ids)
+        ratio = covered / len(expected)
+        if ratio < low_completion_threshold:
+            badges.append("low_completion")
+
+    return badges
+
+
+# ---------------------------------------------------------------------------
+# Score grid (Story 12)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScoreGridColumn:
+    """One scored cell column in the Story 12 grid.
+
+    ``label`` matches the key emitted by ``resolve_rating_cells`` so a
+    consumer can directly index per-camper score dicts. ``field_key``
+    is the schema field this column belongs to; for a ``rating_group``
+    column ``category_key`` is the category, ``None`` for single
+    ratings. ``scale_max`` drives the frontend palette selection.
+    """
+
+    label: str
+    field_key: str
+    field_type: str
+    category_key: str | None
+    scale_max: int
+
+
+def score_grid_columns(template: ReflectionTemplate) -> list[ScoreGridColumn]:
+    """Ordered list of cell columns for the Story 12 grid.
+
+    Order matches the template ``schema['fields']`` sequence (Story 12
+    criterion 7 forbids viewer reordering). Each rating_group expands
+    to one column per declared category in the template's category
+    order.
+    """
+    columns: list[ScoreGridColumn] = []
+    for field, label, sm in iter_scored_fields(template):
+        ftype = field.get("type")
+        fkey = field.get("key")
+        if not isinstance(fkey, str):
+            continue
+        category_key: str | None = None
+        if ftype == "rating_group" and "__" in label:
+            category_key = label.split("__", 1)[1]
+        columns.append(
+            ScoreGridColumn(
+                label=label,
+                field_key=fkey,
+                field_type=ftype or "",
+                category_key=category_key,
+                scale_max=sm,
+            ),
+        )
+    return columns
+
+
+def build_score_grid(
+    *,
+    template: ReflectionTemplate,
+    campers: list[Person],
+    reflections_by_subject: dict[int, Reflection],
+) -> dict:
+    """Build the Story 12 score-grid payload.
+
+    Returns ``{"columns": [...], "rows": [...]}`` where each row has a
+    ``camper`` projection plus a ``cells`` dict keyed by the column
+    label. Missing reflections produce a row of ``None`` cells (the
+    frontend renders these visually distinct from low scores per
+    Story 12 criterion 3).
+    """
+    columns = score_grid_columns(template)
+    column_payload = [
+        {
+            "label": col.label,
+            "field_key": col.field_key,
+            "field_type": col.field_type,
+            "category_key": col.category_key,
+            "scale_max": col.scale_max,
+        }
+        for col in columns
+    ]
+    rows: list[dict] = []
+    schema_fields = (template.schema or {}).get("fields") or []
+    field_by_key = {
+        f["key"]: f for f in schema_fields
+        if isinstance(f, dict) and isinstance(f.get("key"), str)
+    }
+    for camper in campers:
+        reflection = reflections_by_subject.get(camper.id)
+        cells: dict[str, float | None] = {col.label: None for col in columns}
+        if reflection is not None and reflection.answers:
+            for col in columns:
+                field = field_by_key.get(col.field_key)
+                if field is None:
+                    continue
+                cells.update(resolve_rating_cells(field, reflection.answers or {}))
+        rows.append(
+            {
+                "camper": {
+                    "id": camper.id,
+                    "first_name": camper.first_name,
+                    "last_name": camper.last_name,
+                    "preferred_name": camper.preferred_name,
+                },
+                "reflection_id": reflection.id if reflection else None,
+                "cells": cells,
+            },
+        )
+    return {"columns": column_payload, "rows": rows}
+
+
+# ---------------------------------------------------------------------------
+# Bunk concerns surfacing (Story 11 criterion 1.iv, UH2)
+# ---------------------------------------------------------------------------
+
+
+def bunk_concerns_referencing(
+    *,
+    organization: Organization,
+    program: Program,
+    target_date: date,
+) -> dict[int, list[Reflection]]:
+    """Map ``bunk_id -> [Reflection, ...]`` for today's bunk-concern flags.
+
+    Both the counselor self-reflection and the UH self-reflection may
+    flag specific bunks via the ``bunk_concerns_bunks`` field
+    (``option_source="supervised_bunks"``). We materialize those
+    references so the bunk dashboard can surface them in its "Bunk
+    concerns" section regardless of WHICH supervisor wrote them.
+
+    Empty values in ``bunk_concerns_bunks`` (missing key, ``None``,
+    empty list) are skipped — only positive references count.
+    """
+    rows = (
+        Reflection.all_objects.filter(
+            organization=organization,
+            program=program,
+            period_start__lte=target_date,
+            period_end__gte=target_date,
+            is_complete=True,
+        )
+        .select_related("author", "template")
+    )
+    out: dict[int, list[Reflection]] = {}
+    for r in rows:
+        ids = (r.answers or {}).get("bunk_concerns_bunks") or []
+        if not isinstance(ids, list):
+            continue
+        for raw in ids:
+            try:
+                bid = int(raw)
+            except (ValueError, TypeError):
+                continue
+            out.setdefault(bid, []).append(r)
+    return out
+
+
+def help_requested_camper_ids_from(
+    reflections: dict[int, Reflection],
+) -> set[int]:
+    """Subject IDs whose reflection asked for UH help today.
+
+    Looks for either ``request_unit_head_help`` (canonical Crane Lake
+    key per the rbac-seed template) or any field tagged
+    ``dashboard_role="help_request_unit_head"`` (forward-compatible
+    convention). Treats string ``"yes"`` / ``true`` / boolean ``True``
+    as positive.
+    """
+    out: set[int] = set()
+    for camper_id, refl in reflections.items():
+        answers = refl.answers or {}
+        if _is_truthy_yes_no(answers.get("request_unit_head_help")):
+            out.add(camper_id)
+            continue
+        for field in (refl.template.schema or {}).get("fields") or []:
+            if not isinstance(field, dict):
+                continue
+            if field.get("dashboard_role") != "help_request_unit_head":
+                continue
+            key = field.get("key")
+            if isinstance(key, str) and _is_truthy_yes_no(answers.get(key)):
+                out.add(camper_id)
+                break
+    return out
+
+
+def _is_truthy_yes_no(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"yes", "true", "1"}
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Bunk-concerns id validation (Stories 16.7 / UH2 write surface)
+# ---------------------------------------------------------------------------
+
+
+def validate_bunk_concerns_ids(
+    raw: object, supervised: set[int],
+) -> list[int]:
+    """Coerce a submitted ``bunk_concerns_bunks`` value to ``[int]``.
+
+    Used by the UH self-reflection write endpoint to ensure a viewer
+    can't flag bunks they don't supervise. Returns the list of valid
+    bunk IDs (de-duplicated, preserving submission order); raises
+    ``PermissionDenied`` when any submitted ID is outside the viewer's
+    supervised set. An empty / missing input returns ``[]``.
+    """
+    if raw is None or raw == "":
+        return []
+    if not isinstance(raw, list):
+        msg = "bunk_concerns_bunks must be a list of bunk IDs."
+        raise PermissionDenied(msg)
+    seen: list[int] = []
+    for item in raw:
+        try:
+            bid = int(item)
+        except (ValueError, TypeError) as e:
+            msg = "bunk_concerns_bunks entries must be integer bunk IDs."
+            raise PermissionDenied(msg) from e
+        if bid not in supervised:
+            msg = "You can only flag bunks you supervise."
+            raise PermissionDenied(msg)
+        if bid not in seen:
+            seen.append(bid)
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# Datetime helpers (Story 10 criterion 6.iv expected-by gate)
+# ---------------------------------------------------------------------------
+
+
+def expected_by_passed(
+    organization: Organization,
+    target_date: date,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    """Whether the org-configured "expected by" time has passed today.
+
+    Reads ``organization.settings.dashboards.expected_by_hour`` (an int
+    in [0, 23], local time). Default ``18`` (6pm) per Story 58 best
+    practice. Returns ``True`` when the supplied / current time is at
+    or past that hour on ``target_date``; ``False`` otherwise (so low
+    completion doesn't fire in the morning).
+    """
+    settings = (organization.settings or {}).get("dashboards") or {}
+    hour = settings.get("expected_by_hour", 18)
+    try:
+        hour_int = int(hour)
+    except (ValueError, TypeError):
+        hour_int = 18
+    hour_int = max(0, min(23, hour_int))
+
+    from django.utils import timezone
+
+    from bunk_logs.core.time_utils import get_org_timezone
+
+    tz = get_org_timezone(organization)
+    current = (now or timezone.now()).astimezone(tz)
+    if current.date() < target_date:
+        return False
+    if current.date() > target_date:
+        return True
+    return current.hour >= hour_int

--- a/backend/bunk_logs/api/unit_head/dashboard.py
+++ b/backend/bunk_logs/api/unit_head/dashboard.py
@@ -1,0 +1,191 @@
+"""``GET /api/v1/unit-head/dashboard/`` — Story 10.
+
+Returns the supervised bunk list with completion + attention badges
+and the UH's own "My reflection" section state.
+
+Sort order (Story 10 criterion 7):
+  badged bunks first, in ``ATTENTION_BADGE_ORDER`` priority, then
+  unbadged bunks alphabetical.
+
+Caching: a 30s per-(org, viewer, day) entry mirrors the counselor
+dashboard contract — writes to UH/counselor reflections bump the
+same generation key the counselor flow uses so cross-role
+freshness stays consistent.
+"""
+
+from __future__ import annotations
+
+from django.core.cache import cache
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.api.counselor.common import camper_reflection_template
+from bunk_logs.api.counselor.common import is_day_off_answer
+from bunk_logs.api.counselor.common import latest_self_reflection
+
+from .common import ATTENTION_BADGE_ORDER
+from .common import build_score_grid  # noqa: F401 — re-exported for downstream tests
+from .common import bunk_camper_ids
+from .common import bunk_concerns_referencing
+from .common import compute_attention_badges
+from .common import expected_by_passed
+from .common import help_requested_camper_ids_from
+from .common import off_camp_camper_ids
+from .common import supervised_bunks
+from .common import unit_head_self_template
+from .common import viewer_or_403
+
+DASHBOARD_CACHE_TTL_SECONDS = 30
+LOW_COMPLETION_THRESHOLD = 0.5  # Story 10 criterion 6.iv
+
+
+def _cache_key(*, viewer_id: int, organization_id: int, today) -> str:
+    return f"unit_head_dashboard:{organization_id}:{viewer_id}:{today.isoformat()}"
+
+
+class UnitHeadDashboardView(APIView):
+    """Supervised bunks + self-reflection state."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer = ctx.person
+        org = ctx.organization
+        program = ctx.program
+        today = ctx.today
+
+        bypass = (request.query_params.get("nocache") or "").lower() in {"1", "true"}
+        cache_key = _cache_key(viewer_id=viewer.id, organization_id=org.id, today=today)
+        if not bypass:
+            cached = cache.get(cache_key)
+            if cached is not None:
+                return Response(cached)
+
+        bunks = supervised_bunks(ctx.membership, today=today)
+        camper_template = camper_reflection_template(org, program)
+        uh_template = unit_head_self_template(org, program)
+
+        # Bunk-concerns surface (Story 11 criterion 1.iv): which bunk IDs
+        # have AT LEAST one reflection referencing them today? We need this
+        # union to set the per-bunk badge.
+        bc_map = bunk_concerns_referencing(
+            organization=org, program=program, target_date=today,
+        )
+        bc_bunk_ids = set(bc_map.keys())
+
+        bunks_payload: list[dict] = []
+        expected_passed = expected_by_passed(org, today)
+
+        for bunk in bunks:
+            camper_ids = bunk_camper_ids(bunk)
+            off_camp = off_camp_camper_ids(org, today, camper_ids)
+            submitted_ids: set[int] = set()
+            help_ids: set[int] = set()
+            if camper_template and camper_ids:
+                from bunk_logs.core.models import Reflection
+                reflections = {
+                    r.subject_id: r
+                    for r in Reflection.all_objects.filter(
+                        template=camper_template,
+                        assignment_group=bunk,
+                        period_start=today,
+                        period_end=today,
+                        is_complete=True,
+                    ).select_related("template")
+                }
+                submitted_ids = set(reflections.keys())
+                help_ids = help_requested_camper_ids_from(reflections)
+
+            badges = compute_attention_badges(
+                bunk=bunk,
+                bunk_camper_ids_list=camper_ids,
+                off_camp_ids=off_camp,
+                submitted_camper_ids=submitted_ids,
+                help_requested_camper_ids=help_ids,
+                bunk_concerns_referenced_bunk_ids=bc_bunk_ids,
+                low_completion_threshold=LOW_COMPLETION_THRESHOLD,
+                expected_by_passed=expected_passed,
+            )
+
+            on_camp_total = len([c for c in camper_ids if c not in off_camp])
+            submitted_on_camp = len([
+                c for c in camper_ids if c in submitted_ids and c not in off_camp
+            ])
+
+            bunks_payload.append({
+                "id": bunk.id,
+                "name": bunk.name,
+                "slug": bunk.slug,
+                "unit_name": (bunk.parent.name if bunk.parent_id else None),
+                "counselor_names": _counselor_names(bunk),
+                "completion": {
+                    "submitted": submitted_on_camp,
+                    "expected": on_camp_total,
+                    "off_camp": len(off_camp),
+                },
+                "badges": badges,
+            })
+
+        bunks_payload.sort(key=_bunk_sort_key)
+
+        # My self-reflection section
+        self_state = "missing"
+        self_reflection_id: int | None = None
+        editable = False
+        if uh_template is not None:
+            existing = latest_self_reflection(
+                viewer, uh_template, today, today,
+            )
+            if existing is not None:
+                self_state = "day_off" if is_day_off_answer(existing) else "complete"
+                self_reflection_id = existing.id
+                editable = True  # within today by definition
+
+        payload = {
+            "today": today.isoformat(),
+            "bunks": bunks_payload,
+            "self_reflection": {
+                "state": self_state,
+                "reflection_id": self_reflection_id,
+                "template_id": uh_template.id if uh_template else None,
+                "editable": editable,
+            },
+        }
+        cache.set(cache_key, payload, DASHBOARD_CACHE_TTL_SECONDS)
+        return Response(payload)
+
+
+def _counselor_names(bunk) -> list[str]:
+    """Active counselor display names for the bunk."""
+    from bunk_logs.api.counselor.common import person_display_name
+    from bunk_logs.core.models import AssignmentGroupMembership
+
+    rows = (
+        AssignmentGroupMembership.objects.filter(
+            group=bunk, role_in_group="author", is_active=True,
+        )
+        .select_related("person")
+        .order_by("person__last_name", "person__first_name")
+    )
+    return [person_display_name(agm.person) for agm in rows if agm.person]
+
+
+def _bunk_sort_key(bunk_row: dict) -> tuple:
+    """Story 10 criterion 7 sort order.
+
+    Badged bunks first, ordered by the priority of their *highest*
+    badge in ATTENTION_BADGE_ORDER. Within the same band, alphabetical
+    by bunk name (case-insensitive). Unbadged bunks come last, also
+    alphabetical.
+    """
+    badges = bunk_row.get("badges") or []
+    name_key = (bunk_row.get("name") or "").casefold()
+    if not badges:
+        return (1, 99, name_key)
+    priority = min(
+        (ATTENTION_BADGE_ORDER.index(b) for b in badges if b in ATTENTION_BADGE_ORDER),
+        default=99,
+    )
+    return (0, priority, name_key)

--- a/backend/bunk_logs/api/unit_head/self_reflection.py
+++ b/backend/bunk_logs/api/unit_head/self_reflection.py
@@ -1,0 +1,346 @@
+"""UH self-reflection write + history endpoints (Stories 16, 17).
+
+POST / PATCH semantics mirror the counselor self-reflection module:
+the ``day_off`` shortcut, today-only edit window (``enforce_edit_window``),
+idempotency via ``client_submission_id``, audit events, and dashboard
+cache invalidation all behave identically. Differences:
+
+* Authentication requires an active ``unit_head`` Membership (the
+  shared ``viewer_or_403`` raises 403 otherwise).
+* ``answers.bunk_concerns_bunks`` is validated against the viewer's
+  supervised bunk IDs — UH can flag only bunks they supervise (Story
+  16 criterion 7, UH2). Invalid IDs raise 403 rather than 400
+  because the request is making a permission-relevant claim.
+* History rows (Story 17) emit ``editable`` only when the cursor is
+  today AND the row exists. UH reflections from OTHER UHs are not
+  visible (UH6) — the queryset is already scoped to author=viewer.
+"""
+
+from __future__ import annotations
+
+from datetime import date as date_type
+from datetime import timedelta
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
+from rest_framework import status
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.api.counselor.common import find_existing_by_client_submission_id
+from bunk_logs.api.counselor.common import invalidate_dashboard_for_viewers
+from bunk_logs.api.counselor.responses import reflection_response
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import reflection_snapshot
+from bunk_logs.core.models import validate_reflection_answers
+from bunk_logs.core.translation import enqueue_translation_for_reflection
+
+from .common import enforce_edit_window
+from .common import is_day_off_answer
+from .common import supervised_bunk_ids
+from .common import unit_head_self_template
+from .common import validate_bunk_concerns_ids
+from .common import viewer_or_403
+from .serializers import UnitHeadSelfReflectionCreateSerializer
+from .serializers import UnitHeadSelfReflectionUpdateSerializer
+
+
+class UnitHeadSelfReflectionHistoryPagination(PageNumberPagination):
+    """Same shape as the counselor history pagination."""
+
+    page_size = 14
+    page_size_query_param = "page_size"
+    max_page_size = 60
+
+
+def _preview_from_answers(answers: dict | None, max_len: int = 120) -> str:
+    if not answers:
+        return ""
+    for value in answers.values():
+        if isinstance(value, str) and value.strip():
+            text = value.strip()
+            return text if len(text) <= max_len else text[: max_len - 1] + "\u2026"
+    return ""
+
+
+def _day_off_answers() -> dict:
+    return {"day_off": True}
+
+
+class UnitHeadSelfReflectionHistoryView(APIView):
+    """Story 17: prior UH self-reflections + gaps + day-off indicators."""
+
+    permission_classes = [IsAuthenticated]
+    pagination_class = UnitHeadSelfReflectionHistoryPagination
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer = ctx.person
+        today = ctx.today
+
+        template = unit_head_self_template(ctx.organization, ctx.program)
+        if template is None:
+            return Response({
+                "count": 0, "next": None, "previous": None,
+                "page": 1, "page_size": self.pagination_class.page_size,
+                "results": [],
+            })
+
+        paginator = self.pagination_class()
+        page_size = paginator.get_page_size(request) or paginator.page_size
+        try:
+            page_num = max(1, int(request.query_params.get("page", "1")))
+        except (TypeError, ValueError):
+            page_num = 1
+
+        max_days = paginator.max_page_size * 5
+        oldest = today - timedelta(days=max_days - 1)
+
+        start_offset = (page_num - 1) * page_size
+        end_offset = start_offset + page_size - 1
+        period_end_window = today - timedelta(days=start_offset)
+        period_start_window = max(today - timedelta(days=end_offset), oldest)
+
+        reflections_qs = (
+            Reflection.all_objects.filter(
+                author=viewer,
+                subject=viewer,
+                template=template,
+                period_start__gte=period_start_window,
+                period_end__lte=period_end_window,
+            )
+            .order_by("-period_start", "-submitted_at")
+        )
+
+        by_date: dict[date_type, Reflection] = {}
+        for r in reflections_qs:
+            if r.period_start not in by_date:
+                by_date[r.period_start] = r
+
+        results: list[dict] = []
+        cursor = period_end_window
+        while cursor >= period_start_window and len(results) < page_size:
+            reflection = by_date.get(cursor)
+            results.append({
+                "date": cursor.isoformat(),
+                "submitted": reflection is not None and reflection.is_complete,
+                "is_day_off": is_day_off_answer(reflection) if reflection else False,
+                "reflection_id": reflection.id if reflection else None,
+                "submitted_at": (
+                    reflection.submitted_at.isoformat()
+                    if reflection and reflection.submitted_at else None
+                ),
+                "preview": (
+                    _preview_from_answers(reflection.answers)
+                    if reflection and not is_day_off_answer(reflection) else ""
+                ),
+                "editable": reflection is not None and cursor == today,
+                "referenced_bunk_ids": (
+                    list(reflection.answers.get("bunk_concerns_bunks") or [])
+                    if reflection and isinstance(reflection.answers, dict) else []
+                ),
+            })
+            cursor -= timedelta(days=1)
+
+        total_count = max_days
+        has_next = page_num * page_size < total_count
+        has_previous = page_num > 1
+        return Response({
+            "count": total_count,
+            "next": page_num + 1 if has_next else None,
+            "previous": page_num - 1 if has_previous else None,
+            "page": page_num,
+            "page_size": page_size,
+            "results": results,
+        })
+
+
+def _validate_answers_for_template(template, answers: dict) -> tuple[bool, Response | None]:
+    """Run the JSON-schema validator; coerce ValidationError to a DRF 400 response."""
+    try:
+        validate_reflection_answers(template.schema, answers)
+    except DjangoValidationError as e:
+        body = e.message_dict if hasattr(e, "message_dict") else {"answers": str(e)}
+        return False, Response(body, status=status.HTTP_400_BAD_REQUEST)
+    return True, None
+
+
+class UnitHeadSelfReflectionCreateView(APIView):
+    """POST a UH self-reflection for today (Story 16)."""
+
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["post", "head", "options"]
+
+    def post(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer, org, today = ctx.person, ctx.organization, ctx.today
+
+        serializer = UnitHeadSelfReflectionCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        payload = serializer.validated_data
+
+        template = unit_head_self_template(org, ctx.program)
+        if template is None:
+            msg = "No Unit Head self-reflection template configured."
+            raise PermissionDenied(msg)
+
+        existing = find_existing_by_client_submission_id(
+            Reflection, program=ctx.program,
+            client_submission_id=payload["client_submission_id"],
+        )
+        if existing is not None:
+            return Response(reflection_response(existing), status=status.HTTP_200_OK)
+
+        if payload["day_off"]:
+            answers = _day_off_answers()
+        else:
+            answers = dict(payload.get("answers") or {})
+            # Coerce + permission-check bunk_concerns_bunks before schema
+            # validation so we surface 403s before structural complaints.
+            supervised = supervised_bunk_ids(ctx.membership, today=today)
+            answers["bunk_concerns_bunks"] = validate_bunk_concerns_ids(
+                answers.get("bunk_concerns_bunks"), supervised,
+            )
+            ok, err = _validate_answers_for_template(template, answers)
+            if not ok:
+                return err
+
+        with transaction.atomic():
+            reflection = Reflection(
+                organization=org,
+                program=ctx.program,
+                subject=viewer,
+                author=viewer,
+                assignment_group=None,
+                template=template,
+                submitted_by=request.user,
+                period_start=today,
+                period_end=today,
+                answers=answers,
+                language=payload["language"],
+                team_visibility=Reflection.TeamVisibility.SUPERVISORS_ONLY,
+                is_complete=True,
+                client_submission_id=payload["client_submission_id"],
+            )
+            try:
+                reflection.full_clean()
+            except DjangoValidationError as e:
+                body = e.message_dict if hasattr(e, "message_dict") else str(e)
+                return Response(body, status=status.HTTP_400_BAD_REQUEST)
+            reflection.save()
+
+        audit_module.created(
+            ctx.membership,
+            reflection,
+            after_state=reflection_snapshot(reflection),
+            content_type="reflection",
+        )
+        if not payload["day_off"]:
+            enqueue_translation_for_reflection(reflection)
+        invalidate_dashboard_for_viewers(org, {viewer.id}, today)
+        # Also bump the UH dashboard cache since the self-reflection
+        # section reads from it.
+        from django.core.cache import cache
+        cache.delete(f"unit_head_dashboard:{org.id}:{viewer.id}:{today.isoformat()}")
+
+        return Response(reflection_response(reflection), status=status.HTTP_201_CREATED)
+
+
+class UnitHeadSelfReflectionDetailView(APIView):
+    """PATCH a UH self-reflection within today's edit window (Story 17)."""
+
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["patch", "head", "options"]
+
+    def patch(self, request, reflection_id: int, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer, org, today = ctx.person, ctx.organization, ctx.today
+
+        reflection = (
+            Reflection.all_objects.filter(id=reflection_id, organization=org)
+            .select_related("template", "program")
+            .first()
+        )
+        if reflection is None:
+            return Response(
+                {"detail": "Reflection not found."}, status=status.HTTP_404_NOT_FOUND,
+            )
+        if reflection.author_id != viewer.id or reflection.subject_id != viewer.id:
+            msg = "You can only edit your own self-reflection."
+            raise PermissionDenied(msg)
+        enforce_edit_window(reflection, org)
+
+        serializer = UnitHeadSelfReflectionUpdateSerializer(
+            data=request.data, partial=True,
+        )
+        serializer.is_valid(raise_exception=True)
+        payload = serializer.validated_data
+
+        before = reflection_snapshot(reflection)
+        supervised = supervised_bunk_ids(ctx.membership, today=today)
+
+        if "day_off" in payload:
+            if payload["day_off"]:
+                answers = _day_off_answers()
+            else:
+                answers = dict(payload.get("answers") or reflection.answers or {})
+                answers["bunk_concerns_bunks"] = validate_bunk_concerns_ids(
+                    answers.get("bunk_concerns_bunks"), supervised,
+                )
+                ok, err = _validate_answers_for_template(
+                    reflection.template, answers,
+                )
+                if not ok:
+                    return err
+        elif "answers" in payload:
+            answers = dict(payload["answers"])
+            answers["bunk_concerns_bunks"] = validate_bunk_concerns_ids(
+                answers.get("bunk_concerns_bunks"), supervised,
+            )
+            ok, err = _validate_answers_for_template(reflection.template, answers)
+            if not ok:
+                return err
+        else:
+            answers = reflection.answers
+
+        language = payload.get("language", reflection.language)
+        reflection.answers = answers
+        reflection.language = language
+        try:
+            reflection.full_clean()
+        except DjangoValidationError as e:
+            body = e.message_dict if hasattr(e, "message_dict") else str(e)
+            return Response(body, status=status.HTTP_400_BAD_REQUEST)
+        reflection.save()
+        after = reflection_snapshot(reflection)
+
+        if before != after:
+            actor_membership = (
+                Membership.objects.filter(
+                    person=viewer, program=reflection.program, is_active=True,
+                )
+                .order_by("-created_at")
+                .first()
+            )
+            audit_module.edited(
+                actor_membership or request.user,
+                reflection,
+                before, after,
+                content_type="reflection",
+            )
+        if (
+            before.get("answers") != after.get("answers")
+            or before.get("language") != after.get("language")
+        ) and not is_day_off_answer(reflection):
+            enqueue_translation_for_reflection(reflection)
+
+        invalidate_dashboard_for_viewers(org, {viewer.id}, today)
+        from django.core.cache import cache
+        cache.delete(f"unit_head_dashboard:{org.id}:{viewer.id}:{today.isoformat()}")
+
+        return Response(reflection_response(reflection), status=status.HTTP_200_OK)

--- a/backend/bunk_logs/api/unit_head/serializers.py
+++ b/backend/bunk_logs/api/unit_head/serializers.py
@@ -1,0 +1,46 @@
+"""Write-side serializers for Unit Head endpoints (Step 7_7).
+
+UH self-reflection serializers mirror their counselor counterparts in
+shape; the view layer adds UH-specific authorization (active
+``unit_head`` Membership) and ``bunk_concerns_bunks`` validation
+against the viewer's supervised bunks.
+"""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+
+class UnitHeadSelfReflectionCreateSerializer(serializers.Serializer):
+    """UH POST body for daily self-reflection (Story 16).
+
+    Mirrors the counselor self-reflection serializer including the
+    ``day_off`` shortcut. The optional ``bunk_concerns_bunks`` payload
+    lives inside ``answers`` (no top-level field) and is enforced by
+    the view against the viewer's supervised bunk IDs.
+    """
+
+    answers = serializers.JSONField(required=False)
+    day_off = serializers.BooleanField(default=False)
+    language = serializers.CharField(max_length=10, default="en")
+    client_submission_id = serializers.UUIDField()
+
+    def validate(self, attrs):
+        if not attrs.get("day_off") and not attrs.get("answers"):
+            msg = "answers is required unless day_off is true."
+            raise serializers.ValidationError({"answers": msg})
+        return attrs
+
+
+class UnitHeadSelfReflectionUpdateSerializer(serializers.Serializer):
+    """UH PATCH body within today's edit window (Story 17 criterion 2)."""
+
+    answers = serializers.JSONField(required=False)
+    day_off = serializers.BooleanField(required=False)
+    language = serializers.CharField(max_length=10, required=False)
+
+    def validate(self, attrs):
+        if not attrs:
+            msg = "At least one field must be provided."
+            raise serializers.ValidationError(msg)
+        return attrs

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -26,6 +26,10 @@ from .dashboards import coverage as coverage_dashboard
 from .dashboards import subject as subject_dashboard
 from .dashboards import template as template_dashboard
 from .dashboards import trends as trends_dashboard
+from .unit_head import bunk_dashboard as uh_bunk_dashboard
+from .unit_head import camper_dashboard as uh_camper_dashboard
+from .unit_head import dashboard as uh_dashboard
+from .unit_head import self_reflection as uh_self_reflection
 
 router = DefaultRouter()
 
@@ -230,6 +234,42 @@ urlpatterns = [
         "counselor/maintenance-tickets/<uuid:ticket_id>/photos/",
         counselor_maintenance_tickets.MaintenanceTicketPhotoCreateView.as_view(),
         name="counselor-maintenance-ticket-photo-create",
+    ),
+    # ------------------------------------------------------------------
+    # Unit Head (Step 7_7)
+    # Hyphenated namespace ``unit-head/`` deliberately disambiguates from
+    # the legacy single-tenant ``unithead/`` route which still serves
+    # Crane Lake's old User-based path.
+    # ------------------------------------------------------------------
+    path(
+        "unit-head/dashboard/",
+        uh_dashboard.UnitHeadDashboardView.as_view(),
+        name="unit-head-dashboard",
+    ),
+    path(
+        "unit-head/bunks/<int:bunk_id>/",
+        uh_bunk_dashboard.UnitHeadBunkDashboardView.as_view(),
+        name="unit-head-bunk-dashboard",
+    ),
+    path(
+        "unit-head/campers/<int:camper_id>/",
+        uh_camper_dashboard.UnitHeadCamperDashboardView.as_view(),
+        name="unit-head-camper-dashboard",
+    ),
+    path(
+        "unit-head/self-reflection/",
+        uh_self_reflection.UnitHeadSelfReflectionCreateView.as_view(),
+        name="unit-head-self-reflection-create",
+    ),
+    path(
+        "unit-head/self-reflection/history/",
+        uh_self_reflection.UnitHeadSelfReflectionHistoryView.as_view(),
+        name="unit-head-self-reflection-history",
+    ),
+    path(
+        "unit-head/self-reflection/<int:reflection_id>/",
+        uh_self_reflection.UnitHeadSelfReflectionDetailView.as_view(),
+        name="unit-head-self-reflection-detail",
     ),
 ]
 

--- a/backend/bunk_logs/core/filters.py
+++ b/backend/bunk_logs/core/filters.py
@@ -38,6 +38,64 @@ def _viewer_roles(person: Person, program_id: int | None = None) -> frozenset[st
     return frozenset(qs.values_list("role", flat=True))
 
 
+def _supervised_subject_ids_for(person: Person, org_id: int) -> set[int]:
+    """Camper Person IDs reachable from ``person``'s Supervision rows.
+
+    Resolves both ``MEMBERSHIP`` and ``BUNK`` targets to the set of
+    subject Persons rostered into the resulting bunks (today). Used by
+    :func:`_note_visibility_q` so a UH can see non-sensitive notes
+    about campers in their supervised bunks even though the
+    role-audience table alone wouldn't add ``unit_head`` to the
+    specialist-note audience.
+    """
+    from datetime import date as _date
+
+    from bunk_logs.core.models import AssignmentGroupMembership as AGM_  # noqa: N814 — module-private alias
+    from bunk_logs.core.models import Supervision
+
+    today = _date.today()
+    sups = Supervision.all_objects.filter(
+        supervisor_membership__person=person,
+        supervisor_membership__is_active=True,
+        start_date__lte=today,
+        supervisor_membership__program__organization_id=org_id,
+    ).filter(Q(end_date__isnull=True) | Q(end_date__gte=today))
+
+    bunk_ids: set[int] = set()
+    person_ids: set[int] = set()
+    for s in sups.select_related("target_membership", "target_bunk").only(
+        "target_type", "target_membership__person_id", "target_bunk_id",
+    ):
+        if s.target_type == "bunk" and s.target_bunk_id:
+            bunk_ids.add(s.target_bunk_id)
+        elif s.target_type == "membership" and s.target_membership_id:
+            pid = getattr(s.target_membership, "person_id", None)
+            if pid:
+                person_ids.add(pid)
+
+    if person_ids:
+        # Persons supervised via Membership target -> their authored bunks.
+        bunk_ids.update(
+            AGM_.all_objects.filter(
+                person_id__in=person_ids,
+                role_in_group="author",
+                is_active=True,
+                group__is_active=True,
+            ).values_list("group_id", flat=True),
+        )
+
+    if not bunk_ids:
+        return set()
+
+    return set(
+        AGM_.all_objects.filter(
+            group_id__in=bunk_ids,
+            role_in_group="subject",
+            is_active=True,
+        ).values_list("person_id", flat=True),
+    )
+
+
 def _note_visibility_q(person: Person, org_id: int) -> Q | None:
     """Build OR-of-Q filter for notes visible to person (excludes author path)."""
     admin = is_org_admin(person) if person else False
@@ -48,6 +106,17 @@ def _note_visibility_q(person: Person, org_id: int) -> Q | None:
     programs = Membership.all_objects.filter(
         person=person, is_active=True, program__organization_id=org_id,
     ).values_list("program_id", flat=True).distinct()
+
+    # Supervision-based visibility for non-sensitive specialist + camper-care
+    # notes about subjects in the viewer's supervised bunks. Sensitive
+    # variants still flow through the role-table check below.
+    supervised_subject_ids = _supervised_subject_ids_for(person, org_id)
+    if supervised_subject_ids:
+        parts.append(Q(
+            subject_id__in=supervised_subject_ids,
+            note_type__in=(Note.NoteType.SPECIALIST, Note.NoteType.CAMPER_CARE),
+            is_sensitive=False,
+        ))
 
     for program_id in programs:
         roles = _viewer_roles(person, program_id)

--- a/backend/bunk_logs/core/migrations/0030_seed_unit_head_self_reflection_template.py
+++ b/backend/bunk_logs/core/migrations/0030_seed_unit_head_self_reflection_template.py
@@ -1,0 +1,157 @@
+"""Seed the global Unit Head self-reflection ReflectionTemplate (Step 7_7).
+
+Mirrors the counselor seed (migration 0029) in shape: a single
+``organization IS NULL`` template that any tenant can override with an
+org-scoped row via the resolver in ``api/unit_head/common.py``. Targets
+the ``unit_head`` Membership role.
+
+Schema design (Story 16):
+1. ``day_off`` (yes_no) — same shortcut counselors get; UH self-reflections
+   are daily by default.
+2. ``overall_day`` (single_rating) — primary score surfaced in the
+   dashboard "My reflection" section.
+3. ``wins`` / ``improvements`` (text_list) — open-ended reflection.
+4. ``concern`` (textarea) — generic supervisor flag for the UH's own LT.
+5. ``bunk_concerns_bunks`` (multiple_choice, ``option_source="supervised_bunks"``)
+    — optional Story 16 criterion 7 / UH2 field. Options are resolved at
+    render time from the viewer's active counselor supervisions; the
+    write API validates submitted IDs against that set. When populated,
+    the Bunk Dashboard (Story 11) surfaces this UH self-reflection in the
+    "Bunk concerns" section for each referenced bunk.
+6. ``bunk_concerns_note`` (textarea) — narrative paired with the bunk
+    selection above.
+
+All scored / list fields are ``required: false`` so the ``day_off``
+shortcut payload ``{"day_off": true}`` validates without other fields.
+English + Spanish prompts are seeded.
+"""
+
+from django.db import migrations
+
+SLUG = "unit-head-self-reflection"
+NAME = "Unit Head Self-Reflection"
+LANGUAGES = ["en", "es"]
+
+
+def _schema() -> dict:
+    return {
+        "fields": [
+            {
+                "key": "day_off",
+                "type": "yes_no",
+                "required": False,
+                "prompts": {
+                    "en": "Are you taking a day off today?",
+                    "es": "¿Estás tomando un día libre hoy?",
+                },
+            },
+            {
+                "key": "overall_day",
+                "type": "single_rating",
+                "required": False,
+                "scale": [1, 5],
+                "scale_labels": {
+                    "en": ["Difficult", "Tough", "OK", "Good", "Great"],
+                    "es": ["Difícil", "Duro", "Regular", "Bueno", "Excelente"],
+                },
+                "dashboard_role": "primary_rating",
+            },
+            {
+                "key": "wins",
+                "type": "text_list",
+                "required": False,
+                "prompts": {
+                    "en": "What went well across your unit today?",
+                    "es": "¿Qué salió bien en tu unidad hoy?",
+                },
+                "dashboard_role": "wins",
+            },
+            {
+                "key": "improvements",
+                "type": "text_list",
+                "required": False,
+                "prompts": {
+                    "en": "What could go differently tomorrow?",
+                    "es": "¿Qué podría ser diferente mañana?",
+                },
+                "dashboard_role": "improvements",
+            },
+            {
+                "key": "concern",
+                "type": "textarea",
+                "required": False,
+                "prompts": {
+                    "en": "Anything you want to flag for your team?",
+                    "es": "¿Algo que quieras compartir con tu equipo?",
+                },
+                "dashboard_role": "open_concern",
+            },
+            {
+                "key": "bunk_concerns_bunks",
+                "type": "multiple_choice",
+                "required": False,
+                "option_source": "supervised_bunks",
+                "prompts": {
+                    "en": "Which bunks (if any) have something to flag?",
+                    "es": "¿Qué cabañas (si las hay) tienen algo que destacar?",
+                },
+            },
+            {
+                "key": "bunk_concerns_note",
+                "type": "textarea",
+                "required": False,
+                "prompts": {
+                    "en": "What should the bunk team know?",
+                    "es": "¿Qué debe saber el equipo de la cabaña?",
+                },
+            },
+        ],
+    }
+
+
+def _seed_template(apps, schema_editor):
+    ReflectionTemplate = apps.get_model("core", "ReflectionTemplate")
+    ReflectionTemplate.objects.update_or_create(
+        organization=None,
+        slug=SLUG,
+        version=1,
+        defaults={
+            "name": NAME,
+            "description": (
+                "Daily self-reflection for Unit Heads. Includes a 'day off' "
+                "shortcut and an optional bunk-concerns flag whose options are "
+                "populated server-side from the viewer's supervised bunks."
+            ),
+            "cadence": "daily",
+            "schema": _schema(),
+            "languages": LANGUAGES,
+            "is_active": True,
+            "subject_mode": "self",
+            "assignment_scope": "none",
+            "assignment_group_types": [],
+            "author_role_filter": ["unit_head"],
+            "subject_role_filter": [],
+            "required_per_subject_per_period": 1,
+            "subject_visible": False,
+            "supports_privacy": False,
+            "role": "unit_head",
+            "program_type": None,
+        },
+    )
+
+
+def _remove_template(apps, schema_editor):
+    ReflectionTemplate = apps.get_model("core", "ReflectionTemplate")
+    ReflectionTemplate.objects.filter(
+        organization__isnull=True, slug=SLUG, version=1,
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0029_seed_counselor_self_reflection_template"),
+    ]
+
+    operations = [
+        migrations.RunPython(_seed_template, reverse_code=_remove_template),
+    ]

--- a/backend/bunk_logs/core/permissions/visibility.py
+++ b/backend/bunk_logs/core/permissions/visibility.py
@@ -8,6 +8,7 @@ applies the same rules.
 
 from __future__ import annotations
 
+from datetime import date
 from functools import reduce
 from operator import or_
 
@@ -147,6 +148,78 @@ def _author_group_ids_with_descendants(person: Person) -> set[int]:
     return direct | descendants
 
 
+def _supervision_authored_q(person: Person, organization_id: int | None) -> Q | None:
+    """Q filter for reflections reachable via the ``core.Supervision`` model.
+
+    Two patterns covered:
+
+    * ``MEMBERSHIP`` supervision (UH → Counselor, LT → Specialist, …):
+      viewer's active Memberships are supervisors of one or more target
+      Memberships. Each target Membership has a Person; that Person's
+      authored ``AssignmentGroup``s carry reflections we want to surface.
+      Visibility on those groups is supervisor-pipe semantics — we
+      ignore ``team_visibility`` because the whole point of the
+      supervisor relationship is to see "supervisors_only" content.
+    * ``BUNK`` supervision (Camper Care over caseload bunks): viewer
+      directly supervises an ``AssignmentGroup``; reflections on that
+      group flow to viewer regardless of authorship.
+
+    Returns ``None`` when the viewer has no active supervisions so the
+    OR builder in :func:`reflections_visible_to` can skip the empty
+    branch cleanly.
+    """
+    from bunk_logs.core.models import Supervision
+
+    today = date.today()
+    sup_qs = Supervision.all_objects.filter(
+        supervisor_membership__person=person,
+        supervisor_membership__is_active=True,
+        start_date__lte=today,
+    ).filter(Q(end_date__isnull=True) | Q(end_date__gte=today))
+    if organization_id is not None:
+        sup_qs = sup_qs.filter(
+            supervisor_membership__program__organization_id=organization_id,
+        )
+
+    membership_target_person_ids: set[int] = set()
+    bunk_ids: set[int] = set()
+    for sup in sup_qs.select_related("target_membership", "target_bunk").only(
+        "id", "target_type", "target_membership__person_id", "target_bunk_id",
+    ):
+        if sup.target_type == "membership" and sup.target_membership_id:
+            person_id = getattr(sup.target_membership, "person_id", None)
+            if person_id:
+                membership_target_person_ids.add(person_id)
+        elif sup.target_type == "bunk" and sup.target_bunk_id:
+            bunk_ids.add(sup.target_bunk_id)
+
+    parts: list[Q] = []
+
+    if membership_target_person_ids:
+        # Find the authored AssignmentGroups for each supervised Person.
+        sup_group_ids = set(
+            AssignmentGroupMembership.all_objects.filter(
+                person_id__in=membership_target_person_ids,
+                role_in_group="author",
+                is_active=True,
+                group__is_active=True,
+            ).values_list("group_id", flat=True),
+        )
+        if sup_group_ids:
+            parts.append(Q(assignment_group_id__in=sup_group_ids))
+        # Also surface the supervised Persons' OWN self-reflections (UH's
+        # supervisor pipe into their counselors' self-reflections).
+        parts.append(Q(author_id__in=membership_target_person_ids,
+                       subject_id__in=membership_target_person_ids))
+
+    if bunk_ids:
+        parts.append(Q(assignment_group_id__in=bunk_ids))
+
+    if not parts:
+        return None
+    return reduce(or_, parts)
+
+
 def _author_group_ids_split(person: Person) -> tuple[set[int], set[int]]:
     """Return ``(direct_ids, descendant_only_ids)`` for the person's authoring memberships.
 
@@ -261,6 +334,14 @@ def reflections_visible_to(
     sq = _unit_scoped_supervisor_q(person, org_id)
     if sq is not None:
         parts.append(sq)
+
+    # Supervision-based supervisor pipe (Step 7_3 / 7_7). Covers UH → Counselor,
+    # LT → team-role, Camper Care → BUNK targets, etc. Independent of the
+    # AssignmentGroup descendant walk: the Supervision row is the source of
+    # truth for who supervises whom, and that's what binds visibility here.
+    supq = _supervision_authored_q(person, org_id)
+    if supq is not None:
+        parts.append(supq)
 
     wq = _wellness_q(person)
     if wq is not None:

--- a/backend/bunk_logs/core/reflection_scores.py
+++ b/backend/bunk_logs/core/reflection_scores.py
@@ -1,0 +1,201 @@
+"""Reflection score extraction primitives shared across role dashboards.
+
+Counselor, Unit Head, Camper Care, Leadership Team, and Admin all need to
+pull numeric ratings out of a ``Reflection.answers`` JSON blob given the
+matching template schema. Each surface uses ratings slightly differently
+(score grid vs trend graph vs concerns vs aggregations) but they all
+share the same input → numeric extraction logic.
+
+These helpers were duplicated across ``api/dashboards/subject.py`` and
+``api/dashboards/trends.py`` before the Unit Head flow needed a third
+copy. Centralising here lets every role dashboard call into one
+canonical extractor, so a change to (say) how ``rating_group`` averaging
+behaves only needs to land once.
+
+Conventions
+-----------
+
+A template field is *scored* when ``type`` is ``single_rating`` or
+``rating_group``. The "scale" for both is read from the field's
+``scale`` array (``[min, max]``) with a default of ``[1, 5]``.
+
+For a score grid (UH Story 12) we want **every** scored cell — one
+column per ``single_rating`` and one column per ``rating_group``
+category. :func:`resolve_rating_cells` returns that flat ``{label:
+value}`` projection.
+
+For a trend graph (UH Story 13) we typically collapse to a single
+numeric per reflection — either the ``primary_rating`` field or an
+average across ``rating_group`` categories. :func:`reduce_rating` does
+that collapse.
+
+To enumerate the columns of a score grid without inspecting individual
+answers, use :func:`iter_scored_fields` which yields ``(field, label,
+scale_max)`` triples in template order.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from bunk_logs.core.models import ReflectionTemplate
+
+
+SCORED_FIELD_TYPES = frozenset({"single_rating", "rating_group"})
+
+
+def scale_max(field: dict) -> int:
+    """Return the inclusive upper bound of ``field['scale']`` (default 5).
+
+    Used by the frontend ``ratingColor()`` palette selector and by the
+    backend trend grid to size the legend. Anything that yields a
+    non-integer falls back to 5 — the canonical Crane Lake scale.
+    """
+    scale = field.get("scale") or [1, 5]
+    try:
+        return int(scale[-1])
+    except (IndexError, ValueError, TypeError):
+        return 5
+
+
+def find_field_by_dashboard_role(
+    template: ReflectionTemplate, role: str,
+) -> dict | None:
+    """Return the first schema field with ``dashboard_role == role``, if any.
+
+    Templates surface specific scored fields onto dashboards by tagging
+    them: ``primary_rating`` for the main scalar shown in score cards,
+    ``category_ratings`` for the multi-dimensional row, ``open_concern``
+    for the supervisor-flag textarea, etc. The convention lets a single
+    Camper Dashboard payload work across templates that use different
+    field keys.
+    """
+    for f in (template.schema or {}).get("fields") or []:
+        if isinstance(f, dict) and f.get("dashboard_role") == role:
+            return f
+    return None
+
+
+def iter_scored_fields(
+    template: ReflectionTemplate,
+) -> Iterator[tuple[dict, str, int]]:
+    """Yield ``(field, label, scale_max)`` for every scored cell in the template.
+
+    Labels mirror the keying convention used by
+    :func:`resolve_rating_cells` so a caller can build a column list
+    that matches the per-reflection extracted dict. Single ratings use
+    the field key as the label; rating groups expand to one label per
+    category, formatted as ``"<field_key>__<category_key>"``.
+
+    Order is template-defined (the order fields appear in
+    ``schema['fields']``); a UH score grid relies on that order to
+    render columns in a stable, template-author-controlled sequence
+    (Story 12 criterion 7 forbids reordering by the viewer).
+    """
+    for field in (template.schema or {}).get("fields") or []:
+        if not isinstance(field, dict):
+            continue
+        ftype = field.get("type")
+        if ftype not in SCORED_FIELD_TYPES:
+            continue
+        fkey = field.get("key")
+        if not isinstance(fkey, str):
+            continue
+        sm = scale_max(field)
+        if ftype == "single_rating":
+            yield field, fkey, sm
+        else:
+            for cat in field.get("categories") or []:
+                if not isinstance(cat, dict):
+                    continue
+                ck = cat.get("key")
+                if not isinstance(ck, str):
+                    continue
+                yield field, f"{fkey}__{ck}", sm
+
+
+def resolve_rating_cells(field: dict, answers: dict) -> dict[str, float | None]:
+    """Pull numeric rating cells out of an answers blob for a given field.
+
+    Returns a flat ``{label: value}`` projection:
+
+    * ``single_rating`` → one entry keyed by the field key.
+    * ``rating_group`` → one entry per category keyed
+      ``"<field_key>__<category_key>"``.
+
+    Missing or non-numeric values resolve to ``None`` rather than being
+    omitted so the score grid can distinguish "no submission" from "no
+    answer" by checking whether the label appears in the dict at all.
+    """
+    ftype = field.get("type")
+    fkey = field.get("key")
+    out: dict[str, float | None] = {}
+    if ftype == "single_rating":
+        v = answers.get(fkey)
+        out[fkey] = _as_float(v)
+        return out
+    if ftype == "rating_group":
+        block = answers.get(fkey) if isinstance(answers.get(fkey), dict) else {}
+        for cat in field.get("categories") or []:
+            ck = cat.get("key") if isinstance(cat, dict) else None
+            if ck is None:
+                continue
+            label = f"{fkey}__{ck}"
+            out[label] = _as_float(block.get(ck) if isinstance(block, dict) else None)
+    return out
+
+
+def reduce_rating(
+    answers: dict,
+    primary: dict | None,
+    category: dict | None,
+    category_key: str | None = None,
+) -> float | None:
+    """Collapse an answers blob to a single numeric for trend visualisation.
+
+    Resolution order:
+
+    1. If ``primary`` is provided and its value is numeric, return it.
+    2. Else if ``category`` is provided:
+       * with ``category_key`` → return that single category's value.
+       * without → average across all configured categories.
+    3. Else → ``None`` (no data this day).
+
+    Matches the trend-grid contract: one numeric per (subject, date) so
+    the heat grid can colour cells via the shared palette. Callers that
+    want every cell (score grid) should use :func:`resolve_rating_cells`
+    instead.
+    """
+    if primary is not None:
+        v = _as_float(answers.get(primary.get("key")))
+        if v is not None:
+            return v
+    if category is not None:
+        block = answers.get(category.get("key"))
+        if not isinstance(block, dict):
+            return None
+        if category_key:
+            return _as_float(block.get(category_key))
+        vals: list[float] = []
+        for cat in category.get("categories") or []:
+            ck = cat.get("key") if isinstance(cat, dict) else None
+            if ck is None:
+                continue
+            v = _as_float(block.get(ck))
+            if v is not None:
+                vals.append(v)
+        if vals:
+            return sum(vals) / len(vals)
+    return None
+
+
+def _as_float(value: object) -> float | None:
+    """Numeric cast that rejects bool. Used everywhere a rating must not be 0/1 from a bool."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None

--- a/backend/bunk_logs/core/validators/template_schema.py
+++ b/backend/bunk_logs/core/validators/template_schema.py
@@ -56,6 +56,15 @@ RESERVED_KEYS = frozenset(
     },
 )
 
+# Whitelisted ``option_source`` values for choice fields whose options come
+# from a server-resolved query rather than a static list in the schema. The
+# UH "bunk_concerns" field uses ``supervised_bunks`` to populate from the
+# viewer's active Supervision rows; future role flows can extend this set
+# (e.g. ``program_campers`` for Camper Care). When ``option_source`` is set
+# we skip the static-options check in ``_validate_options``; the API view
+# is responsible for validating submitted IDs against the resolved source.
+DYNAMIC_OPTION_SOURCES = frozenset({"supervised_bunks"})
+
 _NON_WORD = re.compile(r"[^a-z0-9]+")
 
 
@@ -120,6 +129,12 @@ def _validate_rating_group(field: dict, loc: str) -> None:
 
 
 def _validate_options(field: dict, ftype: str, loc: str) -> None:
+    # Server-resolved option sources (e.g. UH "supervised_bunks") skip the
+    # static list requirement; the API view validates submitted IDs at
+    # write time against the resolved set.
+    option_source = field.get("option_source")
+    if isinstance(option_source, str) and option_source in DYNAMIC_OPTION_SOURCES:
+        return
     options = field.get("options")
     if not isinstance(options, list) or not options:
         raise ValidationError(

--- a/migration_prompts/0_0_context_prompt.md
+++ b/migration_prompts/0_0_context_prompt.md
@@ -16,3 +16,5 @@ Completion requirements for every migration step:
 1. Run `make test-backend` (must pass) and `make test-frontend` (must pass) before committing.
 2. Commit using the step ID as a conventional-commit scope so the migration dashboard can detect it — e.g. `git commit -m "feat(1_2_resolve_duplicate_viewset): ..."`. The step ID must appear verbatim in the commit message.
 3. After committing, push the branch and open a pull request with `gh pr create`. The PR title should start with the step ID. Do not consider the step done until the PR is open.
+
+Execution mode: lean by default. See `CLAUDE.md` § "Migration step execution: lean by default" for what that means in practice and when to escalate to full mode.


### PR DESCRIPTION
## Summary

Implements the backend for **Step 7_7: Unit Head Flow** (Stories 10-17) per the migration prompt and product spec.

- **Story 10 — UH dashboard**: \`GET /api/v1/unit-head/dashboard/\` lists supervised bunks (via \`Supervision.objects.bunks_for_uh\`), each with completion (off-camp excluded), attention badges (\`help_requested\` / \`bunk_concerns\` / \`off_camp\` / \`low_completion\`), counselor names, and the UH's own \"My reflection\" section state.
- **Story 11 — Bunk dashboard**: \`GET /api/v1/unit-head/bunks/<id>/?date=\` returns header / help_requested / off_camp / bunk_concerns / score_grid / orders / specialist_reports in one payload. Future dates rejected (criterion 3); supervision-gated.
- **Story 12 — Score grid**: columns from the active camper-reflection template (single_rating + rating_group expanded one column per category), template-order preserved, missing scores emitted as \`null\`.
- **Story 13 — Camper Dashboard (SHARED)**: \`GET /api/v1/unit-head/campers/<id>/?date=&range=\` returns header / trend / today_reflection / today_scores / today_flags / specialist_reports / camper_care_notes. Trend ranges \`this_week\` / \`last_4_weeks\` / \`full_session\` / \`custom\`. Missing days appear as null (criterion 4). Built on a role-agnostic helper \`build_camper_dashboard_payload\` so 7_8 (Camper Care), 7_12 (LT), and 7_13 (Admin) can reuse it.
- **Story 14 — Orders**: today's Orders + Maintenance Tickets from THIS bunk's counselors, with carried-over open requests + status counts.
- **Story 15 — Specialist reports**: visibility-filtered \`Note\` rows; sensitive notes the UH can't read surface as per-camper placeholder counts.
- **Stories 16, 17 — Self-reflection**: POST + PATCH + history; \`day_off\` shortcut; idempotent replay via \`client_submission_id\`; edit window enforced (today only); other UHs' reflections invisible (UH6).
- **Bunk concerns surface (UH2)**: \`bunk_concerns_bunks\` field uses the new \`option_source=\"supervised_bunks\"\` schema convention. The API validates submitted IDs against the viewer's supervised bunks (403 otherwise). The Bunk Dashboard surfaces this for counselor or UH self-reflections that referenced the bunk.

### Cross-cutting infrastructure
- **\`core/reflection_scores.py\`** centralises rating extraction (\`resolve_rating_cells\`, \`reduce_rating\`, \`iter_scored_fields\`, \`scale_max\`). \`subject.py\` and \`trends.py\` now re-export from there to avoid a third copy.
- **\`reflections_visible_to\` + \`notes_visible_to\`** gain a Supervision-aware path so a UH sees content authored by counselors they supervise without needing to author a parent AssignmentGroup.
- **Schema validator** allows \`option_source\` on \`multiple_choice\` to skip the static-options check; \`DYNAMIC_OPTION_SOURCES\` whitelist starts with \`supervised_bunks\` (extensible).
- **Migration 0030** seeds the global \`unit-head-self-reflection\` template with day_off / overall_day / wins / improvements / concern / bunk_concerns_bunks / bunk_concerns_note fields, EN + ES prompts.

## Test plan
- [x] 24 endpoint tests in \`test_unit_head_endpoints.py\` covering supervision gates, attention badges + sort, score grid extraction, bunk-concerns surfacing, carried-over orders, sensitive-note exclusion, trend gaps, today flags, bunk_concerns ID permission check, idempotent replay, edit-window 403, history gaps + day-off indicators, UH6 isolation.
- [x] \`pytest bunk_logs/api/dashboards/ bunk_logs/core/permissions/\` — 0 regressions on the visibility primitive after extending it.
- [x] Full backend suite: 899/900 passing (one pre-existing Celery Beat test fails on the base branch, unrelated).
- [x] \`ruff check\` clean across all new + modified files.

## Stack
Stacked on \`feat/7_6g_counselor_dual_write\` (PR #79). Frontend lands in a follow-up PR.

Made with [Cursor](https://cursor.com)