### PR TITLE
chore: Dependabot pip shim + weekly pip/npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Dependabot version updates. The pip grapher requires a recognized manifest;
+# see backend/requirements/requirements.txt (shim that includes production.txt).
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /backend/requirements
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5

--- a/backend/requirements/requirements.txt
+++ b/backend/requirements/requirements.txt
@@ -1,0 +1,9 @@
+# Canonical entry point for pip and GitHub's dependency graph.
+#
+# Local development and CI install from local.txt (which pulls in production
+# and base). This file exists so Dependabot recognizes the requirements tree;
+# it tracks the production lock surface.
+#
+#   pip install -r requirements/local.txt   # dev / CI
+#   pip install -r requirements/production.txt
+-r production.txt


### PR DESCRIPTION
## Summary

- Adds `backend/requirements/requirements.txt` as a recognized pip manifest (`-r production.txt`) so GitHub's dependency graph job stops failing with "No supported dependency file present" ([failed run](https://github.com/pantheonsteve/BunkLogs/actions/runs/26248450346)).
- Adds `.github/dependabot.yml` for weekly pip (`/backend/requirements`) and npm (`/frontend`) version PRs (5 open limit each).

Existing install paths are unchanged: dev/CI still use `local.txt` → `production.txt` → `base.txt`.

## Test plan

- [ ] Merge to `main` and confirm the next "Graph Update: pip" workflow on `main` succeeds (or re-run the dependency graph job from repo Settings → Security).
- [ ] Optional: wait for Monday's first Dependabot PR batch and triage as needed.


Made with [Cursor](https://cursor.com)