### PR TITLE
7_10 Maintenance Staff Flow (Stories 30-36)

### DIFF
--- a/backend/bunk_logs/api/maintenance/common.py
+++ b/backend/bunk_logs/api/maintenance/common.py
@@ -1,0 +1,70 @@
+"""Shared helpers for Maintenance staff endpoints (Step 7_10)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from rest_framework.exceptions import PermissionDenied
+
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.permissions import is_super_admin
+from bunk_logs.core.time_utils import get_today
+
+if TYPE_CHECKING:
+    from datetime import date
+
+
+@dataclass(frozen=True)
+class ViewerContext:
+    """Resolved request context for a Maintenance endpoint."""
+
+    person: Person
+    organization: Organization
+    membership: Membership
+    program: Program
+    today: date
+
+
+def viewer_or_403(request) -> ViewerContext:
+    """Resolve viewer Person + org + active Maintenance/Admin Membership, or 403.
+
+    Maintenance endpoints require all of: organization context, authenticated
+    user, a Person profile, and at least one active ``maintenance`` or ``admin``
+    Membership. Super admins bypass the role gate but still need a Person and
+    an organization context.
+    """
+    org = getattr(request, "organization", None)
+    if org is None:
+        msg = "Organization context required."
+        raise PermissionDenied(msg)
+    if not request.user.is_authenticated:
+        msg = "Authentication required."
+        raise PermissionDenied(msg)
+    person = Person.all_objects.filter(user=request.user).first()
+    if person is None:
+        msg = "Person profile required."
+        raise PermissionDenied(msg)
+
+    qs = Membership.objects.filter(
+        person=person, is_active=True,
+    ).select_related("program", "program__organization")
+
+    if not is_super_admin(request.user):
+        qs = qs.filter(role__in=("maintenance", "admin"))
+
+    membership = qs.order_by("-created_at").first()
+    if membership is None:
+        msg = "Maintenance role required."
+        raise PermissionDenied(msg)
+
+    return ViewerContext(
+        person=person,
+        organization=org,
+        membership=membership,
+        program=membership.program,
+        today=get_today(org),
+    )

--- a/backend/bunk_logs/api/maintenance/digest.py
+++ b/backend/bunk_logs/api/maintenance/digest.py
@@ -1,0 +1,295 @@
+"""Daily maintenance digest email (Step 7_10, Story 36).
+
+Scheduling
+----------
+A single Celery Beat task ``maintenance.dispatch_daily_digests`` runs at
+``05:00`` server time and fans out one ``send_maintenance_digest`` task per
+active org/program pair that has a ``maintenance_digest_email`` configured
+in ``Organization.settings``.
+
+Per-org send time is honoured by checking whether ``now`` in the org's
+timezone is within the configured send window (``maintenance_digest_time``,
+default ``"06:00"``).  Because the dispatcher itself runs at 05:00 UTC and
+most US camp orgs are UTC-4/UTC-5, default 06:00 local hits the window.
+
+Failure tracking
+----------------
+Consecutive failures are counted in
+``Organization.settings["maintenance_digest_consecutive_failures"]``.
+Three consecutive failures emit a ``logger.error`` with enough context for
+Datadog to trigger an alert (the project-wide DD agent reads Python loggers
+at ERROR level).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone as dt_timezone
+from typing import TYPE_CHECKING
+
+from celery import shared_task
+from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
+from django.template.loader import render_to_string
+from django.utils import timezone
+
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import OrderActivityEvent
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Program
+from bunk_logs.core.time_utils import get_org_timezone
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+CONSECUTIVE_FAILURE_ALERT_THRESHOLD = 3
+DEFAULT_DIGEST_TIME = "06:00"
+SEND_WINDOW_MINUTES = 59  # task runs every hour; accept if within 59 min of target
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher (hourly fan-out)
+# ---------------------------------------------------------------------------
+
+
+@shared_task(name="maintenance.dispatch_daily_digests")
+def dispatch_daily_digests() -> None:
+    """Fan-out one digest task per eligible org/program pair."""
+    for org in Organization.objects.filter(is_active=True):
+        digest_email = (org.settings or {}).get("maintenance_digest_email")
+        if not digest_email:
+            continue
+
+        target_time_str: str = (org.settings or {}).get("maintenance_digest_time", DEFAULT_DIGEST_TIME)
+        if not _is_send_window(org, target_time_str):
+            continue
+
+        for program in Program.all_objects.filter(
+            organization=org, is_active=True,
+        ):
+            send_maintenance_digest.delay(str(org.id), str(program.id))
+
+
+def _is_send_window(org: Organization, target_time_str: str) -> bool:
+    """Return True when ``now`` in the org's timezone is within the send window."""
+    try:
+        hour, minute = (int(p) for p in target_time_str.split(":"))
+    except (ValueError, AttributeError):
+        hour, minute = 6, 0
+
+    tz = get_org_timezone(org)
+    now_local = timezone.now().astimezone(tz)
+    target = now_local.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    diff = abs((now_local - target).total_seconds())
+    return diff <= SEND_WINDOW_MINUTES * 60
+
+
+# ---------------------------------------------------------------------------
+# Per-org digest sender
+# ---------------------------------------------------------------------------
+
+
+@shared_task(
+    name="maintenance.send_maintenance_digest",
+    bind=True,
+    max_retries=0,
+)
+def send_maintenance_digest(self, org_id: str, program_id: str) -> None:
+    """Build and send the daily maintenance digest for one org/program pair."""
+    try:
+        org = Organization.objects.get(pk=org_id)
+        program = Program.all_objects.get(pk=program_id, organization=org)
+    except (Organization.DoesNotExist, Program.DoesNotExist):
+        logger.warning("maintenance digest: org %s / program %s not found", org_id, program_id)
+        return
+
+    recipient = (org.settings or {}).get("maintenance_digest_email")
+    if not recipient:
+        return
+
+    tz = get_org_timezone(org)
+    now = timezone.now().astimezone(tz)
+    window_end = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    window_start = window_end - timedelta(days=1)
+
+    ctx = _build_digest_context(org, program, window_start, window_end)
+
+    subject = f"Maintenance Digest — {window_end.strftime('%B %-d, %Y')}"
+    from_email = getattr(settings, "DEFAULT_FROM_EMAIL", "no-reply@bunklogs.net")
+
+    text_body = render_to_string("maintenance/digest.txt", ctx)
+    html_body = render_to_string("maintenance/digest.html", ctx)
+
+    try:
+        msg = EmailMultiAlternatives(subject, text_body, from_email, [recipient])
+        msg.attach_alternative(html_body, "text/html")
+        msg.send()
+        _reset_failure_count(org)
+        logger.info("maintenance digest sent to %s for program %s", recipient, program_id)
+    except Exception as exc:  # noqa: BLE001
+        _increment_failure_count(org)
+        logger.error(
+            "maintenance digest send failure",
+            exc_info=exc,
+            extra={"org_id": org_id, "program_id": program_id, "recipient": recipient},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Digest content builder
+# ---------------------------------------------------------------------------
+
+
+def _build_digest_context(
+    org: Organization,
+    program: Program,
+    window_start: datetime,
+    window_end: datetime,
+) -> dict:
+    all_qs = MaintenanceTicket.objects.filter(program=program)
+
+    urgent_open = list(
+        all_qs.filter(
+            status__in=("new", "in_progress"),
+            urgency="urgent",
+        ).select_related("submitted_by__person").order_by("created_at")
+    )
+
+    new_in_window = list(
+        all_qs.filter(
+            created_at__gte=window_start,
+            created_at__lt=window_end,
+        ).select_related("submitted_by__person").order_by("created_at")
+    )
+
+    closed_in_window = list(
+        all_qs.filter(
+            status__in=("fulfilled", "unable_to_fulfill"),
+            updated_at__gte=window_start,
+            updated_at__lt=window_end,
+        ).select_related("submitted_by__person").order_by("updated_at")
+    )
+
+    reopened_in_window = list(
+        OrderActivityEvent.objects.filter(
+            content_type="maintenance_ticket",
+            from_state__in=("fulfilled", "unable_to_fulfill"),
+            to_state="in_progress",
+            created_at__gte=window_start,
+            created_at__lt=window_end,
+        ).select_related("actor_membership__person")
+    )
+    reopened_ticket_ids = [str(e.content_id) for e in reopened_in_window]
+    reopened_tickets = {
+        str(t.id): t
+        for t in all_qs.filter(id__in=reopened_ticket_ids).select_related("submitted_by__person")
+    }
+
+    still_open = list(
+        all_qs.filter(status__in=("new", "in_progress"))
+        .select_related("submitted_by__person")
+        .order_by("created_at")
+    )
+
+    def _closing_note(ticket):
+        ev = (
+            OrderActivityEvent.objects.filter(
+                content_type="maintenance_ticket",
+                content_id=ticket.id,
+                to_state__in=("fulfilled", "unable_to_fulfill"),
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        return (ev.note or "")[:120] if ev else ""
+
+    def _reopen_reason(event):
+        ev = (
+            OrderActivityEvent.objects.filter(
+                content_type="maintenance_ticket",
+                content_id=event.content_id,
+                from_state__in=("fulfilled", "unable_to_fulfill"),
+                to_state="in_progress",
+                created_at=event.created_at,
+            ).first()
+        )
+        return (ev.note or "") if ev else ""
+
+    base_url = getattr(settings, "FRONTEND_BASE_URL", "https://clc.bunklogs.net")
+
+    return {
+        "org": org,
+        "program": program,
+        "window_start": window_start,
+        "window_end": window_end,
+        "base_url": base_url,
+        "summary": {
+            "new_in_window": len(new_in_window),
+            "closed_in_window": len(closed_in_window),
+            "still_open": len(still_open),
+            "urgent_open": len(urgent_open),
+        },
+        "urgent_open": [_ticket_brief(t, base_url) for t in urgent_open],
+        "new_in_window": [_ticket_brief(t, base_url) for t in new_in_window],
+        "closed_in_window": [
+            {**_ticket_brief(t, base_url), "closing_note": _closing_note(t)}
+            for t in closed_in_window
+        ],
+        "reopened_in_window": [
+            {
+                "ticket": _ticket_brief(reopened_tickets[str(e.content_id)], base_url),
+                "reopen_reason": (e.note or "")[:120],
+            }
+            for e in reopened_in_window
+            if str(e.content_id) in reopened_tickets
+        ],
+        "still_open": [_ticket_brief(t, base_url) for t in still_open],
+    }
+
+
+def _ticket_brief(ticket: MaintenanceTicket, base_url: str) -> dict:
+    submitter = getattr(ticket, "submitted_by", None)
+    person = getattr(submitter, "person", None) if submitter else None
+    return {
+        "id": str(ticket.id),
+        "location": ticket.location,
+        "category": ticket.get_category_display(),
+        "urgency": ticket.urgency,
+        "description": (ticket.description or "")[:100],
+        "submitter_name": f"{person.first_name} {person.last_name}".strip() if person else "",
+        "status": ticket.status,
+        "deep_link": f"{base_url}/maintenance/tickets/{ticket.id}/",
+        "age_days": (timezone.now() - ticket.created_at).days if ticket.created_at else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Failure tracking
+# ---------------------------------------------------------------------------
+
+
+def _reset_failure_count(org: Organization) -> None:
+    settings_copy = dict(org.settings or {})
+    if settings_copy.get("maintenance_digest_consecutive_failures", 0) != 0:
+        settings_copy["maintenance_digest_consecutive_failures"] = 0
+        Organization.objects.filter(pk=org.pk).update(settings=settings_copy)
+
+
+def _increment_failure_count(org: Organization) -> None:
+    settings_copy = dict(org.settings or {})
+    count = settings_copy.get("maintenance_digest_consecutive_failures", 0) + 1
+    settings_copy["maintenance_digest_consecutive_failures"] = count
+    Organization.objects.filter(pk=org.pk).update(settings=settings_copy)
+
+    if count >= CONSECUTIVE_FAILURE_ALERT_THRESHOLD:
+        logger.error(
+            "maintenance digest ALERT: %d consecutive failures for org %s — "
+            "manual intervention required",
+            count,
+            org.slug,
+            extra={"org_id": str(org.id), "consecutive_failures": count},
+        )

--- a/backend/bunk_logs/api/maintenance/digest.py
+++ b/backend/bunk_logs/api/maintenance/digest.py
@@ -26,8 +26,6 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 from datetime import timedelta
-from datetime import timezone as dt_timezone
-from typing import TYPE_CHECKING
 
 from celery import shared_task
 from django.conf import settings
@@ -40,9 +38,6 @@ from bunk_logs.core.models import OrderActivityEvent
 from bunk_logs.core.models import Organization
 from bunk_logs.core.models import Program
 from bunk_logs.core.time_utils import get_org_timezone
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 
@@ -130,12 +125,13 @@ def send_maintenance_digest(self, org_id: str, program_id: str) -> None:
         msg.send()
         _reset_failure_count(org)
         logger.info("maintenance digest sent to %s for program %s", recipient, program_id)
-    except Exception as exc:  # noqa: BLE001
+    except Exception:
         _increment_failure_count(org)
-        logger.error(
-            "maintenance digest send failure",
-            exc_info=exc,
-            extra={"org_id": org_id, "program_id": program_id, "recipient": recipient},
+        logger.exception(
+            "maintenance digest send failure — org %s program %s recipient %s",
+            org_id,
+            program_id,
+            recipient,
         )
 
 
@@ -156,14 +152,14 @@ def _build_digest_context(
         all_qs.filter(
             status__in=("new", "in_progress"),
             urgency="urgent",
-        ).select_related("submitted_by__person").order_by("created_at")
+        ).select_related("submitted_by__person").order_by("created_at"),
     )
 
     new_in_window = list(
         all_qs.filter(
             created_at__gte=window_start,
             created_at__lt=window_end,
-        ).select_related("submitted_by__person").order_by("created_at")
+        ).select_related("submitted_by__person").order_by("created_at"),
     )
 
     closed_in_window = list(
@@ -171,7 +167,7 @@ def _build_digest_context(
             status__in=("fulfilled", "unable_to_fulfill"),
             updated_at__gte=window_start,
             updated_at__lt=window_end,
-        ).select_related("submitted_by__person").order_by("updated_at")
+        ).select_related("submitted_by__person").order_by("updated_at"),
     )
 
     reopened_in_window = list(
@@ -181,7 +177,7 @@ def _build_digest_context(
             to_state="in_progress",
             created_at__gte=window_start,
             created_at__lt=window_end,
-        ).select_related("actor_membership__person")
+        ).select_related("actor_membership__person"),
     )
     reopened_ticket_ids = [str(e.content_id) for e in reopened_in_window]
     reopened_tickets = {
@@ -192,7 +188,7 @@ def _build_digest_context(
     still_open = list(
         all_qs.filter(status__in=("new", "in_progress"))
         .select_related("submitted_by__person")
-        .order_by("created_at")
+        .order_by("created_at"),
     )
 
     def _closing_note(ticket):

--- a/backend/bunk_logs/api/maintenance/queue.py
+++ b/backend/bunk_logs/api/maintenance/queue.py
@@ -1,0 +1,427 @@
+"""Maintenance staff queue, ticket detail, and notes (Step 7_10, Stories 30-35).
+
+Endpoints
+---------
+GET  /api/v1/maintenance/queue/              — active/closed queue with filters
+GET  /api/v1/maintenance/tickets/<id>/       — full ticket detail + activity
+POST /api/v1/maintenance/tickets/<id>/notes/ — add note
+PATCH /api/v1/maintenance/tickets/<id>/notes/<note_id>/ — edit within 24h
+GET  /api/v1/maintenance/notes/audience/     — audience disclosure labels
+
+Notes use :class:`~bunk_logs.core.models.OrderActivityEvent` with
+``event_type='note'``.  Visibility is stored in ``metadata["visibility"]``
+(``"team_only"`` | ``"submitter_visible"``).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from django.db.models import Q
+from django.utils import timezone
+from rest_framework import status as http_status
+from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import OrderActivityEvent
+from bunk_logs.core.models import TicketPhoto
+
+from .common import viewer_or_403
+
+logger = logging.getLogger(__name__)
+
+NOTE_EDIT_WINDOW = timedelta(hours=24)
+
+URGENCY_ORDER: dict[str, int] = {"urgent": 0, "normal": 1, "low": 2, "": 3}
+
+STATUS_OPEN = (
+    MaintenanceTicket.Status.NEW,
+    MaintenanceTicket.Status.IN_PROGRESS,
+)
+STATUS_CLOSED = (
+    MaintenanceTicket.Status.FULFILLED,
+    MaintenanceTicket.Status.UNABLE_TO_FULFILL,
+)
+
+VALID_FILTERS = frozenset({"open", "new", "in_progress", "closed", "all"})
+VALID_VISIBILITY = frozenset({"team_only", "submitter_visible"})
+
+
+# ---------------------------------------------------------------------------
+# Queue
+# ---------------------------------------------------------------------------
+
+
+class MaintenanceQueueView(APIView):
+    """``GET /api/v1/maintenance/queue/`` — maintenance ticket queue.
+
+    Query params:
+
+    * ``filter`` — ``open`` (default), ``new``, ``in_progress``, ``closed``, ``all``
+    * ``search`` — free-text search (description + note bodies); closed only
+    * ``date_from`` / ``date_to`` — YYYY-MM-DD; closed filter date clamp
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        filt = (request.query_params.get("filter") or "open").lower()
+        if filt not in VALID_FILTERS:
+            raise ValidationError({"filter": f"Must be one of: {', '.join(sorted(VALID_FILTERS))}."})
+
+        qs = (
+            MaintenanceTicket.objects.filter(program=ctx.program)
+            .select_related("submitted_by__person")
+        )
+
+        if filt == "open":
+            qs = qs.filter(status__in=STATUS_OPEN)
+        elif filt == "new":
+            qs = qs.filter(status=MaintenanceTicket.Status.NEW)
+        elif filt == "in_progress":
+            qs = qs.filter(status=MaintenanceTicket.Status.IN_PROGRESS)
+        elif filt == "closed":
+            qs = qs.filter(status__in=STATUS_CLOSED)
+            qs = _apply_closed_filters(qs, request)
+        # "all" — no status filter
+
+        tickets = list(qs)
+
+        if filt in ("open", "new", "in_progress", "all"):
+            tickets.sort(key=lambda t: (URGENCY_ORDER.get(t.urgency, 3), t.created_at))
+        else:
+            tickets.sort(key=lambda t: t.updated_at, reverse=True)
+
+        counts = _build_counts(ctx.program)
+        rows = [_ticket_row(t) for t in tickets]
+
+        return Response({"tickets": rows, "counts": counts})
+
+
+def _apply_closed_filters(qs, request):
+    search = (request.query_params.get("search") or "").strip()
+    date_from_raw = request.query_params.get("date_from")
+    date_to_raw = request.query_params.get("date_to")
+
+    if date_from_raw:
+        from django.utils.dateparse import parse_date
+        d = parse_date(date_from_raw)
+        if d is None:
+            raise ValidationError({"date_from": "Expected YYYY-MM-DD."})
+        qs = qs.filter(updated_at__date__gte=d)
+    if date_to_raw:
+        from django.utils.dateparse import parse_date
+        d = parse_date(date_to_raw)
+        if d is None:
+            raise ValidationError({"date_to": "Expected YYYY-MM-DD."})
+        qs = qs.filter(updated_at__date__lte=d)
+
+    if search:
+        # Match on ticket description; note bodies matched via a subquery
+        note_ticket_ids = list(
+            OrderActivityEvent.objects.filter(
+                content_type="maintenance_ticket",
+                event_type=OrderActivityEvent.EventType.NOTE,
+                note__icontains=search,
+            ).values_list("content_id", flat=True).distinct()
+        )
+        qs = qs.filter(
+            Q(description__icontains=search)
+            | Q(location__icontains=search)
+            | Q(category__icontains=search)
+            | Q(id__in=note_ticket_ids)
+        )
+
+    return qs
+
+
+def _build_counts(program) -> dict:
+    qs = MaintenanceTicket.objects.filter(program=program)
+    new_count = qs.filter(status=MaintenanceTicket.Status.NEW).count()
+    in_progress_count = qs.filter(status=MaintenanceTicket.Status.IN_PROGRESS).count()
+    urgent_open_count = qs.filter(
+        status__in=STATUS_OPEN, urgency=MaintenanceTicket.Urgency.URGENT,
+    ).count()
+    return {
+        "new": new_count,
+        "in_progress": in_progress_count,
+        "urgent_open": urgent_open_count,
+    }
+
+
+def _ticket_row(ticket: MaintenanceTicket) -> dict:
+    submitter = ticket.submitted_by
+    submitter_person = getattr(submitter, "person", None) if submitter else None
+    age_seconds = int((timezone.now() - ticket.created_at).total_seconds()) if ticket.created_at else None
+    has_photos = TicketPhoto.all_objects.filter(ticket=ticket).exists()
+
+    acknowledger: dict | None = None
+    if ticket.last_transition_by_id and ticket.status == MaintenanceTicket.Status.IN_PROGRESS:
+        ack_membership = ticket.last_transition_by
+        ack_person = getattr(ack_membership, "person", None) if ack_membership else None
+        acknowledger = {
+            "name": ack_person.full_name if ack_person else None,
+            "at": ticket.last_transition_at.isoformat() if ticket.last_transition_at else None,
+        }
+
+    return {
+        "id": str(ticket.id),
+        "status": ticket.status,
+        "urgency": ticket.urgency,
+        "location": ticket.location,
+        "category": ticket.category,
+        "description": (ticket.description or "")[:120],
+        "submitter_name": (
+            f"{submitter_person.first_name} {submitter_person.last_name}".strip()
+            if submitter_person else None
+        ),
+        "age_seconds": age_seconds,
+        "has_photos": has_photos,
+        "acknowledger": acknowledger,
+        "available_transitions": ticket.available_transitions(),
+        "is_within_correction_window": ticket.can_correct_last_transition(),
+        "created_at": ticket.created_at.isoformat() if ticket.created_at else None,
+        "updated_at": ticket.updated_at.isoformat() if ticket.updated_at else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Ticket detail
+# ---------------------------------------------------------------------------
+
+
+class MaintenanceTicketDetailView(APIView):
+    """``GET /api/v1/maintenance/tickets/<id>/`` — full ticket detail."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, ticket_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        ticket = MaintenanceTicket.objects.filter(
+            pk=ticket_id, program=ctx.program,
+        ).select_related("submitted_by__person", "last_transition_by__person").first()
+        if ticket is None:
+            raise NotFound("Ticket not found.")
+
+        photos = list(
+            TicketPhoto.all_objects.filter(ticket=ticket)
+            .select_related("uploaded_by__person")
+            .order_by("created_at")
+        )
+        activity = list(
+            OrderActivityEvent.objects.filter(
+                content_type="maintenance_ticket", content_id=ticket.id,
+            )
+            .select_related("actor_membership__person")
+            .order_by("created_at")
+        )
+
+        return Response({
+            "ticket": _ticket_detail_payload(ticket),
+            "photos": [_photo_payload(p) for p in photos],
+            "activity": [_activity_event_payload(e) for e in activity],
+        })
+
+
+def _ticket_detail_payload(ticket: MaintenanceTicket) -> dict:
+    submitter = ticket.submitted_by
+    submitter_person = getattr(submitter, "person", None) if submitter else None
+    return {
+        "id": str(ticket.id),
+        "status": ticket.status,
+        "urgency": ticket.urgency,
+        "urgent_reason": ticket.urgent_reason,
+        "location": ticket.location,
+        "category": ticket.category,
+        "description": ticket.description,
+        "title": ticket.title,
+        "submitter_name": (
+            f"{submitter_person.first_name} {submitter_person.last_name}".strip()
+            if submitter_person else None
+        ),
+        "submitted_by_membership_id": str(ticket.submitted_by_id) if ticket.submitted_by_id else None,
+        "available_transitions": ticket.available_transitions(),
+        "is_within_correction_window": ticket.can_correct_last_transition(),
+        "last_transition_at": (
+            ticket.last_transition_at.isoformat() if ticket.last_transition_at else None
+        ),
+        "created_at": ticket.created_at.isoformat() if ticket.created_at else None,
+        "updated_at": ticket.updated_at.isoformat() if ticket.updated_at else None,
+    }
+
+
+def _photo_payload(photo: TicketPhoto) -> dict:
+    uploader = photo.uploaded_by
+    uploader_person = getattr(uploader, "person", None) if uploader else None
+    return {
+        "id": str(photo.id),
+        "image_url": photo.image.url if photo.image else None,
+        "caption": photo.caption,
+        "is_followup": photo.is_followup,
+        "uploaded_by": (
+            f"{uploader_person.first_name} {uploader_person.last_name}".strip()
+            if uploader_person else None
+        ),
+        "created_at": photo.created_at.isoformat() if photo.created_at else None,
+    }
+
+
+def _activity_event_payload(event: OrderActivityEvent) -> dict:
+    actor_person = None
+    if event.actor_membership:
+        actor_person = getattr(event.actor_membership, "person", None)
+    visibility = event.metadata.get("visibility", "team_only") if event.metadata else "team_only"
+    is_editable = (
+        event.event_type == OrderActivityEvent.EventType.NOTE
+        and (timezone.now() - event.created_at) <= NOTE_EDIT_WINDOW
+    )
+    return {
+        "id": str(event.id),
+        "event_type": event.event_type,
+        "from_state": event.from_state,
+        "to_state": event.to_state,
+        "note": event.note,
+        "reason": event.reason,
+        "visibility": visibility,
+        "actor_name": actor_person.full_name if actor_person else None,
+        "actor_membership_id": str(event.actor_membership_id) if event.actor_membership_id else None,
+        "is_within_edit_window": is_editable,
+        "correction_of": str(event.correction_of_id) if event.correction_of_id else None,
+        "created_at": event.created_at.isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Notes
+# ---------------------------------------------------------------------------
+
+
+class MaintenanceNoteCreateView(APIView):
+    """``POST /api/v1/maintenance/tickets/<id>/notes/`` — add a note.
+
+    Body: ``{ "body": "...", "visibility": "team_only"|"submitter_visible" }``
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, ticket_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        ticket = _get_ticket_or_404(ticket_id, ctx.program)
+
+        if ticket.status in STATUS_CLOSED:
+            return Response(
+                {"detail": "Cannot add notes to a closed ticket. Reopen it first."},
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
+
+        data = request.data or {}
+        body = (data.get("body") or "").strip()
+        visibility = (data.get("visibility") or "team_only").strip()
+
+        errors: dict[str, str] = {}
+        if not body:
+            errors["body"] = "Required."
+        if visibility not in VALID_VISIBILITY:
+            errors["visibility"] = f"Must be one of: {', '.join(sorted(VALID_VISIBILITY))}."
+        if errors:
+            return Response(errors, status=http_status.HTTP_400_BAD_REQUEST)
+
+        event = OrderActivityEvent.objects.create(
+            organization=ctx.organization,
+            program=ctx.program,
+            actor_membership=ctx.membership,
+            actor_user=request.user,
+            event_type=OrderActivityEvent.EventType.NOTE,
+            content_type="maintenance_ticket",
+            content_id=ticket.id,
+            note=body,
+            metadata={"visibility": visibility},
+        )
+
+        return Response(_activity_event_payload(event), status=http_status.HTTP_201_CREATED)
+
+
+class MaintenanceNoteDetailView(APIView):
+    """``PATCH /api/v1/maintenance/tickets/<id>/notes/<note_id>/`` — edit within 24h."""
+
+    permission_classes = [IsAuthenticated]
+
+    def patch(self, request, ticket_id, note_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        _get_ticket_or_404(ticket_id, ctx.program)
+
+        event = OrderActivityEvent.objects.filter(
+            pk=note_id,
+            content_type="maintenance_ticket",
+            content_id=ticket_id,
+            event_type=OrderActivityEvent.EventType.NOTE,
+        ).first()
+        if event is None:
+            raise NotFound("Note not found.")
+
+        if event.actor_membership_id != ctx.membership.id:
+            raise PermissionDenied("Only the original author may edit a note.")
+
+        if (timezone.now() - event.created_at) > NOTE_EDIT_WINDOW:
+            raise PermissionDenied("This note can no longer be edited (24h window has closed).")
+
+        data = request.data or {}
+        if "body" in data:
+            body = (data.get("body") or "").strip()
+            if not body:
+                return Response({"body": "Cannot be empty."}, status=http_status.HTTP_400_BAD_REQUEST)
+            event.note = body
+        if "visibility" in data:
+            visibility = (data.get("visibility") or "").strip()
+            if visibility not in VALID_VISIBILITY:
+                return Response(
+                    {"visibility": f"Must be one of: {', '.join(sorted(VALID_VISIBILITY))}."},
+                    status=http_status.HTTP_400_BAD_REQUEST,
+                )
+            event.metadata = {**(event.metadata or {}), "visibility": visibility}
+
+        event.save(update_fields=["note", "metadata"])
+        return Response(_activity_event_payload(event))
+
+
+class MaintenanceNoteAudienceView(APIView):
+    """``GET /api/v1/maintenance/notes/audience/?visibility=<>`` — disclosure copy."""
+
+    permission_classes = [IsAuthenticated]
+
+    _LABELS: dict[str, str] = {
+        "team_only": "This note will be visible to: Maintenance team, Admin.",
+        "submitter_visible": (
+            "This note will be visible to: Submitting counselor, Unit Head, "
+            "Maintenance team, Leadership Team, Admin."
+        ),
+    }
+
+    def get(self, request, *args, **kwargs):
+        viewer_or_403(request)
+        visibility = (request.query_params.get("visibility") or "team_only").strip()
+        if visibility not in VALID_VISIBILITY:
+            visibility = "team_only"
+        return Response({"visibility": visibility, "label": self._LABELS[visibility]})
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_ticket_or_404(ticket_id, program) -> MaintenanceTicket:
+    ticket = MaintenanceTicket.objects.filter(
+        pk=ticket_id, program=program,
+    ).first()
+    if ticket is None:
+        raise NotFound("Ticket not found.")
+    return ticket

--- a/backend/bunk_logs/api/maintenance/views.py
+++ b/backend/bunk_logs/api/maintenance/views.py
@@ -20,6 +20,7 @@ from datetime import timedelta
 
 from django.db.models import Q
 from django.utils import timezone
+from django.utils.dateparse import parse_date
 from rest_framework import status as http_status
 from rest_framework.exceptions import NotFound
 from rest_framework.exceptions import PermissionDenied
@@ -29,7 +30,6 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from bunk_logs.core.models import MaintenanceTicket
-from bunk_logs.core.models import Membership
 from bunk_logs.core.models import OrderActivityEvent
 from bunk_logs.core.models import TicketPhoto
 
@@ -112,13 +112,11 @@ def _apply_closed_filters(qs, request):
     date_to_raw = request.query_params.get("date_to")
 
     if date_from_raw:
-        from django.utils.dateparse import parse_date
         d = parse_date(date_from_raw)
         if d is None:
             raise ValidationError({"date_from": "Expected YYYY-MM-DD."})
         qs = qs.filter(updated_at__date__gte=d)
     if date_to_raw:
-        from django.utils.dateparse import parse_date
         d = parse_date(date_to_raw)
         if d is None:
             raise ValidationError({"date_to": "Expected YYYY-MM-DD."})
@@ -131,13 +129,13 @@ def _apply_closed_filters(qs, request):
                 content_type="maintenance_ticket",
                 event_type=OrderActivityEvent.EventType.NOTE,
                 note__icontains=search,
-            ).values_list("content_id", flat=True).distinct()
+            ).values_list("content_id", flat=True).distinct(),
         )
         qs = qs.filter(
             Q(description__icontains=search)
             | Q(location__icontains=search)
             | Q(category__icontains=search)
-            | Q(id__in=note_ticket_ids)
+            | Q(id__in=note_ticket_ids),
         )
 
     return qs
@@ -209,19 +207,20 @@ class MaintenanceTicketDetailView(APIView):
             pk=ticket_id, program=ctx.program,
         ).select_related("submitted_by__person", "last_transition_by__person").first()
         if ticket is None:
-            raise NotFound("Ticket not found.")
+            msg = "Ticket not found."
+            raise NotFound(msg)
 
         photos = list(
             TicketPhoto.all_objects.filter(ticket=ticket)
             .select_related("uploaded_by__person")
-            .order_by("created_at")
+            .order_by("created_at"),
         )
         activity = list(
             OrderActivityEvent.objects.filter(
                 content_type="maintenance_ticket", content_id=ticket.id,
             )
             .select_related("actor_membership__person")
-            .order_by("created_at")
+            .order_by("created_at"),
         )
 
         return Response({
@@ -365,13 +364,16 @@ class MaintenanceNoteDetailView(APIView):
             event_type=OrderActivityEvent.EventType.NOTE,
         ).first()
         if event is None:
-            raise NotFound("Note not found.")
+            msg = "Note not found."
+            raise NotFound(msg)
 
         if event.actor_membership_id != ctx.membership.id:
-            raise PermissionDenied("Only the original author may edit a note.")
+            msg = "Only the original author may edit a note."
+            raise PermissionDenied(msg)
 
         if (timezone.now() - event.created_at) > NOTE_EDIT_WINDOW:
-            raise PermissionDenied("This note can no longer be edited (24h window has closed).")
+            msg = "This note can no longer be edited (24h window has closed)."
+            raise PermissionDenied(msg)
 
         data = request.data or {}
         if "body" in data:
@@ -423,5 +425,6 @@ def _get_ticket_or_404(ticket_id, program) -> MaintenanceTicket:
         pk=ticket_id, program=program,
     ).first()
     if ticket is None:
-        raise NotFound("Ticket not found.")
+        msg = "Ticket not found."
+        raise NotFound(msg)
     return ticket

--- a/backend/bunk_logs/api/specialist/camper_view.py
+++ b/backend/bunk_logs/api/specialist/camper_view.py
@@ -1,0 +1,158 @@
+"""``GET /api/v1/specialist/campers/<camper_id>/`` — Story 28.
+
+Specialist-scoped camper dashboard variant. Intentionally minimal:
+
+  * **Header** — camper name, bunk, age/grade.
+  * **My notes about this camper** — only notes authored by the requesting
+    Specialist; no other roles' content, no reflections, no flags.
+    Date-range filter via ``date_from`` / ``date_to`` query params (criterion 6).
+
+Visibility filtering is at the queryset level (criterion 4): the query itself
+only returns the viewer's own notes. There is no client-side hiding.
+
+Access gate: the camper must be rostered (active AssignmentGroupMembership as
+"subject") in at least one program where the viewer has an active specialist
+Membership. Direct URL access by non-specialists returns 403 (criterion 5).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.utils import timezone
+from django.utils.dateparse import parse_date
+from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Note
+from bunk_logs.core.models import Person
+
+from .common import specialist_program_ids
+from .common import viewer_or_403
+
+EDIT_WINDOW = timedelta(hours=24)
+
+
+class SpecialistCamperView(APIView):
+    """Specialist-scoped per-camper view (Story 28)."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, camper_id: int, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        program_ids = specialist_program_ids(ctx.person)
+
+        camper = Person.all_objects.filter(
+            id=camper_id, organization=ctx.organization,
+        ).first()
+        if camper is None:
+            msg = "Camper not found."
+            raise NotFound(msg)
+
+        if not _viewer_shares_program(camper, program_ids):
+            msg = "You don't have access to this view."
+            raise PermissionDenied(msg)
+
+        date_from = _parse_date_param(request.query_params.get("date_from"))
+        date_to = _parse_date_param(request.query_params.get("date_to"))
+
+        notes_qs = (
+            Note.objects.filter(
+                organization=ctx.organization,
+                author=ctx.person,
+                subject=camper,
+                note_type=Note.NoteType.SPECIALIST,
+            )
+            .order_by("-created_at")
+        )
+        if date_from:
+            notes_qs = notes_qs.filter(created_at__date__gte=date_from)
+        if date_to:
+            notes_qs = notes_qs.filter(created_at__date__lte=date_to)
+
+        now = timezone.now()
+        bunk_info = _camper_bunk(camper, program_ids)
+
+        return Response({
+            "camper": {
+                "id": camper.id,
+                "display_name": _full_name(camper),
+                "preferred_name": (camper.preferred_name or None),
+                "first_name": camper.first_name,
+                "last_name": camper.last_name,
+                "bunk_name": bunk_info.get("bunk_name"),
+                "unit_name": bunk_info.get("unit_name"),
+            },
+            "my_notes": [_note_payload(n, now) for n in notes_qs],
+            "date_filter": {
+                "from": date_from.isoformat() if date_from else None,
+                "to": date_to.isoformat() if date_to else None,
+            },
+        })
+
+
+def _viewer_shares_program(camper: Person, program_ids: list[int]) -> bool:
+    """True iff the camper is an active subject in any of the viewer's programs."""
+    return AssignmentGroupMembership.objects.filter(
+        person=camper,
+        group__program_id__in=program_ids,
+        role_in_group="subject",
+        is_active=True,
+        group__group_type="bunk",
+        group__is_active=True,
+    ).exists()
+
+
+def _camper_bunk(camper: Person, program_ids: list[int]) -> dict:
+    agm = (
+        AssignmentGroupMembership.objects.filter(
+            person=camper,
+            group__program_id__in=program_ids,
+            role_in_group="subject",
+            is_active=True,
+            group__group_type="bunk",
+            group__is_active=True,
+        )
+        .select_related("group__parent")
+        .first()
+    )
+    if agm is None:
+        return {}
+    return {
+        "bunk_name": agm.group.name,
+        "unit_name": (agm.group.parent.name if agm.group.parent_id else None),
+    }
+
+
+def _full_name(person: Person) -> str:
+    first = (person.preferred_name or person.first_name or "").strip()
+    last = (person.last_name or "").strip()
+    return f"{first} {last}".strip()
+
+
+def _note_payload(note: Note, now) -> dict:
+    return {
+        "id": note.id,
+        "body": note.body,
+        "category": note.category or "",
+        "is_sensitive": bool(note.is_sensitive),
+        "language": note.language,
+        "created_at": note.created_at.isoformat(),
+        "updated_at": note.updated_at.isoformat(),
+        "is_within_edit_window": (now - note.created_at) <= EDIT_WINDOW,
+    }
+
+
+def _parse_date_param(raw: str | None):
+    if not raw:
+        return None
+    parsed = parse_date(raw)
+    if parsed is None:
+        msg = "Invalid date; expected YYYY-MM-DD."
+        raise ValidationError(msg)
+    return parsed

--- a/backend/bunk_logs/api/specialist/campers.py
+++ b/backend/bunk_logs/api/specialist/campers.py
@@ -1,0 +1,165 @@
+"""``GET /api/v1/specialist/campers/?q=<query>`` — Story 25.
+
+Camper picker with two sections:
+  * **Recent** — campers the Specialist noted in the last 7 days (max 8),
+    returned regardless of search query.
+  * **results** — all campers matching the query, alphabetical by last name.
+    Returns all when query is empty (the initial open state shows full roster).
+
+Cross-program: the picker covers all programs where the viewer has an active
+specialist Membership (Story 25 criterion 7). Server-side program-boundary
+enforcement per criterion 7; long-term withdrawn campers excluded per
+criterion 8 (``is_active=False`` AGM rows).
+
+Performance: a single pass through AssignmentGroupMembership returns all
+campers + their bunk group in one query. Bunk info is then attached via a
+dict lookup so N+1 on subjects is avoided (Story 25 criterion 4).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.utils import timezone
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Note
+from bunk_logs.core.models import Person
+
+from .common import specialist_program_ids
+from .common import viewer_or_403
+
+RECENT_DAYS = 7
+RECENT_MAX = 8
+ZERO_RESULTS_MSG = (
+    "No campers match {q}. Try searching by first name, last name, or bunk."
+)
+
+
+class SpecialistCamperPickerView(APIView):
+    """Camper picker for Specialist note form (Story 25)."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        q = (request.query_params.get("q") or "").strip()
+        program_ids = specialist_program_ids(ctx.person)
+        if not program_ids:
+            return Response({"recent": [], "results": [], "zero_results_message": None})
+
+        camper_rows = list(
+            AssignmentGroupMembership.objects.filter(
+                group__program_id__in=program_ids,
+                role_in_group="subject",
+                is_active=True,
+                group__group_type="bunk",
+                group__is_active=True,
+            )
+            .select_related("person", "group")
+            .order_by("person__last_name", "person__first_name"),
+        )
+
+        person_to_bunk: dict[int, str] = {}
+        all_persons: dict[int, Person] = {}
+        for agm in camper_rows:
+            if agm.person_id and agm.person_id not in person_to_bunk:
+                person_to_bunk[agm.person_id] = agm.group.name or ""
+                all_persons[agm.person_id] = agm.person
+
+        recent_subject_ids = _recent_subject_ids(ctx.person, program_ids)
+
+        if q:
+            bunk_match_ids = set(
+                AssignmentGroupMembership.objects.filter(
+                    group__program_id__in=program_ids,
+                    role_in_group="subject",
+                    is_active=True,
+                    group__group_type="bunk",
+                    group__is_active=True,
+                    group__name__icontains=q,
+                ).values_list("person_id", flat=True),
+            )
+            matched_ids = {
+                pid
+                for pid, person in all_persons.items()
+                if (
+                    q.lower() in (person.first_name or "").lower()
+                    or q.lower() in (person.last_name or "").lower()
+                    or q.lower() in (person.preferred_name or "").lower()
+                    or pid in bunk_match_ids
+                )
+            }
+        else:
+            matched_ids = set(all_persons.keys())
+
+        results = [
+            _camper_row(all_persons[pid], person_to_bunk.get(pid, ""))
+            for pid in sorted(
+                matched_ids,
+                key=lambda pid: (
+                    (all_persons[pid].last_name or "").lower(),
+                    (all_persons[pid].first_name or "").lower(),
+                ),
+            )
+        ]
+
+        recent = [
+            _camper_row(all_persons[pid], person_to_bunk.get(pid, ""))
+            for pid in recent_subject_ids
+            if pid in all_persons
+        ][:RECENT_MAX]
+
+        zero_results_message = (
+            ZERO_RESULTS_MSG.format(q=q) if (q and not results) else None
+        )
+
+        return Response({
+            "recent": recent,
+            "results": results,
+            "zero_results_message": zero_results_message,
+        })
+
+
+def _recent_subject_ids(viewer: Person, program_ids: list[int]) -> list[int]:
+    """Person IDs of campers the viewer noted in the last RECENT_DAYS days."""
+    since = timezone.now() - timedelta(days=RECENT_DAYS)
+    rows = (
+        Note.objects.filter(
+            program_id__in=program_ids,
+            author=viewer,
+            note_type=Note.NoteType.SPECIALIST,
+            created_at__gte=since,
+            subject__isnull=False,
+        )
+        .order_by("-created_at")
+        .values("subject_id")
+    )
+    seen: list[int] = []
+    seen_set: set[int] = set()
+    for row in rows:
+        sid = row["subject_id"]
+        if sid and sid not in seen_set:
+            seen.append(sid)
+            seen_set.add(sid)
+        if len(seen) >= RECENT_MAX:
+            break
+    return seen
+
+
+def _camper_row(person: Person, bunk_name: str) -> dict:
+    preferred = (person.preferred_name or "").strip()
+    first = (person.first_name or "").strip()
+    last = (person.last_name or "").strip()
+    display_name = f"{preferred or first} {last}".strip()
+    return {
+        "id": person.id,
+        "display_name": display_name,
+        "first_name": first,
+        "last_name": last,
+        "preferred_name": preferred or None,
+        "bunk_name": bunk_name or None,
+    }

--- a/backend/bunk_logs/api/specialist/common.py
+++ b/backend/bunk_logs/api/specialist/common.py
@@ -1,0 +1,135 @@
+"""Shared helpers for Specialist endpoints (Step 7_9).
+
+Mirrors the structure of ``api/camper_care/common.py``. Key differences
+from other role flows:
+
+* Specialists have no caseload — they can note any camper in the
+  programs they are a Member of (Story 25 criterion 1 + 7).
+* Sub-type label comes from ``membership.tags`` e.g. ``specialist:waterfront``
+  → "Waterfront Specialist" (Story 24 criterion 5).
+* Cross-program: a Specialist may have active memberships in multiple programs;
+  the dashboard shows the newest (primary), but the camper picker spans all.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from django.db.models import Q
+from rest_framework.exceptions import PermissionDenied
+
+from bunk_logs.api.counselor.common import _resolve_template
+from bunk_logs.api.counselor.common import enforce_edit_window  # noqa: F401 (re-export)
+from bunk_logs.api.counselor.common import is_day_off_answer  # noqa: F401 (re-export)
+from bunk_logs.api.counselor.common import is_editable_today  # noqa: F401 (re-export)
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.time_utils import get_today
+
+if TYPE_CHECKING:
+    from datetime import date
+
+    from bunk_logs.core.models import Organization
+    from bunk_logs.core.models import Program
+
+
+__all__ = [
+    "ViewerContext",
+    "specialist_label",
+    "specialist_program_ids",
+    "specialist_self_template",
+    "viewer_or_403",
+]
+
+
+@dataclass(frozen=True)
+class ViewerContext:
+    """Resolved request context for a Specialist endpoint."""
+
+    person: Person
+    organization: Organization
+    membership: Membership
+    program: Program
+    today: date
+
+
+def viewer_or_403(request) -> ViewerContext:
+    """Resolve viewer Person + org + active Specialist Membership, or 403.
+
+    Picks the newest active ``specialist`` Membership as the "primary"
+    program for dashboard scoping. The camper picker uses all programs
+    via :func:`specialist_program_ids`.
+    """
+    org = getattr(request, "organization", None)
+    if org is None:
+        msg = "Organization context required."
+        raise PermissionDenied(msg)
+    if not request.user.is_authenticated:
+        msg = "Authentication required."
+        raise PermissionDenied(msg)
+    person = Person.objects.filter(user=request.user).first()
+    if person is None:
+        msg = "Person profile required."
+        raise PermissionDenied(msg)
+    membership = (
+        Membership.objects.filter(
+            person=person, role="specialist", is_active=True,
+        )
+        .select_related("program", "program__organization")
+        .order_by("-created_at")
+        .first()
+    )
+    if membership is None:
+        msg = "Specialist role required."
+        raise PermissionDenied(msg)
+    return ViewerContext(
+        person=person,
+        organization=org,
+        membership=membership,
+        program=membership.program,
+        today=get_today(org),
+    )
+
+
+def specialist_label(membership: Membership) -> str:
+    """Human-readable role label from membership tags.
+
+    A tag of the form ``specialist:waterfront`` → "Waterfront Specialist".
+    Falls back to "Specialist" when no sub-type tag is present.
+    """
+    for tag in membership.tags or []:
+        if isinstance(tag, str) and tag.startswith("specialist:"):
+            sub = tag[len("specialist:"):]
+            if sub:
+                return f"{sub.replace('-', ' ').title()} Specialist"
+    return "Specialist"
+
+
+def specialist_program_ids(person: Person) -> list[int]:
+    """All active program IDs where ``person`` has a specialist membership."""
+    return list(
+        Membership.objects.filter(
+            person=person, role="specialist", is_active=True,
+        ).values_list("program_id", flat=True),
+    )
+
+
+def specialist_self_template(
+    organization: Organization,
+    program: Program,
+) -> ReflectionTemplate | None:
+    """Active daily specialist self-reflection template for the program.
+
+    Uses the shared org-shadow resolver. Returns ``None`` when no template
+    is configured (dashboard shows a placeholder).
+    """
+    qs = ReflectionTemplate.all_objects.filter(
+        Q(role="specialist") | Q(author_role_filter__contains=["specialist"]),
+        subject_mode="self",
+        cadence="daily",
+    )
+    return _resolve_template(
+        qs, organization=organization, program_type=program.program_type,
+    )

--- a/backend/bunk_logs/api/specialist/dashboard.py
+++ b/backend/bunk_logs/api/specialist/dashboard.py
@@ -1,0 +1,164 @@
+"""``GET /api/v1/specialist/dashboard/`` — Story 24.
+
+Exactly three top-level sections (criterion 3):
+  1. ``write_camper_note`` — entry point to the camper picker / note form.
+  2. ``self_reflection`` — state card for the specialist's daily self-reflection.
+  3. ``recent_notes`` — chronological top-10, with Show-older expansion via
+     offset/limit on ``GET /api/v1/specialist/notes/recent/``.
+
+Sort: ``recent_notes`` newest-first. ``my_reflection`` state follows
+the "missing / complete / day_off / no_template" pattern from other flows.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.utils import timezone
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.api.counselor.common import is_day_off_answer
+from bunk_logs.api.counselor.common import latest_self_reflection
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Flag
+from bunk_logs.core.models import Note
+
+from .common import specialist_label
+from .common import specialist_self_template
+from .common import viewer_or_403
+
+RECENT_NOTES_LIMIT = 10
+EDIT_WINDOW = timedelta(hours=24)
+NOTE_PREVIEW_MAX_LEN = 120
+
+
+class SpecialistDashboardView(APIView):
+    """Minimal Specialist dashboard — Story 24."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer = ctx.person
+        org = ctx.organization
+        today = ctx.today
+
+        template = specialist_self_template(org, ctx.program)
+        self_state = "missing"
+        self_reflection_id: int | None = None
+        editable = False
+        if template is None:
+            self_state = "no_template"
+        else:
+            existing = latest_self_reflection(viewer, template, today, today)
+            if existing is not None:
+                self_state = "day_off" if is_day_off_answer(existing) else "complete"
+                self_reflection_id = existing.id
+                editable = True
+
+        recent_notes_qs = (
+            Note.objects.filter(
+                organization=org,
+                program=ctx.program,
+                author=viewer,
+                note_type=Note.NoteType.SPECIALIST,
+            )
+            .select_related("subject")
+            .order_by("-created_at")[:RECENT_NOTES_LIMIT]
+        )
+        recent_notes_list = list(recent_notes_qs)
+        note_ids = [n.id for n in recent_notes_list]
+
+        flagged_note_ids = set(
+            Flag.all_objects.filter(
+                trigger_content_type="specialist_note",
+                trigger_content_id__in=[str(nid) for nid in note_ids],
+            ).values_list("trigger_content_id", flat=True),
+        )
+
+        subject_ids = {n.subject_id for n in recent_notes_list if n.subject_id}
+        bunk_names = _bunk_names_for_subjects(subject_ids)
+
+        now = timezone.now()
+        payload = {
+            "today": today.isoformat(),
+            "header": {
+                "name": _display_name(viewer),
+                "role_label": specialist_label(ctx.membership),
+                "program_name": ctx.program.name,
+            },
+            "write_camper_note": {
+                "url": "/specialist/notes/new",
+            },
+            "self_reflection": {
+                "state": self_state,
+                "reflection_id": self_reflection_id,
+                "template_id": template.id if template else None,
+                "editable": editable,
+            },
+            "recent_notes": [
+                _note_row(n, bunk_names, flagged_note_ids, now)
+                for n in recent_notes_list
+            ],
+        }
+        return Response(payload)
+
+
+def _display_name(person) -> str:
+    first = (person.preferred_name or person.first_name or "").strip()
+    last = (person.last_name or "").strip()
+    return f"{first} {last}".strip() if (first or last) else ""
+
+
+def _bunk_names_for_subjects(subject_ids: set[int]) -> dict[int, str]:
+    """Return {person_id: bunk_name} for the given subject IDs."""
+    if not subject_ids:
+        return {}
+    rows = (
+        AssignmentGroupMembership.objects.filter(
+            person_id__in=subject_ids,
+            role_in_group="subject",
+            is_active=True,
+            group__group_type="bunk",
+            group__is_active=True,
+        )
+        .select_related("group")
+        .values("person_id", "group__name")
+    )
+    out: dict[int, str] = {}
+    for row in rows:
+        out.setdefault(row["person_id"], row["group__name"] or "")
+    return out
+
+
+def _note_row(
+    note: Note,
+    bunk_names: dict[int, str],
+    flagged_note_ids: set[str],
+    now,
+) -> dict:
+    subject = note.subject
+    first = (
+        (subject.preferred_name or subject.first_name or "").strip()
+        if subject else ""
+    )
+    last_initial = ((subject.last_name or "").strip()[:1] if subject else "")
+    subject_name = (
+        f"{first} {last_initial}." if (first and last_initial) else (first or last_initial or "")
+    )
+    body = note.body or ""
+    preview = body if len(body) <= NOTE_PREVIEW_MAX_LEN else body[:NOTE_PREVIEW_MAX_LEN - 1] + "…"
+    return {
+        "id": note.id,
+        "subject_id": note.subject_id,
+        "subject_name": subject_name,
+        "bunk_name": bunk_names.get(note.subject_id, ""),
+        "category": note.category or "",
+        "body_preview": preview,
+        "is_sensitive": bool(note.is_sensitive),
+        "flag_raised": str(note.id) in flagged_note_ids,
+        "created_at": note.created_at.isoformat(),
+        "is_within_edit_window": (now - note.created_at) <= EDIT_WINDOW,
+    }

--- a/backend/bunk_logs/api/specialist/notes.py
+++ b/backend/bunk_logs/api/specialist/notes.py
@@ -1,0 +1,241 @@
+"""Specialist note write endpoints — Stories 26-27.
+
+Endpoints:
+
+* ``POST  /api/v1/specialist/notes/``         — create a specialist note.
+* ``PATCH /api/v1/specialist/notes/<id>/``    — edit within 24h window.
+* ``GET   /api/v1/specialist/notes/audience/`` — AudienceDisclosure copy.
+
+Category enum for specialist notes (Story 26 criterion 2):
+  positive / concern / milestone / behavioral / other
+These are stored in ``Note.category``; the values are short strings that
+fit within the field's ``max_length`` and are validated in-endpoint rather
+than against ``Note.Category`` (which retains CC-facing values).
+
+Flag creation (Story 26 criterion 7 / Step 7_8 model):
+  Submitting with ``flag_for_camper_care=True`` calls
+  :func:`core.flags.raise_flag_from_specialist_note` which writes a Flag
+  row with ``trigger_content_type='specialist_note'``.
+
+Flag retraction (Story 27 criterion 5 / Decision S5):
+  Once a flag is raised, the PATCH endpoint enforces that
+  ``flag_for_camper_care`` cannot change back to ``False``.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
+from django.utils import timezone
+from rest_framework import status as http_status
+from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.content_visibility import ContentType
+from bunk_logs.core.content_visibility import audience_labels
+from bunk_logs.core.flags import raise_flag_from_specialist_note
+from bunk_logs.core.models import Flag
+from bunk_logs.core.models import Note
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import note_snapshot
+
+from .common import viewer_or_403
+
+EDIT_WINDOW = timedelta(hours=24)
+
+SPECIALIST_CATEGORIES: frozenset[str] = frozenset({
+    "positive", "concern", "milestone", "behavioral", "other",
+})
+EDIT_FIELDS: frozenset[str] = frozenset({"body", "is_sensitive", "category", "language"})
+
+
+class SpecialistNoteCreateView(APIView):
+    """``POST /api/v1/specialist/notes/``."""
+
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["post", "head", "options"]
+
+    def post(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        data = request.data or {}
+
+        subject_id = data.get("subject_id")
+        body = (data.get("body") or "").strip()
+        category = (data.get("category") or "").strip().lower()
+        is_sensitive = bool(data.get("is_sensitive"))
+        flag_for_camper_care = bool(data.get("flag_for_camper_care"))
+        language = (data.get("language") or "en").strip()
+
+        errors: dict[str, str] = {}
+        if subject_id is None:
+            errors["subject_id"] = "Required."
+        if not body:
+            errors["body"] = "Required."
+        if category and category not in SPECIALIST_CATEGORIES:
+            errors["category"] = (
+                f"Must be one of: {', '.join(sorted(SPECIALIST_CATEGORIES))} or blank."
+            )
+        if errors:
+            return Response(errors, status=http_status.HTTP_400_BAD_REQUEST)
+
+        try:
+            subject = Person.all_objects.get(pk=subject_id)
+        except Person.DoesNotExist:
+            return Response(
+                {"subject_id": "Camper not found."},
+                status=http_status.HTTP_404_NOT_FOUND,
+            )
+
+        with transaction.atomic():
+            note = Note(
+                organization=ctx.organization,
+                program=ctx.program,
+                subject=subject,
+                author=ctx.person,
+                note_type=Note.NoteType.SPECIALIST,
+                body=body,
+                category=category,
+                is_sensitive=is_sensitive,
+                language=language,
+            )
+            try:
+                note.full_clean(exclude=["category"])
+            except DjangoValidationError as exc:
+                return Response(
+                    exc.message_dict if hasattr(exc, "message_dict") else {"detail": str(exc)},
+                    status=http_status.HTTP_400_BAD_REQUEST,
+                )
+            note.save()
+
+            audit_module.created(
+                ctx.membership,
+                note,
+                after_state=note_snapshot(note),
+                content_type="note",
+            )
+
+            if flag_for_camper_care:
+                raise_flag_from_specialist_note(note, raised_by=ctx.membership)
+
+        return Response(
+            _note_payload(note, flag_raised=flag_for_camper_care),
+            status=http_status.HTTP_201_CREATED,
+        )
+
+
+class SpecialistNoteDetailView(APIView):
+    """``PATCH /api/v1/specialist/notes/<id>/`` — edit within 24h window."""
+
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["patch", "head", "options"]
+
+    def patch(self, request, note_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        note = (
+            Note.objects.filter(
+                pk=note_id,
+                note_type=Note.NoteType.SPECIALIST,
+                organization=ctx.organization,
+            ).first()
+        )
+        if note is None:
+            msg = "Note not found."
+            raise NotFound(msg)
+
+        if note.author_id != ctx.person.id:
+            msg = "Only the original author may edit a specialist note."
+            raise PermissionDenied(msg)
+
+        if (timezone.now() - note.created_at) > EDIT_WINDOW:
+            msg = "This note can no longer be edited (24h window has closed)."
+            raise PermissionDenied(msg)
+
+        data = request.data or {}
+        unknown = set(data.keys()) - EDIT_FIELDS
+        if unknown:
+            return Response(
+                {"detail": f"Unknown fields: {sorted(unknown)}."},
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
+
+        # S5: Specialist cannot retract a flag they raised.
+        if "flag_for_camper_care" in data:
+            return Response(
+                {"flag_for_camper_care": "Flag state cannot be changed after submission."},
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
+
+        before = note_snapshot(note)
+
+        if "body" in data:
+            new_body = (data.get("body") or "").strip()
+            if not new_body:
+                return Response({"body": "Cannot be empty."}, status=http_status.HTTP_400_BAD_REQUEST)
+            note.body = new_body
+        if "is_sensitive" in data:
+            note.is_sensitive = bool(data["is_sensitive"])
+        if "category" in data:
+            cat = (data.get("category") or "").strip().lower()
+            if cat and cat not in SPECIALIST_CATEGORIES:
+                return Response(
+                    {"category": f"Must be one of: {', '.join(sorted(SPECIALIST_CATEGORIES))} or blank."},
+                    status=http_status.HTTP_400_BAD_REQUEST,
+                )
+            note.category = cat
+        if "language" in data:
+            note.language = (data.get("language") or "en").strip()
+
+        with transaction.atomic():
+            try:
+                note.full_clean(exclude=["category"])
+            except DjangoValidationError as exc:
+                return Response(
+                    exc.message_dict if hasattr(exc, "message_dict") else {"detail": str(exc)},
+                    status=http_status.HTTP_400_BAD_REQUEST,
+                )
+            note.save()
+            after = note_snapshot(note)
+            audit_module.edited(
+                ctx.membership, note, before, after, content_type="note",
+            )
+
+        flag_raised = Flag.all_objects.filter(
+            trigger_content_type="specialist_note",
+            trigger_content_id=str(note.id),
+        ).exists()
+        return Response(_note_payload(note, flag_raised=flag_raised))
+
+
+class SpecialistNoteAudienceView(APIView):
+    """``GET /api/v1/specialist/notes/audience/?is_sensitive=<>`` — AudienceDisclosure."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        viewer_or_403(request)
+        is_sensitive = (request.query_params.get("is_sensitive") or "").lower() in {"1", "true"}
+        labels = audience_labels(ContentType.SPECIALIST_NOTE, is_sensitive=is_sensitive)
+        return Response({"audience": labels, "is_sensitive": is_sensitive})
+
+
+def _note_payload(note: Note, *, flag_raised: bool = False) -> dict:
+    return {
+        "id": note.id,
+        "subject_id": note.subject_id,
+        "author_id": note.author_id,
+        "note_type": note.note_type,
+        "body": note.body,
+        "category": note.category,
+        "is_sensitive": bool(note.is_sensitive),
+        "flag_raised": flag_raised,
+        "language": note.language,
+        "created_at": note.created_at.isoformat(),
+        "updated_at": note.updated_at.isoformat(),
+        "is_within_edit_window": (timezone.now() - note.created_at) <= EDIT_WINDOW,
+    }

--- a/backend/bunk_logs/api/specialist/self_reflection.py
+++ b/backend/bunk_logs/api/specialist/self_reflection.py
@@ -1,0 +1,334 @@
+"""Specialist self-reflection write + history endpoints — Story 29.
+
+Mirrors :mod:`api.camper_care.self_reflection` with two differences:
+
+* Authorization requires an active ``specialist`` Membership.
+* No ``bunk_concerns_bunks`` field — specialists have no caseload to reference.
+
+Edit window: until rollover boundary (today); locked after (criterion 5).
+Visibility: Specialist, Leadership Team, Admin — NOT visible to UH (decision S7).
+"""
+
+from __future__ import annotations
+
+from datetime import date as date_type
+from datetime import timedelta
+
+from django.core.cache import cache
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
+from rest_framework import serializers
+from rest_framework import status
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.api.counselor.common import find_existing_by_client_submission_id
+from bunk_logs.api.counselor.common import invalidate_dashboard_for_viewers
+from bunk_logs.api.counselor.responses import reflection_response
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import reflection_snapshot
+from bunk_logs.core.models import validate_reflection_answers
+from bunk_logs.core.translation import enqueue_translation_for_reflection
+
+from .common import enforce_edit_window
+from .common import is_day_off_answer
+from .common import specialist_self_template
+from .common import viewer_or_403
+
+
+class SpecialistSelfReflectionCreateSerializer(serializers.Serializer):
+    answers = serializers.JSONField(required=False)
+    day_off = serializers.BooleanField(default=False)
+    language = serializers.CharField(max_length=10, default="en")
+    client_submission_id = serializers.UUIDField()
+
+    def validate(self, attrs):
+        if not attrs.get("day_off") and not attrs.get("answers"):
+            raise serializers.ValidationError({"answers": "answers is required unless day_off is true."})
+        return attrs
+
+
+class SpecialistSelfReflectionUpdateSerializer(serializers.Serializer):
+    answers = serializers.JSONField(required=False)
+    day_off = serializers.BooleanField(required=False)
+    language = serializers.CharField(max_length=10, required=False)
+
+    def validate(self, attrs):
+        if not attrs:
+            msg = "At least one field must be provided."
+            raise serializers.ValidationError(msg)
+        return attrs
+
+
+class SpecialistSelfReflectionHistoryPagination(PageNumberPagination):
+    page_size = 14
+    page_size_query_param = "page_size"
+    max_page_size = 60
+
+
+def _day_off_answers() -> dict:
+    return {"day_off": True}
+
+
+def _preview_from_answers(answers: dict | None, max_len: int = 120) -> str:
+    if not answers:
+        return ""
+    for value in answers.values():
+        if isinstance(value, str) and value.strip():
+            text = value.strip()
+            return text if len(text) <= max_len else text[: max_len - 1] + "\u2026"
+    return ""
+
+
+def _bust_specialist_dashboard_cache(org_id: int, viewer_id: int, today) -> None:
+    cache.delete(f"specialist_dashboard:{org_id}:{viewer_id}:{today.isoformat()}")
+
+
+class SpecialistSelfReflectionHistoryView(APIView):
+    """Prior Specialist self-reflections (Story 29 criterion 6)."""
+
+    permission_classes = [IsAuthenticated]
+    pagination_class = SpecialistSelfReflectionHistoryPagination
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer = ctx.person
+        today = ctx.today
+
+        template = specialist_self_template(ctx.organization, ctx.program)
+        if template is None:
+            return Response({
+                "count": 0, "next": None, "previous": None,
+                "page": 1, "page_size": self.pagination_class.page_size,
+                "results": [],
+            })
+
+        paginator = self.pagination_class()
+        page_size = paginator.get_page_size(request) or paginator.page_size
+        try:
+            page_num = max(1, int(request.query_params.get("page", "1")))
+        except (TypeError, ValueError):
+            page_num = 1
+
+        max_days = paginator.max_page_size * 5
+        oldest = today - timedelta(days=max_days - 1)
+        start_offset = (page_num - 1) * page_size
+        end_offset = start_offset + page_size - 1
+        period_end_window = today - timedelta(days=start_offset)
+        period_start_window = max(today - timedelta(days=end_offset), oldest)
+
+        reflections_qs = (
+            Reflection.all_objects.filter(
+                author=viewer,
+                subject=viewer,
+                template=template,
+                period_start__gte=period_start_window,
+                period_end__lte=period_end_window,
+            )
+            .order_by("-period_start", "-submitted_at")
+        )
+
+        by_date: dict[date_type, Reflection] = {}
+        for r in reflections_qs:
+            if r.period_start not in by_date:
+                by_date[r.period_start] = r
+
+        results: list[dict] = []
+        cursor = period_end_window
+        while cursor >= period_start_window and len(results) < page_size:
+            reflection = by_date.get(cursor)
+            results.append({
+                "date": cursor.isoformat(),
+                "submitted": reflection is not None and reflection.is_complete,
+                "is_day_off": is_day_off_answer(reflection) if reflection else False,
+                "reflection_id": reflection.id if reflection else None,
+                "submitted_at": (
+                    reflection.submitted_at.isoformat()
+                    if reflection and reflection.submitted_at else None
+                ),
+                "preview": (
+                    _preview_from_answers(reflection.answers)
+                    if reflection and not is_day_off_answer(reflection) else ""
+                ),
+                "editable": reflection is not None and cursor == today,
+            })
+            cursor -= timedelta(days=1)
+
+        total_count = max_days
+        has_next = page_num * page_size < total_count
+        has_previous = page_num > 1
+        return Response({
+            "count": total_count,
+            "next": page_num + 1 if has_next else None,
+            "previous": page_num - 1 if has_previous else None,
+            "page": page_num,
+            "page_size": page_size,
+            "results": results,
+        })
+
+
+def _validate_answers(template, answers: dict) -> tuple[bool, Response | None]:
+    try:
+        validate_reflection_answers(template.schema, answers)
+    except DjangoValidationError as exc:
+        body = exc.message_dict if hasattr(exc, "message_dict") else {"answers": str(exc)}
+        return False, Response(body, status=status.HTTP_400_BAD_REQUEST)
+    return True, None
+
+
+class SpecialistSelfReflectionCreateView(APIView):
+    """POST a Specialist self-reflection for today (Story 29)."""
+
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["post", "head", "options"]
+
+    def post(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer, org, today = ctx.person, ctx.organization, ctx.today
+
+        ser = SpecialistSelfReflectionCreateSerializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        payload = ser.validated_data
+
+        template = specialist_self_template(org, ctx.program)
+        if template is None:
+            msg = "No Specialist self-reflection template configured."
+            raise PermissionDenied(msg)
+
+        existing = find_existing_by_client_submission_id(
+            Reflection, program=ctx.program,
+            client_submission_id=payload["client_submission_id"],
+        )
+        if existing is not None:
+            return Response(reflection_response(existing), status=status.HTTP_200_OK)
+
+        if payload["day_off"]:
+            answers = _day_off_answers()
+        else:
+            answers = dict(payload.get("answers") or {})
+            ok, err = _validate_answers(template, answers)
+            if not ok:
+                return err
+
+        with transaction.atomic():
+            reflection = Reflection(
+                organization=org,
+                program=ctx.program,
+                subject=viewer,
+                author=viewer,
+                assignment_group=None,
+                template=template,
+                submitted_by=request.user,
+                period_start=today,
+                period_end=today,
+                answers=answers,
+                language=payload["language"],
+                team_visibility=Reflection.TeamVisibility.SUPERVISORS_ONLY,
+                is_complete=True,
+                client_submission_id=payload["client_submission_id"],
+            )
+            try:
+                reflection.full_clean()
+            except DjangoValidationError as exc:
+                body = exc.message_dict if hasattr(exc, "message_dict") else str(exc)
+                return Response(body, status=status.HTTP_400_BAD_REQUEST)
+            reflection.save()
+
+        audit_module.created(
+            ctx.membership,
+            reflection,
+            after_state=reflection_snapshot(reflection),
+            content_type="reflection",
+        )
+        if not payload["day_off"]:
+            enqueue_translation_for_reflection(reflection)
+        invalidate_dashboard_for_viewers(org, {viewer.id}, today)
+        _bust_specialist_dashboard_cache(org.id, viewer.id, today)
+
+        return Response(reflection_response(reflection), status=status.HTTP_201_CREATED)
+
+
+class SpecialistSelfReflectionDetailView(APIView):
+    """PATCH a Specialist self-reflection within today's edit window."""
+
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["patch", "head", "options"]
+
+    def patch(self, request, reflection_id: int, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer, org, today = ctx.person, ctx.organization, ctx.today
+
+        reflection = (
+            Reflection.all_objects.filter(id=reflection_id, organization=org)
+            .select_related("template", "program")
+            .first()
+        )
+        if reflection is None:
+            return Response({"detail": "Reflection not found."}, status=status.HTTP_404_NOT_FOUND)
+        if reflection.author_id != viewer.id or reflection.subject_id != viewer.id:
+            msg = "You can only edit your own self-reflection."
+            raise PermissionDenied(msg)
+        enforce_edit_window(reflection, org)
+
+        ser = SpecialistSelfReflectionUpdateSerializer(data=request.data, partial=True)
+        ser.is_valid(raise_exception=True)
+        payload = ser.validated_data
+
+        before = reflection_snapshot(reflection)
+
+        if "day_off" in payload:
+            if payload["day_off"]:
+                answers = _day_off_answers()
+            else:
+                answers = dict(payload.get("answers") or reflection.answers or {})
+                ok, err = _validate_answers(reflection.template, answers)
+                if not ok:
+                    return err
+        elif "answers" in payload:
+            answers = dict(payload["answers"])
+            ok, err = _validate_answers(reflection.template, answers)
+            if not ok:
+                return err
+        else:
+            answers = reflection.answers
+
+        language = payload.get("language", reflection.language)
+        reflection.answers = answers
+        reflection.language = language
+        try:
+            reflection.full_clean()
+        except DjangoValidationError as exc:
+            body = exc.message_dict if hasattr(exc, "message_dict") else str(exc)
+            return Response(body, status=status.HTTP_400_BAD_REQUEST)
+        reflection.save()
+        after = reflection_snapshot(reflection)
+
+        if before != after:
+            actor_membership = (
+                Membership.objects.filter(
+                    person=viewer, program=reflection.program, is_active=True,
+                )
+                .order_by("-created_at")
+                .first()
+            )
+            audit_module.edited(
+                actor_membership or request.user,
+                reflection,
+                before, after,
+                content_type="reflection",
+            )
+        if (
+            before.get("answers") != after.get("answers")
+            or before.get("language") != after.get("language")
+        ) and not is_day_off_answer(reflection):
+            enqueue_translation_for_reflection(reflection)
+
+        invalidate_dashboard_for_viewers(org, {viewer.id}, today)
+        _bust_specialist_dashboard_cache(org.id, viewer.id, today)
+
+        return Response(reflection_response(reflection), status=status.HTTP_200_OK)

--- a/backend/bunk_logs/api/tests/conftest.py
+++ b/backend/bunk_logs/api/tests/conftest.py
@@ -70,6 +70,23 @@ _UNIT_HEAD_SELF_REFLECTION_SCHEMA = {
     ],
 }
 
+_CAMPER_CARE_SELF_REFLECTION_SCHEMA = {
+    "fields": [
+        {"key": "day_off", "type": "yes_no", "required": False},
+        {"key": "overall_day", "type": "single_rating", "required": False, "scale": [1, 5]},
+        {"key": "wins", "type": "text_list", "required": False},
+        {"key": "improvements", "type": "text_list", "required": False},
+        {"key": "concern", "type": "textarea", "required": False},
+        {
+            "key": "bunk_concerns_bunks",
+            "type": "multiple_choice",
+            "required": False,
+            "option_source": "caseload_bunks",
+        },
+        {"key": "bunk_concerns_note", "type": "textarea", "required": False},
+    ],
+}
+
 
 @pytest.fixture(autouse=True)
 def _ensure_counselor_self_reflection_template(db):
@@ -135,6 +152,39 @@ def _ensure_unit_head_self_reflection_template(db):
             "subject_visible": False,
             "supports_privacy": False,
             "role": "unit_head",
+            "program_type": None,
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def _ensure_camper_care_self_reflection_template(db):
+    """Re-seed the CC self-reflection template before every test (Step 7_8d).
+
+    Same rationale as counselor and UH seeds — ``transaction=True`` tests
+    flush the migration-seeded row, breaking CC self-reflection tests that
+    run later in the session. Aligned with production migration ``core/0032``.
+    """
+    ReflectionTemplate.all_objects.update_or_create(
+        organization=None,
+        slug="camper-care-self-reflection",
+        version=1,
+        defaults={
+            "name": "Camper Care Self-Reflection",
+            "description": "Auto-seeded for tests via api/tests/conftest.py.",
+            "cadence": "daily",
+            "schema": _CAMPER_CARE_SELF_REFLECTION_SCHEMA,
+            "languages": ["en", "es"],
+            "is_active": True,
+            "subject_mode": "self",
+            "assignment_scope": "none",
+            "assignment_group_types": [],
+            "author_role_filter": ["camper_care"],
+            "subject_role_filter": [],
+            "required_per_subject_per_period": 1,
+            "subject_visible": False,
+            "supports_privacy": False,
+            "role": "camper_care",
             "program_type": None,
         },
     )

--- a/backend/bunk_logs/api/tests/test_maintenance_digest.py
+++ b/backend/bunk_logs/api/tests/test_maintenance_digest.py
@@ -2,23 +2,24 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import date
 from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
+from django.contrib.auth import get_user_model
 from django.core import mail
 from django.utils import timezone
 
+from bunk_logs.api.maintenance.digest import _build_digest_context
+from bunk_logs.api.maintenance.digest import send_maintenance_digest
 from bunk_logs.core.context import organization_context
 from bunk_logs.core.models import MaintenanceTicket
 from bunk_logs.core.models import Membership
-from bunk_logs.core.models import OrderActivityEvent
 from bunk_logs.core.models import Organization
 from bunk_logs.core.models import Person
 from bunk_logs.core.models import Program
-from bunk_logs.api.maintenance.digest import send_maintenance_digest
-from bunk_logs.api.maintenance.digest import _build_digest_context
 
 pytestmark = pytest.mark.django_db
 
@@ -49,7 +50,6 @@ def program(org):
 
 @pytest.fixture
 def maint_person(org, program):
-    from django.contrib.auth import get_user_model
     User = get_user_model()
     user = User.objects.create_user(email="dstaff@camp.test", password="pw")
     person = Person.all_objects.create(
@@ -91,7 +91,7 @@ def urgent_ticket(org, program):
 @pytest.fixture
 def closed_ticket(org, program):
     with organization_context(org):
-        t = MaintenanceTicket.objects.create(
+        return MaintenanceTicket.objects.create(
             organization=org,
             program=program,
             location="Bunk 5",
@@ -100,7 +100,6 @@ def closed_ticket(org, program):
             urgency=MaintenanceTicket.Urgency.LOW,
             status=MaintenanceTicket.Status.FULFILLED,
         )
-        return t
 
 
 class TestDigestGeneration:
@@ -148,7 +147,6 @@ class TestDigestGeneration:
         assert org.settings.get("maintenance_digest_consecutive_failures", 0) >= 1
 
     def test_consecutive_failures_logged(self, org, program, open_ticket, caplog):
-        import logging
         org.settings["maintenance_digest_consecutive_failures"] = 2
         org.save()
 

--- a/backend/bunk_logs/api/tests/test_maintenance_digest.py
+++ b/backend/bunk_logs/api/tests/test_maintenance_digest.py
@@ -1,0 +1,170 @@
+"""Tests for maintenance digest generation (Step 7_10, Story 36)."""
+
+from __future__ import annotations
+
+from datetime import date
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.core import mail
+from django.utils import timezone
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import OrderActivityEvent
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.api.maintenance.digest import send_maintenance_digest
+from bunk_logs.api.maintenance.digest import _build_digest_context
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def org():
+    return Organization.objects.create(
+        name="Digest Org",
+        slug="digest-org",
+        settings={
+            "maintenance_digest_email": "maintenance@camp.test",
+            "maintenance_digest_time": "06:00",
+        },
+    )
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="Digest Org Summer",
+        slug="digest-summer",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def maint_person(org, program):
+    from django.contrib.auth import get_user_model
+    User = get_user_model()
+    user = User.objects.create_user(email="dstaff@camp.test", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="Digest", last_name="Staff", user=user,
+    )
+    Membership.all_objects.create(
+        program=program, person=person, role="maintenance", is_active=True,
+    )
+    return person
+
+
+@pytest.fixture
+def open_ticket(org, program):
+    with organization_context(org):
+        return MaintenanceTicket.objects.create(
+            organization=org,
+            program=program,
+            location="Cabin 3",
+            category=MaintenanceTicket.Category.LEAK,
+            description="Roof dripping",
+            urgency=MaintenanceTicket.Urgency.NORMAL,
+        )
+
+
+@pytest.fixture
+def urgent_ticket(org, program):
+    with organization_context(org):
+        return MaintenanceTicket.objects.create(
+            organization=org,
+            program=program,
+            location="Kitchen",
+            category=MaintenanceTicket.Category.PLUMBING,
+            description="Burst pipe",
+            urgency=MaintenanceTicket.Urgency.URGENT,
+            urgent_reason="Water everywhere",
+        )
+
+
+@pytest.fixture
+def closed_ticket(org, program):
+    with organization_context(org):
+        t = MaintenanceTicket.objects.create(
+            organization=org,
+            program=program,
+            location="Bunk 5",
+            category=MaintenanceTicket.Category.BROKEN_LIGHT,
+            description="Bulb out",
+            urgency=MaintenanceTicket.Urgency.LOW,
+            status=MaintenanceTicket.Status.FULFILLED,
+        )
+        return t
+
+
+class TestDigestGeneration:
+    def test_send_triggers_email(self, org, program, open_ticket):
+        send_maintenance_digest(str(org.id), str(program.id))
+        assert len(mail.outbox) == 1
+        msg = mail.outbox[0]
+        assert "maintenance@camp.test" in msg.to
+        assert "Digest" in msg.subject
+
+    def test_digest_includes_six_sections(self, org, program, open_ticket, closed_ticket, urgent_ticket):
+        now = timezone.now()
+        window_end = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        window_start = window_end - timedelta(days=1)
+
+        # Set tickets within window
+        MaintenanceTicket.objects.filter(pk=open_ticket.pk).update(
+            created_at=window_start + timedelta(hours=1),
+        )
+        MaintenanceTicket.objects.filter(pk=closed_ticket.pk).update(
+            updated_at=window_start + timedelta(hours=2),
+        )
+
+        ctx = _build_digest_context(org, program, window_start, window_end)
+        assert "summary" in ctx
+        assert "urgent_open" in ctx
+        assert "new_in_window" in ctx
+        assert "closed_in_window" in ctx
+        assert "reopened_in_window" in ctx
+        assert "still_open" in ctx
+
+    def test_all_clear_still_sends(self, org, program):
+        send_maintenance_digest(str(org.id), str(program.id))
+        assert len(mail.outbox) == 1
+        assert "all clear" in mail.outbox[0].body.lower() or len(mail.outbox[0].body) > 0
+
+    def test_send_failure_increments_counter(self, org, program, open_ticket):
+        with patch(
+            "bunk_logs.api.maintenance.digest.EmailMultiAlternatives.send",
+            side_effect=RuntimeError("SMTP error"),
+        ):
+            send_maintenance_digest(str(org.id), str(program.id))
+
+        org.refresh_from_db()
+        assert org.settings.get("maintenance_digest_consecutive_failures", 0) >= 1
+
+    def test_consecutive_failures_logged(self, org, program, open_ticket, caplog):
+        import logging
+        org.settings["maintenance_digest_consecutive_failures"] = 2
+        org.save()
+
+        with patch(
+            "bunk_logs.api.maintenance.digest.EmailMultiAlternatives.send",
+            side_effect=RuntimeError("SMTP error"),
+        ), caplog.at_level(logging.ERROR):
+            send_maintenance_digest(str(org.id), str(program.id))
+
+        assert any("ALERT" in r.message for r in caplog.records)
+
+    def test_success_resets_failure_count(self, org, program, open_ticket):
+        org.settings["maintenance_digest_consecutive_failures"] = 2
+        org.save()
+
+        send_maintenance_digest(str(org.id), str(program.id))
+
+        org.refresh_from_db()
+        assert org.settings.get("maintenance_digest_consecutive_failures", 0) == 0

--- a/backend/bunk_logs/api/tests/test_maintenance_notes.py
+++ b/backend/bunk_logs/api/tests/test_maintenance_notes.py
@@ -1,0 +1,203 @@
+"""Tests for maintenance notes create + edit (Step 7_10, Story 33)."""
+
+from __future__ import annotations
+
+from datetime import date
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import OrderActivityEvent
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def _hdr(slug: str) -> dict:
+    return {"HTTP_X_ORGANIZATION_SLUG": slug}
+
+
+@pytest.fixture
+def org():
+    return Organization.objects.create(name="Notes Org", slug="notes-org")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="Notes Org Summer",
+        slug="notes-summer",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def maint_user(org, program):
+    user = User.objects.create_user(email="mnotes@notes.com", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="Notes", last_name="Staff", user=user,
+    )
+    Membership.all_objects.create(
+        program=program, person=person, role="maintenance", is_active=True,
+    )
+    return user
+
+
+@pytest.fixture
+def ticket(org, program):
+    with organization_context(org):
+        return MaintenanceTicket.objects.create(
+            organization=org,
+            program=program,
+            location="Field",
+            description="Broken fence",
+            urgency=MaintenanceTicket.Urgency.LOW,
+        )
+
+
+@pytest.fixture
+def api():
+    return APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Note create
+# ---------------------------------------------------------------------------
+
+
+class TestMaintenanceNoteCreate:
+    def test_team_only_note(self, api, org, ticket, maint_user):
+        api.force_authenticate(user=maint_user)
+        r = api.post(
+            f"/api/v1/maintenance/tickets/{ticket.id}/notes/",
+            {"body": "Checked the fence", "visibility": "team_only"},
+            format="json",
+            **_hdr(org.slug),
+        )
+        assert r.status_code == 201, r.content
+        data = r.json()
+        assert data["event_type"] == "note"
+        assert data["note"] == "Checked the fence"
+        assert data["visibility"] == "team_only"
+
+    def test_submitter_visible_note(self, api, org, ticket, maint_user):
+        api.force_authenticate(user=maint_user)
+        r = api.post(
+            f"/api/v1/maintenance/tickets/{ticket.id}/notes/",
+            {"body": "We are on it", "visibility": "submitter_visible"},
+            format="json",
+            **_hdr(org.slug),
+        )
+        assert r.status_code == 201
+        assert r.json()["visibility"] == "submitter_visible"
+
+    def test_note_persisted_in_activity(self, api, org, ticket, maint_user):
+        api.force_authenticate(user=maint_user)
+        api.post(
+            f"/api/v1/maintenance/tickets/{ticket.id}/notes/",
+            {"body": "Persisted note", "visibility": "team_only"},
+            format="json",
+            **_hdr(org.slug),
+        )
+        events = OrderActivityEvent.all_objects.filter(
+            content_type="maintenance_ticket",
+            content_id=ticket.id,
+            event_type=OrderActivityEvent.EventType.NOTE,
+        )
+        assert events.exists()
+        assert events.first().note == "Persisted note"
+
+    def test_body_required(self, api, org, ticket, maint_user):
+        api.force_authenticate(user=maint_user)
+        r = api.post(
+            f"/api/v1/maintenance/tickets/{ticket.id}/notes/",
+            {"body": "", "visibility": "team_only"},
+            format="json",
+            **_hdr(org.slug),
+        )
+        assert r.status_code == 400
+        assert "body" in r.json()
+
+    def test_invalid_visibility_rejected(self, api, org, ticket, maint_user):
+        api.force_authenticate(user=maint_user)
+        r = api.post(
+            f"/api/v1/maintenance/tickets/{ticket.id}/notes/",
+            {"body": "hi", "visibility": "bogus"},
+            format="json",
+            **_hdr(org.slug),
+        )
+        assert r.status_code == 400
+        assert "visibility" in r.json()
+
+    def test_cannot_note_on_closed_ticket(self, api, org, ticket, maint_user):
+        ticket.status = MaintenanceTicket.Status.FULFILLED
+        ticket.save()
+        api.force_authenticate(user=maint_user)
+        r = api.post(
+            f"/api/v1/maintenance/tickets/{ticket.id}/notes/",
+            {"body": "After close", "visibility": "team_only"},
+            format="json",
+            **_hdr(org.slug),
+        )
+        assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Note edit
+# ---------------------------------------------------------------------------
+
+
+class TestMaintenanceNoteEdit:
+    def test_author_can_edit_within_window(self, api, org, ticket, maint_user):
+        api.force_authenticate(user=maint_user)
+        r = api.post(
+            f"/api/v1/maintenance/tickets/{ticket.id}/notes/",
+            {"body": "Original", "visibility": "team_only"},
+            format="json",
+            **_hdr(org.slug),
+        )
+        note_id = r.json()["id"]
+        r2 = api.patch(
+            f"/api/v1/maintenance/tickets/{ticket.id}/notes/{note_id}/",
+            {"body": "Updated", "visibility": "submitter_visible"},
+            format="json",
+            **_hdr(org.slug),
+        )
+        assert r2.status_code == 200, r2.content
+        assert r2.json()["note"] == "Updated"
+        assert r2.json()["visibility"] == "submitter_visible"
+
+    def test_edit_window_enforced(self, api, org, ticket, maint_user):
+        api.force_authenticate(user=maint_user)
+        r = api.post(
+            f"/api/v1/maintenance/tickets/{ticket.id}/notes/",
+            {"body": "Old", "visibility": "team_only"},
+            format="json",
+            **_hdr(org.slug),
+        )
+        note_id = r.json()["id"]
+
+        # Wind back the created_at beyond 24h
+        event = OrderActivityEvent.all_objects.get(pk=note_id)
+        event.created_at = timezone.now() - timedelta(hours=25)
+        event.save(update_fields=["created_at"])
+
+        r2 = api.patch(
+            f"/api/v1/maintenance/tickets/{ticket.id}/notes/{note_id}/",
+            {"body": "Too late"},
+            format="json",
+            **_hdr(org.slug),
+        )
+        assert r2.status_code == 403

--- a/backend/bunk_logs/api/tests/test_maintenance_queue.py
+++ b/backend/bunk_logs/api/tests/test_maintenance_queue.py
@@ -6,12 +6,12 @@ from datetime import date
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from rest_framework.test import APIClient
 
 from bunk_logs.core.context import organization_context
 from bunk_logs.core.models import MaintenanceTicket
 from bunk_logs.core.models import Membership
-from bunk_logs.core.models import OrderActivityEvent
 from bunk_logs.core.models import Organization
 from bunk_logs.core.models import Person
 from bunk_logs.core.models import Program
@@ -221,7 +221,6 @@ class TestUrgencyValidation:
             urgency=MaintenanceTicket.Urgency.URGENT,
             urgent_reason="",
         )
-        from django.core.exceptions import ValidationError
         with pytest.raises(ValidationError, match="urgent_reason"):
             t.full_clean()
 

--- a/backend/bunk_logs/api/tests/test_maintenance_queue.py
+++ b/backend/bunk_logs/api/tests/test_maintenance_queue.py
@@ -1,0 +1,235 @@
+"""Tests for maintenance queue, ticket detail, and urgency validation (Step 7_10)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import OrderActivityEvent
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def _hdr(slug: str) -> dict:
+    return {"HTTP_X_ORGANIZATION_SLUG": slug}
+
+
+@pytest.fixture
+def org():
+    return Organization.objects.create(name="MQ Org", slug="mq-org")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="MQ Org Summer",
+        slug="mq-summer",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def maint_user(org, program):
+    user = User.objects.create_user(email="maint@mq.com", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="Maint", last_name="Staff", user=user,
+    )
+    Membership.all_objects.create(
+        program=program, person=person, role="maintenance", is_active=True,
+    )
+    return user
+
+
+@pytest.fixture
+def counselor_user(org, program):
+    user = User.objects.create_user(email="counselor@mq.com", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="Coun", last_name="Selor", user=user,
+    )
+    Membership.all_objects.create(
+        program=program, person=person, role="counselor", is_active=True,
+    )
+    return user
+
+
+@pytest.fixture
+def ticket(org, program):
+    with organization_context(org):
+        return MaintenanceTicket.objects.create(
+            organization=org,
+            program=program,
+            location="Bunk 12",
+            category=MaintenanceTicket.Category.PLUMBING,
+            description="Sink draining slowly",
+            urgency=MaintenanceTicket.Urgency.NORMAL,
+        )
+
+
+@pytest.fixture
+def urgent_ticket(org, program):
+    with organization_context(org):
+        return MaintenanceTicket.objects.create(
+            organization=org,
+            program=program,
+            location="Dining Hall",
+            category=MaintenanceTicket.Category.LEAK,
+            description="Water pouring from ceiling",
+            urgency=MaintenanceTicket.Urgency.URGENT,
+            urgent_reason="Flooding risk",
+        )
+
+
+@pytest.fixture
+def api():
+    return APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Happy path: queue
+# ---------------------------------------------------------------------------
+
+
+class TestMaintenanceQueue:
+    def test_returns_open_tickets_by_default(self, api, org, ticket, maint_user):
+        api.force_authenticate(user=maint_user)
+        r = api.get("/api/v1/maintenance/queue/", **_hdr(org.slug))
+        assert r.status_code == 200, r.content
+        data = r.json()
+        assert "tickets" in data
+        assert "counts" in data
+        ids = [t["id"] for t in data["tickets"]]
+        assert str(ticket.id) in ids
+
+    def test_counts_header(self, api, org, ticket, urgent_ticket, maint_user):
+        api.force_authenticate(user=maint_user)
+        r = api.get("/api/v1/maintenance/queue/", **_hdr(org.slug))
+        counts = r.json()["counts"]
+        assert counts["new"] >= 2
+        assert counts["urgent_open"] >= 1
+
+    def test_urgent_sorted_first(self, api, org, ticket, urgent_ticket, maint_user):
+        api.force_authenticate(user=maint_user)
+        r = api.get("/api/v1/maintenance/queue/", **_hdr(org.slug))
+        tickets = r.json()["tickets"]
+        urgencies = [t["urgency"] for t in tickets]
+        urgent_idx = urgencies.index("urgent")
+        normal_idx = urgencies.index("normal")
+        assert urgent_idx < normal_idx
+
+    def test_closed_filter(self, api, org, ticket, maint_user):
+        ticket.status = MaintenanceTicket.Status.FULFILLED
+        ticket.save()
+        api.force_authenticate(user=maint_user)
+        r = api.get("/api/v1/maintenance/queue/?filter=closed", **_hdr(org.slug))
+        assert r.status_code == 200
+        ids = [t["id"] for t in r.json()["tickets"]]
+        assert str(ticket.id) in ids
+
+    def test_closed_search(self, api, org, ticket, maint_user):
+        ticket.status = MaintenanceTicket.Status.FULFILLED
+        ticket.save()
+        api.force_authenticate(user=maint_user)
+        r = api.get(
+            "/api/v1/maintenance/queue/?filter=closed&search=draining",
+            **_hdr(org.slug),
+        )
+        assert r.status_code == 200
+        ids = [t["id"] for t in r.json()["tickets"]]
+        assert str(ticket.id) in ids
+
+    def test_invalid_filter_rejected(self, api, org, maint_user):
+        api.force_authenticate(user=maint_user)
+        r = api.get("/api/v1/maintenance/queue/?filter=bogus", **_hdr(org.slug))
+        assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Permission: counselors cannot access maintenance queue
+# ---------------------------------------------------------------------------
+
+
+class TestMaintenanceQueuePermission:
+    def test_counselor_forbidden(self, api, org, counselor_user):
+        api.force_authenticate(user=counselor_user)
+        r = api.get("/api/v1/maintenance/queue/", **_hdr(org.slug))
+        assert r.status_code == 403
+
+    def test_unauthenticated_rejected(self, api, org):
+        r = api.get("/api/v1/maintenance/queue/", **_hdr(org.slug))
+        assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Ticket detail
+# ---------------------------------------------------------------------------
+
+
+class TestMaintenanceTicketDetail:
+    def test_returns_ticket_and_activity(self, api, org, ticket, maint_user):
+        api.force_authenticate(user=maint_user)
+        r = api.get(f"/api/v1/maintenance/tickets/{ticket.id}/", **_hdr(org.slug))
+        assert r.status_code == 200, r.content
+        data = r.json()
+        assert data["ticket"]["id"] == str(ticket.id)
+        assert "activity" in data
+        assert "photos" in data
+
+    def test_404_for_wrong_program(self, api, org, maint_user):
+        other_org = Organization.objects.create(name="Other", slug="other-mq")
+        other_program = Program.all_objects.create(
+            organization=other_org,
+            name="Other Other Program",
+            slug="other-mq-summer",
+            program_type="summer_camp",
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 8, 31),
+        )
+        with organization_context(other_org):
+            other_ticket = MaintenanceTicket.objects.create(
+                organization=other_org,
+                program=other_program,
+                urgency=MaintenanceTicket.Urgency.NORMAL,
+            )
+        api.force_authenticate(user=maint_user)
+        r = api.get(f"/api/v1/maintenance/tickets/{other_ticket.id}/", **_hdr(org.slug))
+        assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Urgency validation
+# ---------------------------------------------------------------------------
+
+
+class TestUrgencyValidation:
+    def test_urgent_requires_reason(self, org, program):
+        t = MaintenanceTicket(
+            organization=org,
+            program=program,
+            urgency=MaintenanceTicket.Urgency.URGENT,
+            urgent_reason="",
+        )
+        from django.core.exceptions import ValidationError
+        with pytest.raises(ValidationError, match="urgent_reason"):
+            t.full_clean()
+
+    def test_urgent_with_reason_valid(self, org, program):
+        t = MaintenanceTicket(
+            organization=org,
+            program=program,
+            urgency=MaintenanceTicket.Urgency.URGENT,
+            urgent_reason="Flooding risk — immediate danger",
+        )
+        t.full_clean()  # should not raise

--- a/backend/bunk_logs/api/tests/test_specialist_endpoints.py
+++ b/backend/bunk_logs/api/tests/test_specialist_endpoints.py
@@ -1,0 +1,507 @@
+"""Tests for ``/api/v1/specialist/*`` (Step 7_9, Stories 24-29).
+
+Coverage (lean mode):
+
+* Happy-path: dashboard, camper picker, note create/edit, camper view.
+* Auth/permission: non-specialist cannot access specialist endpoints.
+* Visibility: Specialist cannot see another Specialist's notes via the
+  camper view endpoint (queryset-level filter, Story 28 criterion 4).
+* Flag creation: ``flag_for_camper_care=True`` raises an Active Flag
+  linked to the note (Story 26 criterion 7).
+* Flag retraction blocked: PATCH cannot un-flag once a flag is raised
+  (Story 27 criterion 5, Decision S5).
+* Camper picker search: 100-camper roster returns all matches within
+  reasonable query count (proxy for the 1,500-camper performance target).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Flag
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Note
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import ReflectionTemplate
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def _hdr(slug: str) -> dict:
+    return {"HTTP_X_ORGANIZATION_SLUG": slug}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def org():
+    return Organization.objects.create(name="SP Org", slug="sp-org")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="SP Org Summer 2026",
+        slug="sp-summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def specialist_template(org, program):
+    return ReflectionTemplate.all_objects.create(
+        organization=None,
+        slug="specialist-self-reflection",
+        version=1,
+        name="Specialist Self-Reflection",
+        description="Test template",
+        cadence="daily",
+        schema={"fields": [
+            {"key": "day_off", "type": "yes_no", "required": False},
+            {"key": "notes", "type": "textarea", "required": False},
+        ]},
+        languages=["en"],
+        is_active=True,
+        subject_mode="self",
+        assignment_scope="none",
+        assignment_group_types=[],
+        author_role_filter=["specialist"],
+        subject_role_filter=[],
+        required_per_subject_per_period=1,
+        subject_visible=False,
+        supports_privacy=False,
+        role="specialist",
+        program_type=None,
+    )
+
+
+def _make_person(org, *, first, last, email):
+    user = User.objects.create_user(email=email, password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name=first, last_name=last, user=user,
+    )
+    return person, user
+
+
+def _make_membership(program, person, role, tags=None):
+    return Membership.all_objects.create(
+        program=program, person=person, role=role, is_active=True,
+        tags=tags or [],
+    )
+
+
+def _make_bunk(org, program, *, name="Elm"):
+    return AssignmentGroup.all_objects.create(
+        organization=org,
+        program=program,
+        name=name,
+        slug=name.lower().replace(" ", "-"),
+        group_type="bunk",
+        is_active=True,
+    )
+
+
+def _assign_camper(bunk, person):
+    return AssignmentGroupMembership.all_objects.create(
+        group=bunk,
+        person=person,
+        role_in_group="subject",
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def sp_person_user(org):
+    return _make_person(org, first="Alex", last="Water", email="sp@sp.test")
+
+
+@pytest.fixture
+def sp_membership(program, sp_person_user):
+    person, _ = sp_person_user
+    return _make_membership(program, person, "specialist", tags=["specialist:waterfront"])
+
+
+@pytest.fixture
+def bunk(org, program):
+    return _make_bunk(org, program, name="Elm")
+
+
+@pytest.fixture
+def camper_person(org):
+    _, camper_user = _make_person(org, first="Jake", last="Smith", email="camper@sp.test")
+    return Person.all_objects.get(user=camper_user)
+
+
+@pytest.fixture
+def camper_agm(bunk, camper_person):
+    return _assign_camper(bunk, camper_person)
+
+
+@pytest.fixture
+def api(sp_person_user, sp_membership):
+    _, user = sp_person_user
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Auth / permission tests
+# ---------------------------------------------------------------------------
+
+
+class TestSpecialistAuthGate:
+    def test_unauthenticated_returns_401_or_403(self, org):
+        client = APIClient()
+        with organization_context(org):
+            r = client.get("/api/v1/specialist/dashboard/", **_hdr(org.slug))
+        assert r.status_code in (401, 403)
+
+    def test_wrong_role_returns_403(self, org, program):
+        person, user = _make_person(org, first="CC", last="User", email="cc2@sp.test")
+        _make_membership(program, person, "camper_care")
+        client = APIClient()
+        client.force_authenticate(user=user)
+        with organization_context(org):
+            r = client.get("/api/v1/specialist/dashboard/", **_hdr(org.slug))
+        assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Dashboard tests
+# ---------------------------------------------------------------------------
+
+
+class TestSpecialistDashboard:
+    def test_dashboard_returns_three_sections(self, api, org, sp_membership):
+        with organization_context(org):
+            r = api.get("/api/v1/specialist/dashboard/", **_hdr(org.slug))
+        assert r.status_code == 200
+        data = r.json()
+        assert "write_camper_note" in data
+        assert "self_reflection" in data
+        assert "recent_notes" in data
+
+    def test_header_shows_specialist_label(self, api, org, sp_membership):
+        with organization_context(org):
+            r = api.get("/api/v1/specialist/dashboard/", **_hdr(org.slug))
+        assert r.json()["header"]["role_label"] == "Waterfront Specialist"
+
+    def test_recent_notes_shows_authored_notes(self, api, org, program, sp_person_user, sp_membership, camper_person, camper_agm):
+        person, _ = sp_person_user
+        Note.all_objects.create(
+            organization=org,
+            program=program,
+            subject=camper_person,
+            author=person,
+            note_type=Note.NoteType.SPECIALIST,
+            body="Good swimmer",
+        )
+        with organization_context(org):
+            r = api.get("/api/v1/specialist/dashboard/", **_hdr(org.slug))
+        notes = r.json()["recent_notes"]
+        assert len(notes) == 1
+        assert notes[0]["body_preview"] == "Good swimmer"
+
+    def test_recent_notes_does_not_show_others_notes(self, api, org, program, sp_person_user, sp_membership, camper_person, camper_agm):
+        other, _ = _make_person(org, first="Oth", last="Sp", email="other@sp.test")
+        Note.all_objects.create(
+            organization=org,
+            program=program,
+            subject=camper_person,
+            author=other,
+            note_type=Note.NoteType.SPECIALIST,
+            body="Someone else's note",
+        )
+        with organization_context(org):
+            r = api.get("/api/v1/specialist/dashboard/", **_hdr(org.slug))
+        assert len(r.json()["recent_notes"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Camper picker tests
+# ---------------------------------------------------------------------------
+
+
+class TestCamperPicker:
+    def test_returns_all_campers_when_no_query(self, api, org, sp_membership, bunk, camper_person, camper_agm):
+        with organization_context(org):
+            r = api.get("/api/v1/specialist/campers/", **_hdr(org.slug))
+        assert r.status_code == 200
+        data = r.json()
+        assert any(c["id"] == camper_person.id for c in data["results"])
+
+    def test_search_by_first_name(self, api, org, sp_membership, bunk, camper_person, camper_agm):
+        with organization_context(org):
+            r = api.get("/api/v1/specialist/campers/?q=Jake", **_hdr(org.slug))
+        assert r.status_code == 200
+        results = r.json()["results"]
+        assert any(c["id"] == camper_person.id for c in results)
+
+    def test_search_by_bunk_name(self, api, org, sp_membership, bunk, camper_person, camper_agm):
+        with organization_context(org):
+            r = api.get("/api/v1/specialist/campers/?q=Elm", **_hdr(org.slug))
+        results = r.json()["results"]
+        assert any(c["id"] == camper_person.id for c in results)
+
+    def test_zero_results_message_on_no_match(self, api, org, sp_membership, bunk, camper_person, camper_agm):
+        with organization_context(org):
+            r = api.get("/api/v1/specialist/campers/?q=XYZ_NOMATCH_99", **_hdr(org.slug))
+        data = r.json()
+        assert data["results"] == []
+        assert "No campers match" in (data["zero_results_message"] or "")
+
+    def test_camper_picker_with_100_campers(self, api, org, program, sp_membership, bunk):
+        """Proxy for the 1,500-camper performance target: 100 campers, no N+1."""
+        persons = []
+        for i in range(100):
+            p, _ = _make_person(org, first=f"Camper{i}", last="Test", email=f"c{i}@sp.test")
+            _assign_camper(bunk, p)
+            persons.append(p)
+        with organization_context(org):
+            r = api.get("/api/v1/specialist/campers/", **_hdr(org.slug))
+        assert r.status_code == 200
+        assert len(r.json()["results"]) >= 100
+
+    def test_cross_program_picker_includes_second_program(self, api, org, program, sp_person_user, sp_membership):
+        person, _ = sp_person_user
+        prog2 = Program.all_objects.create(
+            organization=org, name="SP Org Prog 2", slug="sp-prog2",
+            program_type="summer_camp",
+            start_date=date(2026, 6, 1), end_date=date(2026, 8, 31),
+        )
+        _make_membership(prog2, person, "specialist")
+        bunk2 = _make_bunk(org, prog2, name="Oak")
+        camper2, _ = _make_person(org, first="Prog2", last="Cam", email="p2c@sp.test")
+        _assign_camper(bunk2, camper2)
+
+        with organization_context(org):
+            r = api.get("/api/v1/specialist/campers/", **_hdr(org.slug))
+        assert any(c["id"] == camper2.id for c in r.json()["results"])
+
+
+# ---------------------------------------------------------------------------
+# Note create / edit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSpecialistNoteCreate:
+    def test_create_note_happy_path(self, api, org, program, sp_person_user, sp_membership, camper_person, camper_agm):
+        _person, _ = sp_person_user
+        payload = {
+            "subject_id": camper_person.id,
+            "body": "Great backstroke technique.",
+            "category": "positive",
+            "is_sensitive": False,
+            "flag_for_camper_care": False,
+        }
+        with organization_context(org):
+            r = api.post("/api/v1/specialist/notes/", payload, format="json", **_hdr(org.slug))
+        assert r.status_code == 201
+        data = r.json()
+        assert data["note_type"] == "specialist"
+        assert data["body"] == "Great backstroke technique."
+        assert data["flag_raised"] is False
+
+    def test_create_note_with_flag_creates_flag_record(self, api, org, program, sp_person_user, sp_membership, camper_person, camper_agm):
+        _person, _ = sp_person_user
+        payload = {
+            "subject_id": camper_person.id,
+            "body": "Concerning behavior in water.",
+            "flag_for_camper_care": True,
+        }
+        with organization_context(org):
+            r = api.post("/api/v1/specialist/notes/", payload, format="json", **_hdr(org.slug))
+        assert r.status_code == 201
+        note_id = r.json()["id"]
+        assert r.json()["flag_raised"] is True
+
+        flag = Flag.all_objects.filter(
+            trigger_content_type="specialist_note",
+            trigger_content_id=str(note_id),
+        ).first()
+        assert flag is not None
+        assert flag.status == Flag.Status.ACTIVE
+        assert flag.subject_camper == camper_person
+
+    def test_create_note_missing_body_returns_400(self, api, org, sp_membership, camper_person, camper_agm):
+        with organization_context(org):
+            r = api.post(
+                "/api/v1/specialist/notes/",
+                {"subject_id": camper_person.id, "body": ""},
+                format="json", **_hdr(org.slug),
+            )
+        assert r.status_code == 400
+        assert "body" in r.json()
+
+    def test_create_note_missing_subject_returns_400(self, api, org, sp_membership):
+        with organization_context(org):
+            r = api.post(
+                "/api/v1/specialist/notes/",
+                {"body": "Some note"},
+                format="json", **_hdr(org.slug),
+            )
+        assert r.status_code == 400
+        assert "subject_id" in r.json()
+
+
+class TestSpecialistNoteEdit:
+    def test_edit_within_window_succeeds(self, api, org, program, sp_person_user, sp_membership, camper_person, camper_agm):
+        person, _ = sp_person_user
+        note = Note.all_objects.create(
+            organization=org, program=program, subject=camper_person,
+            author=person, note_type=Note.NoteType.SPECIALIST, body="Original",
+        )
+        with organization_context(org):
+            r = api.patch(
+                f"/api/v1/specialist/notes/{note.id}/",
+                {"body": "Edited body"},
+                format="json", **_hdr(org.slug),
+            )
+        assert r.status_code == 200
+        assert r.json()["body"] == "Edited body"
+
+    def test_edit_by_non_author_returns_403(self, api, org, program, sp_membership, camper_person, camper_agm):
+        other, _ = _make_person(org, first="Oth", last="Sp2", email="oth2@sp.test")
+        note = Note.all_objects.create(
+            organization=org, program=program, subject=camper_person,
+            author=other, note_type=Note.NoteType.SPECIALIST, body="Not mine",
+        )
+        with organization_context(org):
+            r = api.patch(
+                f"/api/v1/specialist/notes/{note.id}/",
+                {"body": "Stealing edit"},
+                format="json", **_hdr(org.slug),
+            )
+        assert r.status_code == 403
+
+    def test_flag_retraction_blocked(self, api, org, program, sp_person_user, sp_membership, camper_person, camper_agm):
+        """S5: Specialist cannot change flag state via PATCH (field rejected)."""
+        person, _ = sp_person_user
+        note = Note.all_objects.create(
+            organization=org, program=program, subject=camper_person,
+            author=person, note_type=Note.NoteType.SPECIALIST, body="Flagged",
+        )
+        with organization_context(org):
+            r = api.patch(
+                f"/api/v1/specialist/notes/{note.id}/",
+                {"flag_for_camper_care": False},
+                format="json", **_hdr(org.slug),
+            )
+        assert r.status_code == 400
+        assert "flag_for_camper_care" in str(r.json())
+
+
+# ---------------------------------------------------------------------------
+# Camper view visibility tests
+# ---------------------------------------------------------------------------
+
+
+class TestSpecialistCamperView:
+    def test_returns_own_notes_only(self, api, org, program, sp_person_user, sp_membership, camper_person, camper_agm):
+        person, _ = sp_person_user
+        other, _ = _make_person(org, first="OtherSp", last="X", email="osp@sp.test")
+        Note.all_objects.create(
+            organization=org, program=program, subject=camper_person,
+            author=person, note_type=Note.NoteType.SPECIALIST, body="My note",
+        )
+        Note.all_objects.create(
+            organization=org, program=program, subject=camper_person,
+            author=other, note_type=Note.NoteType.SPECIALIST, body="Other's note",
+        )
+        with organization_context(org):
+            r = api.get(
+                f"/api/v1/specialist/campers/{camper_person.id}/", **_hdr(org.slug),
+            )
+        assert r.status_code == 200
+        notes = r.json()["my_notes"]
+        assert len(notes) == 1
+        assert notes[0]["body"] == "My note"
+
+    def test_camper_not_in_program_returns_403(self, api, org, program, sp_membership):
+        org2 = Organization.objects.create(name="Other Org", slug="other-org")
+        outsider, _ = _make_person(org2, first="Out", last="Sider", email="out@other.test")
+        with organization_context(org):
+            r = api.get(
+                f"/api/v1/specialist/campers/{outsider.id}/", **_hdr(org.slug),
+            )
+        assert r.status_code in (403, 404)
+
+    def test_non_specialist_returns_403(self, org, program, camper_person, camper_agm):
+        other, user = _make_person(org, first="CC", last="User3", email="cc3@sp.test")
+        _make_membership(program, other, "camper_care")
+        client = APIClient()
+        client.force_authenticate(user=user)
+        with organization_context(org):
+            r = client.get(
+                f"/api/v1/specialist/campers/{camper_person.id}/", **_hdr(org.slug),
+            )
+        assert r.status_code == 403
+
+    def test_date_range_filter(self, api, org, program, sp_person_user, sp_membership, camper_person, camper_agm):
+        person, _ = sp_person_user
+        Note.all_objects.create(
+            organization=org, program=program, subject=camper_person,
+            author=person, note_type=Note.NoteType.SPECIALIST, body="In range",
+        )
+        with organization_context(org):
+            r = api.get(
+                f"/api/v1/specialist/campers/{camper_person.id}/"
+                "?date_from=2026-01-01&date_to=2026-12-31",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 200
+        assert len(r.json()["my_notes"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Audience disclosure test
+# ---------------------------------------------------------------------------
+
+
+class TestNoteAudience:
+    def test_audience_non_sensitive(self, api, org, sp_membership):
+        with organization_context(org):
+            r = api.get(
+                "/api/v1/specialist/notes/audience/?is_sensitive=false",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 200
+        audience = r.json()["audience"]
+        assert "Counselor" in audience
+        assert "Camper Care" in audience
+
+    def test_audience_sensitive_narrows(self, api, org, sp_membership):
+        with organization_context(org):
+            r = api.get(
+                "/api/v1/specialist/notes/audience/?is_sensitive=true",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 200
+        audience = r.json()["audience"]
+        assert "Counselor" not in audience
+        assert "Camper Care" in audience

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -33,16 +33,16 @@ from .dashboards import coverage as coverage_dashboard
 from .dashboards import subject as subject_dashboard
 from .dashboards import template as template_dashboard
 from .dashboards import trends as trends_dashboard
-from .unit_head import bunk_dashboard as uh_bunk_dashboard
-from .unit_head import camper_dashboard as uh_camper_dashboard
-from .unit_head import dashboard as uh_dashboard
-from .unit_head import self_reflection as uh_self_reflection
+from .maintenance import views as maint_views
 from .specialist import camper_view as sp_camper_view
 from .specialist import campers as sp_campers
 from .specialist import dashboard as sp_dashboard
 from .specialist import notes as sp_notes
 from .specialist import self_reflection as sp_self_reflection
-from .maintenance import queue as maint_queue
+from .unit_head import bunk_dashboard as uh_bunk_dashboard
+from .unit_head import camper_dashboard as uh_camper_dashboard
+from .unit_head import dashboard as uh_dashboard
+from .unit_head import self_reflection as uh_self_reflection
 
 router = DefaultRouter()
 
@@ -110,27 +110,27 @@ urlpatterns = [
     # ------------------------------------------------------------------
     path(
         "maintenance/queue/",
-        maint_queue.MaintenanceQueueView.as_view(),
+        maint_views.MaintenanceQueueView.as_view(),
         name="maintenance-queue",
     ),
     path(
         "maintenance/tickets/<uuid:ticket_id>/",
-        maint_queue.MaintenanceTicketDetailView.as_view(),
+        maint_views.MaintenanceTicketDetailView.as_view(),
         name="maintenance-ticket-detail",
     ),
     path(
         "maintenance/tickets/<uuid:ticket_id>/notes/",
-        maint_queue.MaintenanceNoteCreateView.as_view(),
+        maint_views.MaintenanceNoteCreateView.as_view(),
         name="maintenance-note-create",
     ),
     path(
         "maintenance/tickets/<uuid:ticket_id>/notes/<uuid:note_id>/",
-        maint_queue.MaintenanceNoteDetailView.as_view(),
+        maint_views.MaintenanceNoteDetailView.as_view(),
         name="maintenance-note-detail",
     ),
     path(
         "maintenance/notes/audience/",
-        maint_queue.MaintenanceNoteAudienceView.as_view(),
+        maint_views.MaintenanceNoteAudienceView.as_view(),
         name="maintenance-note-audience",
     ),
     path("", include(router.urls)),

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -37,6 +37,12 @@ from .unit_head import bunk_dashboard as uh_bunk_dashboard
 from .unit_head import camper_dashboard as uh_camper_dashboard
 from .unit_head import dashboard as uh_dashboard
 from .unit_head import self_reflection as uh_self_reflection
+from .specialist import camper_view as sp_camper_view
+from .specialist import campers as sp_campers
+from .specialist import dashboard as sp_dashboard
+from .specialist import notes as sp_notes
+from .specialist import self_reflection as sp_self_reflection
+from .maintenance import queue as maint_queue
 
 router = DefaultRouter()
 
@@ -98,6 +104,34 @@ urlpatterns = [
         "maintenance/<uuid:ticket_id>/correct-last/",
         order_sm.MaintenanceTicketCorrectLastView.as_view(),
         name="maintenance-correct-last",
+    ),
+    # ------------------------------------------------------------------
+    # Maintenance staff queue (Step 7_10, Stories 30-35)
+    # ------------------------------------------------------------------
+    path(
+        "maintenance/queue/",
+        maint_queue.MaintenanceQueueView.as_view(),
+        name="maintenance-queue",
+    ),
+    path(
+        "maintenance/tickets/<uuid:ticket_id>/",
+        maint_queue.MaintenanceTicketDetailView.as_view(),
+        name="maintenance-ticket-detail",
+    ),
+    path(
+        "maintenance/tickets/<uuid:ticket_id>/notes/",
+        maint_queue.MaintenanceNoteCreateView.as_view(),
+        name="maintenance-note-create",
+    ),
+    path(
+        "maintenance/tickets/<uuid:ticket_id>/notes/<uuid:note_id>/",
+        maint_queue.MaintenanceNoteDetailView.as_view(),
+        name="maintenance-note-detail",
+    ),
+    path(
+        "maintenance/notes/audience/",
+        maint_queue.MaintenanceNoteAudienceView.as_view(),
+        name="maintenance-note-audience",
     ),
     path("", include(router.urls)),
 
@@ -361,6 +395,55 @@ urlpatterns = [
         "camper-care/self-reflection/<int:reflection_id>/",
         cc_self_reflection.CamperCareSelfReflectionDetailView.as_view(),
         name="camper-care-self-reflection-detail",
+    ),
+
+    # ------------------------------------------------------------------
+    # Specialist (Step 7_9, Stories 24-29)
+    # ------------------------------------------------------------------
+    path(
+        "specialist/dashboard/",
+        sp_dashboard.SpecialistDashboardView.as_view(),
+        name="specialist-dashboard",
+    ),
+    path(
+        "specialist/campers/",
+        sp_campers.SpecialistCamperPickerView.as_view(),
+        name="specialist-campers",
+    ),
+    path(
+        "specialist/campers/<int:camper_id>/",
+        sp_camper_view.SpecialistCamperView.as_view(),
+        name="specialist-camper-view",
+    ),
+    path(
+        "specialist/notes/audience/",
+        sp_notes.SpecialistNoteAudienceView.as_view(),
+        name="specialist-note-audience",
+    ),
+    path(
+        "specialist/notes/",
+        sp_notes.SpecialistNoteCreateView.as_view(),
+        name="specialist-note-create",
+    ),
+    path(
+        "specialist/notes/<int:note_id>/",
+        sp_notes.SpecialistNoteDetailView.as_view(),
+        name="specialist-note-detail",
+    ),
+    path(
+        "specialist/self-reflection/",
+        sp_self_reflection.SpecialistSelfReflectionCreateView.as_view(),
+        name="specialist-self-reflection-create",
+    ),
+    path(
+        "specialist/self-reflection/history/",
+        sp_self_reflection.SpecialistSelfReflectionHistoryView.as_view(),
+        name="specialist-self-reflection-history",
+    ),
+    path(
+        "specialist/self-reflection/<int:reflection_id>/",
+        sp_self_reflection.SpecialistSelfReflectionDetailView.as_view(),
+        name="specialist-self-reflection-detail",
     ),
 ]
 

--- a/backend/bunk_logs/templates/maintenance/digest.html
+++ b/backend/bunk_logs/templates/maintenance/digest.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Maintenance Digest</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif; font-size: 15px; color: #1a1a1a; background: #f5f5f5; margin: 0; padding: 0; }
+  .wrap { max-width: 600px; margin: 0 auto; background: #fff; }
+  .header { background: #1e3a5f; color: #fff; padding: 20px 24px; }
+  .header h1 { margin: 0; font-size: 20px; }
+  .header p { margin: 4px 0 0; font-size: 13px; opacity: .8; }
+  .summary { background: #f0f4f8; padding: 16px 24px; border-bottom: 1px solid #dde; }
+  .summary-row { display: inline-block; margin-right: 16px; font-size: 14px; font-weight: 600; }
+  .summary-row .num { font-size: 20px; display: block; }
+  .section { padding: 16px 24px; border-bottom: 1px solid #eee; }
+  .section h2 { font-size: 14px; text-transform: uppercase; letter-spacing: .5px; color: #555; margin: 0 0 12px; }
+  .ticket { margin-bottom: 12px; padding: 10px 12px; border: 1px solid #e0e0e0; border-radius: 6px; }
+  .ticket .meta { font-size: 12px; color: #666; margin-bottom: 4px; }
+  .ticket .desc { font-size: 14px; color: #222; }
+  .ticket .link { font-size: 12px; margin-top: 6px; }
+  .ticket .link a { color: #1e3a5f; }
+  .badge-urgent { background: #fee2e2; color: #991b1b; font-size: 11px; font-weight: 700; padding: 2px 6px; border-radius: 4px; margin-left: 6px; }
+  .none { color: #888; font-size: 14px; font-style: italic; }
+  .footer { padding: 16px 24px; font-size: 12px; color: #999; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #1a1a1a; }
+    .wrap { background: #222; color: #eee; }
+    .summary { background: #2a2a2a; }
+    .ticket { border-color: #444; background: #2a2a2a; }
+    .ticket .desc { color: #ddd; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="header">
+    <h1>Maintenance Digest</h1>
+    <p>{{ window_end|date:"N j, Y" }} &mdash; {{ program.name }}</p>
+  </div>
+
+  <div class="summary">
+    <span class="summary-row"><span class="num">{{ summary.new_in_window }}</span>new</span>
+    <span class="summary-row"><span class="num">{{ summary.closed_in_window }}</span>closed</span>
+    <span class="summary-row"><span class="num">{{ summary.still_open }}</span>still open</span>
+    <span class="summary-row"><span class="num">{{ summary.urgent_open }}</span>urgent open</span>
+  </div>
+
+  {% if urgent_open %}
+  <div class="section">
+    <h2>Urgent Open ({{ urgent_open|length }})</h2>
+    {% for t in urgent_open %}
+    <div class="ticket">
+      <div class="meta">{{ t.location }} / {{ t.category }} &mdash; {{ t.age_days }}d old <span class="badge-urgent">URGENT</span></div>
+      <div class="desc">{{ t.description }}</div>
+      <div class="link"><a href="{{ t.deep_link }}">View ticket &rarr;</a></div>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  <div class="section">
+    <h2>New in Window ({{ new_in_window|length }})</h2>
+    {% if new_in_window %}
+      {% for t in new_in_window %}
+      <div class="ticket">
+        <div class="meta">
+          {{ t.location }} / {{ t.category }}
+          {% if t.urgency == "urgent" %}<span class="badge-urgent">URGENT</span>{% endif %}
+          &mdash; by {{ t.submitter_name }}
+        </div>
+        <div class="desc">{{ t.description }}</div>
+        <div class="link"><a href="{{ t.deep_link }}">View ticket &rarr;</a></div>
+      </div>
+      {% endfor %}
+    {% else %}
+      <p class="none">None.</p>
+    {% endif %}
+  </div>
+
+  <div class="section">
+    <h2>Closed in Window ({{ closed_in_window|length }})</h2>
+    {% if closed_in_window %}
+      {% for t in closed_in_window %}
+      <div class="ticket">
+        <div class="meta">{{ t.location }} / {{ t.category }} &mdash; {{ t.status }}</div>
+        <div class="desc">{{ t.description }}</div>
+        {% if t.closing_note %}<div class="desc" style="color:#555;font-size:13px;margin-top:4px;">Note: {{ t.closing_note }}</div>{% endif %}
+        <div class="link"><a href="{{ t.deep_link }}">View ticket &rarr;</a></div>
+      </div>
+      {% endfor %}
+    {% else %}
+      <p class="none">None.</p>
+    {% endif %}
+  </div>
+
+  <div class="section">
+    <h2>Reopened in Window ({{ reopened_in_window|length }})</h2>
+    {% if reopened_in_window %}
+      {% for r in reopened_in_window %}
+      <div class="ticket">
+        <div class="meta">{{ r.ticket.location }} / {{ r.ticket.category }}</div>
+        {% if r.reopen_reason %}<div class="desc">Reason: {{ r.reopen_reason }}</div>{% endif %}
+        <div class="link"><a href="{{ r.ticket.deep_link }}">View ticket &rarr;</a></div>
+      </div>
+      {% endfor %}
+    {% else %}
+      <p class="none">None.</p>
+    {% endif %}
+  </div>
+
+  <div class="section">
+    <h2>Still Open ({{ still_open|length }})</h2>
+    {% if still_open %}
+      {% for t in still_open %}
+      <div class="ticket">
+        <div class="meta">[{{ t.status }}] {{ t.location }} / {{ t.category }} &mdash; {{ t.age_days }}d old</div>
+        <div class="desc">{{ t.description }}</div>
+        <div class="link"><a href="{{ t.deep_link }}">View ticket &rarr;</a></div>
+      </div>
+      {% endfor %}
+    {% else %}
+      <p class="none">All clear &mdash; no open tickets.</p>
+    {% endif %}
+  </div>
+
+  <div class="footer">
+    Sent by BunkLogs for {{ org.name }}. To configure digest preferences, contact your admin.
+  </div>
+</div>
+</body>
+</html>

--- a/backend/bunk_logs/templates/maintenance/digest.txt
+++ b/backend/bunk_logs/templates/maintenance/digest.txt
@@ -1,0 +1,69 @@
+Maintenance Digest — {{ window_end|date:"N j, Y" }}
+{{ program.name }}
+
+SUMMARY
+-------
+{{ summary.new_in_window }} new  •  {{ summary.closed_in_window }} closed  •  {{ summary.still_open }} still open  •  {{ summary.urgent_open }} urgent open
+
+
+{% if urgent_open %}
+URGENT OPEN ({{ urgent_open|length }})
+-----------
+{% for t in urgent_open %}
+[URGENT] {{ t.location }} / {{ t.category }}
+  {{ t.description }}
+  Age: {{ t.age_days }} day{{ t.age_days|pluralize }}
+  {{ t.deep_link }}
+{% endfor %}
+{% endif %}
+
+
+NEW IN WINDOW ({{ new_in_window|length }})
+-------------
+{% if new_in_window %}{% for t in new_in_window %}
+{{ t.location }} / {{ t.category }}{% if t.urgency == "urgent" %} [URGENT]{% endif %}
+  {{ t.description }}
+  Submitted by: {{ t.submitter_name }}
+  {{ t.deep_link }}
+{% endfor %}{% else %}
+None.
+{% endif %}
+
+
+CLOSED IN WINDOW ({{ closed_in_window|length }})
+----------------
+{% if closed_in_window %}{% for t in closed_in_window %}
+{{ t.location }} / {{ t.category }} — {{ t.status }}
+  {{ t.description }}
+  {% if t.closing_note %}Closing note: {{ t.closing_note }}{% endif %}
+  {{ t.deep_link }}
+{% endfor %}{% else %}
+None.
+{% endif %}
+
+
+REOPENED IN WINDOW ({{ reopened_in_window|length }})
+------------------
+{% if reopened_in_window %}{% for r in reopened_in_window %}
+{{ r.ticket.location }} / {{ r.ticket.category }}
+  Reason: {{ r.reopen_reason }}
+  {{ r.ticket.deep_link }}
+{% endfor %}{% else %}
+None.
+{% endif %}
+
+
+STILL OPEN AT WINDOW END ({{ still_open|length }})
+------------------------
+{% if still_open %}{% for t in still_open %}
+[{{ t.status }}] {{ t.location }} / {{ t.category }}  ({{ t.age_days }}d old)
+  {{ t.description }}
+  {{ t.deep_link }}
+{% endfor %}{% else %}
+All clear — no open tickets.
+{% endif %}
+
+
+---
+Sent by BunkLogs for {{ org.name }}.
+To configure digest preferences, contact your admin.

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -72,6 +72,7 @@ DJANGO_APPS = [
     "django.contrib.staticfiles",
     # "django.contrib.humanize", # Handy template tags
     "django.contrib.admin",
+    "django.contrib.postgres",
     "django.forms",
 ]
 THIRD_PARTY_APPS = [
@@ -340,6 +341,11 @@ CELERY_RESULT_SERIALIZER = "json"
 CELERY_TIMEZONE = TIME_ZONE
 CELERY_TASK_TRACK_STARTED = True
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
+
+# MAINTENANCE DIGEST
+# ------------------------------------------------------------------------------
+# Base URL used in deep-links inside the daily digest email.
+FRONTEND_BASE_URL = env("FRONTEND_BASE_URL", default="https://clc.bunklogs.net")
 
 # AUTO-TRANSLATION (Step 7_5; see docs/user_stories/00_cross_cutting/i18n.md)
 # ------------------------------------------------------------------------------

--- a/docs/role_flows/maintenance.md
+++ b/docs/role_flows/maintenance.md
@@ -1,0 +1,57 @@
+# Maintenance Staff Flow
+
+**Step:** 7_10 | **Stories:** 30–36
+
+## Overview
+
+Maintenance staff see a single ticket queue immediately after sign-in. There is no self-reflection requirement for this role. The queue shows all tickets for the program; it is a team queue — every maintenance staff member sees all tickets.
+
+## Key invariants
+
+- Ticket states: `new → in_progress → fulfilled | unable_to_fulfill`. Both terminal states can reopen to `in_progress`.
+- Urgency: `low | normal | urgent`. Urgent requires a non-empty `urgent_reason`.
+- Queue default sort: urgency (Urgent first) then age (oldest first).
+- Notes use `OrderActivityEvent(event_type='note')`. Visibility stored in `metadata["visibility"]`: `team_only` (default) or `submitter_visible`.
+- Note edit window: 24 hours from original submission, original author only.
+- State transition correction window: 5 minutes, shared with the camper-care state machine (Step 7_2).
+
+## Endpoints (Step 7_10)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/v1/maintenance/queue/` | Active/closed queue with filter + search |
+| GET | `/api/v1/maintenance/tickets/<id>/` | Full ticket detail + activity + photos |
+| POST | `/api/v1/maintenance/tickets/<id>/notes/` | Add note (visibility required) |
+| PATCH | `/api/v1/maintenance/tickets/<id>/notes/<note_id>/` | Edit note within 24h |
+| GET | `/api/v1/maintenance/notes/audience/` | Audience disclosure label for form |
+| POST | `/api/v1/maintenance/<id>/transition/` | State transition (Step 7_2) |
+| POST | `/api/v1/maintenance/<id>/correct-last/` | Undo last transition (5-min window) |
+| POST | `/api/v1/maintenance/bulk-transition/` | Bulk fulfill (Step 7_2) |
+
+## Queue filters
+
+`?filter=open` (default) | `new` | `in_progress` | `closed` | `all`
+
+Closed filter also accepts `?search=<text>` (matches description, location, category, note bodies) and `?date_from=YYYY-MM-DD&date_to=YYYY-MM-DD`.
+
+## Note visibility
+
+| Value | Visible to |
+|-------|-----------|
+| `team_only` | Maintenance staff, Admin |
+| `submitter_visible` | Submitting counselor, Unit Head, Maintenance staff, Leadership Team, Admin |
+
+## Daily digest email (Story 36)
+
+Configured per org in `Organization.settings`:
+- `maintenance_digest_email` — recipient address (required to enable)
+- `maintenance_digest_time` — HH:MM in org timezone, default `"06:00"`
+
+The Celery Beat task `maintenance.dispatch_daily_digests` runs hourly and fans out one `send_maintenance_digest` task per eligible org/program. Consecutive send failures are counted in `Organization.settings["maintenance_digest_consecutive_failures"]`; three or more consecutive failures emit a `logger.error` for Datadog alerting.
+
+## Frontend routes
+
+| Path | Component |
+|------|-----------|
+| `/maintenance` | `pages/maintenance/Queue.jsx` |
+| `/maintenance/tickets/:ticketId` | `pages/maintenance/TicketDetail.jsx` |

--- a/docs/role_flows/specialist.md
+++ b/docs/role_flows/specialist.md
@@ -1,0 +1,183 @@
+# Specialist flow — developer reference
+
+This document describes the **Specialist flow** introduced in migration
+step `7_9` (Stories 24-29). It is the canonical developer-facing reference
+for everything the Specialist role touches in the new multi-tenant stack.
+
+If you are looking for the product spec (acceptance criteria, screens, copy),
+see `docs/user_stories/04_specialist/STORIES.md`. The routing prompt lives
+in `migration_prompts/7_9_specialist_flow.md`.
+
+The Specialist role has **no legacy counterpart** — there is no Crane Lake
+"specialist log" table to bridge. All data lives in the new multi-tenant
+model from day one.
+
+---
+
+## 1. Surface area
+
+### 1.1 Backend endpoints
+
+All Specialist-scoped APIs live under `/api/v1/specialist/`:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/dashboard/` | Home: header, self-reflection state, and last 10 authored notes. Cached per-viewer for 30 s. |
+| `GET` | `/campers/?q=` | Camper picker — returns `recent` (last 7 days, max 8) and `results` (all/search) sections. |
+| `GET` | `/campers/<camper_id>/` | Specialist-scoped camper view: header + only notes authored by this specialist. |
+| `POST` | `/notes/` | Create a specialist note (optionally flag for Camper Care). |
+| `PATCH` | `/notes/<note_id>/` | Edit a specialist note within the 24-hour edit window. Cannot un-flag. |
+| `GET` | `/notes/audience/` | Preview audience labels for a note given current field values. |
+| `POST` | `/self-reflection/` | Submit today's specialist self-reflection (day-off support, optional translation). |
+| `PATCH` | `/self-reflection/<reflection_id>/` | Edit within the edit window. |
+| `GET` | `/self-reflection/history/` | Paginated history of own self-reflections. |
+
+### 1.2 Backend file layout
+
+```
+backend/bunk_logs/api/specialist/
+├── __init__.py
+├── common.py           # ViewerContext, viewer_or_403, specialist_label, specialist_program_ids
+├── dashboard.py        # GET /specialist/dashboard/
+├── campers.py          # GET /specialist/campers/
+├── camper_view.py      # GET /specialist/campers/<id>/
+├── notes.py            # POST/PATCH /notes/ and GET /notes/audience/
+└── self_reflection.py  # POST/PATCH/GET /self-reflection/
+```
+
+Tests live in `backend/bunk_logs/api/tests/test_specialist_endpoints.py`.
+
+### 1.3 Frontend pages and components
+
+```
+frontend/src/pages/specialist/
+├── Dashboard.jsx          # Story 24 — home screen
+├── CamperPicker.jsx       # Story 25 — debounced search
+├── NoteForm.jsx           # Stories 26-27 — create/edit
+├── CamperView.jsx         # Story 28 — camper drill-down
+└── SelfReflectionPage.jsx # Story 29 — daily self-reflection form
+
+frontend/src/api/specialist.js  # all API calls for the above pages
+
+frontend/src/pages/specialist/__tests__/
+├── Dashboard.test.jsx
+├── CamperPicker.test.jsx
+└── NoteForm.test.jsx
+```
+
+Routes registered in `frontend/src/Router.jsx`:
+- `/specialist` — Dashboard
+- `/specialist/notes/new`
+- `/specialist/notes/:noteId/edit`
+- `/specialist/campers/:camperId`
+- `/specialist/self-reflection/new`
+- `/specialist/self-reflection/:reflectionId/edit`
+
+---
+
+## 2. Auth and tenancy
+
+Access gate: `viewer_or_403` in `common.py` requires the request user to have
+an **active** `Membership` with `role="specialist"` in the request
+organization. Every response is scoped to the programs listed in that
+membership's `program_ids` field.
+
+Header tenant resolution uses the `X-Organization-Slug` request header
+(standard across all new role flows).
+
+---
+
+## 3. Visibility model
+
+Notes written by Specialists use `NoteType.SPECIALIST`. Audience resolution
+follows `content_visibility.py`:
+
+| Condition | Audience |
+|---|---|
+| `is_sensitive=False` | Counselor, Unit Head, Camper Care, Leadership Team, Admin |
+| `is_sensitive=True` | Camper Care, Health Center, Special Diets, Admin |
+
+The `GET /notes/audience/` endpoint lets the frontend preview this audience
+before save (used in the `AudienceDisclosure` component).
+
+---
+
+## 4. Specialist note categories
+
+Rather than extending the `Note.Category` enum (which would require a schema
+migration), specialist notes use plain string values stored in the
+`note.category` field (max 16 chars). The allowed values and their display
+labels are:
+
+| Value | Display label |
+|---|---|
+| `positive` | Positive observation |
+| `concern` | Concern |
+| `milestone` | Skill milestone |
+| `behavioral` | Behavioral |
+| `other` | Other |
+
+Validation occurs in `SpecialistNoteCreateView` and `SpecialistNoteDetailView`.
+The frontend uses `SPECIALIST_NOTE_CATEGORIES` from `src/api/specialist.js`.
+
+---
+
+## 5. Flag for Camper Care
+
+When a note is created with `flag_for_camper_care: true`, the backend calls
+`raise_flag_from_specialist_note` (defined in `core/flags.py`), which creates
+a `Flag` record linked to the note's primary subject.
+
+**Key invariant**: once a flag is raised it cannot be retracted via PATCH.
+The backend rejects `PATCH` requests that attempt to set `flag_for_camper_care`
+to `false` on a note whose flag is already `flag_raised=True`. The frontend
+checkbox is disabled when `note.flag_raised=true`.
+
+---
+
+## 6. Edit window
+
+Both notes and self-reflections enforce a 24-hour edit window enforced in
+the PATCH views. Requests outside the window receive HTTP 403. The frontend
+shows a banner ("Edit window closed") when the note's `created_at` is older
+than 24 hours.
+
+---
+
+## 7. Dashboard caching
+
+`GET /specialist/dashboard/` is cached per-viewer (cache key includes
+`org.slug` and `person.id`) for 30 seconds using `django.core.cache`.
+Any write that changes the dashboard data (note create/edit, self-reflection
+submit/edit) calls `_bust_specialist_dashboard_cache` to invalidate the entry
+immediately.
+
+---
+
+## 8. Specialist label derivation
+
+The display label shown in the dashboard header (e.g. "Waterfront Specialist")
+is derived from the `tags` field of the specialist's `Membership` record.
+`specialist_label()` in `common.py` looks for a tag ending with `_specialist`
+and formats it into title case. Falls back to "Specialist" if no matching
+tag is found.
+
+---
+
+## 9. Camper picker — scoping
+
+The picker (`GET /specialist/campers/`) returns only campers whose
+`AssignmentGroupMembership.group.program_id` is in the specialist's program
+list. The "Recent" section shows the up-to-8 campers this specialist wrote a
+note about in the last 7 days; the "All campers" / "Results" section lists
+(or filters) the full program-scoped roster.
+
+---
+
+## 10. Self-reflection template
+
+`specialist_self_template()` in `common.py` queries `ReflectionTemplate` for
+a record with `role="specialist"` that is active in one of the specialist's
+programs. If no template is configured, the dashboard and self-reflection
+endpoints return `state: "no_template"` and the frontend hides the
+self-reflection card.

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -61,6 +61,12 @@ import CamperCareOrdersPage from './pages/camper-care/Orders';
 import CamperCareNoteFormPage from './pages/camper-care/NoteForm';
 import CamperCareSelfReflectionPage from './pages/camper-care/SelfReflectionPage';
 import CamperCareSelfReflectionHistoryPage from './pages/camper-care/SelfReflectionHistoryPage';
+import SpecialistDashboard from './pages/specialist/Dashboard';
+import SpecialistNoteForm from './pages/specialist/NoteForm';
+import SpecialistCamperView from './pages/specialist/CamperView';
+import SpecialistSelfReflectionPage from './pages/specialist/SelfReflectionPage';
+import MaintenanceQueue from './pages/maintenance/Queue';
+import MaintenanceTicketDetail from './pages/maintenance/TicketDetail';
 import CamperReflectionListPage from './pages/counselor/CamperReflectionListPage';
 import CamperReflectionFormPage from './pages/counselor/CamperReflectionFormPage';
 import CounselorSelfReflectionPage from './pages/counselor/CounselorSelfReflectionPage';
@@ -470,7 +476,70 @@ function Router() {
             path="/camper-care/self-reflection/:reflectionId/edit"
             element={<CamperCareSelfReflectionPage />}
           />
+          {/* 7_10: Maintenance staff flow. The queue is the post-login landing
+              page for maintenance staff (Story 30 criterion 2). No self-
+              reflection card — maintenance has no reflection requirement
+              (Story 30 criterion 9). The ticket detail preserves the active
+              queue filter via the `from` query param so back navigation
+              restores the correct view. */}
+          <Route path="/maintenance" element={<MaintenanceQueue />} />
+          <Route
+            path="/maintenance/tickets/:ticketId"
+            element={<MaintenanceTicketDetail />}
+          />
         </Route>
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Specialist (Step 7_9, Stories 24-29)                               */}
+        {/* ------------------------------------------------------------------ */}
+        <Route
+          path="/specialist"
+          element={
+            <ProtectedRoute>
+              <SpecialistDashboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/specialist/notes/new"
+          element={
+            <ProtectedRoute>
+              <SpecialistNoteForm />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/specialist/notes/:noteId/edit"
+          element={
+            <ProtectedRoute>
+              <SpecialistNoteForm />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/specialist/campers/:camperId"
+          element={
+            <ProtectedRoute>
+              <SpecialistCamperView />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/specialist/self-reflection/new"
+          element={
+            <ProtectedRoute>
+              <SpecialistSelfReflectionPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/specialist/self-reflection/:reflectionId/edit"
+          element={
+            <ProtectedRoute>
+              <SpecialistSelfReflectionPage />
+            </ProtectedRoute>
+          }
+        />
 
         <Route
           path="/my-reflections"

--- a/frontend/src/api/maintenance.js
+++ b/frontend/src/api/maintenance.js
@@ -1,0 +1,84 @@
+/**
+ * Maintenance staff flow API client (Step 7_10).
+ *
+ * Wrappers around `/api/v1/maintenance/*` (Stories 30-35). Transition
+ * endpoints are shared with the state machine from Step 7_2 (same URLs);
+ * the queue, detail, and notes endpoints are new in this step.
+ */
+
+import api from '../api';
+
+/** Maintenance ticket queue with optional filter and closed-view params. */
+export async function fetchMaintenanceQueue({
+  filter = 'open',
+  search,
+  dateFrom,
+  dateTo,
+} = {}) {
+  const params = { filter };
+  if (search) params.search = search;
+  if (dateFrom) params.date_from = dateFrom;
+  if (dateTo) params.date_to = dateTo;
+  const { data } = await api.get('/api/v1/maintenance/queue/', { params });
+  return data;
+}
+
+/** Full ticket detail including photos and activity. */
+export async function fetchTicketDetail(ticketId) {
+  const { data } = await api.get(`/api/v1/maintenance/tickets/${ticketId}/`);
+  return data;
+}
+
+/** Transition a single ticket (delegates to the 7_2 state machine endpoint). */
+export async function transitionTicket(ticketId, { toState, note, reason } = {}) {
+  const { data } = await api.post(
+    `/api/v1/maintenance/${ticketId}/transition/`,
+    { to_state: toState, note, reason },
+  );
+  return data;
+}
+
+/** Correct the last transition within the 5-minute window. */
+export async function correctLastTransition(ticketId) {
+  const { data } = await api.post(`/api/v1/maintenance/${ticketId}/correct-last/`);
+  return data;
+}
+
+/** Bulk transition multiple tickets. */
+export async function bulkTransitionTickets({ ids, toState, note } = {}) {
+  const { data } = await api.post('/api/v1/maintenance/bulk-transition/', {
+    ids,
+    to_state: toState,
+    note,
+  });
+  return data;
+}
+
+/** Add a note to a ticket. */
+export async function createTicketNote(ticketId, { body, visibility = 'team_only' } = {}) {
+  const { data } = await api.post(
+    `/api/v1/maintenance/tickets/${ticketId}/notes/`,
+    { body, visibility },
+  );
+  return data;
+}
+
+/** Edit a note within the 24h window. */
+export async function editTicketNote(ticketId, noteId, { body, visibility } = {}) {
+  const payload = {};
+  if (body !== undefined) payload.body = body;
+  if (visibility !== undefined) payload.visibility = visibility;
+  const { data } = await api.patch(
+    `/api/v1/maintenance/tickets/${ticketId}/notes/${noteId}/`,
+    payload,
+  );
+  return data;
+}
+
+/** Audience disclosure label for a given visibility value. */
+export async function fetchNoteAudience(visibility = 'team_only') {
+  const { data } = await api.get('/api/v1/maintenance/notes/audience/', {
+    params: { visibility },
+  });
+  return data;
+}

--- a/frontend/src/api/specialist.js
+++ b/frontend/src/api/specialist.js
@@ -1,0 +1,132 @@
+/**
+ * Specialist flow API client (Step 7_9).
+ *
+ * Wrappers around `/api/v1/specialist/*` (Stories 24-29). Mirrors the
+ * shape of `api/camperCare.js`: thin axios calls, named exports per endpoint.
+ */
+
+import api from '../api';
+import { newClientSubmissionId } from './counselor';
+
+export { newClientSubmissionId };
+
+/** Specialist dashboard (Story 24). */
+export async function fetchSpecialistDashboard({ noCache = false } = {}) {
+  const params = {};
+  if (noCache) params.nocache = '1';
+  const { data } = await api.get('/api/v1/specialist/dashboard/', { params });
+  return data;
+}
+
+/**
+ * Camper picker (Story 25).
+ * @param q — search query (empty = all campers in recent + all sections).
+ */
+export async function fetchSpecialistCampers({ q = '' } = {}) {
+  const params = {};
+  if (q) params.q = q;
+  const { data } = await api.get('/api/v1/specialist/campers/', { params });
+  return data;
+}
+
+/**
+ * Specialist-scoped camper view (Story 28).
+ * Returns only the requesting Specialist's notes for the camper.
+ * @param dateFrom / dateTo — ISO date strings for date-range filter.
+ */
+export async function fetchSpecialistCamperView(camperId, { dateFrom, dateTo } = {}) {
+  const params = {};
+  if (dateFrom) params.date_from = dateFrom;
+  if (dateTo) params.date_to = dateTo;
+  const { data } = await api.get(`/api/v1/specialist/campers/${camperId}/`, { params });
+  return data;
+}
+
+/**
+ * Submit a specialist note (Story 26).
+ * Returns `{ data, status }` so the caller can distinguish 201 from retries.
+ */
+export async function createSpecialistNote({
+  subjectId, body, category = '', isSensitive = false,
+  flagForCamperCare = false, language = 'en',
+}) {
+  const payload = {
+    subject_id: subjectId,
+    body,
+    is_sensitive: isSensitive,
+    flag_for_camper_care: flagForCamperCare,
+    language,
+  };
+  if (category) payload.category = category;
+  const res = await api.post('/api/v1/specialist/notes/', payload);
+  return { data: res.data, status: res.status };
+}
+
+/** Edit a specialist note within the 24h window (Story 27). */
+export async function patchSpecialistNote(noteId, { body, isSensitive, category, language }) {
+  const payload = {};
+  if (body !== undefined) payload.body = body;
+  if (isSensitive !== undefined) payload.is_sensitive = isSensitive;
+  if (category !== undefined) payload.category = category;
+  if (language !== undefined) payload.language = language;
+  const { data } = await api.patch(`/api/v1/specialist/notes/${noteId}/`, payload);
+  return data;
+}
+
+/**
+ * Resolve the audience disclosure copy for the note form (Story 26.5).
+ */
+export async function fetchSpecialistNoteAudience({ isSensitive = false } = {}) {
+  const params = { is_sensitive: isSensitive ? 'true' : 'false' };
+  const { data } = await api.get('/api/v1/specialist/notes/audience/', { params });
+  return data;
+}
+
+/** Categories enum for specialist notes (Story 26 criterion 2). */
+export const SPECIALIST_NOTE_CATEGORIES = Object.freeze([
+  { value: 'positive', label: 'Positive observation' },
+  { value: 'concern', label: 'Concern' },
+  { value: 'milestone', label: 'Skill milestone' },
+  { value: 'behavioral', label: 'Behavioral' },
+  { value: 'other', label: 'Other' },
+]);
+
+/**
+ * Submit a Specialist self-reflection (Story 29).
+ * Mirrors the CC/UH write contract.
+ */
+export async function createSpecialistSelfReflection({
+  answers, dayOff = false, language = 'en', clientSubmissionId,
+}) {
+  const payload = {
+    day_off: dayOff,
+    language,
+    client_submission_id: clientSubmissionId,
+  };
+  if (!dayOff && answers !== undefined) {
+    payload.answers = answers;
+  }
+  const res = await api.post('/api/v1/specialist/self-reflection/', payload);
+  return { data: res.data, status: res.status };
+}
+
+/** Edit a Specialist self-reflection inside today's edit window. */
+export async function patchSpecialistSelfReflection(reflectionId, { answers, dayOff, language }) {
+  const payload = {};
+  if (answers !== undefined) payload.answers = answers;
+  if (dayOff !== undefined) payload.day_off = dayOff;
+  if (language !== undefined) payload.language = language;
+  const { data } = await api.patch(
+    `/api/v1/specialist/self-reflection/${reflectionId}/`,
+    payload,
+  );
+  return data;
+}
+
+/** Paginated Specialist self-reflection history. */
+export async function fetchSpecialistSelfReflectionHistory({ page = 1, pageSize } = {}) {
+  const params = { page };
+  if (pageSize) params.page_size = pageSize;
+  const { data } = await api.get('/api/v1/specialist/self-reflection/history/', { params });
+  return data;
+}

--- a/frontend/src/pages/maintenance/Queue.jsx
+++ b/frontend/src/pages/maintenance/Queue.jsx
@@ -1,0 +1,486 @@
+/**
+ * Maintenance ticket queue — Step 7_10, Stories 30-31, 34-35.
+ *
+ * Features:
+ *  - Status filter: Open (default) / New / In Progress / Closed / All
+ *  - Header counts: n new • m in progress • k urgent
+ *  - Default sort: urgency (Urgent first) then age (oldest first) — enforced server-side
+ *  - Bulk select + fulfill for In Progress rows (Story 23 pattern)
+ *  - Closed view with date range and free-text search
+ *  - Click row → navigates to /maintenance/tickets/:id
+ *  - No self-reflection card (Story 30 criterion 9)
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  fetchMaintenanceQueue,
+  transitionTicket,
+  bulkTransitionTickets,
+} from '../../api/maintenance';
+
+const URGENCY_BADGE = {
+  urgent: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-100',
+  normal: '',
+  low: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300',
+};
+
+const STATUS_BADGE = {
+  new: 'bg-blue-100 text-blue-900 dark:bg-blue-900/40 dark:text-blue-100',
+  in_progress: 'bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-100',
+  fulfilled: 'bg-green-100 text-green-900 dark:bg-green-900/40 dark:text-green-100',
+  unable_to_fulfill: 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-100',
+};
+
+const STATUS_LABEL = {
+  new: 'New',
+  in_progress: 'In Progress',
+  fulfilled: 'Fulfilled',
+  unable_to_fulfill: 'Unable to fulfill',
+};
+
+const TRANSITION_LABEL = {
+  in_progress: 'Mark In Progress',
+  fulfilled: 'Mark Fulfilled',
+  unable_to_fulfill: 'Unable to fulfill',
+  new: 'Reopen',
+};
+
+const AGE_THRESHOLD_SECONDS = 4 * 3600;
+
+function formatAge(seconds) {
+  if (seconds == null) return '';
+  if (seconds < 60) return `${seconds}s ago`;
+  const m = Math.round(seconds / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 48) return `${h}h ago`;
+  return `${Math.round(h / 24)}d ago`;
+}
+
+function TicketRow({ ticket, selectable, selected, onSelectToggle, onTransition, onClick }) {
+  const aged = ticket.age_seconds != null && ticket.age_seconds >= AGE_THRESHOLD_SECONDS;
+  return (
+    <li
+      data-testid={`ticket-row-${ticket.id}`}
+      data-status={ticket.status}
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3 shadow-sm cursor-pointer hover:border-blue-300 dark:hover:border-blue-600 transition-colors"
+      onClick={() => onClick(ticket.id)}
+    >
+      <div className="flex items-start gap-3">
+        {selectable && (
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={(e) => { e.stopPropagation(); onSelectToggle(ticket.id); }}
+            onClick={(e) => e.stopPropagation()}
+            aria-label={`Select ticket at ${ticket.location}`}
+            data-testid={`ticket-select-${ticket.id}`}
+            className="mt-1 h-4 w-4 rounded border-gray-300"
+          />
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                {ticket.urgency === 'urgent' && (
+                  <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${URGENCY_BADGE.urgent}`}>
+                    Urgent
+                  </span>
+                )}
+                <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${STATUS_BADGE[ticket.status] || ''}`}>
+                  {STATUS_LABEL[ticket.status] || ticket.status}
+                </span>
+                {ticket.status === 'new' && ticket.acknowledger == null && aged && (
+                  <span className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-200 text-[10px] font-medium">
+                    Aged
+                  </span>
+                )}
+              </div>
+              <h3 className="font-medium text-gray-900 dark:text-white mt-1">
+                {ticket.location}
+                {ticket.category ? ` — ${ticket.category.replace(/_/g, ' ')}` : ''}
+              </h3>
+              {ticket.description && (
+                <p className="text-sm text-gray-600 dark:text-gray-300 mt-0.5 line-clamp-2">
+                  {ticket.description}
+                </p>
+              )}
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                {ticket.submitter_name ? `From ${ticket.submitter_name} · ` : ''}
+                {formatAge(ticket.age_seconds)}
+              </p>
+              {ticket.acknowledger && (
+                <p className="text-xs text-amber-700 dark:text-amber-300 mt-0.5">
+                  In progress: {ticket.acknowledger.name}
+                </p>
+              )}
+              {ticket.has_photos && (
+                <span className="text-xs text-gray-500 dark:text-gray-400">(photo attached)</span>
+              )}
+            </div>
+          </div>
+          {ticket.available_transitions?.length > 0 && (
+            <div className="flex flex-wrap gap-2 mt-3" onClick={(e) => e.stopPropagation()}>
+              {ticket.available_transitions.map((next) => (
+                <button
+                  key={next}
+                  type="button"
+                  onClick={() => onTransition(ticket, next)}
+                  data-testid={`ticket-action-${next}-${ticket.id}`}
+                  className="inline-flex items-center px-3 min-h-[34px] rounded-lg border border-gray-300 dark:border-gray-700 text-sm text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
+                >
+                  {TRANSITION_LABEL[next] || next}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function TransitionModal({ ticket, toState, onClose, onSubmitted }) {
+  const [note, setNote] = useState('');
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  if (!ticket) return null;
+  const reasonRequired = toState === 'unable_to_fulfill';
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    if (reasonRequired && reason.trim().length < 10) {
+      setError('Please provide a reason (at least 10 characters).');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await transitionTicket(ticket.id, {
+        toState,
+        note: note.trim() || undefined,
+        reason: reason.trim() || undefined,
+      });
+      onSubmitted();
+    } catch (err) {
+      const d = err?.response?.data;
+      const detail = d?.detail || d?.to_state || d?.reason || err?.message || 'Could not apply transition.';
+      setError(typeof detail === 'string' ? detail : JSON.stringify(detail));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 px-4"
+      role="dialog"
+      aria-modal="true"
+      data-testid="ticket-transition-modal"
+    >
+      <div className="w-full sm:max-w-md bg-white dark:bg-gray-900 rounded-t-2xl sm:rounded-2xl shadow-xl p-4">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          {TRANSITION_LABEL[toState] || toState}
+        </h2>
+        <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
+          {ticket.location}
+        </p>
+        <form onSubmit={handleSubmit} className="mt-3 space-y-3">
+          <label className="block text-sm">
+            <span className="text-gray-700 dark:text-gray-200">
+              Note {reasonRequired ? '' : '(optional)'}
+            </span>
+            <textarea
+              value={reasonRequired ? reason : note}
+              onChange={(e) => reasonRequired ? setReason(e.target.value) : setNote(e.target.value)}
+              rows={3}
+              required={reasonRequired}
+              data-testid="ticket-transition-note"
+              className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+            />
+          </label>
+          {!reasonRequired && toState !== 'in_progress' && (
+            <label className="block text-sm">
+              <span className="text-gray-700 dark:text-gray-200">Optional closing note</span>
+              <textarea
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                rows={2}
+                data-testid="ticket-transition-closing-note"
+                className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+              />
+            </label>
+          )}
+          {error && (
+            <p role="alert" className="text-sm text-red-700 dark:text-red-300" data-testid="ticket-transition-error">
+              {error}
+            </p>
+          )}
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="inline-flex items-center px-3 min-h-[40px] rounded-lg border border-gray-300 dark:border-gray-700 text-sm text-gray-800 dark:text-gray-100"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              data-testid="ticket-transition-submit"
+              className="inline-flex items-center px-4 min-h-[40px] rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-60"
+            >
+              {submitting ? 'Working…' : 'Apply'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function FilterBar({ filter, search, dateFrom, dateTo, onChange }) {
+  const isClosed = filter === 'closed';
+  return (
+    <div
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 shadow-sm space-y-2"
+      data-testid="maint-queue-filter"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        {['open', 'new', 'in_progress', 'closed', 'all'].map((f) => (
+          <button
+            key={f}
+            type="button"
+            onClick={() => onChange({ filter: f, search: '', dateFrom: '', dateTo: '' })}
+            data-testid={`filter-${f}`}
+            className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+              filter === f
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-700'
+            }`}
+          >
+            {f === 'in_progress' ? 'In Progress' : f.charAt(0).toUpperCase() + f.slice(1)}
+          </button>
+        ))}
+      </div>
+      {isClosed && (
+        <div className="flex flex-wrap gap-2">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => onChange({ filter, search: e.target.value, dateFrom, dateTo })}
+            placeholder="Search…"
+            data-testid="maint-queue-search"
+            className="flex-1 min-w-[120px] rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-2 py-1 text-sm"
+          />
+          <input
+            type="date"
+            value={dateFrom}
+            onChange={(e) => onChange({ filter, search, dateFrom: e.target.value, dateTo })}
+            data-testid="maint-queue-date-from"
+            className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-2 py-1 text-sm"
+          />
+          <input
+            type="date"
+            value={dateTo}
+            onChange={(e) => onChange({ filter, search, dateFrom, dateTo: e.target.value })}
+            data-testid="maint-queue-date-to"
+            className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-2 py-1 text-sm"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function MaintenanceQueue() {
+  const navigate = useNavigate();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [filter, setFilter] = useState('open');
+  const [search, setSearch] = useState('');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [selected, setSelected] = useState(() => new Set());
+  const [bulkNote, setBulkNote] = useState('');
+  const [bulkSubmitting, setBulkSubmitting] = useState(false);
+  const [bulkError, setBulkError] = useState('');
+  const [modal, setModal] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await fetchMaintenanceQueue({
+        filter,
+        search: search || undefined,
+        dateFrom: dateFrom || undefined,
+        dateTo: dateTo || undefined,
+      });
+      setData(result);
+      setError('');
+    } catch (err) {
+      const detail = err?.response?.data?.detail || err?.message || 'Failed to load queue.';
+      setError(typeof detail === 'string' ? detail : JSON.stringify(detail));
+    } finally {
+      setLoading(false);
+    }
+  }, [filter, search, dateFrom, dateTo]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleFilterChange = ({ filter: f, search: s, dateFrom: df, dateTo: dt }) => {
+    setFilter(f); setSearch(s); setDateFrom(df); setDateTo(dt);
+    setSelected(new Set());
+  };
+
+  const handleTransition = (ticket, toState) => setModal({ ticket, toState });
+  const handleSubmitted = () => { setModal(null); setSelected(new Set()); setBulkNote(''); load(); };
+
+  const handleSelectToggle = (id) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  const handleBulkFulfill = async () => {
+    setBulkError('');
+    const ids = Array.from(selected);
+    if (!ids.length) return;
+    setBulkSubmitting(true);
+    try {
+      const result = await bulkTransitionTickets({ ids, toState: 'fulfilled', note: bulkNote.trim() || undefined });
+      if (result.failed?.length) {
+        setBulkError(`${result.failed.length} ticket(s) could not be transitioned.`);
+      }
+      handleSubmitted();
+    } catch (err) {
+      setBulkError(err?.response?.data?.detail || err?.message || 'Bulk update failed.');
+    } finally {
+      setBulkSubmitting(false);
+    }
+  };
+
+  const tickets = data?.tickets ?? [];
+  const counts = data?.counts ?? { new: 0, in_progress: 0, urgent_open: 0 };
+  const inProgressTickets = tickets.filter((t) => t.status === 'in_progress');
+  const eligibleSelected = useMemo(
+    () => inProgressTickets.filter((t) => selected.has(t.id)),
+    [inProgressTickets, selected],
+  );
+
+  if (loading && !data) {
+    return (
+      <div className="px-4 py-6 max-w-3xl mx-auto" data-testid="maint-queue-loading">
+        <p className="text-gray-600 dark:text-gray-400">Loading queue…</p>
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="px-4 py-6 max-w-3xl mx-auto">
+        <div role="alert" className="rounded-xl border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-900/30 px-4 py-3 text-sm text-amber-900 dark:text-amber-100" data-testid="maint-queue-error">
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="maint-queue" className="px-4 py-6 pb-24 max-w-3xl mx-auto space-y-4">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Maintenance Queue</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-400" data-testid="maint-queue-counts">
+          {counts.new} new&nbsp;·&nbsp;{counts.in_progress} in progress&nbsp;·&nbsp;{counts.urgent_open} urgent
+        </p>
+      </header>
+
+      <FilterBar
+        filter={filter}
+        search={search}
+        dateFrom={dateFrom}
+        dateTo={dateTo}
+        onChange={handleFilterChange}
+      />
+
+      {error && (
+        <div role="alert" className="rounded-xl border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-900/30 px-4 py-3 text-sm text-amber-900 dark:text-amber-100">
+          {error}
+        </div>
+      )}
+
+      {tickets.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400" data-testid="maint-queue-empty">
+          {filter === 'closed' ? 'No closed tickets match.' : 'No tickets in this view.'}
+        </p>
+      ) : (
+        <ul className="space-y-2" data-testid="maint-queue-list">
+          {tickets.map((t) => (
+            <TicketRow
+              key={t.id}
+              ticket={t}
+              selectable={t.status === 'in_progress'}
+              selected={selected.has(t.id)}
+              onSelectToggle={handleSelectToggle}
+              onTransition={handleTransition}
+              onClick={(id) => navigate(`/maintenance/tickets/${id}`)}
+            />
+          ))}
+        </ul>
+      )}
+
+      {eligibleSelected.length > 0 && (
+        <div
+          className="mt-3 rounded-xl border border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/30 px-4 py-3 shadow-sm"
+          data-testid="maint-queue-bulk-bar"
+        >
+          <p className="text-sm font-medium text-blue-900 dark:text-blue-100">
+            {eligibleSelected.length} selected
+          </p>
+          <label className="block text-sm mt-2">
+            <span className="text-blue-900 dark:text-blue-100">Closing note (optional)</span>
+            <textarea
+              value={bulkNote}
+              onChange={(e) => setBulkNote(e.target.value)}
+              rows={2}
+              data-testid="maint-queue-bulk-note"
+              className="mt-1 block w-full rounded-md border border-blue-200 dark:border-blue-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm"
+            />
+          </label>
+          {bulkError && (
+            <p role="alert" className="text-sm text-red-700 dark:text-red-300 mt-1" data-testid="maint-queue-bulk-error">
+              {bulkError}
+            </p>
+          )}
+          <div className="flex justify-end mt-3">
+            <button
+              type="button"
+              onClick={handleBulkFulfill}
+              disabled={bulkSubmitting}
+              data-testid="maint-queue-bulk-submit"
+              className="inline-flex items-center px-4 min-h-[40px] rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-60"
+            >
+              {bulkSubmitting ? 'Working…' : 'Mark all fulfilled'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {modal && (
+        <TransitionModal
+          ticket={modal.ticket}
+          toState={modal.toState}
+          onClose={() => setModal(null)}
+          onSubmitted={handleSubmitted}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/maintenance/TicketDetail.jsx
+++ b/frontend/src/pages/maintenance/TicketDetail.jsx
@@ -1,0 +1,568 @@
+/**
+ * Maintenance ticket detail — Step 7_10, Stories 31-35.
+ *
+ * Sections (Story 31 criterion 1):
+ *   Header  — location, category, urgency (w/ reason if Urgent), status, submitter, time
+ *   Description
+ *   Photos  — original submission photos
+ *   Activity — chronological state changes + notes + photos added during work
+ *   Actions  — pinned to bottom, vary by current status
+ *
+ * Notes (Story 33):
+ *   Inline form (no modal). Visibility radio: Team only | Submitter and team.
+ *   AudienceDisclosure updates dynamically with the radio.
+ *   Author can edit own notes within 24h.
+ *
+ * Back nav restores prior queue filter state via query param ?from=<filter>.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import {
+  fetchTicketDetail,
+  transitionTicket,
+  correctLastTransition,
+  createTicketNote,
+  editTicketNote,
+  fetchNoteAudience,
+} from '../../api/maintenance';
+
+const STATUS_BADGE = {
+  new: 'bg-blue-100 text-blue-900 dark:bg-blue-900/40 dark:text-blue-100',
+  in_progress: 'bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-100',
+  fulfilled: 'bg-green-100 text-green-900 dark:bg-green-900/40 dark:text-green-100',
+  unable_to_fulfill: 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-100',
+};
+
+const STATUS_LABEL = { new: 'New', in_progress: 'In Progress', fulfilled: 'Fulfilled', unable_to_fulfill: 'Unable to Fulfill' };
+const TRANSITION_LABEL = { in_progress: 'Mark In Progress', fulfilled: 'Mark Fulfilled', unable_to_fulfill: 'Unable to Fulfill', new: 'Reopen' };
+const EVENT_TYPE_LABEL = { state_change: 'Status change', correction: 'Correction', note: 'Note' };
+
+function formatTime(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+function formatAge(seconds) {
+  if (seconds == null) return '';
+  const h = Math.round(seconds / 3600);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.round(h / 24)}d ago`;
+}
+
+function ActivityEvent({ event, ticketId, onNoteUpdated }) {
+  const [editing, setEditing] = useState(false);
+  const [editBody, setEditBody] = useState(event.note || '');
+  const [editVisibility, setEditVisibility] = useState(event.visibility || 'team_only');
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState('');
+
+  const isNote = event.event_type === 'note';
+
+  const handleSave = async () => {
+    setSaveError('');
+    if (!editBody.trim()) { setSaveError('Body required.'); return; }
+    setSaving(true);
+    try {
+      const updated = await editTicketNote(ticketId, event.id, {
+        body: editBody.trim(),
+        visibility: editVisibility,
+      });
+      onNoteUpdated(updated);
+      setEditing(false);
+    } catch (err) {
+      setSaveError(err?.response?.data?.detail || err?.message || 'Save failed.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      data-testid={`activity-${event.id}`}
+      className="flex gap-3"
+    >
+      <div className="w-1.5 flex-shrink-0 mt-1.5">
+        <div className={`w-1.5 h-1.5 rounded-full ${isNote ? 'bg-blue-400' : 'bg-gray-400'}`} />
+      </div>
+      <div className="flex-1 min-w-0 pb-4 border-b border-gray-100 dark:border-gray-800 last:border-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-xs font-medium text-gray-700 dark:text-gray-200">
+            {event.actor_name || 'System'}
+          </span>
+          <span className="text-xs text-gray-400">{formatTime(event.created_at)}</span>
+          {isNote && (
+            <span className="text-xs px-1.5 py-0.5 rounded-full bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-200">
+              {event.visibility === 'submitter_visible' ? 'Visible to submitter' : 'Team only'}
+            </span>
+          )}
+          {!isNote && (
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              {event.from_state && event.to_state
+                ? `${STATUS_LABEL[event.from_state] || event.from_state} → ${STATUS_LABEL[event.to_state] || event.to_state}`
+                : EVENT_TYPE_LABEL[event.event_type] || event.event_type
+              }
+            </span>
+          )}
+        </div>
+
+        {isNote && !editing ? (
+          <>
+            <p className="text-sm text-gray-800 dark:text-gray-100 mt-1 whitespace-pre-wrap">{event.note}</p>
+            {event.is_within_edit_window && (
+              <button
+                type="button"
+                onClick={() => setEditing(true)}
+                className="text-xs text-blue-600 dark:text-blue-400 hover:underline mt-1"
+                data-testid={`note-edit-${event.id}`}
+              >
+                Edit
+              </button>
+            )}
+          </>
+        ) : isNote && editing ? (
+          <div className="mt-2 space-y-2">
+            <textarea
+              value={editBody}
+              onChange={(e) => setEditBody(e.target.value)}
+              rows={3}
+              className="block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+            />
+            <div className="flex gap-4 text-sm">
+              <label className="flex items-center gap-1.5 cursor-pointer">
+                <input
+                  type="radio"
+                  name={`vis-edit-${event.id}`}
+                  value="team_only"
+                  checked={editVisibility === 'team_only'}
+                  onChange={() => setEditVisibility('team_only')}
+                />
+                Team only
+              </label>
+              <label className="flex items-center gap-1.5 cursor-pointer">
+                <input
+                  type="radio"
+                  name={`vis-edit-${event.id}`}
+                  value="submitter_visible"
+                  checked={editVisibility === 'submitter_visible'}
+                  onChange={() => setEditVisibility('submitter_visible')}
+                />
+                Submitter and team
+              </label>
+            </div>
+            {saveError && <p className="text-xs text-red-600 dark:text-red-400">{saveError}</p>}
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={saving}
+                className="px-3 py-1 rounded bg-blue-600 text-white text-xs hover:bg-blue-700 disabled:opacity-60"
+              >
+                {saving ? 'Saving…' : 'Save'}
+              </button>
+              <button
+                type="button"
+                onClick={() => { setEditing(false); setEditBody(event.note); }}
+                className="px-3 py-1 rounded border text-xs"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {!isNote && event.note && (
+          <p className="text-sm text-gray-600 dark:text-gray-300 mt-1 italic">{event.note}</p>
+        )}
+        {event.reason && (
+          <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">Reason: {event.reason}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function NoteForm({ ticketId, onNoteAdded }) {
+  const [body, setBody] = useState('');
+  const [visibility, setVisibility] = useState('team_only');
+  const [audienceLabel, setAudienceLabel] = useState('This note will be visible to: Maintenance team, Admin.');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    fetchNoteAudience(visibility)
+      .then((d) => setAudienceLabel(d.label))
+      .catch(() => {});
+  }, [visibility]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    if (!body.trim()) { setError('Note body is required.'); return; }
+    setSubmitting(true);
+    try {
+      const event = await createTicketNote(ticketId, { body: body.trim(), visibility });
+      onNoteAdded(event);
+      setBody('');
+      setVisibility('team_only');
+    } catch (err) {
+      setError(err?.response?.data?.body || err?.response?.data?.detail || err?.message || 'Failed to save note.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3" data-testid="note-form">
+      <textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        rows={3}
+        placeholder="Add a note…"
+        data-testid="note-body"
+        className="block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+      />
+      <div className="flex gap-4 text-sm">
+        <label className="flex items-center gap-1.5 cursor-pointer">
+          <input
+            type="radio"
+            name="visibility"
+            value="team_only"
+            checked={visibility === 'team_only'}
+            onChange={() => setVisibility('team_only')}
+          />
+          Team only
+        </label>
+        <label className="flex items-center gap-1.5 cursor-pointer">
+          <input
+            type="radio"
+            name="visibility"
+            value="submitter_visible"
+            checked={visibility === 'submitter_visible'}
+            onChange={() => setVisibility('submitter_visible')}
+          />
+          Submitter and team
+        </label>
+      </div>
+      <p className="text-xs text-gray-500 dark:text-gray-400 italic" data-testid="audience-disclosure">
+        {audienceLabel}
+      </p>
+      {error && <p role="alert" className="text-sm text-red-700 dark:text-red-300">{error}</p>}
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={submitting}
+          data-testid="note-submit"
+          className="inline-flex items-center px-4 min-h-[36px] rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-60"
+        >
+          {submitting ? 'Saving…' : 'Add note'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function TransitionActions({ ticket, onTransition, onUndo }) {
+  const isTerminal = ['fulfilled', 'unable_to_fulfill'].includes(ticket.status);
+  const canUndo = ticket.is_within_correction_window;
+
+  return (
+    <div
+      className="sticky bottom-0 bg-white dark:bg-gray-950 border-t border-gray-200 dark:border-gray-700 px-4 py-3 flex flex-wrap gap-2 justify-between items-center"
+      data-testid="ticket-actions"
+    >
+      <div className="flex flex-wrap gap-2">
+        {ticket.available_transitions?.map((next) => (
+          <button
+            key={next}
+            type="button"
+            onClick={() => onTransition(next)}
+            data-testid={`action-${next}`}
+            className={`inline-flex items-center px-4 min-h-[40px] rounded-lg text-sm font-medium ${
+              next === 'fulfilled'
+                ? 'bg-green-600 text-white hover:bg-green-700'
+                : next === 'unable_to_fulfill'
+                  ? 'border border-gray-300 dark:border-gray-700 text-gray-800 dark:text-gray-100 bg-white dark:bg-gray-800 hover:bg-gray-50'
+                  : next === 'in_progress'
+                    ? 'bg-blue-600 text-white hover:bg-blue-700'
+                    : 'border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 hover:bg-gray-50'
+            }`}
+          >
+            {TRANSITION_LABEL[next] || next}
+          </button>
+        ))}
+      </div>
+      {canUndo && (
+        <button
+          type="button"
+          onClick={onUndo}
+          data-testid="action-undo"
+          className="text-sm text-gray-500 dark:text-gray-400 hover:underline"
+        >
+          Undo last action
+        </button>
+      )}
+    </div>
+  );
+}
+
+function TransitionModal({ toState, ticket, onClose, onSubmitted }) {
+  const [note, setNote] = useState('');
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  if (!toState) return null;
+  const reasonRequired = toState === 'unable_to_fulfill' || toState === 'new';
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    const body = reasonRequired ? reason : note;
+    if (reasonRequired && body.trim().length < 10) {
+      setError('Please provide a reason (at least 10 characters).');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await transitionTicket(ticket.id, {
+        toState,
+        note: !reasonRequired ? (note.trim() || undefined) : reason.trim(),
+        reason: reasonRequired ? reason.trim() : undefined,
+      });
+      onSubmitted();
+    } catch (err) {
+      const d = err?.response?.data;
+      setError(d?.detail || d?.to_state || d?.reason || err?.message || 'Could not apply transition.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 px-4" role="dialog" aria-modal="true">
+      <div className="w-full sm:max-w-md bg-white dark:bg-gray-900 rounded-t-2xl sm:rounded-2xl shadow-xl p-4">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{TRANSITION_LABEL[toState] || toState}</h2>
+        <form onSubmit={handleSubmit} className="mt-3 space-y-3">
+          <label className="block text-sm">
+            <span className="text-gray-700 dark:text-gray-200">
+              {reasonRequired ? 'Reason (required)' : 'Note (optional)'}
+            </span>
+            <textarea
+              value={reasonRequired ? reason : note}
+              onChange={(e) => reasonRequired ? setReason(e.target.value) : setNote(e.target.value)}
+              rows={3}
+              required={reasonRequired}
+              className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+            />
+          </label>
+          {error && <p role="alert" className="text-sm text-red-700 dark:text-red-300">{error}</p>}
+          <div className="flex justify-end gap-2">
+            <button type="button" onClick={onClose} disabled={submitting} className="px-3 min-h-[40px] rounded-lg border text-sm">Cancel</button>
+            <button type="submit" disabled={submitting} className="px-4 min-h-[40px] rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-60">
+              {submitting ? 'Working…' : 'Apply'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default function TicketDetail() {
+  const { ticketId } = useParams();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [modal, setModal] = useState(null);
+  const activityRef = useRef(null);
+
+  const fromFilter = searchParams.get('from') || 'open';
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await fetchTicketDetail(ticketId);
+      setData(result);
+      setError('');
+    } catch (err) {
+      setError(err?.response?.data?.detail || err?.message || 'Failed to load ticket.');
+    } finally {
+      setLoading(false);
+    }
+  }, [ticketId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleNoteAdded = (event) => {
+    setData((prev) => ({
+      ...prev,
+      activity: [...(prev?.activity ?? []), event],
+    }));
+    activityRef.current?.lastElementChild?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  const handleNoteUpdated = (updated) => {
+    setData((prev) => ({
+      ...prev,
+      activity: prev.activity.map((e) => (e.id === updated.id ? updated : e)),
+    }));
+  };
+
+  const handleTransitionSubmitted = () => { setModal(null); load(); };
+
+  const handleUndo = async () => {
+    try {
+      await correctLastTransition(ticketId);
+      load();
+    } catch (err) {
+      alert(err?.response?.data?.detail || 'Could not undo transition.');
+    }
+  };
+
+  if (loading && !data) {
+    return <div className="px-4 py-6 max-w-2xl mx-auto"><p className="text-gray-500">Loading…</p></div>;
+  }
+
+  if (error && !data) {
+    return (
+      <div className="px-4 py-6 max-w-2xl mx-auto">
+        <div role="alert" className="rounded-xl border border-red-200 bg-red-50 dark:bg-red-900/20 px-4 py-3 text-sm text-red-800 dark:text-red-200">
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  const { ticket, photos = [], activity = [] } = data || {};
+  const isOpen = ticket && ['new', 'in_progress'].includes(ticket.status);
+
+  return (
+    <div className="max-w-2xl mx-auto pb-32" data-testid="ticket-detail">
+      {/* Header */}
+      <div className="sticky top-0 z-10 bg-white dark:bg-gray-950 border-b border-gray-200 dark:border-gray-700 px-4 py-3 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => navigate(`/maintenance?filter=${fromFilter}`)}
+          className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+          data-testid="back-button"
+        >
+          ← Queue
+        </button>
+        {ticket && (
+          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${STATUS_BADGE[ticket.status] || ''}`}>
+            {STATUS_LABEL[ticket.status] || ticket.status}
+          </span>
+        )}
+      </div>
+
+      {ticket && (
+        <div className="px-4 py-4 space-y-4">
+          {/* Ticket header section */}
+          <section data-testid="ticket-header">
+            <div className="flex items-start justify-between gap-2 flex-wrap">
+              <div>
+                <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
+                  {ticket.location}
+                </h1>
+                <p className="text-sm text-gray-600 dark:text-gray-400 mt-0.5">
+                  {ticket.category?.replace(/_/g, ' ')}
+                  {ticket.urgency === 'urgent' && (
+                    <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded-full bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-100 text-xs font-semibold">
+                      Urgent
+                    </span>
+                  )}
+                </p>
+                {ticket.urgency === 'urgent' && ticket.urgent_reason && (
+                  <p className="text-sm text-red-700 dark:text-red-300 mt-1">
+                    Reason: {ticket.urgent_reason}
+                  </p>
+                )}
+              </div>
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+              {ticket.submitter_name ? `Submitted by ${ticket.submitter_name} · ` : ''}
+              {ticket.created_at ? new Date(ticket.created_at).toLocaleString() : ''}
+            </p>
+          </section>
+
+          {/* Description */}
+          {ticket.description && (
+            <section data-testid="ticket-description">
+              <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-1">Description</h2>
+              <p className="text-sm text-gray-800 dark:text-gray-100 whitespace-pre-wrap">{ticket.description}</p>
+            </section>
+          )}
+
+          {/* Photos — original submission */}
+          {photos.filter((p) => !p.is_followup).length > 0 && (
+            <section data-testid="ticket-photos">
+              <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">Photos</h2>
+              <div className="flex flex-wrap gap-2">
+                {photos.filter((p) => !p.is_followup).map((p) => (
+                  <a
+                    key={p.id}
+                    href={p.image_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block w-20 h-20 rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700"
+                  >
+                    <img src={p.image_url} alt={p.caption || 'Ticket photo'} className="w-full h-full object-cover" />
+                  </a>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Activity */}
+          <section data-testid="ticket-activity">
+            <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">Activity</h2>
+            {activity.length === 0 ? (
+              <p className="text-sm text-gray-500 dark:text-gray-400">No activity yet.</p>
+            ) : (
+              <div ref={activityRef} className="space-y-0">
+                {activity.map((e) => (
+                  <ActivityEvent
+                    key={e.id}
+                    event={e}
+                    ticketId={ticketId}
+                    onNoteUpdated={handleNoteUpdated}
+                  />
+                ))}
+              </div>
+            )}
+
+            {/* Inline note form */}
+            {isOpen && (
+              <div className="mt-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 p-3">
+                <h3 className="text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">Add note</h3>
+                <NoteForm ticketId={ticketId} onNoteAdded={handleNoteAdded} />
+              </div>
+            )}
+          </section>
+        </div>
+      )}
+
+      {/* Actions pinned to bottom */}
+      {ticket && (
+        <TransitionActions
+          ticket={ticket}
+          onTransition={(toState) => setModal(toState)}
+          onUndo={handleUndo}
+        />
+      )}
+
+      {modal && (
+        <TransitionModal
+          toState={modal}
+          ticket={ticket}
+          onClose={() => setModal(null)}
+          onSubmitted={handleTransitionSubmitted}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/maintenance/__tests__/Queue.test.jsx
+++ b/frontend/src/pages/maintenance/__tests__/Queue.test.jsx
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import MaintenanceQueue from '../Queue';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: (...args) => postMock(...args),
+  },
+}));
+
+// useNavigate is used by Queue; stub it
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+beforeEach(() => {
+  getMock.mockReset();
+  postMock.mockReset();
+});
+
+const sampleTickets = [
+  {
+    id: 'aaaa1111-aaaa-1111-aaaa-111111111111',
+    status: 'new',
+    urgency: 'urgent',
+    location: 'Dining Hall',
+    category: 'plumbing',
+    description: 'Burst pipe',
+    submitter_name: 'Alex Smith',
+    age_seconds: 3600,
+    has_photos: false,
+    acknowledger: null,
+    available_transitions: ['in_progress', 'unable_to_fulfill'],
+    is_within_correction_window: false,
+    created_at: '2026-07-10T08:00:00Z',
+    updated_at: '2026-07-10T08:00:00Z',
+  },
+  {
+    id: 'bbbb2222-bbbb-2222-bbbb-222222222222',
+    status: 'in_progress',
+    urgency: 'normal',
+    location: 'Bunk 12',
+    category: 'broken_light',
+    description: 'Overhead light out',
+    submitter_name: 'Jordan Lee',
+    age_seconds: 7200,
+    has_photos: true,
+    acknowledger: { name: 'Mike T.', at: '2026-07-10T09:00:00Z' },
+    available_transitions: ['fulfilled', 'unable_to_fulfill'],
+    is_within_correction_window: true,
+    created_at: '2026-07-10T07:00:00Z',
+    updated_at: '2026-07-10T09:00:00Z',
+  },
+];
+
+const emptyPayload = { tickets: [], counts: { new: 0, in_progress: 0, urgent_open: 0 } };
+const samplePayload = { tickets: sampleTickets, counts: { new: 1, in_progress: 1, urgent_open: 1 } };
+
+function renderQueue() {
+  return render(
+    <MemoryRouter>
+      <MaintenanceQueue />
+    </MemoryRouter>,
+  );
+}
+
+describe('MaintenanceQueue', () => {
+  it('renders tickets from the API', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    renderQueue();
+    await waitFor(() => expect(screen.getByTestId('maint-queue-list')).toBeInTheDocument());
+    expect(screen.getByTestId(`ticket-row-${sampleTickets[0].id}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`ticket-row-${sampleTickets[1].id}`)).toBeInTheDocument();
+  });
+
+  it('shows header counts', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    renderQueue();
+    await waitFor(() => screen.getByTestId('maint-queue-counts'));
+    expect(screen.getByTestId('maint-queue-counts').textContent).toMatch(/1 new/);
+    expect(screen.getByTestId('maint-queue-counts').textContent).toMatch(/1 urgent/);
+  });
+
+  it('shows empty state when no tickets', async () => {
+    getMock.mockResolvedValueOnce({ data: emptyPayload });
+    renderQueue();
+    await waitFor(() => screen.getByTestId('maint-queue-empty'));
+    expect(screen.getByTestId('maint-queue-empty')).toBeInTheDocument();
+  });
+
+  it('status filters reload the queue', async () => {
+    getMock.mockResolvedValue({ data: emptyPayload });
+    renderQueue();
+    await waitFor(() => screen.getByTestId('filter-closed'));
+    await userEvent.click(screen.getByTestId('filter-closed'));
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2));
+    const secondCall = getMock.mock.calls[1][1];
+    expect(secondCall?.params?.filter).toBe('closed');
+  });
+
+  it('bulk bar appears when in-progress tickets selected', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    renderQueue();
+    await waitFor(() => screen.getByTestId(`ticket-select-${sampleTickets[1].id}`));
+    await userEvent.click(screen.getByTestId(`ticket-select-${sampleTickets[1].id}`));
+    expect(screen.getByTestId('maint-queue-bulk-bar')).toBeInTheDocument();
+  });
+
+  it('handles API error gracefully', async () => {
+    getMock.mockRejectedValueOnce(new Error('Network error'));
+    renderQueue();
+    await waitFor(() => screen.getByTestId('maint-queue-error'));
+    expect(screen.getByTestId('maint-queue-error').textContent).toMatch(/Network error/);
+  });
+});

--- a/frontend/src/pages/specialist/CamperPicker.jsx
+++ b/frontend/src/pages/specialist/CamperPicker.jsx
@@ -1,0 +1,168 @@
+/**
+ * Specialist camper picker — Step 7_9, Story 25.
+ *
+ * Two sections:
+ *   - Recent: campers noted in the last 7 days (max 8), shown before search results.
+ *   - All campers: full roster alphabetical, filtered by search query.
+ *
+ * Debounced 250ms search (criterion 4). Virtualized via CSS contain so the DOM
+ * doesn't stack on a 1,500-row list (full virtualisation lib kept out of scope
+ * for Tier 1 — results are paginated server-side at ≤1,500 rows which renders
+ * acceptably on mid-tier devices with CSS containment).
+ *
+ * Zero-results copy per criterion 9. Selecting a camper calls `onSelect(camper)`.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { fetchSpecialistCampers } from '../../api/specialist';
+
+const DEBOUNCE_MS = 250;
+
+function CamperRow({ camper, onSelect }) {
+  const preferred = camper.preferred_name;
+  const name = preferred
+    ? `${preferred} ${camper.last_name} (${camper.first_name})`
+    : `${camper.first_name} ${camper.last_name}`;
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onSelect(camper)}
+        className="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors text-left"
+        data-testid={`sp-camper-row-${camper.id}`}
+      >
+        <span className="flex-shrink-0 h-8 w-8 rounded-full bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase">
+          {(camper.first_name?.[0] || '') + (camper.last_name?.[0] || '')}
+        </span>
+        <span className="flex-1 min-w-0">
+          <span className="block text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            {name}
+          </span>
+          {camper.bunk_name && (
+            <span className="block text-xs text-gray-500 dark:text-gray-400 truncate">
+              {camper.bunk_name}
+            </span>
+          )}
+        </span>
+      </button>
+    </li>
+  );
+}
+
+function Section({ title, campers, onSelect, 'data-testid': testId }) {
+  if (!campers || campers.length === 0) return null;
+  return (
+    <div data-testid={testId}>
+      <p className="px-3 py-1.5 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide bg-gray-50 dark:bg-gray-800 sticky top-0">
+        {title}
+      </p>
+      <ul>
+        {campers.map((c) => (
+          <CamperRow key={c.id} camper={c} onSelect={onSelect} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default function CamperPicker({ onSelect, onCancel }) {
+  const [query, setQuery] = useState('');
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const debounceRef = useRef(null);
+  const inputRef = useRef(null);
+
+  const fetchCampers = useCallback(async (q) => {
+    setLoading(true);
+    try {
+      const result = await fetchSpecialistCampers({ q });
+      setData(result);
+      setError('');
+    } catch (err) {
+      setError(err?.message || 'Could not load campers.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchCampers('');
+    inputRef.current?.focus();
+  }, [fetchCampers]);
+
+  const handleQueryChange = (e) => {
+    const q = e.target.value;
+    setQuery(q);
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => fetchCampers(q), DEBOUNCE_MS);
+  };
+
+  useEffect(() => () => clearTimeout(debounceRef.current), []);
+
+  return (
+    <div className="flex flex-col h-full" data-testid="sp-camper-picker">
+      {/* Search bar */}
+      <div className="px-3 py-3 border-b border-gray-200 dark:border-gray-700 sticky top-0 bg-white dark:bg-gray-800 z-10">
+        <div className="flex items-center gap-2">
+          <input
+            ref={inputRef}
+            type="search"
+            value={query}
+            onChange={handleQueryChange}
+            placeholder="Search by name or bunk…"
+            aria-label="Search campers"
+            className="flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            data-testid="sp-camper-search"
+          />
+          {onCancel && (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="text-sm text-gray-500 dark:text-gray-400 px-2 py-2"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Results */}
+      <div className="flex-1 overflow-y-auto" style={{ contain: 'content' }}>
+        {loading && (
+          <p className="px-3 py-4 text-sm text-gray-500 dark:text-gray-400" data-testid="sp-picker-loading">
+            Loading…
+          </p>
+        )}
+        {error && !loading && (
+          <p className="px-3 py-4 text-sm text-red-600 dark:text-red-400" role="alert">{error}</p>
+        )}
+        {!loading && !error && data && (
+          <>
+            {!query && (
+              <Section
+                title="Recent"
+                campers={data.recent}
+                onSelect={onSelect}
+                data-testid="sp-picker-recent"
+              />
+            )}
+            {data.zero_results_message ? (
+              <p className="px-3 py-4 text-sm text-gray-500 dark:text-gray-400" data-testid="sp-picker-zero">
+                {data.zero_results_message}
+              </p>
+            ) : (
+              <Section
+                title={query ? 'Results' : 'All campers'}
+                campers={data.results}
+                onSelect={onSelect}
+                data-testid="sp-picker-results"
+              />
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/specialist/CamperView.jsx
+++ b/frontend/src/pages/specialist/CamperView.jsx
@@ -1,0 +1,244 @@
+/**
+ * Specialist-scoped camper view — Step 7_9, Story 28.
+ *
+ * Renders only the requesting Specialist's notes for this camper.
+ * No trend graph, no other roles' notes, no reflections, no flags.
+ * Server-side filtering (criterion 4); direct URL by non-Specialist returns 403.
+ *
+ * Sections:
+ *   - Camper header (name, bunk)
+ *   - Date-range filter (criterion 6)
+ *   - My notes about this camper (chronological, full body)
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { fetchSpecialistCamperView } from '../../api/specialist';
+
+const EDIT_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+function isWithinEditWindow(createdAt) {
+  if (!createdAt) return false;
+  const created = new Date(createdAt).getTime();
+  if (Number.isNaN(created)) return false;
+  return Date.now() - created <= EDIT_WINDOW_MS;
+}
+
+function NoteCard({ note }) {
+  const created = new Date(note.created_at);
+  const dateStr = created.toLocaleDateString(undefined, {
+    month: 'short', day: 'numeric', year: 'numeric',
+  });
+  const timeStr = created.toLocaleTimeString(undefined, {
+    hour: '2-digit', minute: '2-digit',
+  });
+  const editable = isWithinEditWindow(note.created_at);
+  const categoryLabel = note.category
+    ? note.category.charAt(0).toUpperCase() + note.category.slice(1)
+    : null;
+
+  return (
+    <article
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+      data-testid={`sp-camper-note-${note.id}`}
+    >
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <div className="flex items-center gap-2 flex-wrap">
+          {categoryLabel && (
+            <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200">
+              {categoryLabel}
+            </span>
+          )}
+          {note.is_sensitive && (
+            <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-200">
+              Sensitive
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="text-xs text-gray-500 dark:text-gray-400">{dateStr} {timeStr}</span>
+          {editable && (
+            <Link
+              to={`/specialist/notes/${note.id}/edit`}
+              state={{ note }}
+              className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              Edit
+            </Link>
+          )}
+        </div>
+      </div>
+      <p className="text-sm text-gray-800 dark:text-gray-200 whitespace-pre-wrap">{note.body}</p>
+      {note.updated_at && note.updated_at !== note.created_at && (
+        <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">
+          Edited {new Date(note.updated_at).toLocaleDateString()}
+        </p>
+      )}
+    </article>
+  );
+}
+
+export default function SpecialistCamperView() {
+  const { camperId } = useParams();
+  const navigate = useNavigate();
+
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [filterApplied, setFilterApplied] = useState(false);
+
+  const load = useCallback(async (from, to) => {
+    setLoading(true);
+    try {
+      const result = await fetchSpecialistCamperView(camperId, {
+        dateFrom: from || undefined,
+        dateTo: to || undefined,
+      });
+      setData(result);
+      setError('');
+    } catch (err) {
+      if (err?.response?.status === 403) {
+        setError("You don't have access to this view.");
+      } else {
+        setError(err?.message || 'Could not load camper data.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [camperId]);
+
+  useEffect(() => {
+    load('', '');
+  }, [load]);
+
+  const handleFilterApply = () => {
+    setFilterApplied(true);
+    load(dateFrom, dateTo);
+  };
+
+  const handleFilterClear = () => {
+    setDateFrom('');
+    setDateTo('');
+    setFilterApplied(false);
+    load('', '');
+  };
+
+  if (loading) {
+    return (
+      <div className="px-4 py-6 max-w-lg mx-auto" data-testid="sp-camper-view-loading">
+        <p className="text-sm text-gray-500 dark:text-gray-400">Loading…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="px-4 py-6 max-w-lg mx-auto space-y-3">
+        <p className="text-sm text-red-600 dark:text-red-400" role="alert">{error}</p>
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          className="text-sm text-blue-600 dark:text-blue-400 underline"
+        >
+          Go back
+        </button>
+      </div>
+    );
+  }
+
+  const camper = data?.camper;
+  const notes = data?.my_notes || [];
+
+  return (
+    <div className="px-4 py-6 max-w-lg mx-auto space-y-5" data-testid="sp-camper-view">
+      {/* Camper header */}
+      <header>
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          className="text-sm text-gray-500 dark:text-gray-400 mb-2 hover:underline"
+        >
+          ← Back
+        </button>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">{camper?.display_name}</h1>
+        {camper?.bunk_name && (
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+            {camper.bunk_name}
+            {camper.unit_name && ` · ${camper.unit_name}`}
+          </p>
+        )}
+      </header>
+
+      {/* Date-range filter (criterion 6) */}
+      <section
+        className="rounded-lg border border-gray-200 dark:border-gray-700 p-3 space-y-2"
+        aria-label="Date range filter"
+      >
+        <p className="text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">
+          Filter by date
+        </p>
+        <div className="flex items-center gap-2 flex-wrap">
+          <input
+            type="date"
+            value={dateFrom}
+            onChange={(e) => setDateFrom(e.target.value)}
+            className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-2 py-1 text-sm"
+            aria-label="From date"
+          />
+          <span className="text-sm text-gray-500">to</span>
+          <input
+            type="date"
+            value={dateTo}
+            onChange={(e) => setDateTo(e.target.value)}
+            className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-2 py-1 text-sm"
+            aria-label="To date"
+          />
+          <button
+            type="button"
+            onClick={handleFilterApply}
+            className="px-3 py-1 rounded-md bg-blue-600 text-white text-sm"
+          >
+            Apply
+          </button>
+          {filterApplied && (
+            <button
+              type="button"
+              onClick={handleFilterClear}
+              className="px-3 py-1 rounded-md border border-gray-300 dark:border-gray-600 text-sm text-gray-700 dark:text-gray-300"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      </section>
+
+      {/* Notes */}
+      <section aria-label="My notes about this camper">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+            My notes about this camper
+          </h2>
+          <Link
+            to={`/specialist/notes/new?camperId=${camper?.id}`}
+            className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            + Add note
+          </Link>
+        </div>
+        {notes.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {filterApplied
+              ? 'No notes in this date range.'
+              : 'No notes for this camper yet.'}
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {notes.map((note) => <NoteCard key={note.id} note={note} />)}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/specialist/Dashboard.jsx
+++ b/frontend/src/pages/specialist/Dashboard.jsx
@@ -1,0 +1,219 @@
+/**
+ * Specialist dashboard — Step 7_9, Story 24.
+ *
+ * Exactly three top-level elements (criterion 3):
+ *   1. Write a camper note — opens the camper picker.
+ *   2. My reflection — daily self-reflection card.
+ *   3. My recent notes — top 10 chronological, with Show older expansion.
+ *
+ * Header: user name, role label (from membership tags), active program.
+ * No operational signals, no bunk lists, no flag aggregates.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { fetchSpecialistDashboard } from '../../api/specialist';
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+function SelfReflectionCard({ selfReflection }) {
+  if (!selfReflection) return null;
+  const { state, reflection_id, template_id, editable } = selfReflection;
+
+  if (state === 'no_template') {
+    return (
+      <section
+        aria-label="My reflection"
+        className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+        data-testid="sp-self-reflection-card"
+      >
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-1">My reflection</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400">No reflection template configured.</p>
+      </section>
+    );
+  }
+
+  const isComplete = state === 'complete' || state === 'day_off';
+  const editPath = editable && reflection_id
+    ? `/specialist/self-reflection/${reflection_id}/edit`
+    : '/specialist/self-reflection/new';
+
+  return (
+    <section
+      aria-label="My reflection"
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+      data-testid="sp-self-reflection-card"
+    >
+      <div className="flex items-center justify-between mb-1">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white">My reflection</h2>
+        {isComplete ? (
+          <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200">
+            {state === 'day_off' ? 'Day off' : 'Done'}
+          </span>
+        ) : (
+          <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+            Pending
+          </span>
+        )}
+      </div>
+      <Link
+        to={editPath}
+        className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+      >
+        {isComplete ? (editable ? 'Edit reflection' : 'View reflection') : 'Start reflection'}
+      </Link>
+    </section>
+  );
+}
+
+function NoteRow({ note }) {
+  const categoryLabel = note.category
+    ? note.category.charAt(0).toUpperCase() + note.category.slice(1)
+    : null;
+  const date = note.created_at
+    ? new Date(note.created_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+    : '';
+
+  return (
+    <li className="py-3 first:pt-0 last:pb-0 border-b border-gray-100 dark:border-gray-700 last:border-0">
+      <Link
+        to={`/specialist/campers/${note.subject_id}`}
+        className="flex items-start gap-2 group"
+        data-testid={`sp-note-row-${note.id}`}
+      >
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+              {note.subject_name}
+            </span>
+            {note.bunk_name && (
+              <span className="text-xs text-gray-500 dark:text-gray-400">· {note.bunk_name}</span>
+            )}
+            {categoryLabel && (
+              <span className="text-xs text-gray-500 dark:text-gray-400">· {categoryLabel}</span>
+            )}
+            {note.is_sensitive && (
+              <span className="text-xs px-1.5 py-0.5 rounded bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-200">
+                Sensitive
+              </span>
+            )}
+            {note.flag_raised && (
+              <span className="text-xs px-1.5 py-0.5 rounded bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-200">
+                Flagged
+              </span>
+            )}
+          </div>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-0.5 line-clamp-1">
+            {note.body_preview}
+          </p>
+        </div>
+        <span className="text-xs text-gray-400 dark:text-gray-500 shrink-0 mt-0.5">{date}</span>
+      </Link>
+    </li>
+  );
+}
+
+export default function SpecialistDashboard() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  const load = useCallback(async (force = false) => {
+    try {
+      const result = await fetchSpecialistDashboard({ noCache: force });
+      setData(result);
+      setError('');
+    } catch (err) {
+      setError(err?.message || 'Could not load dashboard.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+    const interval = setInterval(() => load(), REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="px-4 py-6 max-w-lg mx-auto" data-testid="sp-dashboard-loading">
+        <p className="text-sm text-gray-500 dark:text-gray-400">Loading…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="px-4 py-6 max-w-lg mx-auto">
+        <p className="text-sm text-red-600 dark:text-red-400" role="alert">{error}</p>
+        <button
+          onClick={() => load(true)}
+          className="mt-2 text-sm text-blue-600 dark:text-blue-400 underline"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const { header, self_reflection, recent_notes = [] } = data || {};
+
+  return (
+    <div className="px-4 py-6 max-w-lg mx-auto space-y-5" data-testid="sp-dashboard">
+      {/* Header */}
+      <header>
+        <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+          {header?.role_label} · {header?.program_name}
+        </p>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white mt-0.5">
+          {header?.name}
+        </h1>
+      </header>
+
+      {/* 1. Write a camper note */}
+      <button
+        type="button"
+        onClick={() => navigate('/specialist/notes/new')}
+        className="w-full flex items-center justify-between rounded-xl border border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-900/20 px-4 py-3 text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors"
+        data-testid="sp-write-note-btn"
+      >
+        <span>Write a camper note</span>
+        <span aria-hidden="true">→</span>
+      </button>
+
+      {/* 2. My reflection */}
+      <SelfReflectionCard selfReflection={self_reflection} />
+
+      {/* 3. My recent notes */}
+      <section aria-label="My recent notes" data-testid="sp-recent-notes">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-3">
+          My recent notes
+        </h2>
+        {recent_notes.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            No notes yet. Use the button above to write your first.
+          </p>
+        ) : (
+          <>
+            <ul className="divide-y divide-gray-100 dark:divide-gray-700">
+              {recent_notes.map((note) => (
+                <NoteRow key={note.id} note={note} />
+              ))}
+            </ul>
+            {recent_notes.length >= 10 && (
+              <Link
+                to="/specialist/notes/history"
+                className="block mt-3 text-sm text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Show older notes
+              </Link>
+            )}
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/specialist/NoteForm.jsx
+++ b/frontend/src/pages/specialist/NoteForm.jsx
@@ -1,0 +1,375 @@
+/**
+ * Specialist note form — Step 7_9, Stories 26-27.
+ *
+ * Two modes:
+ *   - Create: route `/specialist/notes/new` — opens camper picker first,
+ *     then the form with the selected camper pre-populated.
+ *   - Edit: route `/specialist/notes/:noteId/edit` — populated from
+ *     `location.state.note`. Direct deep-links without state show a notice.
+ *
+ * Fields (Story 26 criterion 2):
+ *   - Body (required, plain text)
+ *   - Category (optional enum)
+ *   - Sensitive (boolean, default unchecked)
+ *   - Flag for Camper Care (boolean, default unchecked)
+ *   - Language
+ *
+ * AudienceDisclosure updates dynamically when Sensitive is toggled (criterion 5).
+ * Flag state cannot be changed after submission (Decision S5).
+ * Submit button is visible above the mobile keyboard via sticky footer.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
+import AudienceDisclosure from '../../components/AudienceDisclosure';
+import {
+  SPECIALIST_NOTE_CATEGORIES,
+  createSpecialistNote,
+  fetchSpecialistNoteAudience,
+  patchSpecialistNote,
+} from '../../api/specialist';
+import CamperPicker from './CamperPicker';
+
+function isWithinEditWindow(createdAt) {
+  if (!createdAt) return false;
+  const created = new Date(createdAt).getTime();
+  if (Number.isNaN(created)) return false;
+  return Date.now() - created <= 24 * 60 * 60 * 1000;
+}
+
+function FieldRow({ label, htmlFor, required, error, children, hint }) {
+  return (
+    <label htmlFor={htmlFor} className="block text-sm">
+      <span className="text-gray-800 dark:text-gray-100 font-medium">
+        {label}
+        {required && <span aria-hidden="true" className="text-red-600 ml-1">*</span>}
+      </span>
+      {hint && <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{hint}</p>}
+      <div className="mt-1">{children}</div>
+      {error && (
+        <p role="alert" className="text-xs text-red-700 dark:text-red-300 mt-1">{error}</p>
+      )}
+    </label>
+  );
+}
+
+export default function SpecialistNoteForm() {
+  const { noteId } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const initialFromState = location.state?.note || null;
+
+  const [showPicker, setShowPicker] = useState(!initialFromState && !noteId);
+  const [selectedCamper, setSelectedCamper] = useState(
+    initialFromState ? { id: initialFromState.subject_id } : null,
+  );
+  const [noteRow, setNoteRow] = useState(initialFromState);
+
+  const [body, setBody] = useState(initialFromState?.body ?? '');
+  const [category, setCategory] = useState(initialFromState?.category ?? '');
+  const [isSensitive, setIsSensitive] = useState(Boolean(initialFromState?.is_sensitive));
+  const [flagForCamperCare, setFlagForCamperCare] = useState(
+    Boolean(initialFromState?.flag_raised),
+  );
+  const [language, setLanguage] = useState(initialFromState?.language ?? 'en');
+
+  const [audience, setAudience] = useState([]);
+  const [audienceLoading, setAudienceLoading] = useState(true);
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [submitError, setSubmitError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [successNote, setSuccessNote] = useState(null);
+
+  const isEditMode = Boolean(noteRow?.id || noteId);
+  const editable = noteRow ? isWithinEditWindow(noteRow.created_at) : !isEditMode;
+  const flagAlreadyRaised = Boolean(noteRow?.flag_raised);
+
+  const loadAudience = useCallback(async (sensitive) => {
+    setAudienceLoading(true);
+    try {
+      const payload = await fetchSpecialistNoteAudience({ isSensitive: sensitive });
+      setAudience(payload.audience || []);
+    } catch {
+      setAudience([]);
+    } finally {
+      setAudienceLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadAudience(isSensitive);
+  }, [isSensitive, loadAudience]);
+
+  const handleCamperSelect = (camper) => {
+    setSelectedCamper(camper);
+    setShowPicker(false);
+  };
+
+  const validate = () => {
+    const errs = {};
+    if (!body.trim()) errs.body = 'Required.';
+    if (!selectedCamper && !noteRow) errs.subject = 'Select a camper first.';
+    setFieldErrors(errs);
+    return Object.keys(errs).length === 0;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitError('');
+    setSuccessNote(null);
+    if (!validate()) return;
+    setSubmitting(true);
+    try {
+      if (noteRow?.id) {
+        const updated = await patchSpecialistNote(noteRow.id, {
+          body: body.trim(),
+          category,
+          isSensitive,
+          language,
+        });
+        setNoteRow(updated);
+        setSuccessNote(updated);
+      } else {
+        const { data } = await createSpecialistNote({
+          subjectId: selectedCamper.id,
+          body: body.trim(),
+          category,
+          isSensitive,
+          flagForCamperCare,
+          language,
+        });
+        setNoteRow(data);
+        setSuccessNote(data);
+        navigate('/specialist', { replace: false });
+      }
+    } catch (err) {
+      const respData = err?.response?.data;
+      if (respData && typeof respData === 'object' && !Array.isArray(respData)) {
+        const flat = {};
+        Object.entries(respData).forEach(([k, v]) => {
+          flat[k] = Array.isArray(v) ? v.join(' ') : String(v);
+        });
+        setFieldErrors((prev) => ({ ...prev, ...flat }));
+        setSubmitError(respData.detail || 'Could not save note.');
+      } else {
+        setSubmitError(err?.message || 'Could not save note.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const heading = useMemo(() => {
+    if (noteRow?.id) return 'Edit specialist note';
+    return 'New specialist note';
+  }, [noteRow]);
+
+  if (showPicker) {
+    return (
+      <div className="h-screen flex flex-col bg-white dark:bg-gray-900" data-testid="sp-noteform-picker">
+        <header className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="text-sm text-gray-500 dark:text-gray-400"
+          >
+            ← Back
+          </button>
+          <h1 className="text-lg font-semibold text-gray-900 dark:text-white">Select camper</h1>
+        </header>
+        <CamperPicker onSelect={handleCamperSelect} onCancel={() => navigate(-1)} />
+      </div>
+    );
+  }
+
+  if (isEditMode && !noteRow) {
+    return (
+      <div className="px-4 py-6 max-w-lg mx-auto space-y-3">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Edit specialist note</h1>
+        <div
+          role="alert"
+          className="rounded-xl border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-900/30 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+          data-testid="sp-noteform-missing-state"
+        >
+          This page must be opened from the note success screen or the camper view edit link.
+        </div>
+        <Link
+          to="/specialist"
+          className="inline-flex items-center px-3 min-h-[40px] rounded-lg border border-gray-300 dark:border-gray-700 text-sm text-gray-800 dark:text-gray-100"
+        >
+          Back to dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  const formDisabled = isEditMode && !editable;
+
+  return (
+    <div className="px-4 py-6 pb-32 max-w-lg mx-auto" data-testid="sp-noteform">
+      <header className="mb-3">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">{heading}</h1>
+        {selectedCamper && (
+          <div className="flex items-center gap-2 mt-1">
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {selectedCamper.display_name ||
+                [selectedCamper.first_name, selectedCamper.last_name].filter(Boolean).join(' ')}
+              {selectedCamper.bunk_name && ` · ${selectedCamper.bunk_name}`}
+            </p>
+            {!isEditMode && (
+              <button
+                type="button"
+                onClick={() => setShowPicker(true)}
+                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Change
+              </button>
+            )}
+          </div>
+        )}
+        {formDisabled && (
+          <p className="text-sm text-amber-700 dark:text-amber-200 mt-1" data-testid="sp-noteform-window-closed">
+            This note is past the 24-hour edit window and can no longer be changed.
+          </p>
+        )}
+      </header>
+
+      <AudienceDisclosure
+        audience={audienceLoading ? [] : audience}
+        contextHint={
+          audienceLoading
+            ? 'Resolving audience…'
+            : isSensitive
+              ? 'Sensitive notes are visible only to Camper Care, Health Center, Special Diets, and Admin.'
+              : 'Non-sensitive notes are visible to Counselors, Unit Heads, Camper Care, Leadership Team, and Admin.'
+        }
+      />
+
+      <form onSubmit={handleSubmit} className="space-y-4 mt-4" data-testid="sp-noteform-form">
+        <FieldRow
+          label="Body"
+          htmlFor="sp-note-body"
+          required
+          error={fieldErrors.body}
+          hint="A sentence or two is fine."
+        >
+          <textarea
+            id="sp-note-body"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            rows={5}
+            disabled={formDisabled || submitting}
+            data-testid="sp-noteform-body"
+            className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+          />
+        </FieldRow>
+
+        <FieldRow label="Category" htmlFor="sp-note-category" error={fieldErrors.category}>
+          <select
+            id="sp-note-category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            disabled={formDisabled || submitting}
+            data-testid="sp-noteform-category"
+            className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+          >
+            <option value="">None</option>
+            {SPECIALIST_NOTE_CATEGORIES.map((c) => (
+              <option key={c.value} value={c.value}>{c.label}</option>
+            ))}
+          </select>
+        </FieldRow>
+
+        <fieldset
+          className="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2 space-y-2"
+          data-testid="sp-noteform-visibility-block"
+        >
+          <legend className="text-sm font-medium text-gray-800 dark:text-gray-100 px-1">Visibility & flags</legend>
+
+          <label className="flex items-start gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={isSensitive}
+              onChange={(e) => setIsSensitive(e.target.checked)}
+              disabled={formDisabled || submitting}
+              data-testid="sp-noteform-sensitive"
+              className="mt-1 h-4 w-4 rounded border-gray-300"
+            />
+            <span className="text-gray-700 dark:text-gray-200">
+              Sensitive — restrict to Camper Care, Health Center, Special Diets, and Admin.
+            </span>
+          </label>
+
+          <label className="flex items-start gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={flagForCamperCare}
+              onChange={(e) => setFlagForCamperCare(e.target.checked)}
+              disabled={formDisabled || submitting || flagAlreadyRaised}
+              data-testid="sp-noteform-flag"
+              className="mt-1 h-4 w-4 rounded border-gray-300"
+            />
+            <span className="text-gray-700 dark:text-gray-200">
+              Flag for Camper Care
+              {flagAlreadyRaised && (
+                <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">(raised — cannot retract)</span>
+              )}
+            </span>
+          </label>
+        </fieldset>
+
+        <FieldRow label="Language" htmlFor="sp-note-language">
+          <select
+            id="sp-note-language"
+            value={language}
+            onChange={(e) => setLanguage(e.target.value)}
+            disabled={formDisabled || submitting}
+            data-testid="sp-noteform-language"
+            className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+          >
+            <option value="en">English</option>
+            <option value="es">Spanish</option>
+          </select>
+        </FieldRow>
+
+        {fieldErrors.subject && (
+          <p role="alert" className="text-sm text-red-700 dark:text-red-300">{fieldErrors.subject}</p>
+        )}
+        {submitError && (
+          <p role="alert" className="text-sm text-red-700 dark:text-red-300" data-testid="sp-noteform-error">
+            {submitError}
+          </p>
+        )}
+        {successNote && (
+          <div
+            role="status"
+            className="rounded-md border border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-900/30 px-3 py-2 text-sm text-green-900 dark:text-green-100"
+            data-testid="sp-noteform-success"
+          >
+            Note {noteRow?.id ? 'updated' : 'added'}.
+          </div>
+        )}
+
+        <div className="fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 px-4 py-3 flex items-center justify-end gap-2 max-w-lg mx-auto">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="inline-flex items-center px-3 min-h-[44px] rounded-lg border border-gray-300 dark:border-gray-700 text-sm text-gray-800 dark:text-gray-100"
+            disabled={submitting}
+          >
+            Back
+          </button>
+          <button
+            type="submit"
+            disabled={formDisabled || submitting}
+            data-testid="sp-noteform-submit"
+            className="inline-flex items-center px-4 min-h-[44px] rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-60"
+          >
+            {submitting ? 'Saving…' : (noteRow?.id ? 'Save changes' : 'Add note')}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/specialist/SelfReflectionPage.jsx
+++ b/frontend/src/pages/specialist/SelfReflectionPage.jsx
@@ -1,0 +1,233 @@
+/**
+ * Specialist self-reflection form — Step 7_9, Story 29.
+ *
+ * Mirrors the Camper Care self-reflection form with two differences:
+ *   - No `bunk_concerns_bunks` field (Specialists have no caseload).
+ *   - Template may include an optional `camper_observation` field linking
+ *     to recent camper notes (criterion 8); rendered generically by ReflectionField.
+ *
+ * Edit window: until rollover boundary (today). Locked after.
+ * Visibility: Specialist, Leadership Team, Admin — NOT Unit Head (Decision S7).
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import ReflectionField from '../../components/templates/ReflectionField';
+import {
+  buildDefaultAnswers,
+  validateReflectionAnswers,
+} from '../../utils/reflection/reflectionFormValidation';
+import { fetchReflection, fetchTemplateById, newClientSubmissionId } from '../../api/counselor';
+import {
+  createSpecialistSelfReflection,
+  patchSpecialistSelfReflection,
+} from '../../api/specialist';
+
+const DAY_OFF_FIELD_KEY = 'day_off';
+
+function flattenError(err, fallback) {
+  const body = err?.response?.data;
+  if (!body) return err?.message || fallback;
+  if (typeof body === 'string') return body;
+  if (typeof body.detail === 'string') return body.detail;
+  if (typeof body === 'object') {
+    try { return JSON.stringify(body); } catch { return fallback; }
+  }
+  return fallback;
+}
+
+export default function SpecialistSelfReflectionPage() {
+  const { reflectionId } = useParams();
+  const navigate = useNavigate();
+  const isEdit = Boolean(reflectionId);
+
+  const [template, setTemplate] = useState(null);
+  const [answers, setAnswers] = useState({});
+  const [existingReflection, setExistingReflection] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState('');
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [submitted, setSubmitted] = useState(false);
+  const clientIdRef = useRef(newClientSubmissionId());
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      if (isEdit && reflectionId) {
+        const reflection = await fetchReflection(reflectionId);
+        setExistingReflection(reflection);
+        if (reflection.template?.id) {
+          const tpl = await fetchTemplateById(reflection.template.id);
+          setTemplate(tpl);
+          setAnswers(reflection.answers || buildDefaultAnswers(tpl.schema));
+        }
+      } else {
+        // New: load template from dashboard context (template_id from self_reflection.template_id)
+        // For now we load a known slug; the backend returns it in the dashboard payload.
+        // The form fetches the full template once we have the ID.
+        const dashRes = await import('../../api/specialist').then(m =>
+          m.fetchSpecialistDashboard(),
+        );
+        const templateId = dashRes?.self_reflection?.template_id;
+        if (templateId) {
+          const tpl = await fetchTemplateById(templateId);
+          setTemplate(tpl);
+          setAnswers(buildDefaultAnswers(tpl.schema));
+        }
+      }
+    } catch (err) {
+      setSubmitError(flattenError(err, 'Could not load reflection form.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [isEdit, reflectionId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const isDayOff = useMemo(
+    () => Boolean(answers[DAY_OFF_FIELD_KEY]),
+    [answers],
+  );
+
+  const nonDayOffFields = useMemo(() => {
+    if (!template?.schema?.fields) return [];
+    return template.schema.fields.filter((f) => f.key !== DAY_OFF_FIELD_KEY);
+  }, [template]);
+
+  const dayOffField = useMemo(
+    () => template?.schema?.fields?.find((f) => f.key === DAY_OFF_FIELD_KEY),
+    [template],
+  );
+
+  const handleAnswer = (key, value) => {
+    setAnswers((prev) => ({ ...prev, [key]: value }));
+    setFieldErrors((prev) => { const e = { ...prev }; delete e[key]; return e; });
+  };
+
+  const validate = () => {
+    if (!template || isDayOff) return true;
+    const errs = validateReflectionAnswers(template.schema, answers);
+    setFieldErrors(errs);
+    return Object.keys(errs).length === 0;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitError('');
+    if (!validate()) return;
+    setSubmitting(true);
+    try {
+      if (isEdit && reflectionId) {
+        await patchSpecialistSelfReflection(reflectionId, {
+          answers: isDayOff ? undefined : answers,
+          dayOff: isDayOff,
+          language: existingReflection?.language || 'en',
+        });
+      } else {
+        await createSpecialistSelfReflection({
+          answers: isDayOff ? undefined : answers,
+          dayOff: isDayOff,
+          language: 'en',
+          clientSubmissionId: clientIdRef.current,
+        });
+      }
+      setSubmitted(true);
+      setTimeout(() => navigate('/specialist'), 1500);
+    } catch (err) {
+      setSubmitError(flattenError(err, 'Could not save reflection.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="px-4 py-6 max-w-lg mx-auto" data-testid="sp-sr-loading">
+        <p className="text-sm text-gray-500 dark:text-gray-400">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!template) {
+    return (
+      <div className="px-4 py-6 max-w-lg mx-auto space-y-3">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">My reflection</h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400">No reflection template configured.</p>
+        <Link to="/specialist" className="text-sm text-blue-600 dark:text-blue-400 underline">
+          Back to dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 py-6 pb-32 max-w-lg mx-auto" data-testid="sp-sr-form">
+      <header className="mb-4">
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          className="text-sm text-gray-500 dark:text-gray-400 mb-2 hover:underline"
+        >
+          ← Back
+        </button>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">My reflection</h1>
+      </header>
+
+      {submitted && (
+        <div
+          role="status"
+          className="rounded-md border border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-900/30 px-3 py-2 text-sm text-green-900 dark:text-green-100 mb-4"
+        >
+          Reflection saved! Returning to dashboard…
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-5">
+        {dayOffField && (
+          <ReflectionField
+            field={dayOffField}
+            value={answers[dayOffField.key]}
+            onChange={(v) => handleAnswer(dayOffField.key, v)}
+            error={fieldErrors[dayOffField.key]}
+            disabled={submitting}
+          />
+        )}
+
+        {!isDayOff && nonDayOffFields.map((field) => (
+          <ReflectionField
+            key={field.key}
+            field={field}
+            value={answers[field.key]}
+            onChange={(v) => handleAnswer(field.key, v)}
+            error={fieldErrors[field.key]}
+            disabled={submitting}
+          />
+        ))}
+
+        {submitError && (
+          <p role="alert" className="text-sm text-red-700 dark:text-red-300">{submitError}</p>
+        )}
+
+        <div className="fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 px-4 py-3 flex items-center justify-end gap-2 max-w-lg mx-auto">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="inline-flex items-center px-3 min-h-[44px] rounded-lg border border-gray-300 dark:border-gray-700 text-sm text-gray-800 dark:text-gray-100"
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting || submitted}
+            data-testid="sp-sr-submit"
+            className="inline-flex items-center px-4 min-h-[44px] rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-60"
+          >
+            {submitting ? 'Saving…' : 'Save reflection'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/specialist/__tests__/CamperPicker.test.jsx
+++ b/frontend/src/pages/specialist/__tests__/CamperPicker.test.jsx
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import CamperPicker from '../CamperPicker';
+
+const getMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+  },
+}));
+
+beforeEach(() => {
+  getMock.mockReset();
+});
+
+const sampleData = {
+  recent: [
+    { id: 10, display_name: 'Recent Cam', first_name: 'Recent', last_name: 'Cam', bunk_name: 'Oak', preferred_name: null },
+  ],
+  results: [
+    { id: 11, display_name: 'Jake Smith', first_name: 'Jake', last_name: 'Smith', bunk_name: 'Elm', preferred_name: null },
+    { id: 12, display_name: 'Alice Johnson', first_name: 'Alice', last_name: 'Johnson', bunk_name: 'Pine', preferred_name: null },
+  ],
+  zero_results_message: null,
+};
+
+describe('CamperPicker', () => {
+  it('renders all campers in initial load', async () => {
+    getMock.mockResolvedValue({ data: sampleData });
+    render(<MemoryRouter><CamperPicker onSelect={vi.fn()} /></MemoryRouter>);
+    await waitFor(() => {
+      expect(screen.queryByTestId('sp-picker-loading')).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('sp-camper-row-11')).toBeInTheDocument();
+    expect(screen.getByTestId('sp-camper-row-12')).toBeInTheDocument();
+  });
+
+  it('renders Recent section when not searching', async () => {
+    getMock.mockResolvedValue({ data: sampleData });
+    render(<MemoryRouter><CamperPicker onSelect={vi.fn()} /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByTestId('sp-picker-recent')).toBeInTheDocument());
+    expect(screen.getByTestId('sp-camper-row-10')).toBeInTheDocument();
+  });
+
+  it('calls onSelect with camper when row is clicked', async () => {
+    const onSelect = vi.fn();
+    getMock.mockResolvedValue({ data: sampleData });
+    render(<MemoryRouter><CamperPicker onSelect={onSelect} /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByTestId('sp-camper-row-11')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('sp-camper-row-11'));
+    expect(onSelect).toHaveBeenCalledWith(sampleData.results[0]);
+  });
+
+  it('shows zero results message when no matches', async () => {
+    getMock.mockResolvedValue({
+      data: { recent: [], results: [], zero_results_message: 'No campers match XYZ.' },
+    });
+    render(<MemoryRouter><CamperPicker onSelect={vi.fn()} /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByTestId('sp-picker-zero')).toBeInTheDocument());
+    expect(screen.getByText(/No campers match XYZ/)).toBeInTheDocument();
+  });
+
+  it('does not fire second API call before debounce interval', async () => {
+    getMock.mockResolvedValue({ data: sampleData });
+    render(<MemoryRouter><CamperPicker onSelect={vi.fn()} /></MemoryRouter>);
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByTestId('sp-camper-search');
+    fireEvent.change(input, { target: { value: 'J' } });
+    fireEvent.change(input, { target: { value: 'Ja' } });
+    // Rapid typing should not fire immediately beyond the initial call
+    expect(getMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders 20 campers without error (performance proxy)', async () => {
+    const many = Array.from({ length: 20 }, (_, i) => ({
+      id: i + 1,
+      display_name: `Camper ${i}`,
+      first_name: 'Camper',
+      last_name: `${i}`,
+      bunk_name: 'Elm',
+      preferred_name: null,
+    }));
+    getMock.mockResolvedValue({ data: { recent: [], results: many, zero_results_message: null } });
+    render(<MemoryRouter><CamperPicker onSelect={vi.fn()} /></MemoryRouter>);
+    await waitFor(() => {
+      expect(screen.getByTestId('sp-camper-row-1')).toBeInTheDocument();
+    }, { timeout: 10000 });
+    expect(screen.getByTestId('sp-camper-row-20')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/specialist/__tests__/Dashboard.test.jsx
+++ b/frontend/src/pages/specialist/__tests__/Dashboard.test.jsx
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SpecialistDashboard from '../Dashboard';
+
+const getMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+  },
+}));
+
+beforeEach(() => {
+  getMock.mockReset();
+  window.sessionStorage?.clear?.();
+});
+
+const samplePayload = {
+  today: '2026-07-10',
+  header: { name: 'Alex Water', role_label: 'Waterfront Specialist', program_name: 'Summer 2026' },
+  write_camper_note: { url: '/specialist/notes/new' },
+  self_reflection: { state: 'missing', reflection_id: null, template_id: 5, editable: false },
+  recent_notes: [
+    {
+      id: 1,
+      subject_id: 42,
+      subject_name: 'Jake S.',
+      bunk_name: 'Elm',
+      category: 'positive',
+      body_preview: 'Great backstroke technique.',
+      is_sensitive: false,
+      flag_raised: false,
+      created_at: new Date().toISOString(),
+      is_within_edit_window: true,
+    },
+  ],
+};
+
+describe('SpecialistDashboard', () => {
+  it('renders all three sections', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    render(<MemoryRouter><SpecialistDashboard /></MemoryRouter>);
+    await waitFor(() => {
+      expect(screen.getByTestId('sp-dashboard')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('sp-write-note-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('sp-self-reflection-card')).toBeInTheDocument();
+    expect(screen.getByTestId('sp-recent-notes')).toBeInTheDocument();
+  });
+
+  it('shows role label and program in header', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    render(<MemoryRouter><SpecialistDashboard /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByTestId('sp-dashboard')).toBeInTheDocument());
+    expect(screen.getByText(/Waterfront Specialist/)).toBeInTheDocument();
+    expect(screen.getByText(/Alex Water/)).toBeInTheDocument();
+  });
+
+  it('renders recent notes with camper name and preview', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    render(<MemoryRouter><SpecialistDashboard /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByTestId('sp-dashboard')).toBeInTheDocument());
+    expect(screen.getByText('Jake S.')).toBeInTheDocument();
+    expect(screen.getByText('Great backstroke technique.')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no recent notes', async () => {
+    getMock.mockResolvedValueOnce({ data: { ...samplePayload, recent_notes: [] } });
+    render(<MemoryRouter><SpecialistDashboard /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByTestId('sp-recent-notes')).toBeInTheDocument());
+    expect(screen.getByText(/No notes yet/i)).toBeInTheDocument();
+  });
+
+  it('shows self-reflection as complete when state=complete', async () => {
+    const payload = {
+      ...samplePayload,
+      self_reflection: { state: 'complete', reflection_id: 7, template_id: 5, editable: true },
+    };
+    getMock.mockResolvedValueOnce({ data: payload });
+    render(<MemoryRouter><SpecialistDashboard /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByTestId('sp-self-reflection-card')).toBeInTheDocument());
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+
+  it('shows loading state initially', () => {
+    getMock.mockReturnValue(new Promise(() => {}));
+    render(<MemoryRouter><SpecialistDashboard /></MemoryRouter>);
+    expect(screen.getByTestId('sp-dashboard-loading')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/specialist/__tests__/NoteForm.test.jsx
+++ b/frontend/src/pages/specialist/__tests__/NoteForm.test.jsx
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import SpecialistNoteForm from '../NoteForm';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: (...args) => postMock(...args),
+    patch: (...args) => postMock(...args),
+  },
+}));
+
+const mockAudience = { audience: ['Counselor', 'Unit Head', 'Camper Care', 'Leadership Team', 'Admin'], is_sensitive: false };
+const mockSensitiveAudience = { audience: ['Camper Care', 'Health Center', 'Special Diets', 'Admin'], is_sensitive: true };
+
+beforeEach(() => {
+  getMock.mockReset();
+  postMock.mockReset();
+  getMock.mockResolvedValue({ data: mockAudience });
+});
+
+function renderNoteForm(routeState = {}, path = '/specialist/notes/new') {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: path, state: routeState }]}>
+      <Routes>
+        <Route path="/specialist/notes/new" element={<SpecialistNoteForm />} />
+        <Route path="/specialist/notes/:noteId/edit" element={<SpecialistNoteForm />} />
+        <Route path="/specialist" element={<div>dashboard</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('SpecialistNoteForm', () => {
+  it('shows camper picker first when no camper selected', async () => {
+    renderNoteForm();
+    await waitFor(() => {
+      expect(screen.getByTestId('sp-noteform-picker')).toBeInTheDocument();
+    });
+  });
+
+  it('renders form after camper is pre-selected via state', async () => {
+    const note = {
+      id: null,
+      subject_id: 42,
+      body: '',
+      category: '',
+      is_sensitive: false,
+      flag_raised: false,
+      language: 'en',
+    };
+    renderNoteForm({});
+    // The form opens picker first; we test the form state by providing a note via location.state
+  });
+
+  it('shows Flag for Camper Care checkbox in form', async () => {
+    getMock.mockResolvedValue({ data: mockAudience });
+    // Render form in edit mode with a note from location.state
+    const noteState = {
+      note: {
+        id: 7,
+        subject_id: 42,
+        body: 'Original body',
+        category: 'positive',
+        is_sensitive: false,
+        flag_raised: false,
+        language: 'en',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    };
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/specialist/notes/7/edit', state: noteState }]}>
+        <Routes>
+          <Route path="/specialist/notes/:noteId/edit" element={<SpecialistNoteForm />} />
+          <Route path="/specialist" element={<div>dashboard</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByTestId('sp-noteform-form')).toBeInTheDocument());
+    expect(screen.getByTestId('sp-noteform-flag')).toBeInTheDocument();
+  });
+
+  it('flag checkbox disabled when flag already raised', async () => {
+    const noteState = {
+      note: {
+        id: 7,
+        subject_id: 42,
+        body: 'Flagged note',
+        category: '',
+        is_sensitive: false,
+        flag_raised: true,
+        language: 'en',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    };
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/specialist/notes/7/edit', state: noteState }]}>
+        <Routes>
+          <Route path="/specialist/notes/:noteId/edit" element={<SpecialistNoteForm />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByTestId('sp-noteform-flag')).toBeInTheDocument());
+    expect(screen.getByTestId('sp-noteform-flag')).toBeDisabled();
+  });
+
+  it('audience disclosure updates when Sensitive is toggled', async () => {
+    getMock
+      .mockResolvedValueOnce({ data: mockAudience })
+      .mockResolvedValueOnce({ data: mockSensitiveAudience });
+
+    const noteState = {
+      note: {
+        id: 3,
+        subject_id: 42,
+        body: 'Test',
+        category: '',
+        is_sensitive: false,
+        flag_raised: false,
+        language: 'en',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    };
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/specialist/notes/3/edit', state: noteState }]}>
+        <Routes>
+          <Route path="/specialist/notes/:noteId/edit" element={<SpecialistNoteForm />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByTestId('sp-noteform-form')).toBeInTheDocument());
+    const sensitiveCheckbox = screen.getByTestId('sp-noteform-sensitive');
+    fireEvent.click(sensitiveCheckbox);
+    // Second audience fetch is triggered
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows window-closed message when note is outside 24h edit window', async () => {
+    const oldDate = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    const noteState = {
+      note: {
+        id: 5,
+        subject_id: 42,
+        body: 'Old note',
+        category: '',
+        is_sensitive: false,
+        flag_raised: false,
+        language: 'en',
+        created_at: oldDate,
+        updated_at: oldDate,
+      },
+    };
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/specialist/notes/5/edit', state: noteState }]}>
+        <Routes>
+          <Route path="/specialist/notes/:noteId/edit" element={<SpecialistNoteForm />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByTestId('sp-noteform-window-closed')).toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
## Summary

- **Backend:** New `api/maintenance/` package with queue, ticket detail, notes, and daily digest endpoints. Notes use `OrderActivityEvent(event_type='note')` with visibility stored in `metadata["visibility"]`. Urgency sort (Urgent → Normal → Low) then age enforced server-side. Closed-view search across description, location, category, and note bodies.
- **Frontend:** `Queue.jsx` with status filter chips, header counts, bulk-fulfill bar, and transition modal. `TicketDetail.jsx` with header/description/photos/activity sections, inline note form with AudienceDisclosure, and pinned TransitionActions with correction-window undo. Routes at `/maintenance` and `/maintenance/tickets/:id`.
- **Digest:** Celery task `maintenance.dispatch_daily_digests` fans out per org/program; per-org send time from `Organization.settings["maintenance_digest_time"]` (default `"06:00"`); 3+ consecutive failures emit Datadog-ready `logger.error`.

## Test plan

- [ ] Backend: `make test-backend` passes (996 passing, 1 pre-existing translation beat failure unrelated to this step)
- [ ] Frontend: `make test-frontend` passes (503 tests)
- [ ] Queue loads at `/maintenance` for a user with `maintenance` role
- [ ] Filter chips (Open / New / In Progress / Closed / All) reload the list
- [ ] Closed filter: search and date-range fields appear; search matches description/notes
- [ ] Ticket rows navigate to `/maintenance/tickets/:id` on click
- [ ] Ticket detail shows Header / Description / Photos / Activity sections
- [ ] Note form: visibility radio changes AudienceDisclosure copy dynamically
- [ ] Notes created as `event_type='note'` OrderActivityEvent; visible in Activity section
- [ ] Note edit affordance appears within 24h for the author; absent after window
- [ ] Transition actions pinned to bottom; "Undo last action" appears within 5-min window
- [ ] Bulk-select checkboxes on In Progress rows; bulk-fulfill bar appears on selection
- [ ] `Maintenance Staff` role cannot access camper-care or specialist endpoints
- [ ] Counselors cannot access `/api/v1/maintenance/queue/` (403)

Made with [Cursor](https://cursor.com)