### PR TITLE
7_8c: Camper Care bunk + camper drill-downs (Story 18 c.9, Story 21)

### DIFF
--- a/backend/bunk_logs/api/camper_care/bunk_dashboard.py
+++ b/backend/bunk_logs/api/camper_care/bunk_dashboard.py
@@ -1,0 +1,74 @@
+"""``GET /api/v1/camper-care/bunks/<bunk_id>/?date=<>`` — Story 18 criterion 9.
+
+Camper Care drill-down to the per-bunk dashboard. Delegates payload
+construction to :func:`api.unit_head.bunk_dashboard.build_bunk_dashboard_payload`
+(extracted in 7_8c) so the view stays focused on viewer resolution
+plus the caseload gate. CC's gate uses ``caseload_bunks`` (Supervision
+rows with ``target_type='bunk'``) rather than UH's per-counselor
+supervision.
+"""
+
+from __future__ import annotations
+
+from django.utils.dateparse import parse_date
+from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.api.unit_head.bunk_dashboard import build_bunk_dashboard_payload
+from bunk_logs.core.models import AssignmentGroup
+
+from .common import caseload_bunks
+from .common import viewer_or_403
+
+
+class CamperCareBunkDashboardView(APIView):
+    """Per-bunk read payload for Camper Care."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, bunk_id: int, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        target_date = _parse_date_param(
+            request.query_params.get("date"), default=ctx.today,
+        )
+        if target_date > ctx.today:
+            msg = "Future dates are not selectable."
+            raise ValidationError(msg)
+
+        # Caseload gate: viewer must have the bunk on their caseload
+        # AS OF TODAY (not the selected date) so history browsing works
+        # on currently supervised bunks.
+        owned_ids = {b.id for b in caseload_bunks(ctx.membership, today=ctx.today)}
+        if int(bunk_id) not in owned_ids:
+            msg = "This bunk is not on your caseload."
+            raise PermissionDenied(msg)
+
+        bunk = AssignmentGroup.all_objects.filter(
+            id=bunk_id, group_type="bunk", is_active=True,
+        ).select_related("parent").first()
+        if bunk is None:
+            msg = "Bunk not found."
+            raise NotFound(msg)
+
+        return Response(build_bunk_dashboard_payload(
+            request=request,
+            bunk=bunk,
+            target_date=target_date,
+            organization=ctx.organization,
+            program=ctx.program,
+            today=ctx.today,
+        ))
+
+
+def _parse_date_param(raw, *, default):
+    if not raw:
+        return default
+    parsed = parse_date(raw)
+    if parsed is None:
+        msg = "Invalid 'date' parameter; expected YYYY-MM-DD."
+        raise ValidationError(msg)
+    return parsed

--- a/backend/bunk_logs/api/camper_care/camper_dashboard.py
+++ b/backend/bunk_logs/api/camper_care/camper_dashboard.py
@@ -1,0 +1,90 @@
+"""``GET /api/v1/camper-care/campers/<camper_id>/?date=&range=`` — Story 18 + 21.
+
+Camper Care drill-down to the per-camper dashboard. Delegates to the
+shared :func:`api.unit_head.camper_dashboard.build_camper_dashboard_payload`
+so the section contract (trend grid, today's reflection, scores,
+flags, specialist reports, camper-care notes) stays role-agnostic.
+
+Access gate: the camper must be rostered on a bunk currently on the
+viewer's Camper Care caseload. Overlapping caseloads (CC2) are allowed
+naturally — any CC member with the bunk on their caseload can open
+the camper.
+"""
+
+from __future__ import annotations
+
+from django.utils.dateparse import parse_date
+from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.api.unit_head.camper_dashboard import build_camper_dashboard_payload
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Person
+
+from .common import caseload_bunks
+from .common import viewer_or_403
+
+
+class CamperCareCamperDashboardView(APIView):
+    """Per-camper read payload for Camper Care."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, camper_id: int, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        target_date = _parse_date_param(
+            request.query_params.get("date"), default=ctx.today,
+        )
+        if target_date > ctx.today:
+            msg = "Future dates are not selectable."
+            raise ValidationError(msg)
+
+        camper = Person.all_objects.filter(
+            id=camper_id, organization=ctx.organization,
+        ).first()
+        if camper is None:
+            msg = "Camper not found."
+            raise NotFound(msg)
+
+        if not _viewer_has_camper_on_caseload(ctx, camper):
+            msg = "This camper is not on your caseload."
+            raise PermissionDenied(msg)
+
+        payload = build_camper_dashboard_payload(
+            request=request,
+            camper=camper,
+            organization=ctx.organization,
+            program=ctx.program,
+            target_date=target_date,
+            range_key=request.query_params.get("range") or "last_4_weeks",
+            date_start_raw=request.query_params.get("date_start"),
+            date_end_raw=request.query_params.get("date_end"),
+        )
+        return Response(payload)
+
+
+def _viewer_has_camper_on_caseload(ctx, camper: Person) -> bool:
+    """True iff ``camper`` is rostered on a bunk in the viewer's caseload."""
+    bunk_ids = {b.id for b in caseload_bunks(ctx.membership, today=ctx.today)}
+    if not bunk_ids:
+        return False
+    return AssignmentGroupMembership.objects.filter(
+        group_id__in=bunk_ids,
+        person=camper,
+        role_in_group="subject",
+        is_active=True,
+    ).exists()
+
+
+def _parse_date_param(raw, *, default):
+    if not raw:
+        return default
+    parsed = parse_date(raw)
+    if parsed is None:
+        msg = "Invalid 'date' parameter; expected YYYY-MM-DD."
+        raise ValidationError(msg)
+    return parsed

--- a/backend/bunk_logs/api/tests/test_camper_care_endpoints.py
+++ b/backend/bunk_logs/api/tests/test_camper_care_endpoints.py
@@ -695,3 +695,146 @@ class TestCamperCareNotes:
         assert "Camper Care" in body["audience"]
         assert "Leadership Team" in body["audience"]
         assert "Health Center" not in body["audience"]
+
+
+# ---------------------------------------------------------------------------
+# Bunk + Camper drill-down (Step 7_8c) — Story 18 c.9 + Story 21 in-context
+# ---------------------------------------------------------------------------
+
+
+class TestCamperCareBunkDashboard:
+    """``GET /api/v1/camper-care/bunks/<id>/`` — Story 18 criterion 9.
+
+    Reuses the shared `build_bunk_dashboard_payload` extracted from the
+    UH view, so we only test the CC-specific gate + payload shape here.
+    The UH bunk dashboard tests already cover the section contracts.
+    """
+
+    def test_returns_payload_for_bunk_on_caseload(
+        self, api, org, cc_person_user, cc_membership, cc_caseload,
+        bunk, unit, camper, camper_in_bunk,
+    ):
+        _, user = cc_person_user
+        api.force_authenticate(user=user)
+        with organization_context(org):
+            r = api.get(
+                f"/api/v1/camper-care/bunks/{bunk.id}/", **_hdr(org.slug),
+            )
+        assert r.status_code == 200, r.content
+        body = r.json()
+        assert body["header"]["bunk"]["id"] == bunk.id
+        assert body["header"]["bunk"]["name"] == bunk.name
+        assert body["header"]["bunk"]["unit_name"] == unit.name
+        # Section keys present (shape contract from the shared helper).
+        for key in (
+            "help_requested", "off_camp", "bunk_concerns",
+            "score_grid", "orders", "specialist_reports",
+        ):
+            assert key in body, f"missing section {key!r}"
+
+    def test_bunk_off_caseload_rejected(
+        self, api, org, cc_person_user, cc_membership, cc_caseload,
+        other_bunk,
+    ):
+        """CC member with `bunk` on caseload cannot open `other_bunk`."""
+        _, user = cc_person_user
+        api.force_authenticate(user=user)
+        with organization_context(org):
+            r = api.get(
+                f"/api/v1/camper-care/bunks/{other_bunk.id}/",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 403
+
+    def test_requires_camper_care_role(
+        self, api, org, counselor_person_user, counselor_membership, bunk,
+    ):
+        _, user = counselor_person_user
+        api.force_authenticate(user=user)
+        with organization_context(org):
+            r = api.get(
+                f"/api/v1/camper-care/bunks/{bunk.id}/", **_hdr(org.slug),
+            )
+        assert r.status_code == 403
+
+    def test_future_date_rejected(
+        self, api, org, cc_person_user, cc_membership, cc_caseload, bunk,
+    ):
+        _, user = cc_person_user
+        api.force_authenticate(user=user)
+        future = (date.today() + timedelta(days=30)).isoformat()
+        with organization_context(org):
+            r = api.get(
+                f"/api/v1/camper-care/bunks/{bunk.id}/?date={future}",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 400
+
+
+class TestCamperCareCamperDashboard:
+    """``GET /api/v1/camper-care/campers/<id>/`` — Story 18 c.9 + Story 21."""
+
+    def test_returns_payload_for_camper_on_caseload(
+        self, api, org, cc_person_user, cc_membership, cc_caseload,
+        bunk, camper, camper_in_bunk,
+    ):
+        _, user = cc_person_user
+        api.force_authenticate(user=user)
+        with organization_context(org):
+            r = api.get(
+                f"/api/v1/camper-care/campers/{camper.id}/", **_hdr(org.slug),
+            )
+        assert r.status_code == 200, r.content
+        body = r.json()
+        assert body["header"]["camper"]["id"] == camper.id
+        # Section keys present (shape contract from the shared helper).
+        for key in (
+            "trend", "today_reflection", "today_scores", "today_flags",
+            "specialist_reports", "camper_care_notes",
+        ):
+            assert key in body, f"missing section {key!r}"
+
+    def test_camper_off_caseload_rejected(
+        self, api, org, cc_person_user, cc_membership, cc_caseload,
+        other_bunk,
+    ):
+        """Camper rostered to a bunk NOT on viewer's caseload -> 403."""
+        # Camper is in `other_bunk`, which is not on cc_membership's caseload.
+        outsider = Person.all_objects.create(
+            organization=org, first_name="Quinn", last_name="Out",
+        )
+        AssignmentGroupMembership.all_objects.create(
+            group=other_bunk, person=outsider,
+            role_in_group="subject", is_active=True,
+        )
+        _, user = cc_person_user
+        api.force_authenticate(user=user)
+        with organization_context(org):
+            r = api.get(
+                f"/api/v1/camper-care/campers/{outsider.id}/",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 403
+
+    def test_camper_not_found(
+        self, api, org, cc_person_user, cc_membership, cc_caseload,
+    ):
+        _, user = cc_person_user
+        api.force_authenticate(user=user)
+        with organization_context(org):
+            r = api.get(
+                "/api/v1/camper-care/campers/99999999/", **_hdr(org.slug),
+            )
+        assert r.status_code == 404
+
+    def test_requires_camper_care_role(
+        self, api, org, counselor_person_user, counselor_membership,
+        camper, camper_in_bunk,
+    ):
+        _, user = counselor_person_user
+        api.force_authenticate(user=user)
+        with organization_context(org):
+            r = api.get(
+                f"/api/v1/camper-care/campers/{camper.id}/", **_hdr(org.slug),
+            )
+        assert r.status_code == 403

--- a/backend/bunk_logs/api/unit_head/bunk_dashboard.py
+++ b/backend/bunk_logs/api/unit_head/bunk_dashboard.py
@@ -91,85 +91,117 @@ class UnitHeadBunkDashboardView(APIView):
             msg = "Bunk not found."
             raise NotFound(msg)
 
-        campers = bunk_camper_persons([bunk]).get(bunk.id, [])
-        camper_ids = [c.id for c in campers]
-
-        off_camp = off_camp_camper_ids(ctx.organization, target_date, camper_ids)
-        off_camp_payload = [
-            _camper_brief(c, off_camp=True) for c in campers if c.id in off_camp
-        ]
-
-        # Today's camper reflections (visibility-filtered) for help
-        # surface + score grid.
-        camper_template = camper_reflection_template(ctx.organization, ctx.program)
-        reflections_by_subject: dict[int, Reflection] = {}
-        if camper_template is not None and campers:
-            visible_qs = reflections_visible_for_user(
-                request.user,
-                Reflection.all_objects.filter(
-                    template=camper_template,
-                    assignment_group=bunk,
-                    period_start=target_date,
-                    period_end=target_date,
-                    is_complete=True,
-                ).select_related("template", "author"),
-            )
-            for r in visible_qs:
-                if r.subject_id is not None:
-                    reflections_by_subject[r.subject_id] = r
-
-        help_ids = help_requested_camper_ids_from(reflections_by_subject)
-        help_payload = [
-            _camper_brief(c) for c in campers if c.id in help_ids
-        ]
-
-        # Bunk-concerns referencing this bunk today.
-        bc_map = bunk_concerns_referencing(
+        return Response(build_bunk_dashboard_payload(
+            request=request,
+            bunk=bunk,
+            target_date=target_date,
             organization=ctx.organization,
             program=ctx.program,
-            target_date=target_date,
-        )
-        bc_payload = _serialize_bunk_concerns(bc_map.get(bunk.id, []))
+            today=ctx.today,
+        ))
 
-        # Score grid (Story 12).
-        score_grid_payload = (
-            build_score_grid(
+
+# ---------------------------------------------------------------------------
+# Shared payload builder (role-agnostic; reused by Camper Care 7_8c)
+# ---------------------------------------------------------------------------
+
+
+def build_bunk_dashboard_payload(
+    *,
+    request,
+    bunk: AssignmentGroup,
+    target_date: date,
+    organization,
+    program,
+    today: date,
+) -> dict:
+    """Compose the per-bunk dashboard payload, viewer-visibility-filtered.
+
+    Pulled out of the UH view so Camper Care (7_8c), LT, and Admin
+    can call it with their own role-specific viewer + supervision
+    gates while sharing the same payload contract. Visibility is
+    enforced inside via ``request.user`` so the caller cannot widen
+    audience by handing in a different organization or program.
+    """
+    campers = bunk_camper_persons([bunk]).get(bunk.id, [])
+    camper_ids = [c.id for c in campers]
+
+    off_camp = off_camp_camper_ids(organization, target_date, camper_ids)
+    off_camp_payload = [
+        _camper_brief(c, off_camp=True) for c in campers if c.id in off_camp
+    ]
+
+    # Today's camper reflections (visibility-filtered) for help
+    # surface + score grid.
+    camper_template = camper_reflection_template(organization, program)
+    reflections_by_subject: dict[int, Reflection] = {}
+    if camper_template is not None and campers:
+        visible_qs = reflections_visible_for_user(
+            request.user,
+            Reflection.all_objects.filter(
                 template=camper_template,
-                campers=campers,
-                reflections_by_subject=reflections_by_subject,
-            ) if camper_template else {"columns": [], "rows": []}
+                assignment_group=bunk,
+                period_start=target_date,
+                period_end=target_date,
+                is_complete=True,
+            ).select_related("template", "author"),
         )
+        for r in visible_qs:
+            if r.subject_id is not None:
+                reflections_by_subject[r.subject_id] = r
 
-        # Orders + Maintenance Tickets for the bunk (Story 14).
-        orders_payload = _orders_for_bunk(
-            bunk=bunk, target_date=target_date, organization=ctx.organization,
-            program=ctx.program,
-        )
+    help_ids = help_requested_camper_ids_from(reflections_by_subject)
+    help_payload = [
+        _camper_brief(c) for c in campers if c.id in help_ids
+    ]
 
-        # Specialist reports (Story 15).
-        spec_payload = _specialist_reports_for_bunk(
-            request=request, camper_ids=camper_ids, target_date=target_date,
-        )
+    # Bunk-concerns referencing this bunk today.
+    bc_map = bunk_concerns_referencing(
+        organization=organization,
+        program=program,
+        target_date=target_date,
+    )
+    bc_payload = _serialize_bunk_concerns(bc_map.get(bunk.id, []))
 
-        return Response({
-            "header": {
-                "bunk": {
-                    "id": bunk.id,
-                    "name": bunk.name,
-                    "slug": bunk.slug,
-                    "unit_name": (bunk.parent.name if bunk.parent_id else None),
-                },
-                "date": target_date.isoformat(),
-                "today": ctx.today.isoformat(),
-                "counselor_names": _counselor_names(bunk),
+    # Score grid (Story 12).
+    score_grid_payload = (
+        build_score_grid(
+            template=camper_template,
+            campers=campers,
+            reflections_by_subject=reflections_by_subject,
+        ) if camper_template else {"columns": [], "rows": []}
+    )
+
+    # Orders + Maintenance Tickets for the bunk (Story 14).
+    orders_payload = _orders_for_bunk(
+        bunk=bunk, target_date=target_date, organization=organization,
+        program=program,
+    )
+
+    # Specialist reports (Story 15).
+    spec_payload = _specialist_reports_for_bunk(
+        request=request, camper_ids=camper_ids, target_date=target_date,
+    )
+
+    return {
+        "header": {
+            "bunk": {
+                "id": bunk.id,
+                "name": bunk.name,
+                "slug": bunk.slug,
+                "unit_name": (bunk.parent.name if bunk.parent_id else None),
             },
-            "help_requested": help_payload,
-            "off_camp": off_camp_payload,
-            "bunk_concerns": bc_payload,
-            "score_grid": score_grid_payload,
-            "orders": orders_payload,
-            "specialist_reports": spec_payload,
-        })
+            "date": target_date.isoformat(),
+            "today": today.isoformat(),
+            "counselor_names": _counselor_names(bunk),
+        },
+        "help_requested": help_payload,
+        "off_camp": off_camp_payload,
+        "bunk_concerns": bc_payload,
+        "score_grid": score_grid_payload,
+        "orders": orders_payload,
+        "specialist_reports": spec_payload,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -26,6 +26,8 @@ from .dashboards import coverage as coverage_dashboard
 from .dashboards import subject as subject_dashboard
 from .dashboards import template as template_dashboard
 from .dashboards import trends as trends_dashboard
+from .camper_care import bunk_dashboard as cc_bunk_dashboard
+from .camper_care import camper_dashboard as cc_camper_dashboard
 from .camper_care import dashboard as cc_dashboard
 from .camper_care import flags as cc_flags
 from .camper_care import notes as cc_notes
@@ -283,6 +285,16 @@ urlpatterns = [
         "camper-care/dashboard/",
         cc_dashboard.CamperCareDashboardView.as_view(),
         name="camper-care-dashboard",
+    ),
+    path(
+        "camper-care/bunks/<int:bunk_id>/",
+        cc_bunk_dashboard.CamperCareBunkDashboardView.as_view(),
+        name="camper-care-bunk-dashboard",
+    ),
+    path(
+        "camper-care/campers/<int:camper_id>/",
+        cc_camper_dashboard.CamperCareCamperDashboardView.as_view(),
+        name="camper-care-camper-dashboard",
     ),
     path(
         "camper-care/flags/",

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -54,6 +54,8 @@ import UnitHeadCamperDashboardPage from './pages/unit-head/UnitHeadCamperDashboa
 import UnitHeadSelfReflectionPage from './pages/unit-head/UnitHeadSelfReflectionPage';
 import UnitHeadSelfReflectionHistoryPage from './pages/unit-head/UnitHeadSelfReflectionHistoryPage';
 import CamperCareDashboardV2 from './pages/camper-care/Dashboard';
+import CamperCareBunkDashboardPage from './pages/camper-care/BunkDashboardPage';
+import CamperCareCamperDashboardPage from './pages/camper-care/CamperDashboardPage';
 import CamperCareFlagsPage from './pages/camper-care/Flags';
 import CamperCareOrdersPage from './pages/camper-care/Orders';
 import CamperCareNoteFormPage from './pages/camper-care/NoteForm';
@@ -435,10 +437,18 @@ function Router() {
               `/dashboard/campercare` route still serves the old
               CamperCareDashboard.jsx surface and is untouched while
               wave 5 migration progresses. Bunk + camper drill-down
-              endpoints (Story 18 c.9) are not yet wired; a follow-up
-              PR will add `/api/v1/camper-care/bunks/<id>/` plus the
-              corresponding page wrappers. */}
+              pages (Story 18 c.9 + Story 21 in-context note CTA) were
+              shipped in 7_8c and reuse the shared BunkDashboard +
+              CamperDashboard components with caseload-scoped CC views. */}
           <Route path="/camper-care" element={<CamperCareDashboardV2 />} />
+          <Route
+            path="/camper-care/bunks/:bunkId"
+            element={<CamperCareBunkDashboardPage />}
+          />
+          <Route
+            path="/camper-care/campers/:camperId"
+            element={<CamperCareCamperDashboardPage />}
+          />
           <Route path="/camper-care/flags" element={<CamperCareFlagsPage />} />
           <Route path="/camper-care/orders" element={<CamperCareOrdersPage />} />
           <Route path="/camper-care/notes/new" element={<CamperCareNoteFormPage />} />

--- a/frontend/src/api/camperCare.js
+++ b/frontend/src/api/camperCare.js
@@ -22,6 +22,37 @@ export async function fetchCamperCareDashboard({ date, noCache = false } = {}) {
   return data;
 }
 
+/** Bunk drill-down payload (Story 18 c.9) for a bunk on a date. */
+export async function fetchBunkDashboard(bunkId, { date } = {}) {
+  const params = date ? { date } : {};
+  const { data } = await api.get(
+    `/api/v1/camper-care/bunks/${bunkId}/`,
+    { params },
+  );
+  return data;
+}
+
+/**
+ * Camper drill-down payload (Story 18 c.9 + Story 21 in-context notes).
+ * Reuses the role-agnostic shape served by the shared payload builder.
+ */
+export async function fetchCamperDashboard(camperId, {
+  date,
+  range = 'last_4_weeks',
+  dateStart,
+  dateEnd,
+} = {}) {
+  const params = { range };
+  if (date) params.date = date;
+  if (dateStart) params.date_start = dateStart;
+  if (dateEnd) params.date_end = dateEnd;
+  const { data } = await api.get(
+    `/api/v1/camper-care/campers/${camperId}/`,
+    { params },
+  );
+  return data;
+}
+
 /**
  * Flag workspace listing (Story 20).
  *

--- a/frontend/src/pages/camper-care/BunkDashboardPage.jsx
+++ b/frontend/src/pages/camper-care/BunkDashboardPage.jsx
@@ -1,0 +1,92 @@
+/**
+ * Camper Care Bunk Dashboard page — Step 7_8c, Story 18 c.9.
+ *
+ * Thin route-bound wrapper around the shared `<BunkDashboard />`. Date
+ * lives in the URL query so a deep link is shareable; auto-refresh
+ * every 60s when viewing today.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import BunkDashboard from '../../components/BunkDashboard';
+import { fetchBunkDashboard } from '../../api/camperCare';
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+export default function CamperCareBunkDashboardPage() {
+  const { bunkId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const dateParam = searchParams.get('date') || '';
+
+  const [data, setData] = useState(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const payload = await fetchBunkDashboard(bunkId, {
+        date: dateParam || undefined,
+      });
+      setData(payload);
+      setError('');
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      setError(typeof detail === 'string' ? detail : err?.message || 'Could not load this bunk.');
+    } finally {
+      setLoading(false);
+    }
+  }, [bunkId, dateParam]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const isToday = useMemo(() => {
+    if (!data?.header?.date || !data?.header?.today) return false;
+    return data.header.date === data.header.today;
+  }, [data]);
+
+  useEffect(() => {
+    if (!isToday) return undefined;
+    const id = setInterval(load, REFRESH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [isToday, load]);
+
+  const handleDateChange = (next) => {
+    const params = new URLSearchParams(searchParams);
+    if (next) params.set('date', next);
+    else params.delete('date');
+    setSearchParams(params, { replace: true });
+  };
+
+  if (loading && !data) {
+    return (
+      <div className="px-4 py-6 max-w-3xl mx-auto">
+        <p className="text-gray-600 dark:text-gray-400">Loading bunk dashboard…</p>
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="px-4 py-6 max-w-3xl mx-auto">
+        <div
+          role="alert"
+          className="rounded-xl border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-900/30 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+          data-testid="cc-bunk-dashboard-error"
+        >
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <BunkDashboard
+      data={data}
+      selectedDate={dateParam || data?.header?.date}
+      onDateChange={handleDateChange}
+      camperDashboardPath="/camper-care/campers"
+      backTo="/camper-care"
+    />
+  );
+}

--- a/frontend/src/pages/camper-care/CamperDashboardPage.jsx
+++ b/frontend/src/pages/camper-care/CamperDashboardPage.jsx
@@ -1,0 +1,100 @@
+/**
+ * Camper Care Camper Dashboard page — Step 7_8c, Story 18 c.9 + Story 21.
+ *
+ * Wraps the shared `<CamperDashboard />` and adds the in-context
+ * "Add Camper Care note" CTA above the dashboard so authors can drop
+ * a note without losing context. The note form route accepts
+ * `?camperId=` so the deep-linked CTA pre-fills the subject. Date +
+ * range live in the URL so a deep link is shareable.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
+import CamperDashboard from '../../components/CamperDashboard';
+import { fetchCamperDashboard } from '../../api/camperCare';
+
+export default function CamperCareCamperDashboardPage() {
+  const { camperId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const dateParam = searchParams.get('date') || '';
+  const rangeParam = searchParams.get('range') || 'last_4_weeks';
+
+  const [data, setData] = useState(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const payload = await fetchCamperDashboard(camperId, {
+        date: dateParam || undefined,
+        range: rangeParam,
+      });
+      setData(payload);
+      setError('');
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      setError(typeof detail === 'string' ? detail : err?.message || 'Could not load this camper.');
+    } finally {
+      setLoading(false);
+    }
+  }, [camperId, dateParam, rangeParam]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const updateParam = (key, value) => {
+    const params = new URLSearchParams(searchParams);
+    if (value) params.set(key, value);
+    else params.delete(key);
+    setSearchParams(params, { replace: true });
+  };
+
+  if (loading && !data) {
+    return (
+      <div className="px-4 py-6 max-w-3xl mx-auto">
+        <p className="text-gray-600 dark:text-gray-400">Loading camper dashboard…</p>
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="px-4 py-6 max-w-3xl mx-auto">
+        <div
+          role="alert"
+          className="rounded-xl border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-900/30 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+          data-testid="cc-camper-dashboard-error"
+        >
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <CamperDashboard
+        data={data}
+        selectedDate={dateParam || data?.header?.date}
+        selectedRange={rangeParam}
+        onDateChange={(next) => updateParam('date', next)}
+        onRangeChange={(next) => updateParam('range', next)}
+        backTo="/camper-care"
+      />
+      <div
+        data-testid="cc-camper-add-note-bar"
+        className="fixed bottom-0 inset-x-0 z-30 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3 shadow-md"
+      >
+        <div className="max-w-3xl mx-auto flex items-center justify-end">
+          <Link
+            to={`/camper-care/notes/new?camperId=${encodeURIComponent(camperId)}`}
+            data-testid="cc-camper-add-note"
+            className="inline-flex items-center justify-center min-h-[44px] px-4 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
+          >
+            Add Camper Care note
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/camper-care/Dashboard.jsx
+++ b/frontend/src/pages/camper-care/Dashboard.jsx
@@ -6,10 +6,10 @@
  *   2. Workspace entries — Flagged campers, Orders, My reflection
  *   3. Caseload tree — Units expand to Bunks with completion + attention badges
  *
- * The bunk-tap drill-down (Story 18 criterion 9 → Bunk Dashboard) is
- * deferred to a follow-up PR that wires `/api/v1/camper-care/bunks/<id>/`;
- * for now bunk rows are informational (completion + badges) without a
- * clickable target.
+ * Bunk rows link to the per-bunk Camper Care drill-down (Story 18
+ * criterion 9). Tapping a bunk navigates to `/camper-care/bunks/<id>`
+ * which reuses the shared BunkDashboard component, scoped to the CC
+ * caseload by the backend.
  */
 
 import { useCallback, useEffect, useState } from 'react';
@@ -86,30 +86,33 @@ function CompletionLabel({ completion }) {
 
 function BunkRow({ bunk }) {
   return (
-    <li
-      data-testid={`cc-bunk-row-${bunk.id}`}
-      className="rounded-lg border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 px-3 py-2"
-    >
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <p className="font-medium text-sm text-gray-900 dark:text-white truncate">{bunk.name}</p>
-          {bunk.counselor_names?.length > 0 && (
-            <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
-              {bunk.counselor_names.join(' · ')}
-            </p>
-          )}
+    <li data-testid={`cc-bunk-row-${bunk.id}`}>
+      <Link
+        to={`/camper-care/bunks/${bunk.id}`}
+        data-testid={`cc-bunk-link-${bunk.id}`}
+        className="block rounded-lg border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 px-3 py-2 hover:border-blue-300 dark:hover:border-blue-700 hover:shadow-sm transition"
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <p className="font-medium text-sm text-gray-900 dark:text-white truncate">{bunk.name}</p>
+            {bunk.counselor_names?.length > 0 && (
+              <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                {bunk.counselor_names.join(' · ')}
+              </p>
+            )}
+          </div>
+          <div className="text-xs text-right shrink-0 text-gray-700 dark:text-gray-200">
+            <CompletionLabel completion={bunk.completion} />
+          </div>
         </div>
-        <div className="text-xs text-right shrink-0 text-gray-700 dark:text-gray-200">
-          <CompletionLabel completion={bunk.completion} />
-        </div>
-      </div>
-      {bunk.badges?.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 mt-2">
-          {bunk.badges.map((b) => (
-            <Badge key={b} kind={b} />
-          ))}
-        </div>
-      )}
+        {bunk.badges?.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mt-2">
+            {bunk.badges.map((b) => (
+              <Badge key={b} kind={b} />
+            ))}
+          </div>
+        )}
+      </Link>
     </li>
   );
 }

--- a/frontend/src/pages/camper-care/__tests__/BunkDashboardPage.test.jsx
+++ b/frontend/src/pages/camper-care/__tests__/BunkDashboardPage.test.jsx
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import CamperCareBunkDashboardPage from '../BunkDashboardPage';
+
+const getMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+  },
+}));
+
+beforeEach(() => {
+  getMock.mockReset();
+});
+
+const samplePayload = {
+  header: {
+    bunk: { id: 11, name: 'Cabin Birch', slug: 'cabin-birch', unit_name: 'Senior Village' },
+    date: '2026-07-04',
+    today: '2026-07-04',
+    counselor_names: ['Pat L.', 'Sam R.'],
+  },
+  help_requested: [
+    { id: 901, first_name: 'Sarah', preferred_name: '', last_name: 'L' },
+  ],
+  off_camp: [],
+  bunk_concerns: [],
+  score_grid: { columns: [], rows: [] },
+  orders: [],
+  specialist_reports: { today: [], recent: [] },
+};
+
+function renderAt(path) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="/camper-care/bunks/:bunkId"
+          element={<CamperCareBunkDashboardPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('CamperCareBunkDashboardPage', () => {
+  it('renders the shared BunkDashboard payload for a bunk on the caseload', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    renderAt('/camper-care/bunks/11');
+    await waitFor(() => {
+      expect(screen.getByTestId('bunk-dashboard')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Cabin Birch')).toBeInTheDocument();
+    expect(screen.getByText('Senior Village')).toBeInTheDocument();
+    // Hits the CC-scoped endpoint (not the UH one).
+    expect(getMock).toHaveBeenCalledWith(
+      '/api/v1/camper-care/bunks/11/',
+      expect.any(Object),
+    );
+  });
+
+  it('shows an error banner when the fetch fails with a permission error', async () => {
+    getMock.mockRejectedValueOnce({
+      response: { data: { detail: 'This bunk is not on your caseload.' } },
+    });
+    renderAt('/camper-care/bunks/99');
+    await waitFor(() => {
+      expect(screen.getByTestId('cc-bunk-dashboard-error')).toHaveTextContent(
+        /not on your caseload/i,
+      );
+    });
+  });
+});

--- a/frontend/src/pages/camper-care/__tests__/CamperDashboardPage.test.jsx
+++ b/frontend/src/pages/camper-care/__tests__/CamperDashboardPage.test.jsx
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import CamperCareCamperDashboardPage from '../CamperDashboardPage';
+
+const getMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+  },
+}));
+
+beforeEach(() => {
+  getMock.mockReset();
+});
+
+const samplePayload = {
+  header: {
+    camper: { id: 7, first_name: 'Sarah', preferred_name: '', last_name: 'Levin' },
+    bunk: { id: 11, name: 'Cabin Birch' },
+    unit: { id: 100, name: 'Senior Village' },
+    today: '2026-07-04',
+    date: '2026-07-04',
+    range: { key: 'last_4_weeks', date_start: '2026-06-06', date_end: '2026-07-04' },
+  },
+  trend: { series: [], points: [] },
+  today_reflection: null,
+  today_scores: [],
+  today_flags: [],
+  specialist_reports: [],
+  camper_care_notes: [],
+};
+
+function renderAt(path) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="/camper-care/campers/:camperId"
+          element={<CamperCareCamperDashboardPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('CamperCareCamperDashboardPage', () => {
+  it('renders the shared CamperDashboard and offers an in-context Add Camper Care note CTA (Story 21)', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    renderAt('/camper-care/campers/7');
+    await waitFor(() => {
+      expect(screen.getByTestId('camper-dashboard')).toBeInTheDocument();
+    });
+    expect(getMock).toHaveBeenCalledWith(
+      '/api/v1/camper-care/campers/7/',
+      expect.any(Object),
+    );
+    const cta = screen.getByTestId('cc-camper-add-note');
+    expect(cta).toHaveTextContent(/add camper care note/i);
+    expect(cta).toHaveAttribute('href', '/camper-care/notes/new?camperId=7');
+  });
+
+  it('surfaces an error when the camper is off-caseload', async () => {
+    getMock.mockRejectedValueOnce({
+      response: { data: { detail: 'This camper is not on your caseload.' } },
+    });
+    renderAt('/camper-care/campers/9999');
+    await waitFor(() => {
+      expect(screen.getByTestId('cc-camper-dashboard-error')).toHaveTextContent(
+        /not on your caseload/i,
+      );
+    });
+  });
+});

--- a/frontend/src/pages/camper-care/__tests__/Dashboard.test.jsx
+++ b/frontend/src/pages/camper-care/__tests__/Dashboard.test.jsx
@@ -100,4 +100,20 @@ describe('CamperCareDashboard', () => {
       expect(screen.getByTestId('cc-dashboard-error')).toHaveTextContent('Forbidden');
     });
   });
+
+  it('links bunk rows to the per-bunk Camper Care dashboard (Story 18 c.9)', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    render(
+      <MemoryRouter>
+        <CamperCareDashboard />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('cc-bunk-link-11')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('cc-bunk-link-11')).toHaveAttribute(
+      'href',
+      '/camper-care/bunks/11',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Closes out the Camper Care follow-up work deferred in #100 (7_8b). After this PR, Camper Care members can tap a bunk on their dashboard to open the per-bunk drill-down, navigate into a camper, and drop an in-context Camper Care note. All visibility + caseload gating is enforced server-side.

Stacked on `feat/7_6d_counselor_frontend` (which contains 7_7, 7_8a, and 7_8b).

## What's in this PR

### Backend (4 files + tests)

- **Refactor**: pull the per-bunk payload builder out of the UH view.
  `UnitHeadBunkDashboardView.get` now calls the new module-level
  `build_bunk_dashboard_payload(*, request, bunk, target_date, organization, program, today)`
  so the role-agnostic payload contract (header, help, off-camp, bunk concerns,
  score grid, orders, specialist reports) is reusable. The 23 existing UH
  tests still pass unchanged.
- **`GET /api/v1/camper-care/bunks/<bunk_id>/`** — viewer must have the bunk
  on their CC caseload (as of today). Delegates to the shared helper above.
- **`GET /api/v1/camper-care/campers/<camper_id>/`** — camper must be rostered
  to a bunk on the viewer's caseload. Delegates to the shared
  `build_camper_dashboard_payload` already factored out for the UH camper
  dashboard in 7_7.
- Both new URLs registered under `bunk_logs.api.urls`.

Tests (8 new, all green): happy path + caseload gate + role gate + future
date + not-found for both endpoints. The CC + UH suites together: **55
passed** locally.

### Frontend (4 new files + 4 edits + tests)

- `api/camperCare.js`: add `fetchBunkDashboard` and `fetchCamperDashboard`.
- `pages/camper-care/BunkDashboardPage.jsx`: thin wrapper that mounts the
  shared `<BunkDashboard />` and passes `camperDashboardPath=\"/camper-care/campers\"`
  so camper pills route inside the CC namespace.
- `pages/camper-care/CamperDashboardPage.jsx`: wraps `<CamperDashboard />`
  with a sticky **Add Camper Care note** CTA that deep-links to
  \`/camper-care/notes/new?camperId=<id>\` — fulfilling Story 21's
  in-context note creation requirement.
- `pages/camper-care/Dashboard.jsx`: bunk rows on the caseload tree are
  now clickable links to the drill-down (Story 18 criterion 9); docstring
  updated to reflect the now-shipped behavior.
- `Router.jsx`: register `/camper-care/bunks/:bunkId` and
  `/camper-care/campers/:camperId` under `AppLayout` + `ProtectedRoute`.

Tests (5 new, all green): dashboard bunk-link assertion + 2 BunkDashboardPage
+ 2 CamperDashboardPage. **All 471 frontend tests pass; production build
is clean.**

## Visibility / tenancy boundary notes

- The CC bunk endpoint uses `caseload_bunks(membership, today=today)` (added
  in 7_8a) to gate access — same primitive used by `CamperCareDashboardView`.
- The CC camper endpoint additionally checks that the camper is rostered as
  `subject` on at least one bunk in the viewer's caseload via
  `AssignmentGroupMembership`. Overlapping caseloads (CC2) work naturally:
  any CC member with the bunk on their caseload can open the camper.
- Visibility filtering inside both payloads is unchanged — the shared
  builders use `request.user` so authors / readers / sensitive notes / CC5
  rules are applied identically across UH and CC.

## Test plan

- [x] `make test-backend` — 930 passed, 1 unrelated pre-existing failure
  (`test_translation.py::TestBeatRegistration::test_migration_installs_the_periodic_task_row`)
- [x] CC + UH suite focused run: 55 passed
- [x] `cd frontend && npm test` — 471/471 passed
- [x] `cd frontend && npm run build` — clean
- [ ] Manual smoke (post-deploy): CC user taps bunk from caseload → bunk
  dashboard renders → taps camper pill → camper dashboard renders →
  taps **Add Camper Care note** → note form pre-fills camper.

## Stacking

```
main
  └── feat/7_6d_counselor_frontend   (PRs #97, #98, #99, #100 stack here)
       └── feat/7_8c_camper_care_drill_downs   ← this PR
```

Merge order: parent stack drains to `main` together when ready. Optionally
this PR can be retargeted to `main` later if the parent stack lands first.


Made with [Cursor](https://cursor.com)