### PR TITLE
7_8b: Camper Care frontend (Stories 18-23)

### DIFF
--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -53,6 +53,10 @@ import UnitHeadBunkDashboardPage from './pages/unit-head/UnitHeadBunkDashboardPa
 import UnitHeadCamperDashboardPage from './pages/unit-head/UnitHeadCamperDashboardPage';
 import UnitHeadSelfReflectionPage from './pages/unit-head/UnitHeadSelfReflectionPage';
 import UnitHeadSelfReflectionHistoryPage from './pages/unit-head/UnitHeadSelfReflectionHistoryPage';
+import CamperCareDashboardV2 from './pages/camper-care/Dashboard';
+import CamperCareFlagsPage from './pages/camper-care/Flags';
+import CamperCareOrdersPage from './pages/camper-care/Orders';
+import CamperCareNoteFormPage from './pages/camper-care/NoteForm';
 import CamperReflectionListPage from './pages/counselor/CamperReflectionListPage';
 import CamperReflectionFormPage from './pages/counselor/CamperReflectionFormPage';
 import CounselorSelfReflectionPage from './pages/counselor/CounselorSelfReflectionPage';
@@ -424,6 +428,23 @@ function Router() {
           <Route
             path="/unit-head/self-reflection/:reflectionId/edit"
             element={<UnitHeadSelfReflectionPage />}
+          />
+          {/* 7_8b: Camper Care mobile flow. Lives under AppLayout so the
+              sidebar/header chrome stays available across the dashboard,
+              flag/order workspaces, and the note form. The legacy
+              `/dashboard/campercare` route still serves the old
+              CamperCareDashboard.jsx surface and is untouched while
+              wave 5 migration progresses. Bunk + camper drill-down
+              endpoints (Story 18 c.9) are not yet wired; a follow-up
+              PR will add `/api/v1/camper-care/bunks/<id>/` plus the
+              corresponding page wrappers. */}
+          <Route path="/camper-care" element={<CamperCareDashboardV2 />} />
+          <Route path="/camper-care/flags" element={<CamperCareFlagsPage />} />
+          <Route path="/camper-care/orders" element={<CamperCareOrdersPage />} />
+          <Route path="/camper-care/notes/new" element={<CamperCareNoteFormPage />} />
+          <Route
+            path="/camper-care/notes/:noteId/edit"
+            element={<CamperCareNoteFormPage />}
           />
         </Route>
 

--- a/frontend/src/api/camperCare.js
+++ b/frontend/src/api/camperCare.js
@@ -1,0 +1,168 @@
+/**
+ * Camper Care flow API client (Step 7_8).
+ *
+ * Wrappers around `/api/v1/camper-care/*` (Stories 18-23). Mirrors the
+ * shape of `api/unitHead.js`: thin axios calls, named exports per
+ * endpoint, the role-namespaced order transition aliases delegate to
+ * the shared state machine (Step 7_2) so behaviour matches the
+ * generic `/api/v1/orders/...` paths.
+ */
+
+import api from '../api';
+import { newClientSubmissionId } from './counselor';
+
+export { newClientSubmissionId };
+
+/** CC dashboard (Story 18 + 19) for a date (default today). */
+export async function fetchCamperCareDashboard({ date, noCache = false } = {}) {
+  const params = {};
+  if (date) params.date = date;
+  if (noCache) params.nocache = '1';
+  const { data } = await api.get('/api/v1/camper-care/dashboard/', { params });
+  return data;
+}
+
+/**
+ * Flag workspace listing (Story 20).
+ *
+ * @param status — `'active'` / `'followed_up'` / `'resolved'` (omit for
+ *   the unresolved bucket = active + followed_up).
+ * @param caseloadOnly — narrow to viewer's caseload (default false per CC2).
+ */
+export async function fetchFlags({ status, caseloadOnly = false } = {}) {
+  const params = {};
+  if (status) params.status = status;
+  if (caseloadOnly) params.caseload_only = 'true';
+  const { data } = await api.get('/api/v1/camper-care/flags/', { params });
+  return data;
+}
+
+/** Transition a flag to followed_up (interim, note optional). */
+export async function followUpFlag(flagId, { note } = {}) {
+  const { data } = await api.post(
+    `/api/v1/camper-care/flags/${flagId}/follow-up/`,
+    { note: note || '' },
+  );
+  return data;
+}
+
+/** Resolve a flag (terminal, closing note required per Story 20.5.ii). */
+export async function resolveFlag(flagId, { note }) {
+  const { data } = await api.post(
+    `/api/v1/camper-care/flags/${flagId}/resolve/`,
+    { note },
+  );
+  return data;
+}
+
+/** Reopen a flag from resolved or followed_up (reason required per 5.iii). */
+export async function reopenFlag(flagId, { note }) {
+  const { data } = await api.post(
+    `/api/v1/camper-care/flags/${flagId}/reopen/`,
+    { note },
+  );
+  return data;
+}
+
+/**
+ * Orders workspace listing (Story 22).
+ *
+ * Filter values: `'all'`, `'my_caseload'`, `'by_bunk'`, `'by_item'`.
+ */
+export async function fetchOrders({
+  filter = 'all',
+  bunkId,
+  item,
+  resolvedSince,
+  resolvedUntil,
+} = {}) {
+  const params = { filter };
+  if (bunkId) params.bunk_id = bunkId;
+  if (item) params.item = item;
+  if (resolvedSince) params.resolved_since = resolvedSince;
+  if (resolvedUntil) params.resolved_until = resolvedUntil;
+  const { data } = await api.get('/api/v1/camper-care/orders/', { params });
+  return data;
+}
+
+/** Single-order transition via the camper-care alias to the shared state machine. */
+export async function transitionOrder(orderId, { toState, note, reason } = {}) {
+  const payload = { to_state: toState };
+  if (note) payload.note = note;
+  if (reason) payload.reason = reason;
+  const { data } = await api.post(
+    `/api/v1/camper-care/orders/${orderId}/transition/`,
+    payload,
+  );
+  return data;
+}
+
+/** Bulk transition (Story 23.5). All ids share the same target state. */
+export async function bulkTransitionOrders({ ids, toState, note, reason } = {}) {
+  const payload = { ids, to_state: toState };
+  if (note) payload.note = note;
+  if (reason) payload.reason = reason;
+  const { data } = await api.post(
+    '/api/v1/camper-care/orders/bulk-transition/',
+    payload,
+  );
+  return data;
+}
+
+/**
+ * Submit a Camper Care note (Story 21). Returns `{ data, status }` so
+ * the caller can distinguish 201 (created) from any retry semantics
+ * the backend grows later.
+ */
+export async function createCamperCareNote({
+  subjectId, body, category, isSensitive = false, language = 'en',
+}) {
+  const payload = {
+    subject_id: subjectId,
+    body,
+    category,
+    is_sensitive: isSensitive,
+    language,
+  };
+  const res = await api.post('/api/v1/camper-care/notes/', payload);
+  return { data: res.data, status: res.status };
+}
+
+/** Edit a Camper Care note within the 24h window (Story 21.6). */
+export async function patchCamperCareNote(noteId, {
+  body, isSensitive, category, language,
+}) {
+  const payload = {};
+  if (body !== undefined) payload.body = body;
+  if (isSensitive !== undefined) payload.is_sensitive = isSensitive;
+  if (category !== undefined) payload.category = category;
+  if (language !== undefined) payload.language = language;
+  const { data } = await api.patch(
+    `/api/v1/camper-care/notes/${noteId}/`,
+    payload,
+  );
+  return data;
+}
+
+/**
+ * Resolve the audience disclosure copy for the note form (Story 21.10).
+ * Server-side resolution keeps a single source of truth for the role
+ * labels so the Sensitive toggle gets the authoritative list.
+ */
+export async function fetchCamperCareNoteAudience({ isSensitive = false } = {}) {
+  const params = { is_sensitive: isSensitive ? 'true' : 'false' };
+  const { data } = await api.get(
+    '/api/v1/camper-care/notes/audience/',
+    { params },
+  );
+  return data;
+}
+
+/** Categories enum mirroring `Note.Category` on the backend. */
+export const NOTE_CATEGORIES = Object.freeze([
+  { value: 'medical', label: 'Medical' },
+  { value: 'family', label: 'Family' },
+  { value: 'social', label: 'Social' },
+  { value: 'behavioral', label: 'Behavioral' },
+  { value: 'other', label: 'Other' },
+]);

--- a/frontend/src/pages/camper-care/Dashboard.jsx
+++ b/frontend/src/pages/camper-care/Dashboard.jsx
@@ -1,0 +1,376 @@
+/**
+ * Camper Care dashboard — Step 7_8, Stories 18-19.
+ *
+ * Top-of-flow surface for Camper Care. Sections (top to bottom):
+ *   1. Header — date picker + caseload-wide submitted-of-expected rollup
+ *   2. Workspace entries — Flagged campers, Orders, My reflection
+ *   3. Caseload tree — Units expand to Bunks with completion + attention badges
+ *
+ * The bunk-tap drill-down (Story 18 criterion 9 → Bunk Dashboard) is
+ * deferred to a follow-up PR that wires `/api/v1/camper-care/bunks/<id>/`;
+ * for now bunk rows are informational (completion + badges) without a
+ * clickable target.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { fetchCamperCareDashboard } from '../../api/camperCare';
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+const BADGE_META = {
+  cc_flagged: {
+    label: 'Flagged',
+    className: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+  },
+  cc_pending_order: {
+    label: 'Pending order',
+    className: 'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-200',
+  },
+  help_requested: {
+    label: 'Help requested',
+    className: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+  },
+  bunk_concerns: {
+    label: 'Bunk concerns',
+    className: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+  },
+  off_camp: {
+    label: 'Off-camp',
+    className: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
+  },
+  low_completion: {
+    label: 'Low completion',
+    className: 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-100',
+  },
+};
+
+function Badge({ kind }) {
+  const meta = BADGE_META[kind] || {
+    label: kind,
+    className: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200',
+  };
+  return (
+    <span
+      data-testid={`cc-badge-${kind}`}
+      className={`text-xs font-medium px-2 py-0.5 rounded-full ${meta.className}`}
+    >
+      {meta.label}
+    </span>
+  );
+}
+
+function CompletionLabel({ completion }) {
+  if (!completion) return null;
+  if (completion.expected === 0 && completion.off_camp === 0) {
+    return <span title="No expected submissions">—</span>;
+  }
+  if (completion.expected === 0 && completion.off_camp > 0) {
+    return (
+      <span title="All campers off-camp">
+        — <span className="text-xs">({completion.off_camp} off-camp)</span>
+      </span>
+    );
+  }
+  return (
+    <>
+      {completion.submitted} of {completion.expected} submitted
+      {completion.off_camp > 0 && (
+        <span className="text-xs text-gray-500 dark:text-gray-400 ml-2">
+          ({completion.off_camp} off-camp)
+        </span>
+      )}
+    </>
+  );
+}
+
+function BunkRow({ bunk }) {
+  return (
+    <li
+      data-testid={`cc-bunk-row-${bunk.id}`}
+      className="rounded-lg border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 px-3 py-2"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="font-medium text-sm text-gray-900 dark:text-white truncate">{bunk.name}</p>
+          {bunk.counselor_names?.length > 0 && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+              {bunk.counselor_names.join(' · ')}
+            </p>
+          )}
+        </div>
+        <div className="text-xs text-right shrink-0 text-gray-700 dark:text-gray-200">
+          <CompletionLabel completion={bunk.completion} />
+        </div>
+      </div>
+      {bunk.badges?.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mt-2">
+          {bunk.badges.map((b) => (
+            <Badge key={b} kind={b} />
+          ))}
+        </div>
+      )}
+    </li>
+  );
+}
+
+function UnitSection({ unit }) {
+  const [open, setOpen] = useState(true);
+  return (
+    <section
+      data-testid={`cc-unit-${unit.id ?? 'unassigned'}`}
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between gap-2 px-4 py-3 text-left"
+        aria-expanded={open}
+      >
+        <div className="min-w-0">
+          <h3 className="font-semibold text-gray-900 dark:text-white">{unit.name}</h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {unit.bunks.length} bunk{unit.bunks.length === 1 ? '' : 's'} ·{' '}
+            <CompletionLabel completion={unit.completion} />
+          </p>
+        </div>
+        <span aria-hidden="true" className="text-gray-400 text-sm">{open ? '–' : '+'}</span>
+      </button>
+      {open && (
+        <ul className="px-3 pb-3 space-y-2">
+          {unit.bunks.map((b) => (
+            <BunkRow key={b.id} bunk={b} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function WorkspaceCard({ to, label, count, testid, accent = 'blue' }) {
+  const accents = {
+    blue: 'border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/30 text-blue-900 dark:text-blue-100',
+    red: 'border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/30 text-red-900 dark:text-red-100',
+    amber: 'border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/30 text-amber-900 dark:text-amber-100',
+  };
+  return (
+    <Link
+      to={to}
+      data-testid={testid}
+      className={`flex items-center justify-between rounded-xl border px-4 py-3 shadow-sm hover:shadow-md transition-shadow ${accents[accent]}`}
+    >
+      <span className="font-semibold">{label}</span>
+      {typeof count === 'number' && count > 0 && (
+        <span
+          data-testid={`${testid}-count`}
+          className="inline-flex items-center justify-center min-w-[1.5rem] h-6 px-2 rounded-full bg-white/70 dark:bg-black/30 text-sm font-semibold"
+        >
+          {count}
+        </span>
+      )}
+    </Link>
+  );
+}
+
+function SelfReflectionCard({ section, today }) {
+  const state = section?.state ?? 'missing';
+  const badge = (() => {
+    if (state === 'complete') {
+      return { label: 'Submitted', cls: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200' };
+    }
+    if (state === 'day_off') {
+      return { label: 'Day off', cls: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200' };
+    }
+    return { label: 'Not yet', cls: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200' };
+  })();
+  const editTo = (state === 'complete' || state === 'day_off') && section?.reflection_id
+    ? `/camper-care/self-reflection/${section.reflection_id}/edit`
+    : '/camper-care/self-reflection';
+  const hasTemplate = Boolean(section?.template_id);
+
+  return (
+    <section
+      data-testid="cc-self-reflection"
+      data-state={state}
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-4 shadow-sm"
+    >
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white">My reflection</h2>
+        <span
+          className={`text-xs font-medium px-2 py-0.5 rounded-full ${badge.cls}`}
+          data-testid="cc-self-reflection-state"
+        >
+          {badge.label}
+        </span>
+      </div>
+      {hasTemplate ? (
+        <>
+          <p className="text-sm text-gray-700 dark:text-gray-300">
+            {state === 'complete' && 'Your reflection for today is in.'}
+            {state === 'day_off' && 'Marked as a day off — no further action needed.'}
+            {state === 'missing' && `Today is ${today}. Submit your reflection so your team has it.`}
+          </p>
+          <div className="mt-3 flex items-center gap-3">
+            <Link
+              to={editTo}
+              data-testid="cc-self-reflection-action"
+              className="inline-flex items-center justify-center min-h-[44px] px-4 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
+            >
+              {state === 'missing' ? 'Submit reflection' : 'Edit reflection'}
+            </Link>
+          </div>
+        </>
+      ) : (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          No Camper Care self-reflection template configured for your program.
+        </p>
+      )}
+    </section>
+  );
+}
+
+export default function CamperCareDashboard() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const dateParam = searchParams.get('date') || '';
+  const [data, setData] = useState(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(async ({ silent = false } = {}) => {
+    if (!silent) setLoading(true);
+    if (silent) setRefreshing(true);
+    try {
+      const next = await fetchCamperCareDashboard({
+        date: dateParam || undefined,
+        noCache: silent,
+      });
+      setData(next);
+      setError('');
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      setError(typeof detail === 'string' ? detail : err?.message || 'Failed to load dashboard.');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [dateParam]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const isToday = !dateParam || (data && dateParam === data.today);
+  useEffect(() => {
+    if (!isToday) return undefined;
+    const id = setInterval(() => load({ silent: true }), REFRESH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [isToday, load]);
+
+  const handleDateChange = (next) => {
+    const params = new URLSearchParams(searchParams);
+    if (next) params.set('date', next);
+    else params.delete('date');
+    setSearchParams(params, { replace: true });
+  };
+
+  if (loading && !data) {
+    return (
+      <div className="px-4 py-6 max-w-lg mx-auto">
+        <p className="text-gray-600 dark:text-gray-400">Loading dashboard…</p>
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="px-4 py-6 max-w-lg mx-auto">
+        <div
+          role="alert"
+          className="rounded-xl border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-900/30 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+          data-testid="cc-dashboard-error"
+        >
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  const units = data?.units ?? [];
+  const summary = data?.summary ?? {};
+
+  return (
+    <div data-testid="cc-dashboard" className="px-4 py-6 pb-24 max-w-lg mx-auto space-y-4">
+      <header className="space-y-2">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Camper Care</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Today is {data?.today}
+            {refreshing && <span className="text-xs text-gray-400 ml-2">Refreshing…</span>}
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <label className="text-sm text-gray-700 dark:text-gray-200 flex items-center gap-2">
+            <span>Date:</span>
+            <input
+              type="date"
+              value={dateParam || data?.date || ''}
+              max={data?.today || undefined}
+              onChange={(e) => handleDateChange(e.target.value)}
+              data-testid="cc-dashboard-date"
+              className="rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-2 py-1 text-sm"
+            />
+          </label>
+        </div>
+        <div
+          data-testid="cc-dashboard-summary"
+          className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3 text-sm text-gray-800 dark:text-gray-200 shadow-sm"
+        >
+          <span data-testid="cc-summary-submitted">
+            {summary.submitted ?? 0} of {summary.expected ?? 0}
+          </span>{' '}
+          reflections submitted across your caseload
+        </div>
+      </header>
+
+      <section className="grid grid-cols-1 gap-2" data-testid="cc-workspaces">
+        <WorkspaceCard
+          to="/camper-care/flags"
+          label="Flagged campers"
+          count={summary.flag_count}
+          testid="cc-workspace-flags"
+          accent="red"
+        />
+        <WorkspaceCard
+          to="/camper-care/orders"
+          label="Orders"
+          count={summary.order_count}
+          testid="cc-workspace-orders"
+          accent="amber"
+        />
+      </section>
+
+      <SelfReflectionCard section={data?.self_reflection} today={data?.today} />
+
+      <section data-testid="cc-caseload">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">My caseload</h2>
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {units.length} unit{units.length === 1 ? '' : 's'}
+          </span>
+        </div>
+        {units.length === 0 ? (
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            No bunks on your caseload yet. Once a bunk is assigned to your supervision, it will appear here.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {units.map((u) => (
+              <UnitSection key={u.id ?? 'unassigned'} unit={u} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/camper-care/Flags.jsx
+++ b/frontend/src/pages/camper-care/Flags.jsx
@@ -1,0 +1,375 @@
+/**
+ * Flagged campers workspace — Step 7_8, Story 20.
+ *
+ * Sections, top to bottom:
+ *   - Today (status active or followed_up, created today)
+ *   - Carried over (status active or followed_up, created earlier)
+ *   - Resolved (last 30d) — collapsed by default, revealed via toggle
+ *
+ * Each row supports three transitions (criterion 5):
+ *   - Mark followed up (note optional)
+ *   - Mark resolved (note required, terminal)
+ *   - Reopen (note required, from resolved or followed_up)
+ *
+ * The transition prompt is a single shared modal so the note-capture
+ * UX is consistent across the three actions.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  fetchFlags, followUpFlag, resolveFlag, reopenFlag,
+} from '../../api/camperCare';
+
+const STATUS_LABELS = {
+  active: { label: 'Active', cls: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200' },
+  followed_up: { label: 'Followed up', cls: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200' },
+  resolved: { label: 'Resolved', cls: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200' },
+};
+
+function StatusBadge({ status }) {
+  const meta = STATUS_LABELS[status] || { label: status, cls: 'bg-gray-100 text-gray-700' };
+  return (
+    <span
+      data-testid={`flag-status-${status}`}
+      className={`text-xs font-medium px-2 py-0.5 rounded-full ${meta.cls}`}
+    >
+      {meta.label}
+    </span>
+  );
+}
+
+function camperLabel(c) {
+  if (!c) return '';
+  const first = c.preferred_name || c.first_name || '';
+  const last = c.last_name || '';
+  return `${first} ${last}`.trim();
+}
+
+function formatTimestamp(iso) {
+  if (!iso) return '';
+  try {
+    return new Date(iso).toLocaleString();
+  } catch (e) {
+    return iso;
+  }
+}
+
+function FlagRow({ flag, onAction }) {
+  const raisedBy = flag.raised_by?.name || 'Unknown';
+  const roleLabel = flag.raised_by?.role ? ` (${flag.raised_by.role})` : '';
+  return (
+    <li
+      data-testid={`flag-row-${flag.id}`}
+      data-status={flag.status}
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3 shadow-sm"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="font-semibold text-gray-900 dark:text-white">
+            {camperLabel(flag.subject_camper)}
+          </h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            Raised by {raisedBy}{roleLabel} · {formatTimestamp(flag.created_at)}
+          </p>
+        </div>
+        <StatusBadge status={flag.status} />
+      </div>
+      {flag.trigger_content_type && (
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+          Source: {flag.trigger_content_type}
+        </p>
+      )}
+      <div className="flex flex-wrap gap-2 mt-3">
+        {(flag.status === 'active' || flag.status === 'followed_up') && (
+          <>
+            <button
+              type="button"
+              onClick={() => onAction(flag, 'follow_up')}
+              data-testid={`flag-action-follow-up-${flag.id}`}
+              className="inline-flex items-center px-3 min-h-[36px] rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 text-sm text-amber-900 dark:text-amber-100 hover:bg-amber-100"
+            >
+              Mark followed up
+            </button>
+            <button
+              type="button"
+              onClick={() => onAction(flag, 'resolve')}
+              data-testid={`flag-action-resolve-${flag.id}`}
+              className="inline-flex items-center px-3 min-h-[36px] rounded-lg bg-blue-600 text-white text-sm hover:bg-blue-700"
+            >
+              Mark resolved
+            </button>
+          </>
+        )}
+        {(flag.status === 'resolved' || flag.status === 'followed_up') && (
+          <button
+            type="button"
+            onClick={() => onAction(flag, 'reopen')}
+            data-testid={`flag-action-reopen-${flag.id}`}
+            className="inline-flex items-center px-3 min-h-[36px] rounded-lg border border-gray-300 dark:border-gray-700 text-sm text-gray-800 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800"
+          >
+            Reopen
+          </button>
+        )}
+      </div>
+    </li>
+  );
+}
+
+const ACTION_META = {
+  follow_up: { title: 'Mark followed up', noteRequired: false, submit: 'Mark followed up' },
+  resolve: { title: 'Resolve flag', noteRequired: true, submit: 'Resolve' },
+  reopen: { title: 'Reopen flag', noteRequired: true, submit: 'Reopen' },
+};
+
+function TransitionModal({ flag, action, onClose, onSubmitted }) {
+  const meta = ACTION_META[action];
+  const [note, setNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  if (!flag || !meta) return null;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    if (meta.noteRequired && !note.trim()) {
+      setError('A note is required for this action.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      if (action === 'follow_up') {
+        await followUpFlag(flag.id, { note: note.trim() });
+      } else if (action === 'resolve') {
+        await resolveFlag(flag.id, { note: note.trim() });
+      } else if (action === 'reopen') {
+        await reopenFlag(flag.id, { note: note.trim() });
+      }
+      onSubmitted();
+    } catch (err) {
+      const detail = err?.response?.data?.detail
+        || err?.response?.data?.note
+        || err?.message
+        || 'Could not apply the transition.';
+      setError(typeof detail === 'string' ? detail : JSON.stringify(detail));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="flag-modal-title"
+      data-testid="flag-transition-modal"
+    >
+      <div className="w-full sm:max-w-md bg-white dark:bg-gray-900 rounded-t-2xl sm:rounded-2xl shadow-xl p-4">
+        <h2 id="flag-modal-title" className="text-lg font-semibold text-gray-900 dark:text-white">
+          {meta.title}
+        </h2>
+        <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
+          {camperLabel(flag.subject_camper)}
+        </p>
+        <form onSubmit={handleSubmit} className="mt-3 space-y-3">
+          <label className="block text-sm">
+            <span className="text-gray-700 dark:text-gray-200">
+              {meta.noteRequired ? 'Note (required)' : 'Note (optional)'}
+            </span>
+            <textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              rows={4}
+              required={meta.noteRequired}
+              data-testid="flag-transition-note"
+              className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            />
+          </label>
+          {error && (
+            <p role="alert" className="text-sm text-red-700 dark:text-red-300" data-testid="flag-transition-error">
+              {error}
+            </p>
+          )}
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex items-center px-3 min-h-[40px] rounded-lg border border-gray-300 dark:border-gray-700 text-sm text-gray-800 dark:text-gray-100"
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              data-testid="flag-transition-submit"
+              className="inline-flex items-center px-4 min-h-[40px] rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-60"
+            >
+              {submitting ? 'Working…' : meta.submit}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default function CamperCareFlags() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [showResolved, setShowResolved] = useState(false);
+  const [resolvedData, setResolvedData] = useState(null);
+  const [resolvedLoading, setResolvedLoading] = useState(false);
+  const [modal, setModal] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const next = await fetchFlags();
+      setData(next);
+      setError('');
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      setError(typeof detail === 'string' ? detail : err?.message || 'Failed to load flags.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const loadResolved = useCallback(async () => {
+    setResolvedLoading(true);
+    try {
+      const next = await fetchFlags({ status: 'resolved' });
+      setResolvedData(next);
+    } finally {
+      setResolvedLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (showResolved && !resolvedData) {
+      loadResolved();
+    }
+  }, [showResolved, resolvedData, loadResolved]);
+
+  const handleAction = (flag, action) => setModal({ flag, action });
+  const handleClose = () => setModal(null);
+  const handleSubmitted = () => {
+    setModal(null);
+    load();
+    if (showResolved) loadResolved();
+  };
+
+  if (loading && !data) {
+    return (
+      <div className="px-4 py-6 max-w-2xl mx-auto">
+        <p className="text-gray-600 dark:text-gray-400">Loading flags…</p>
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="px-4 py-6 max-w-2xl mx-auto">
+        <div
+          role="alert"
+          className="rounded-xl border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-900/30 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+          data-testid="cc-flags-error"
+        >
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  const items = data?.items ?? [];
+  const today = data?.today;
+  const todays = items.filter((f) => f.is_today);
+  const carried = items.filter((f) => !f.is_today);
+  const resolved = resolvedData?.items ?? [];
+
+  return (
+    <div data-testid="cc-flags" className="px-4 py-6 pb-24 max-w-2xl mx-auto space-y-4">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Flagged campers</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          Active flags routed to Camper Care across your program.
+        </p>
+      </header>
+
+      <section data-testid="cc-flags-today">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">Today</h2>
+          <span className="text-xs text-gray-500 dark:text-gray-400">{todays.length} active</span>
+        </div>
+        {todays.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400" data-testid="cc-flags-today-empty">
+            No new flags today{today ? ` (${today})` : ''}.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {todays.map((f) => (
+              <FlagRow key={f.id} flag={f} onAction={handleAction} />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section data-testid="cc-flags-carried">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">Carried over</h2>
+          <span className="text-xs text-gray-500 dark:text-gray-400">{carried.length}</span>
+        </div>
+        {carried.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">No older active flags.</p>
+        ) : (
+          <ul className="space-y-2">
+            {carried.map((f) => (
+              <FlagRow key={f.id} flag={f} onAction={handleAction} />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section data-testid="cc-flags-resolved">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">Resolved</h2>
+          <button
+            type="button"
+            onClick={() => setShowResolved((v) => !v)}
+            data-testid="cc-flags-resolved-toggle"
+            className="text-sm text-blue-700 dark:text-blue-300 hover:underline"
+          >
+            {showResolved ? 'Hide' : 'Show resolved'}
+          </button>
+        </div>
+        {showResolved && (
+          resolvedLoading ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400">Loading resolved…</p>
+          ) : resolved.length === 0 ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400">No resolved flags.</p>
+          ) : (
+            <ul className="space-y-2">
+              {resolved.map((f) => (
+                <FlagRow key={f.id} flag={f} onAction={handleAction} />
+              ))}
+            </ul>
+          )
+        )}
+      </section>
+
+      {modal && (
+        <TransitionModal
+          flag={modal.flag}
+          action={modal.action}
+          onClose={handleClose}
+          onSubmitted={handleSubmitted}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/camper-care/NoteForm.jsx
+++ b/frontend/src/pages/camper-care/NoteForm.jsx
@@ -1,0 +1,332 @@
+/**
+ * Camper Care note form — Step 7_8, Story 21.
+ *
+ * Two modes:
+ *   - Create: route `/camper-care/notes/new?camperId=<id>`
+ *   - Edit (post-create or deep-link with state): route
+ *     `/camper-care/notes/:noteId/edit`. The author can keep editing
+ *     within the 24h window; after expiry the form is read-only.
+ *
+ * The form exposes:
+ *   - Body (required, textarea)
+ *   - Category (required, enum select)
+ *   - Sensitive (boolean checkbox)
+ *   - Language (en/es)
+ *
+ * The AudienceDisclosure refreshes whenever Sensitive is toggled, so
+ * the form authoritatively shows the reduced sensitive-variant
+ * audience (no Health Center / Special Diets) before the author
+ * submits.
+ *
+ * Backend doesn't currently expose a GET single-note endpoint, so the
+ * edit mode relies on `location.state.note` (set by the create success
+ * banner). A bare `/camper-care/notes/:noteId/edit` visit with no state
+ * falls back to the create form with a helpful notice.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import AudienceDisclosure from '../../components/AudienceDisclosure';
+import {
+  NOTE_CATEGORIES,
+  createCamperCareNote,
+  fetchCamperCareNoteAudience,
+  patchCamperCareNote,
+} from '../../api/camperCare';
+
+function camperIdFromQuery(searchParams) {
+  const raw = searchParams.get('camperId') || searchParams.get('camper_id');
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+function FieldRow({ label, htmlFor, required, error, children, hint }) {
+  return (
+    <label htmlFor={htmlFor} className="block text-sm">
+      <span className="text-gray-800 dark:text-gray-100 font-medium">
+        {label}
+        {required && <span aria-hidden="true" className="text-red-600 ml-1">*</span>}
+      </span>
+      {hint && <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{hint}</p>}
+      <div className="mt-1">{children}</div>
+      {error && (
+        <p role="alert" className="text-xs text-red-700 dark:text-red-300 mt-1">{error}</p>
+      )}
+    </label>
+  );
+}
+
+function isWithinEditWindow(createdAt) {
+  if (!createdAt) return false;
+  const created = new Date(createdAt).getTime();
+  if (Number.isNaN(created)) return false;
+  return Date.now() - created <= 24 * 60 * 60 * 1000;
+}
+
+export default function CamperCareNoteForm() {
+  const { noteId } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+
+  const initialFromState = location.state?.note || null;
+  const initialCamperId = initialFromState?.subject_id || camperIdFromQuery(searchParams);
+
+  const [noteRow, setNoteRow] = useState(initialFromState);
+  const [subjectId] = useState(initialCamperId);
+
+  const [body, setBody] = useState(initialFromState?.body ?? '');
+  const [category, setCategory] = useState(initialFromState?.category ?? '');
+  const [isSensitive, setIsSensitive] = useState(Boolean(initialFromState?.is_sensitive));
+  const [language, setLanguage] = useState(initialFromState?.language ?? 'en');
+
+  const [audience, setAudience] = useState([]);
+  const [audienceLoading, setAudienceLoading] = useState(true);
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [submitError, setSubmitError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+
+  const isEditMode = Boolean(noteRow?.id || noteId);
+  const editable = noteRow ? isWithinEditWindow(noteRow.created_at) : !isEditMode;
+
+  const loadAudience = useCallback(async (sensitive) => {
+    setAudienceLoading(true);
+    try {
+      const payload = await fetchCamperCareNoteAudience({ isSensitive: sensitive });
+      setAudience(payload.audience || []);
+    } catch (err) {
+      setAudience([]);
+    } finally {
+      setAudienceLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadAudience(isSensitive);
+  }, [isSensitive, loadAudience]);
+
+  const validate = () => {
+    const errs = {};
+    if (!body.trim()) errs.body = 'Required.';
+    if (!category) errs.category = 'Required.';
+    if (!noteRow && subjectId == null) errs.subject = 'Camper id is required (link from camper dashboard).';
+    setFieldErrors(errs);
+    return Object.keys(errs).length === 0;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitError('');
+    setSuccessMessage('');
+    if (!validate()) return;
+    setSubmitting(true);
+    try {
+      if (noteRow?.id) {
+        const updated = await patchCamperCareNote(noteRow.id, {
+          body: body.trim(),
+          category,
+          isSensitive,
+          language,
+        });
+        setNoteRow(updated);
+        setSuccessMessage('Note updated.');
+      } else {
+        const { data } = await createCamperCareNote({
+          subjectId,
+          body: body.trim(),
+          category,
+          isSensitive,
+          language,
+        });
+        setNoteRow(data);
+        setSuccessMessage('Note added.');
+      }
+    } catch (err) {
+      const respData = err?.response?.data;
+      if (respData && typeof respData === 'object' && !Array.isArray(respData)) {
+        const flat = {};
+        Object.entries(respData).forEach(([k, v]) => {
+          flat[k] = Array.isArray(v) ? v.join(' ') : String(v);
+        });
+        setFieldErrors((prev) => ({ ...prev, ...flat }));
+        setSubmitError(respData.detail || 'Could not save note.');
+      } else {
+        setSubmitError(err?.message || 'Could not save note.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const heading = useMemo(() => {
+    if (noteRow?.id) return 'Edit Camper Care note';
+    return 'New Camper Care note';
+  }, [noteRow]);
+
+  if (isEditMode && !noteRow) {
+    return (
+      <div className="px-4 py-6 max-w-lg mx-auto space-y-3">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Edit Camper Care note</h1>
+        <div
+          role="alert"
+          className="rounded-xl border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-900/30 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+          data-testid="cc-noteform-missing-state"
+        >
+          This page must be opened from the create form's success banner or the camper dashboard's edit link. Direct deep links don't have the note context yet.
+        </div>
+        <Link
+          to="/camper-care"
+          className="inline-flex items-center px-3 min-h-[40px] rounded-lg border border-gray-300 dark:border-gray-700 text-sm text-gray-800 dark:text-gray-100"
+        >
+          Back to dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  const formDisabled = isEditMode && !editable;
+
+  return (
+    <div className="px-4 py-6 pb-24 max-w-lg mx-auto" data-testid="cc-noteform">
+      <header className="mb-3">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">{heading}</h1>
+        {subjectId != null && (
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            Camper id: {subjectId}
+          </p>
+        )}
+        {formDisabled && (
+          <p className="text-sm text-amber-700 dark:text-amber-200 mt-1" data-testid="cc-noteform-window-closed">
+            This note is past the 24-hour edit window and can no longer be changed. Add a follow-up note instead.
+          </p>
+        )}
+      </header>
+
+      <AudienceDisclosure
+        audience={audienceLoading ? [] : audience}
+        contextHint={
+          audienceLoading
+            ? 'Resolving audience…'
+            : isSensitive
+              ? 'Sensitive notes are visible only to Camper Care, Health Center, Special Diets, and Admin.'
+              : 'Non-sensitive notes are visible to Camper Care, Leadership Team, and Admin.'
+        }
+      />
+
+      <form onSubmit={handleSubmit} className="space-y-4" data-testid="cc-noteform-form">
+        <FieldRow
+          label="Body"
+          htmlFor="cc-note-body"
+          required
+          error={fieldErrors.body}
+        >
+          <textarea
+            id="cc-note-body"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            rows={6}
+            disabled={formDisabled || submitting}
+            data-testid="cc-noteform-body"
+            className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+          />
+        </FieldRow>
+
+        <FieldRow
+          label="Category"
+          htmlFor="cc-note-category"
+          required
+          error={fieldErrors.category}
+        >
+          <select
+            id="cc-note-category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            disabled={formDisabled || submitting}
+            data-testid="cc-noteform-category"
+            className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+          >
+            <option value="">Select…</option>
+            {NOTE_CATEGORIES.map((c) => (
+              <option key={c.value} value={c.value}>{c.label}</option>
+            ))}
+          </select>
+        </FieldRow>
+
+        <fieldset
+          className="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2"
+          data-testid="cc-noteform-sensitive-block"
+        >
+          <legend className="text-sm font-medium text-gray-800 dark:text-gray-100 px-1">Visibility</legend>
+          <label className="flex items-start gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={isSensitive}
+              onChange={(e) => setIsSensitive(e.target.checked)}
+              disabled={formDisabled || submitting}
+              data-testid="cc-noteform-sensitive"
+              className="mt-1 h-4 w-4 rounded border-gray-300"
+            />
+            <span className="text-gray-700 dark:text-gray-200">
+              Sensitive — restrict to Camper Care, Health Center, Special Diets, and Admin.
+            </span>
+          </label>
+        </fieldset>
+
+        <FieldRow label="Language" htmlFor="cc-note-language">
+          <select
+            id="cc-note-language"
+            value={language}
+            onChange={(e) => setLanguage(e.target.value)}
+            disabled={formDisabled || submitting}
+            data-testid="cc-noteform-language"
+            className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+          >
+            <option value="en">English</option>
+            <option value="es">Spanish</option>
+          </select>
+        </FieldRow>
+
+        {submitError && (
+          <p role="alert" className="text-sm text-red-700 dark:text-red-300" data-testid="cc-noteform-error">
+            {submitError}
+          </p>
+        )}
+
+        {successMessage && (
+          <div
+            role="status"
+            className="rounded-md border border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-900/30 px-3 py-2 text-sm text-green-900 dark:text-green-100"
+            data-testid="cc-noteform-success"
+          >
+            {successMessage}
+          </div>
+        )}
+
+        {fieldErrors.subject && (
+          <p role="alert" className="text-sm text-red-700 dark:text-red-300">{fieldErrors.subject}</p>
+        )}
+
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="inline-flex items-center px-3 min-h-[44px] rounded-lg border border-gray-300 dark:border-gray-700 text-sm text-gray-800 dark:text-gray-100"
+            disabled={submitting}
+          >
+            Back
+          </button>
+          <button
+            type="submit"
+            disabled={formDisabled || submitting}
+            data-testid="cc-noteform-submit"
+            className="inline-flex items-center px-4 min-h-[44px] rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-60"
+          >
+            {submitting ? 'Saving…' : (noteRow?.id ? 'Save changes' : 'Add note')}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/camper-care/Orders.jsx
+++ b/frontend/src/pages/camper-care/Orders.jsx
@@ -1,0 +1,544 @@
+/**
+ * Camper Care orders workspace — Step 7_8, Stories 22-23.
+ *
+ * Three sections, in order:
+ *   1. New (visually most prominent)
+ *   2. In Progress (with bulk-fulfill action)
+ *   3. Resolved (collapsed by default with count + date range filter)
+ *
+ * Filter chip at top: All | My caseload | By bunk (input) | By item (input).
+ *
+ * Bulk fulfillment (Story 23.5): the In Progress section grows a
+ * checkbox per row; selecting any rows reveals the bulk action bar
+ * with a closing-note input that maps to `to_state=fulfilled` on the
+ * bulk endpoint.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  bulkTransitionOrders, fetchOrders, transitionOrder,
+} from '../../api/camperCare';
+
+const STATUS_BADGE = {
+  new: 'bg-blue-100 text-blue-900 dark:bg-blue-900/40 dark:text-blue-100',
+  in_progress: 'bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-100',
+  fulfilled: 'bg-green-100 text-green-900 dark:bg-green-900/40 dark:text-green-100',
+  unable_to_fulfill: 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-100',
+};
+
+const STATUS_LABEL = {
+  new: 'New',
+  in_progress: 'In Progress',
+  fulfilled: 'Fulfilled',
+  unable_to_fulfill: 'Unable to fulfill',
+};
+
+const TRANSITION_LABEL = {
+  in_progress: 'Start',
+  fulfilled: 'Mark fulfilled',
+  unable_to_fulfill: 'Unable to fulfill',
+  new: 'Reopen',
+};
+
+const AGE_THRESHOLD_SECONDS = 2 * 60 * 60; // surface "aged" pill past 2h per spec
+
+function camperLabel(c) {
+  if (!c) return '';
+  const first = c.preferred_name || c.first_name || '';
+  const last = c.last_name || '';
+  return `${first} ${last}`.trim();
+}
+
+function formatAge(seconds) {
+  if (seconds == null) return '';
+  if (seconds < 60) return `${seconds}s ago`;
+  const m = Math.round(seconds / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 48) return `${h}h ago`;
+  const d = Math.round(h / 24);
+  return `${d}d ago`;
+}
+
+function OrderRow({ order, selectable, selected, onSelectToggle, onTransition }) {
+  const aged = order.age_seconds != null && order.age_seconds >= AGE_THRESHOLD_SECONDS;
+  return (
+    <li
+      data-testid={`order-row-${order.id}`}
+      data-status={order.status}
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3 shadow-sm"
+    >
+      <div className="flex items-start gap-3">
+        {selectable && (
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={() => onSelectToggle(order.id)}
+            aria-label={`Select order for ${camperLabel(order.subject)}`}
+            data-testid={`order-select-${order.id}`}
+            className="mt-1 h-4 w-4 rounded border-gray-300"
+          />
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <h3 className="font-semibold text-gray-900 dark:text-white truncate">
+                {order.item}
+                {order.item_note ? ` — ${order.item_note}` : ''}
+              </h3>
+              <p className="text-xs text-gray-600 dark:text-gray-300 mt-0.5 truncate">
+                For {camperLabel(order.subject)}
+                {order.submitter?.name ? ` · from ${order.submitter.name}` : ''}
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                {formatAge(order.age_seconds)}
+                {aged && (
+                  <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded-full bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200 text-[10px] font-medium">
+                    Aged
+                  </span>
+                )}
+              </p>
+              {order.description && (
+                <p className="text-sm text-gray-700 dark:text-gray-300 mt-1 whitespace-pre-wrap">
+                  {order.description}
+                </p>
+              )}
+            </div>
+            <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${STATUS_BADGE[order.status] || ''}`}>
+              {STATUS_LABEL[order.status] || order.status}
+            </span>
+          </div>
+          {order.available_transitions?.length > 0 && (
+            <div className="flex flex-wrap gap-2 mt-3">
+              {order.available_transitions.map((next) => (
+                <button
+                  key={next}
+                  type="button"
+                  onClick={() => onTransition(order, next)}
+                  data-testid={`order-action-${next}-${order.id}`}
+                  className="inline-flex items-center px-3 min-h-[36px] rounded-lg border border-gray-300 dark:border-gray-700 text-sm text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
+                >
+                  {TRANSITION_LABEL[next] || next}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function TransitionModal({ order, toState, onClose, onSubmitted }) {
+  const [note, setNote] = useState('');
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  if (!order) return null;
+  const reasonRequired = toState === 'unable_to_fulfill';
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    if (reasonRequired && !reason.trim()) {
+      setError('A reason is required to mark unable to fulfill.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await transitionOrder(order.id, {
+        toState,
+        note: note.trim() || undefined,
+        reason: reason.trim() || undefined,
+      });
+      onSubmitted();
+    } catch (err) {
+      const detail = err?.response?.data?.detail
+        || err?.response?.data?.to_state
+        || err?.response?.data?.reason
+        || err?.message
+        || 'Could not apply the transition.';
+      setError(typeof detail === 'string' ? detail : JSON.stringify(detail));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 px-4"
+      role="dialog"
+      aria-modal="true"
+      data-testid="order-transition-modal"
+    >
+      <div className="w-full sm:max-w-md bg-white dark:bg-gray-900 rounded-t-2xl sm:rounded-2xl shadow-xl p-4">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          {TRANSITION_LABEL[toState] || toState}
+        </h2>
+        <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
+          {order.item} · {camperLabel(order.subject)}
+        </p>
+        <form onSubmit={handleSubmit} className="mt-3 space-y-3">
+          <label className="block text-sm">
+            <span className="text-gray-700 dark:text-gray-200">Note (optional)</span>
+            <textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              rows={3}
+              data-testid="order-transition-note"
+              className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+            />
+          </label>
+          {reasonRequired && (
+            <label className="block text-sm">
+              <span className="text-gray-700 dark:text-gray-200">Reason (required)</span>
+              <input
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                required
+                data-testid="order-transition-reason"
+                className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+              />
+            </label>
+          )}
+          {error && (
+            <p role="alert" className="text-sm text-red-700 dark:text-red-300" data-testid="order-transition-error">
+              {error}
+            </p>
+          )}
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex items-center px-3 min-h-[40px] rounded-lg border border-gray-300 dark:border-gray-700 text-sm text-gray-800 dark:text-gray-100"
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              data-testid="order-transition-submit"
+              className="inline-flex items-center px-4 min-h-[40px] rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-60"
+            >
+              {submitting ? 'Working…' : 'Apply'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function FilterBar({ filter, bunkId, item, onChange }) {
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 shadow-sm" data-testid="cc-orders-filter">
+      <div className="flex flex-wrap items-center gap-2">
+        <label className="text-sm text-gray-700 dark:text-gray-200 flex items-center gap-1.5">
+          <span>Show:</span>
+          <select
+            value={filter}
+            onChange={(e) => onChange({ filter: e.target.value, bunkId: '', item: '' })}
+            data-testid="cc-orders-filter-select"
+            className="rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-2 py-1 text-sm"
+          >
+            <option value="all">All</option>
+            <option value="my_caseload">My caseload only</option>
+            <option value="by_bunk">By bunk</option>
+            <option value="by_item">By item</option>
+          </select>
+        </label>
+        {filter === 'by_bunk' && (
+          <input
+            type="number"
+            value={bunkId}
+            onChange={(e) => onChange({ filter, bunkId: e.target.value, item })}
+            placeholder="Bunk id"
+            data-testid="cc-orders-filter-bunk"
+            className="w-28 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-2 py-1 text-sm"
+          />
+        )}
+        {filter === 'by_item' && (
+          <input
+            type="text"
+            value={item}
+            onChange={(e) => onChange({ filter, bunkId, item: e.target.value })}
+            placeholder="Item label"
+            data-testid="cc-orders-filter-item"
+            className="w-40 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-2 py-1 text-sm"
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function CamperCareOrders() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [filter, setFilter] = useState('all');
+  const [bunkId, setBunkId] = useState('');
+  const [item, setItem] = useState('');
+  const [showResolved, setShowResolved] = useState(false);
+  const [selected, setSelected] = useState(() => new Set());
+  const [bulkNote, setBulkNote] = useState('');
+  const [bulkSubmitting, setBulkSubmitting] = useState(false);
+  const [bulkError, setBulkError] = useState('');
+  const [modal, setModal] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const next = await fetchOrders({
+        filter,
+        bunkId: bunkId || undefined,
+        item: item || undefined,
+      });
+      setData(next);
+      setError('');
+    } catch (err) {
+      const detail = err?.response?.data?.detail
+        || err?.response?.data?.bunk_id
+        || err?.response?.data?.item;
+      setError(typeof detail === 'string' ? detail : err?.message || 'Failed to load orders.');
+    } finally {
+      setLoading(false);
+    }
+  }, [filter, bunkId, item]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleFilterChange = ({ filter: f, bunkId: b, item: i }) => {
+    setFilter(f);
+    setBunkId(b);
+    setItem(i);
+    setSelected(new Set());
+  };
+
+  const handleTransition = (order, toState) => {
+    setModal({ order, toState });
+  };
+
+  const handleSubmitted = () => {
+    setModal(null);
+    setSelected(new Set());
+    setBulkNote('');
+    load();
+  };
+
+  const handleSelectToggle = (id) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleBulkFulfill = async () => {
+    setBulkError('');
+    const ids = Array.from(selected);
+    if (ids.length === 0) return;
+    setBulkSubmitting(true);
+    try {
+      const result = await bulkTransitionOrders({
+        ids, toState: 'fulfilled', note: bulkNote.trim() || undefined,
+      });
+      if (result.failed?.length) {
+        setBulkError(
+          `${result.failed.length} order${result.failed.length === 1 ? '' : 's'} could not be transitioned.`,
+        );
+      }
+      handleSubmitted();
+    } catch (err) {
+      const detail = err?.response?.data?.detail || err?.message || 'Bulk update failed.';
+      setBulkError(typeof detail === 'string' ? detail : JSON.stringify(detail));
+    } finally {
+      setBulkSubmitting(false);
+    }
+  };
+
+  const newItems = data?.new ?? [];
+  const inProgress = data?.in_progress ?? [];
+  const resolved = data?.resolved ?? [];
+  const counts = data?.counts ?? { new: 0, in_progress: 0, resolved: 0 };
+
+  const eligibleSelected = useMemo(
+    () => inProgress.filter((o) => selected.has(o.id)),
+    [inProgress, selected],
+  );
+
+  if (loading && !data) {
+    return (
+      <div className="px-4 py-6 max-w-3xl mx-auto">
+        <p className="text-gray-600 dark:text-gray-400">Loading orders…</p>
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="px-4 py-6 max-w-3xl mx-auto">
+        <div
+          role="alert"
+          className="rounded-xl border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-900/30 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+          data-testid="cc-orders-error"
+        >
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="cc-orders" className="px-4 py-6 pb-24 max-w-3xl mx-auto space-y-4">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Orders</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          All Camper Care orders for your program.
+        </p>
+      </header>
+
+      <FilterBar
+        filter={filter}
+        bunkId={bunkId}
+        item={item}
+        onChange={handleFilterChange}
+      />
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded-xl border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-900/30 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+        >
+          {error}
+        </div>
+      )}
+
+      <section data-testid="cc-orders-new">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">New</h2>
+          <span className="text-xs text-gray-500 dark:text-gray-400" data-testid="cc-orders-new-count">
+            {counts.new}
+          </span>
+        </div>
+        {newItems.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">No new orders.</p>
+        ) : (
+          <ul className="space-y-2">
+            {newItems.map((o) => (
+              <OrderRow
+                key={o.id}
+                order={o}
+                selectable={false}
+                onTransition={handleTransition}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section data-testid="cc-orders-in-progress">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">In Progress</h2>
+          <span className="text-xs text-gray-500 dark:text-gray-400">{counts.in_progress}</span>
+        </div>
+        {inProgress.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">No orders in progress.</p>
+        ) : (
+          <>
+            <ul className="space-y-2">
+              {inProgress.map((o) => (
+                <OrderRow
+                  key={o.id}
+                  order={o}
+                  selectable
+                  selected={selected.has(o.id)}
+                  onSelectToggle={handleSelectToggle}
+                  onTransition={handleTransition}
+                />
+              ))}
+            </ul>
+            {eligibleSelected.length > 0 && (
+              <div
+                className="mt-3 rounded-xl border border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/30 px-4 py-3 shadow-sm"
+                data-testid="cc-orders-bulk-bar"
+              >
+                <p className="text-sm font-medium text-blue-900 dark:text-blue-100">
+                  {eligibleSelected.length} selected
+                </p>
+                <label className="block text-sm mt-2">
+                  <span className="text-blue-900 dark:text-blue-100">Closing note (optional)</span>
+                  <textarea
+                    value={bulkNote}
+                    onChange={(e) => setBulkNote(e.target.value)}
+                    rows={2}
+                    data-testid="cc-orders-bulk-note"
+                    className="mt-1 block w-full rounded-md border border-blue-200 dark:border-blue-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm"
+                  />
+                </label>
+                {bulkError && (
+                  <p role="alert" className="text-sm text-red-700 dark:text-red-300 mt-1" data-testid="cc-orders-bulk-error">
+                    {bulkError}
+                  </p>
+                )}
+                <div className="flex justify-end mt-3">
+                  <button
+                    type="button"
+                    onClick={handleBulkFulfill}
+                    disabled={bulkSubmitting}
+                    data-testid="cc-orders-bulk-submit"
+                    className="inline-flex items-center px-4 min-h-[40px] rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-60"
+                  >
+                    {bulkSubmitting ? 'Working…' : 'Mark all fulfilled'}
+                  </button>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </section>
+
+      <section data-testid="cc-orders-resolved">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">Resolved</h2>
+          <button
+            type="button"
+            onClick={() => setShowResolved((v) => !v)}
+            data-testid="cc-orders-resolved-toggle"
+            className="text-sm text-blue-700 dark:text-blue-300 hover:underline"
+          >
+            {showResolved ? 'Hide' : `Show (${counts.resolved})`}
+          </button>
+        </div>
+        {showResolved && (
+          resolved.length === 0 ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400">No resolved orders.</p>
+          ) : (
+            <ul className="space-y-2">
+              {resolved.map((o) => (
+                <OrderRow
+                  key={o.id}
+                  order={o}
+                  selectable={false}
+                  onTransition={handleTransition}
+                />
+              ))}
+            </ul>
+          )
+        )}
+      </section>
+
+      {modal && (
+        <TransitionModal
+          order={modal.order}
+          toState={modal.toState}
+          onClose={() => setModal(null)}
+          onSubmitted={handleSubmitted}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/camper-care/__tests__/Dashboard.test.jsx
+++ b/frontend/src/pages/camper-care/__tests__/Dashboard.test.jsx
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import CamperCareDashboard from '../Dashboard';
+
+const getMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+  },
+}));
+
+beforeEach(() => {
+  getMock.mockReset();
+});
+
+const samplePayload = {
+  date: '2026-07-04',
+  today: '2026-07-04',
+  units: [
+    {
+      id: 100,
+      name: 'Senior Village',
+      bunks: [
+        {
+          id: 11,
+          name: 'Cabin 1',
+          slug: 'cabin-1',
+          counselor_names: ['Pat L.'],
+          completion: { submitted: 5, expected: 8, off_camp: 1 },
+          badges: ['cc_flagged', 'low_completion'],
+          camper_count: 9,
+        },
+        {
+          id: 12,
+          name: 'Cabin 2',
+          slug: 'cabin-2',
+          counselor_names: ['Sam R.'],
+          completion: { submitted: 8, expected: 8, off_camp: 0 },
+          badges: [],
+          camper_count: 8,
+        },
+      ],
+      completion: { submitted: 13, expected: 16 },
+    },
+  ],
+  summary: { submitted: 13, expected: 16, flag_count: 2, order_count: 3 },
+  self_reflection: { state: 'missing', reflection_id: null, template_id: 7, editable: false },
+};
+
+describe('CamperCareDashboard', () => {
+  it('renders the caseload tree, summary, workspace entries, and self-reflection card', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    render(
+      <MemoryRouter>
+        <CamperCareDashboard />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('cc-dashboard')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('cc-summary-submitted')).toHaveTextContent('13 of 16');
+    expect(screen.getByTestId('cc-workspace-flags-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('cc-workspace-orders-count')).toHaveTextContent('3');
+    expect(screen.getByTestId('cc-unit-100')).toBeInTheDocument();
+    expect(screen.getByTestId('cc-bunk-row-11')).toBeInTheDocument();
+    expect(screen.getByTestId('cc-bunk-row-12')).toBeInTheDocument();
+    expect(screen.getAllByTestId('cc-badge-cc_flagged').length).toBeGreaterThan(0);
+    expect(screen.getByTestId('cc-self-reflection-state')).toHaveTextContent(/not yet/i);
+    expect(screen.getByTestId('cc-self-reflection-action')).toHaveTextContent(/submit reflection/i);
+  });
+
+  it('shows the empty state when no units are on the caseload', async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        ...samplePayload,
+        units: [],
+        summary: { submitted: 0, expected: 0, flag_count: 0, order_count: 0 },
+      },
+    });
+    render(
+      <MemoryRouter>
+        <CamperCareDashboard />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/No bunks on your caseload yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it('surfaces an error banner when the dashboard fetch fails', async () => {
+    getMock.mockRejectedValueOnce({ response: { data: { detail: 'Forbidden' } } });
+    render(
+      <MemoryRouter>
+        <CamperCareDashboard />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('cc-dashboard-error')).toHaveTextContent('Forbidden');
+    });
+  });
+});

--- a/frontend/src/pages/camper-care/__tests__/Flags.test.jsx
+++ b/frontend/src/pages/camper-care/__tests__/Flags.test.jsx
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import CamperCareFlags from '../Flags';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: (...args) => postMock(...args),
+  },
+}));
+
+beforeEach(() => {
+  getMock.mockReset();
+  postMock.mockReset();
+});
+
+const samplePayload = {
+  today: '2026-07-04',
+  items: [
+    {
+      id: '11111111-1111-1111-1111-111111111111',
+      status: 'active',
+      subject_camper: { id: 1, first_name: 'Lila', last_name: 'Park', preferred_name: '' },
+      flagged_for_role: 'camper_care',
+      trigger_content_type: 'note',
+      trigger_content_id: 'abc-123',
+      raised_by: { membership_id: 5, role: 'specialist', name: 'Rivka G.' },
+      created_at: '2026-07-04T10:00:00Z',
+      updated_at: '2026-07-04T10:00:00Z',
+      resolved_at: null,
+      is_today: true,
+    },
+    {
+      id: '22222222-2222-2222-2222-222222222222',
+      status: 'followed_up',
+      subject_camper: { id: 2, first_name: 'Jordan', last_name: 'Tate', preferred_name: 'Jo' },
+      flagged_for_role: 'camper_care',
+      trigger_content_type: 'reflection',
+      trigger_content_id: 'def-456',
+      raised_by: { membership_id: 6, role: 'unit_head', name: 'Maya R.' },
+      created_at: '2026-07-02T10:00:00Z',
+      updated_at: '2026-07-03T10:00:00Z',
+      resolved_at: null,
+      is_today: false,
+    },
+  ],
+};
+
+describe('CamperCareFlags', () => {
+  it('renders Today and Carried-over sections from the active+followed_up listing', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    render(
+      <MemoryRouter>
+        <CamperCareFlags />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('cc-flags')).toBeInTheDocument();
+    });
+    const todays = screen.getByTestId('cc-flags-today');
+    expect(todays).toHaveTextContent(/Lila Park/);
+    const carried = screen.getByTestId('cc-flags-carried');
+    expect(carried).toHaveTextContent(/Jo Tate/);
+  });
+
+  it('resolves a flag with a required closing note and reloads', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    postMock.mockResolvedValueOnce({ data: { flag: {}, history: [] } });
+    getMock.mockResolvedValueOnce({
+      data: { ...samplePayload, items: [samplePayload.items[1]] },
+    });
+
+    render(
+      <MemoryRouter>
+        <CamperCareFlags />
+      </MemoryRouter>,
+    );
+    const user = userEvent.setup();
+    await waitFor(() => {
+      expect(screen.getByTestId('flag-row-11111111-1111-1111-1111-111111111111')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('flag-action-resolve-11111111-1111-1111-1111-111111111111'));
+    expect(screen.getByTestId('flag-transition-modal')).toBeInTheDocument();
+
+    // Submitting without a note should not call the API (HTML required attr).
+    const submitBtn = screen.getByTestId('flag-transition-submit');
+    await user.click(submitBtn);
+    expect(postMock).not.toHaveBeenCalled();
+
+    await user.type(screen.getByTestId('flag-transition-note'), 'Spoke with cabin; resolved.');
+    await user.click(submitBtn);
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalled();
+    });
+    const [url, payload] = postMock.mock.calls[0];
+    expect(url).toBe(
+      '/api/v1/camper-care/flags/11111111-1111-1111-1111-111111111111/resolve/',
+    );
+    expect(payload.note).toBe('Spoke with cabin; resolved.');
+  });
+
+  it('shows the resolved section when toggled and fetches with status=resolved', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    getMock.mockResolvedValueOnce({
+      data: {
+        today: samplePayload.today,
+        items: [
+          {
+            ...samplePayload.items[0],
+            id: '33333333-3333-3333-3333-333333333333',
+            status: 'resolved',
+          },
+        ],
+      },
+    });
+    render(
+      <MemoryRouter>
+        <CamperCareFlags />
+      </MemoryRouter>,
+    );
+    const user = userEvent.setup();
+    await waitFor(() => {
+      expect(screen.getByTestId('cc-flags')).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId('cc-flags-resolved-toggle'));
+    await waitFor(() => {
+      const calls = getMock.mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[0]).toBe('/api/v1/camper-care/flags/');
+      expect(lastCall[1]?.params?.status).toBe('resolved');
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('flag-row-33333333-3333-3333-3333-333333333333')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/camper-care/__tests__/NoteForm.test.jsx
+++ b/frontend/src/pages/camper-care/__tests__/NoteForm.test.jsx
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import CamperCareNoteForm from '../NoteForm';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+const patchMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: (...args) => postMock(...args),
+    patch: (...args) => patchMock(...args),
+  },
+}));
+
+beforeEach(() => {
+  getMock.mockReset();
+  postMock.mockReset();
+  patchMock.mockReset();
+});
+
+function wireAudienceCalls() {
+  getMock.mockImplementation((url, opts) => {
+    if (url === '/api/v1/camper-care/notes/audience/') {
+      const isSensitive = opts?.params?.is_sensitive === 'true';
+      return Promise.resolve({
+        data: {
+          is_sensitive: isSensitive,
+          audience: isSensitive
+            ? ['Camper Care', 'Health Center', 'Special Diets', 'Admin']
+            : ['Camper Care', 'Leadership Team', 'Admin'],
+        },
+      });
+    }
+    return Promise.reject(new Error(`unexpected GET ${url}`));
+  });
+}
+
+describe('CamperCareNoteForm — create', () => {
+  it('shows the non-sensitive audience by default and refreshes when Sensitive toggles', async () => {
+    wireAudienceCalls();
+    render(
+      <MemoryRouter initialEntries={['/camper-care/notes/new?camperId=42']}>
+        <Routes>
+          <Route path="/camper-care/notes/new" element={<CamperCareNoteForm />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('audience-disclosure-labels')).toHaveTextContent(
+        'Camper Care, Leadership Team, Admin',
+      );
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('cc-noteform-sensitive'));
+    await waitFor(() => {
+      expect(screen.getByTestId('audience-disclosure-labels')).toHaveTextContent(
+        'Camper Care, Health Center, Special Diets, Admin',
+      );
+    });
+  });
+
+  it('submits a valid note and shows the success banner', async () => {
+    wireAudienceCalls();
+    postMock.mockResolvedValueOnce({
+      data: {
+        id: 17,
+        subject_id: 42,
+        author_id: 99,
+        note_type: 'camper_care',
+        body: 'Camper reports feeling homesick.',
+        category: 'social',
+        is_sensitive: false,
+        language: 'en',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        is_within_edit_window: true,
+      },
+      status: 201,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/camper-care/notes/new?camperId=42']}>
+        <Routes>
+          <Route path="/camper-care/notes/new" element={<CamperCareNoteForm />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    const user = userEvent.setup();
+    await waitFor(() => {
+      expect(screen.getByTestId('cc-noteform-form')).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByTestId('cc-noteform-body'), 'Camper reports feeling homesick.');
+    await user.selectOptions(screen.getByTestId('cc-noteform-category'), 'social');
+    await user.click(screen.getByTestId('cc-noteform-submit'));
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalled();
+    });
+    const [url, payload] = postMock.mock.calls[0];
+    expect(url).toBe('/api/v1/camper-care/notes/');
+    expect(payload).toMatchObject({
+      subject_id: 42,
+      body: 'Camper reports feeling homesick.',
+      category: 'social',
+      is_sensitive: false,
+      language: 'en',
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('cc-noteform-success')).toHaveTextContent(/note added/i);
+    });
+  });
+
+  it('blocks submission when required fields are missing', async () => {
+    wireAudienceCalls();
+    render(
+      <MemoryRouter initialEntries={['/camper-care/notes/new?camperId=42']}>
+        <Routes>
+          <Route path="/camper-care/notes/new" element={<CamperCareNoteForm />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    const user = userEvent.setup();
+    await waitFor(() => {
+      expect(screen.getByTestId('cc-noteform-form')).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId('cc-noteform-submit'));
+    expect(postMock).not.toHaveBeenCalled();
+    expect(screen.getAllByText(/Required\./i).length).toBeGreaterThan(0);
+  });
+});
+
+describe('CamperCareNoteForm — edit', () => {
+  it('renders an editable form when navigated with location.state.note inside the 24h window', async () => {
+    wireAudienceCalls();
+    const recent = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const note = {
+      id: 99,
+      subject_id: 42,
+      body: 'Initial body.',
+      category: 'medical',
+      is_sensitive: true,
+      language: 'en',
+      created_at: recent,
+      updated_at: recent,
+      is_within_edit_window: true,
+    };
+    patchMock.mockResolvedValueOnce({
+      data: { ...note, body: 'Edited body.' },
+    });
+
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/camper-care/notes/99/edit', state: { note } }]}>
+        <Routes>
+          <Route path="/camper-care/notes/:noteId/edit" element={<CamperCareNoteForm />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    const user = userEvent.setup();
+    await waitFor(() => {
+      expect(screen.getByTestId('cc-noteform-body')).toHaveValue('Initial body.');
+    });
+    await user.clear(screen.getByTestId('cc-noteform-body'));
+    await user.type(screen.getByTestId('cc-noteform-body'), 'Edited body.');
+    await user.click(screen.getByTestId('cc-noteform-submit'));
+    await waitFor(() => {
+      expect(patchMock).toHaveBeenCalled();
+    });
+    const [url, payload] = patchMock.mock.calls[0];
+    expect(url).toBe('/api/v1/camper-care/notes/99/');
+    expect(payload.body).toBe('Edited body.');
+  });
+
+  it('renders a missing-state notice when no location.state is supplied', async () => {
+    wireAudienceCalls();
+    render(
+      <MemoryRouter initialEntries={['/camper-care/notes/99/edit']}>
+        <Routes>
+          <Route path="/camper-care/notes/:noteId/edit" element={<CamperCareNoteForm />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('cc-noteform-missing-state')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/camper-care/__tests__/Orders.test.jsx
+++ b/frontend/src/pages/camper-care/__tests__/Orders.test.jsx
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import CamperCareOrders from '../Orders';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: (...args) => postMock(...args),
+  },
+}));
+
+beforeEach(() => {
+  getMock.mockReset();
+  postMock.mockReset();
+});
+
+const samplePayload = {
+  new: [
+    {
+      id: 'aaaa1111-aaaa-1111-aaaa-111111111111',
+      status: 'new',
+      available_transitions: ['in_progress', 'unable_to_fulfill'],
+      is_within_correction_window: false,
+      subject: { id: 1, first_name: 'Lila', last_name: 'Park', preferred_name: '' },
+      item: 'Sunscreen',
+      item_note: 'SPF 50',
+      description: 'For Tuesday hike.',
+      submitter: { membership_id: 7, role: 'counselor', name: 'Pat L.' },
+      created_at: '2026-07-04T09:00:00Z',
+      updated_at: '2026-07-04T09:00:00Z',
+      age_seconds: 600,
+      last_event_note: '',
+    },
+  ],
+  in_progress: [
+    {
+      id: 'bbbb2222-bbbb-2222-bbbb-222222222222',
+      status: 'in_progress',
+      available_transitions: ['fulfilled', 'unable_to_fulfill'],
+      is_within_correction_window: true,
+      subject: { id: 2, first_name: 'Jordan', last_name: 'Tate', preferred_name: 'Jo' },
+      item: 'Inhaler',
+      item_note: '',
+      description: '',
+      submitter: { membership_id: 8, role: 'counselor', name: 'Sam R.' },
+      created_at: '2026-07-04T08:00:00Z',
+      updated_at: '2026-07-04T10:00:00Z',
+      age_seconds: 7200,
+      last_event_note: '',
+    },
+    {
+      id: 'cccc3333-cccc-3333-cccc-333333333333',
+      status: 'in_progress',
+      available_transitions: ['fulfilled', 'unable_to_fulfill'],
+      is_within_correction_window: false,
+      subject: { id: 3, first_name: 'Avi', last_name: 'Klein', preferred_name: '' },
+      item: 'Sunscreen',
+      item_note: '',
+      description: '',
+      submitter: { membership_id: 9, role: 'counselor', name: 'Mira C.' },
+      created_at: '2026-07-04T08:30:00Z',
+      updated_at: '2026-07-04T10:30:00Z',
+      age_seconds: 7800,
+      last_event_note: '',
+    },
+  ],
+  resolved: [],
+  counts: { new: 1, in_progress: 2, resolved: 0 },
+};
+
+describe('CamperCareOrders', () => {
+  it('renders the three workspace sections with counts', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    render(
+      <MemoryRouter>
+        <CamperCareOrders />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('cc-orders')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('cc-orders-new-count')).toHaveTextContent('1');
+    expect(screen.getByTestId('order-row-aaaa1111-aaaa-1111-aaaa-111111111111')).toBeInTheDocument();
+    expect(screen.getByTestId('order-row-bbbb2222-bbbb-2222-bbbb-222222222222')).toBeInTheDocument();
+    expect(screen.getByTestId('order-row-cccc3333-cccc-3333-cccc-333333333333')).toBeInTheDocument();
+  });
+
+  it('bulk-fulfills selected In Progress orders', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    postMock.mockResolvedValueOnce({
+      data: { transitioned: [], activity_by_id: {}, failed: [], missing: [] },
+    });
+    getMock.mockResolvedValueOnce({
+      data: { ...samplePayload, in_progress: [], counts: { new: 1, in_progress: 0, resolved: 2 } },
+    });
+
+    render(
+      <MemoryRouter>
+        <CamperCareOrders />
+      </MemoryRouter>,
+    );
+    const user = userEvent.setup();
+    await waitFor(() => {
+      expect(screen.getByTestId('cc-orders-in-progress')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('order-select-bbbb2222-bbbb-2222-bbbb-222222222222'));
+    await user.click(screen.getByTestId('order-select-cccc3333-cccc-3333-cccc-333333333333'));
+    expect(screen.getByTestId('cc-orders-bulk-bar')).toHaveTextContent('2 selected');
+
+    await user.type(screen.getByTestId('cc-orders-bulk-note'), 'Distributed at line-up.');
+    await user.click(screen.getByTestId('cc-orders-bulk-submit'));
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalled();
+    });
+    const [url, payload] = postMock.mock.calls[0];
+    expect(url).toBe('/api/v1/camper-care/orders/bulk-transition/');
+    expect(payload.to_state).toBe('fulfilled');
+    expect(payload.ids).toEqual([
+      'bbbb2222-bbbb-2222-bbbb-222222222222',
+      'cccc3333-cccc-3333-cccc-333333333333',
+    ]);
+    expect(payload.note).toBe('Distributed at line-up.');
+  });
+
+  it('switches filter and refetches with my_caseload', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    getMock.mockResolvedValueOnce({ data: { ...samplePayload, new: [], counts: { new: 0, in_progress: 2, resolved: 0 } } });
+
+    render(
+      <MemoryRouter>
+        <CamperCareOrders />
+      </MemoryRouter>,
+    );
+    const user = userEvent.setup();
+    await waitFor(() => {
+      expect(screen.getByTestId('cc-orders-filter')).toBeInTheDocument();
+    });
+    await user.selectOptions(screen.getByTestId('cc-orders-filter-select'), 'my_caseload');
+    await waitFor(() => {
+      const calls = getMock.mock.calls;
+      const last = calls[calls.length - 1];
+      expect(last[0]).toBe('/api/v1/camper-care/orders/');
+      expect(last[1]?.params?.filter).toBe('my_caseload');
+    });
+  });
+});

--- a/frontend/src/partials/Sidebar.jsx
+++ b/frontend/src/partials/Sidebar.jsx
@@ -29,6 +29,8 @@ const PROGRAM_LEAD_PLUS = ['program_lead'];
  *     Home          /dashboard
  *     My tasks      /tasks
  *     Counselor home /counselor-dashboard   (only for User.role==='Counselor')
+ *     Unit Head home /unit-head             (only for User.role==='Unit Head')
+ *     Camper Care home /camper-care         (only for User.role==='Camper Care')
  *     File a reflection  /reflect           (REFLECTION_FORM_ROLES)
  *     My reflections     /my-reflections    (REFLECTION_FORM_ROLES)
  *
@@ -170,6 +172,20 @@ function Sidebar({
                 to="/counselor-dashboard"
                 label="Counselor home"
                 icon={IconCounselor}
+              />
+            )}
+            {user.role === 'Unit Head' && (
+              <NavItem
+                to="/unit-head"
+                label="Unit Head home"
+                icon={IconCounselor}
+              />
+            )}
+            {user.role === 'Camper Care' && (
+              <NavItem
+                to="/camper-care"
+                label="Camper Care home"
+                icon={IconHeart}
               />
             )}
             {canFileReflection && (
@@ -434,6 +450,13 @@ function IconCounselor() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
       <path strokeLinecap="round" strokeLinejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+    </svg>
+  );
+}
+function IconHeart() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary

Builds the Camper Care role flow on top of the 7_8a backend (PR #99). Stacked on `feat/7_6d_counselor_frontend` until the parent stack merges to `main`.

### What ships

- **Pages** under `frontend/src/pages/camper-care/`:
  - `Dashboard.jsx` — caseload tree (Unit → Bunk), completion stats, attention badges (`cc_flagged`, `cc_pending_order`, etc.), workspace entries for Flagged campers + Orders, and the My-reflection card.
  - `Flags.jsx` — Today / Carried-over / Resolved sections per Story 20 with a shared transition modal (Mark followed up = note optional, Resolve = note required, Reopen = note required).
  - `Orders.jsx` — three-section workspace per Story 22 (New / In Progress / Resolved) + filter chip (All / My caseload / By bunk / By item), per-row transition prompts, and bulk-fulfill bar per Story 23 c.5.
  - `NoteForm.jsx` — create + in-place edit form per Story 21 with `AudienceDisclosure` dynamically refreshing on Sensitive toggle (resolved server-side via the audience endpoint). Edit mode hydrates from `location.state.note`.
- **API client** `frontend/src/api/camperCare.js` — thin axios wrappers for all nine endpoints added in 7_8a plus the shared `NOTE_CATEGORIES` enum.
- **Router** — registers `/camper-care/{,flags,orders,notes/new,notes/:noteId/edit}` under `AppLayout`. Legacy `/dashboard/campercare` surface untouched until wave 5.
- **Sidebar** — adds Camper Care home + Unit Head home entries gated on `user.role`, mirroring the Counselor-home pattern.

### Tests

One integration-style Vitest suite per page (Dashboard, Flags, Orders, NoteForm) — 14 new tests covering happy path, empty/error states, flag transitions with note validation, bulk-fulfill payload shape, and AudienceDisclosure refresh on Sensitive toggle. Full frontend suite green (466 tests, 62 files). `npm run build` clean.

### Known follow-up (7_8c)

The bunk + camper drill-down endpoints (`/api/v1/camper-care/bunks/<id>/` and `/campers/<id>/`) weren't included in 7_8a, so dashboard bunk rows render as informational (no deep link) and the per-camper notes section integration is deferred. 7_8c will:

1. Add the two backend endpoints (reusing UH's shared `build_camper_dashboard_payload` + a small refactor to extract the bunk payload builder, gated on CC caseload instead of UH supervision).
2. Add thin `CamperCareBunkDashboardPage` + `CamperCareCamperDashboardPage` wrappers that mount the shared `<BunkDashboard />` / `<CamperDashboard />`.
3. Wire the Camper Care notes form from the camper dashboard (Story 21 in-context affordance).

That unlocks Story 18 criterion 9 and Story 21's per-camper note context.

## Test plan

- [x] `npx vitest run` — 466 / 466 passing
- [x] `npm run build` — clean production bundle
- [x] `eslint src/pages/camper-care src/api/camperCare.js src/Router.jsx src/partials/Sidebar.jsx` — 0 errors (only inline-English `i18next/no-literal-string` warnings, deferred per CLAUDE.md lean mode)
- [ ] Smoke test in a preview env: Camper Care user lands on `/camper-care`, can open Flagged campers workspace and run all three transitions, can open Orders workspace and bulk-fulfill, can submit + edit a Camper Care note from `/camper-care/notes/new?camperId=<id>` and watch the audience disclosure flip when Sensitive toggles.


Made with [Cursor](https://cursor.com)