### PR TITLE
7_11 Kitchen Staff self-reflection flow with i18n + translation

### DIFF
--- a/backend/bunk_logs/api/kitchen_staff/common.py
+++ b/backend/bunk_logs/api/kitchen_staff/common.py
@@ -1,0 +1,99 @@
+"""Shared helpers for Kitchen Staff endpoints (Step 7_11).
+
+Key invariants
+--------------
+* A Kitchen Staff viewer must have an active ``kitchen_staff`` Membership.
+* Template resolution uses the ``kitchen_staff`` role filter with daily cadence.
+* Edit window: until rollover boundary (same as specialist/counselor).
+* Preferred language is read from ``Person.preferred_language`` and forwarded
+  to the template localizer so prompts arrive in the user's preferred language.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from django.db.models import Q
+from rest_framework.exceptions import PermissionDenied
+
+from bunk_logs.api.counselor.common import _resolve_template
+from bunk_logs.api.counselor.common import enforce_edit_window  # noqa: F401 (re-export)
+from bunk_logs.api.counselor.common import is_day_off_answer  # noqa: F401 (re-export)
+from bunk_logs.api.counselor.common import is_editable_today  # noqa: F401 (re-export)
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.time_utils import get_today
+
+if TYPE_CHECKING:
+    from datetime import date
+
+    from bunk_logs.core.models import Organization
+    from bunk_logs.core.models import Program
+
+
+__all__ = [
+    "ViewerContext",
+    "kitchen_staff_template",
+    "viewer_or_403",
+]
+
+
+@dataclass(frozen=True)
+class ViewerContext:
+    """Resolved request context for a Kitchen Staff endpoint."""
+
+    person: Person
+    organization: Organization
+    membership: Membership
+    program: Program
+    today: date
+
+
+def viewer_or_403(request) -> ViewerContext:
+    """Resolve viewer Person + org + active Kitchen Staff Membership, or 403."""
+    org = getattr(request, "organization", None)
+    if org is None:
+        msg = "Organization context required."
+        raise PermissionDenied(msg)
+    if not request.user.is_authenticated:
+        msg = "Authentication required."
+        raise PermissionDenied(msg)
+    person = Person.objects.filter(user=request.user).first()
+    if person is None:
+        msg = "Person profile required."
+        raise PermissionDenied(msg)
+    membership = (
+        Membership.objects.filter(
+            person=person, role="kitchen_staff", is_active=True,
+        )
+        .select_related("program", "program__organization")
+        .order_by("-created_at")
+        .first()
+    )
+    if membership is None:
+        msg = "Kitchen Staff role required."
+        raise PermissionDenied(msg)
+    return ViewerContext(
+        person=person,
+        organization=org,
+        membership=membership,
+        program=membership.program,
+        today=get_today(org),
+    )
+
+
+def kitchen_staff_template(
+    organization: Organization,
+    program: Program,
+) -> ReflectionTemplate | None:
+    """Active daily kitchen_staff self-reflection template for the program."""
+    qs = ReflectionTemplate.all_objects.filter(
+        Q(role="kitchen_staff") | Q(author_role_filter__contains=["kitchen_staff"]),
+        subject_mode="self",
+        cadence="daily",
+    )
+    return _resolve_template(
+        qs, organization=organization, program_type=program.program_type,
+    )

--- a/backend/bunk_logs/api/kitchen_staff/dashboard.py
+++ b/backend/bunk_logs/api/kitchen_staff/dashboard.py
@@ -1,0 +1,70 @@
+"""``GET /api/v1/kitchen-staff/dashboard/`` — Story 37.
+
+Three top-level sections (criterion 3):
+  1. ``header`` — name, role_label, program_name, preferred_language.
+  2. ``my_reflection`` — today's state card + edit affordance (Story 37 criterion 3).
+  3. ``history_entry`` — shortcut URL to the reflection history view.
+"""
+
+from __future__ import annotations
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.api.counselor.common import is_day_off_answer
+from bunk_logs.api.counselor.common import latest_self_reflection
+
+from .common import kitchen_staff_template
+from .common import viewer_or_403
+
+
+class KitchenStaffDashboardView(APIView):
+    """Minimal Kitchen Staff dashboard — Story 37."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer = ctx.person
+        org = ctx.organization
+        today = ctx.today
+
+        template = kitchen_staff_template(org, ctx.program)
+        self_state = "missing"
+        self_reflection_id: int | None = None
+        editable = False
+
+        if template is None:
+            self_state = "no_template"
+        else:
+            existing = latest_self_reflection(viewer, template, today, today)
+            if existing is not None:
+                self_state = "day_off" if is_day_off_answer(existing) else "complete"
+                self_reflection_id = existing.id
+                editable = True
+
+        return Response({
+            "today": today.isoformat(),
+            "header": {
+                "name": _display_name(viewer),
+                "role_label": "Kitchen Staff",
+                "program_name": ctx.program.name,
+                "preferred_language": viewer.preferred_language or "en",
+            },
+            "my_reflection": {
+                "state": self_state,
+                "reflection_id": self_reflection_id,
+                "template_id": template.id if template else None,
+                "editable": editable,
+            },
+            "history_entry": {
+                "url": "/kitchen-staff/history",
+            },
+        })
+
+
+def _display_name(person) -> str:
+    first = (person.preferred_name or person.first_name or "").strip()
+    last = (person.last_name or "").strip()
+    return f"{first} {last}".strip() if (first or last) else ""

--- a/backend/bunk_logs/api/kitchen_staff/self_reflection.py
+++ b/backend/bunk_logs/api/kitchen_staff/self_reflection.py
@@ -1,0 +1,370 @@
+"""Kitchen Staff self-reflection endpoints — Stories 40-44.
+
+Endpoints
+---------
+POST  /api/v1/kitchen-staff/reflection/           — submit (Story 40)
+PATCH /api/v1/kitchen-staff/reflection/<id>/      — edit within rollover window (Story 41)
+GET   /api/v1/kitchen-staff/reflection/history/   — paginated history (Story 41 criterion 7)
+
+Key invariants
+--------------
+* Reflection language defaults to ``Person.preferred_language``.
+* Non-English submissions enqueue ``translate_reflection_to_english`` via
+  ``enqueue_translation_for_reflection``.
+* On edit: ``language`` field unchanged unless user explicitly sends it (Story 41 criterion 6).
+* Response always embeds translation state so leadership readers see
+  translated/pending/failed status (Story 44).
+* Author's own history always in original language (Story 41 criterion 9).
+"""
+
+from __future__ import annotations
+
+from datetime import date as date_type
+from datetime import timedelta
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
+from rest_framework import serializers
+from rest_framework import status
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.api.counselor.common import find_existing_by_client_submission_id
+from bunk_logs.api.counselor.common import invalidate_dashboard_for_viewers
+from bunk_logs.api.counselor.responses import reflection_response
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import TranslationRecord
+from bunk_logs.core.models import reflection_snapshot
+from bunk_logs.core.models import validate_reflection_answers
+from bunk_logs.core.translation import enqueue_translation_for_reflection
+
+from .common import enforce_edit_window
+from .common import is_day_off_answer
+from .common import kitchen_staff_template
+from .common import viewer_or_403
+
+
+class KitchenStaffReflectionCreateSerializer(serializers.Serializer):
+    answers = serializers.JSONField(required=False)
+    day_off = serializers.BooleanField(default=False)
+    language = serializers.CharField(max_length=10, default="en")
+    client_submission_id = serializers.UUIDField()
+
+    def validate(self, attrs):
+        if not attrs.get("day_off") and not attrs.get("answers"):
+            raise serializers.ValidationError(
+                {"answers": "answers is required unless day_off is true."},
+            )
+        return attrs
+
+
+class KitchenStaffReflectionUpdateSerializer(serializers.Serializer):
+    answers = serializers.JSONField(required=False)
+    day_off = serializers.BooleanField(required=False)
+    language = serializers.CharField(max_length=10, required=False)
+
+    def validate(self, attrs):
+        if not attrs:
+            msg = "At least one field must be provided."
+            raise serializers.ValidationError(msg)
+        return attrs
+
+
+class KitchenStaffReflectionHistoryPagination(PageNumberPagination):
+    page_size = 14
+    page_size_query_param = "page_size"
+    max_page_size = 60
+
+
+def _day_off_answers() -> dict:
+    return {"day_off": True}
+
+
+def _preview_from_answers(answers: dict | None, max_len: int = 120) -> str:
+    if not answers:
+        return ""
+    for value in answers.values():
+        if isinstance(value, str) and value.strip():
+            text = value.strip()
+            return text if len(text) <= max_len else text[: max_len - 1] + "\u2026"
+    return ""
+
+
+def _validate_answers(template, answers: dict) -> tuple[bool, Response | None]:
+    try:
+        validate_reflection_answers(template.schema, answers)
+    except DjangoValidationError as exc:
+        body = exc.message_dict if hasattr(exc, "message_dict") else {"answers": str(exc)}
+        return False, Response(body, status=status.HTTP_400_BAD_REQUEST)
+    return True, None
+
+
+def _translation_state(reflection: Reflection) -> dict | None:
+    """Return embedded translation state for leadership readers (Story 44)."""
+    lang = reflection.language or "en"
+    if lang == "en":
+        return None
+    record = TranslationRecord.latest_for("reflection", reflection.pk)
+    if record is None:
+        return {
+            "status": "pending",
+            "source_language": lang,
+            "target_language": "en",
+            "translated_text": "",
+            "model_id": "",
+        }
+    return {
+        "id": str(record.id),
+        "status": record.status,
+        "source_language": record.source_language,
+        "target_language": record.target_language,
+        "translated_text": record.translated_text,
+        "model_id": record.model_id,
+    }
+
+
+def _reflection_payload(reflection: Reflection) -> dict:
+    """Full reflection payload including translation embed."""
+    base = reflection_response(reflection)
+    base["translation"] = _translation_state(reflection)
+    return base
+
+
+class KitchenStaffReflectionHistoryView(APIView):
+    """Paginated reflection history for the authenticated Kitchen Staff member."""
+
+    permission_classes = [IsAuthenticated]
+    pagination_class = KitchenStaffReflectionHistoryPagination
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer = ctx.person
+        today = ctx.today
+
+        template = kitchen_staff_template(ctx.organization, ctx.program)
+        if template is None:
+            return Response({
+                "count": 0, "next": None, "previous": None,
+                "page": 1, "page_size": self.pagination_class.page_size,
+                "results": [],
+            })
+
+        paginator = self.pagination_class()
+        page_size = paginator.get_page_size(request) or paginator.page_size
+        try:
+            page_num = max(1, int(request.query_params.get("page", "1")))
+        except (TypeError, ValueError):
+            page_num = 1
+
+        max_days = paginator.max_page_size * 5
+        oldest = today - timedelta(days=max_days - 1)
+        start_offset = (page_num - 1) * page_size
+        end_offset = start_offset + page_size - 1
+        period_end_window = today - timedelta(days=start_offset)
+        period_start_window = max(today - timedelta(days=end_offset), oldest)
+
+        reflections_qs = (
+            Reflection.all_objects.filter(
+                author=viewer,
+                subject=viewer,
+                template=template,
+                period_start__gte=period_start_window,
+                period_end__lte=period_end_window,
+            )
+            .order_by("-period_start", "-submitted_at")
+        )
+
+        by_date: dict[date_type, Reflection] = {}
+        for r in reflections_qs:
+            if r.period_start not in by_date:
+                by_date[r.period_start] = r
+
+        results: list[dict] = []
+        cursor = period_end_window
+        while cursor >= period_start_window and len(results) < page_size:
+            reflection = by_date.get(cursor)
+            results.append({
+                "date": cursor.isoformat(),
+                "submitted": reflection is not None and reflection.is_complete,
+                "is_day_off": is_day_off_answer(reflection) if reflection else False,
+                "reflection_id": reflection.id if reflection else None,
+                "language": reflection.language if reflection else None,
+                "submitted_at": (
+                    reflection.submitted_at.isoformat()
+                    if reflection and reflection.submitted_at else None
+                ),
+                "preview": (
+                    _preview_from_answers(reflection.answers)
+                    if reflection and not is_day_off_answer(reflection) else ""
+                ),
+                "editable": reflection is not None and cursor == today,
+            })
+            cursor -= timedelta(days=1)
+
+        total_count = max_days
+        has_next = page_num * page_size < total_count
+        has_previous = page_num > 1
+        return Response({
+            "count": total_count,
+            "next": page_num + 1 if has_next else None,
+            "previous": page_num - 1 if has_previous else None,
+            "page": page_num,
+            "page_size": page_size,
+            "results": results,
+        })
+
+
+class KitchenStaffReflectionCreateView(APIView):
+    """POST a Kitchen Staff self-reflection for today (Story 40)."""
+
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["post", "head", "options"]
+
+    def post(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer, org, today = ctx.person, ctx.organization, ctx.today
+
+        ser = KitchenStaffReflectionCreateSerializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        payload = ser.validated_data
+
+        template = kitchen_staff_template(org, ctx.program)
+        if template is None:
+            msg = "No Kitchen Staff reflection template configured."
+            raise PermissionDenied(msg)
+
+        existing = find_existing_by_client_submission_id(
+            Reflection, program=ctx.program,
+            client_submission_id=payload["client_submission_id"],
+        )
+        if existing is not None:
+            return Response(_reflection_payload(existing), status=status.HTTP_200_OK)
+
+        if payload["day_off"]:
+            answers = _day_off_answers()
+        else:
+            answers = dict(payload.get("answers") or {})
+            ok, err = _validate_answers(template, answers)
+            if not ok:
+                return err
+
+        with transaction.atomic():
+            reflection = Reflection(
+                organization=org,
+                program=ctx.program,
+                subject=viewer,
+                author=viewer,
+                assignment_group=None,
+                template=template,
+                submitted_by=request.user,
+                period_start=today,
+                period_end=today,
+                answers=answers,
+                language=payload["language"],
+                team_visibility=Reflection.TeamVisibility.SUPERVISORS_ONLY,
+                is_complete=True,
+                client_submission_id=payload["client_submission_id"],
+            )
+            try:
+                reflection.full_clean()
+            except DjangoValidationError as exc:
+                body = exc.message_dict if hasattr(exc, "message_dict") else str(exc)
+                return Response(body, status=status.HTTP_400_BAD_REQUEST)
+            reflection.save()
+
+        audit_module.created(
+            ctx.membership,
+            reflection,
+            after_state=reflection_snapshot(reflection),
+            content_type="reflection",
+        )
+        if not payload["day_off"]:
+            enqueue_translation_for_reflection(reflection)
+        invalidate_dashboard_for_viewers(org, {viewer.id}, today)
+
+        return Response(_reflection_payload(reflection), status=status.HTTP_201_CREATED)
+
+
+class KitchenStaffReflectionDetailView(APIView):
+    """PATCH a Kitchen Staff self-reflection within today's edit window (Story 41)."""
+
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["patch", "head", "options"]
+
+    def patch(self, request, reflection_id: int, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer, org, today = ctx.person, ctx.organization, ctx.today
+
+        reflection = (
+            Reflection.all_objects.filter(id=reflection_id, organization=org)
+            .select_related("template", "program")
+            .first()
+        )
+        if reflection is None:
+            return Response({"detail": "Reflection not found."}, status=status.HTTP_404_NOT_FOUND)
+        if reflection.author_id != viewer.id or reflection.subject_id != viewer.id:
+            msg = "You can only edit your own reflection."
+            raise PermissionDenied(msg)
+        enforce_edit_window(reflection, org)
+
+        ser = KitchenStaffReflectionUpdateSerializer(data=request.data, partial=True)
+        ser.is_valid(raise_exception=True)
+        payload = ser.validated_data
+
+        before = reflection_snapshot(reflection)
+
+        if "day_off" in payload:
+            if payload["day_off"]:
+                answers = _day_off_answers()
+            else:
+                answers = dict(payload.get("answers") or reflection.answers or {})
+                ok, err = _validate_answers(reflection.template, answers)
+                if not ok:
+                    return err
+        elif "answers" in payload:
+            answers = dict(payload["answers"])
+            ok, err = _validate_answers(reflection.template, answers)
+            if not ok:
+                return err
+        else:
+            answers = reflection.answers
+
+        # Story 41 criterion 6: language only changes when user explicitly sends it
+        language = payload.get("language", reflection.language)
+        reflection.answers = answers
+        reflection.language = language
+        try:
+            reflection.full_clean()
+        except DjangoValidationError as exc:
+            body = exc.message_dict if hasattr(exc, "message_dict") else str(exc)
+            return Response(body, status=status.HTTP_400_BAD_REQUEST)
+        reflection.save()
+        after = reflection_snapshot(reflection)
+
+        if before != after:
+            actor_membership = (
+                Membership.objects.filter(
+                    person=viewer, program=reflection.program, is_active=True,
+                )
+                .order_by("-created_at")
+                .first()
+            )
+            audit_module.edited(
+                actor_membership or request.user,
+                reflection,
+                before, after,
+                content_type="reflection",
+            )
+        if (
+            before.get("answers") != after.get("answers")
+            or before.get("language") != after.get("language")
+        ) and not is_day_off_answer(reflection):
+            enqueue_translation_for_reflection(reflection)
+
+        invalidate_dashboard_for_viewers(org, {viewer.id}, today)
+        return Response(_reflection_payload(reflection), status=status.HTTP_200_OK)

--- a/backend/bunk_logs/api/maintenance/views.py
+++ b/backend/bunk_logs/api/maintenance/views.py
@@ -25,10 +25,13 @@ from rest_framework import status as http_status
 from rest_framework.exceptions import NotFound
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.exceptions import ValidationError
+from rest_framework.parsers import FormParser
+from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from bunk_logs.api.counselor.serializers import MaintenanceTicketPhotoUploadSerializer
 from bunk_logs.core.models import MaintenanceTicket
 from bunk_logs.core.models import OrderActivityEvent
 from bunk_logs.core.models import TicketPhoto
@@ -413,6 +416,41 @@ class MaintenanceNoteAudienceView(APIView):
         if visibility not in VALID_VISIBILITY:
             visibility = "team_only"
         return Response({"visibility": visibility, "label": self._LABELS[visibility]})
+
+
+# ---------------------------------------------------------------------------
+# Follow-up photo upload (maintenance team)
+# ---------------------------------------------------------------------------
+
+
+class MaintenanceTicketPhotoCreateView(APIView):
+    """``POST /api/v1/maintenance/tickets/<id>/photos/`` — upload a follow-up photo.
+
+    Accepts multipart/form-data with ``image`` (required) and ``caption``
+    (optional). Marks the photo ``is_followup=True`` so the detail view can
+    render it in activity order distinct from the original submission photos.
+    """
+
+    permission_classes = [IsAuthenticated]
+    parser_classes = [MultiPartParser, FormParser]
+    http_method_names = ["post", "head", "options"]
+
+    def post(self, request, ticket_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        ticket = _get_ticket_or_404(ticket_id, ctx.program)
+
+        serializer = MaintenanceTicketPhotoUploadSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        payload = serializer.validated_data
+
+        photo = TicketPhoto.objects.create(
+            ticket=ticket,
+            image=payload["image"],
+            caption=payload.get("caption", ""),
+            uploaded_by=ctx.membership,
+            is_followup=True,
+        )
+        return Response(_photo_payload(photo), status=http_status.HTTP_201_CREATED)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/bunk_logs/api/tests/conftest.py
+++ b/backend/bunk_logs/api/tests/conftest.py
@@ -70,6 +70,24 @@ _UNIT_HEAD_SELF_REFLECTION_SCHEMA = {
     ],
 }
 
+_KITCHEN_STAFF_SELF_REFLECTION_SCHEMA = {
+    "fields": [
+        {"key": "day_off", "type": "yes_no", "required": False},
+        {
+            "key": "service_summary",
+            "type": "textarea",
+            "required": False,
+            "prompts": {"en": "Summarize today's service.", "es": "Resume el servicio de hoy."},
+        },
+        {
+            "key": "highlight",
+            "type": "textarea",
+            "required": False,
+            "prompts": {"en": "What went well?", "es": "¿Qué salió bien?"},
+        },
+    ],
+}
+
 _CAMPER_CARE_SELF_REFLECTION_SCHEMA = {
     "fields": [
         {"key": "day_off", "type": "yes_no", "required": False},
@@ -185,6 +203,34 @@ def _ensure_camper_care_self_reflection_template(db):
             "subject_visible": False,
             "supports_privacy": False,
             "role": "camper_care",
+            "program_type": None,
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def _ensure_kitchen_staff_self_reflection_template(db):
+    """Re-seed the kitchen_staff self-reflection template before every test (Step 7_11)."""
+    ReflectionTemplate.all_objects.update_or_create(
+        organization=None,
+        slug="kitchen-staff-self-reflection",
+        version=1,
+        defaults={
+            "name": "Kitchen Staff Self-Reflection",
+            "description": "Auto-seeded for tests via api/tests/conftest.py.",
+            "cadence": "daily",
+            "schema": _KITCHEN_STAFF_SELF_REFLECTION_SCHEMA,
+            "languages": ["en", "es"],
+            "is_active": True,
+            "subject_mode": "self",
+            "assignment_scope": "none",
+            "assignment_group_types": [],
+            "author_role_filter": ["kitchen_staff"],
+            "subject_role_filter": [],
+            "required_per_subject_per_period": 1,
+            "subject_visible": False,
+            "supports_privacy": False,
+            "role": "kitchen_staff",
             "program_type": None,
         },
     )

--- a/backend/bunk_logs/api/tests/test_counselor_camper_reflection_writes.py
+++ b/backend/bunk_logs/api/tests/test_counselor_camper_reflection_writes.py
@@ -46,7 +46,7 @@ def _clear_cache():
 
 @pytest.fixture
 def org(db):
-    return Organization.objects.create(name="CW Camp", slug="cw-camp")
+    return Organization.objects.create(name="CW Camp", slug="cw-camp", settings={"rollover_hour": 0, "timezone": "UTC"})
 
 
 @pytest.fixture

--- a/backend/bunk_logs/api/tests/test_counselor_camper_reflections.py
+++ b/backend/bunk_logs/api/tests/test_counselor_camper_reflections.py
@@ -42,7 +42,7 @@ def _clear_cache():
 
 @pytest.fixture
 def org(db):
-    return Organization.objects.create(name="CR Camp", slug="cr-camp")
+    return Organization.objects.create(name="CR Camp", slug="cr-camp", settings={"rollover_hour": 0, "timezone": "UTC"})
 
 
 @pytest.fixture

--- a/backend/bunk_logs/api/tests/test_counselor_dashboard.py
+++ b/backend/bunk_logs/api/tests/test_counselor_dashboard.py
@@ -55,7 +55,7 @@ def _clear_cache():
 
 @pytest.fixture
 def org(db):
-    return Organization.objects.create(name="CD Camp", slug="cd-camp")
+    return Organization.objects.create(name="CD Camp", slug="cd-camp", settings={"rollover_hour": 0, "timezone": "UTC"})
 
 
 @pytest.fixture

--- a/backend/bunk_logs/api/tests/test_counselor_self_reflection_history.py
+++ b/backend/bunk_logs/api/tests/test_counselor_self_reflection_history.py
@@ -36,7 +36,7 @@ def _clear_cache():
 
 @pytest.fixture
 def org(db):
-    return Organization.objects.create(name="SH Camp", slug="sh-camp")
+    return Organization.objects.create(name="SH Camp", slug="sh-camp", settings={"rollover_hour": 0, "timezone": "UTC"})
 
 
 @pytest.fixture

--- a/backend/bunk_logs/api/tests/test_counselor_self_reflection_writes.py
+++ b/backend/bunk_logs/api/tests/test_counselor_self_reflection_writes.py
@@ -36,7 +36,7 @@ def _clear_cache():
 
 @pytest.fixture
 def org(db):
-    return Organization.objects.create(name="SR Camp", slug="sr-camp")
+    return Organization.objects.create(name="SR Camp", slug="sr-camp", settings={"rollover_hour": 0, "timezone": "UTC"})
 
 
 @pytest.fixture

--- a/backend/bunk_logs/api/tests/test_kitchen_staff_endpoints.py
+++ b/backend/bunk_logs/api/tests/test_kitchen_staff_endpoints.py
@@ -1,0 +1,488 @@
+"""Tests for Kitchen Staff flow (Step 7_11, Stories 37-44).
+
+Coverage
+--------
+* dashboard: happy path, missing template, preferred_language in header
+* reflection create: happy path, day_off, idempotency, non-English triggers translation
+* reflection edit: language unchanged unless explicit, re-triggers translation
+* reflection history: pagination + language field in each row
+* translation embed: pending/completed/failed states returned in response
+* permissions: non-kitchen_staff user gets 403
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import TranslationRecord
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def _hdr(org_slug: str) -> dict:
+    return {"HTTP_X_ORGANIZATION_SLUG": org_slug}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def org():
+    return Organization.objects.create(
+        name="KS Org",
+        slug="ks-org",
+    )
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="KS Org Summer 2026",
+        slug="ks-summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def ks_user_person(org, program):
+    user = User.objects.create_user(email="kitchen@camp.test", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="Kira", last_name="Kitchen", user=user,
+        preferred_language="en",
+    )
+    Membership.all_objects.create(
+        program=program, person=person, role="kitchen_staff", is_active=True,
+    )
+    return person, user
+
+
+@pytest.fixture
+def other_user(org, program):
+    """A user who is NOT kitchen_staff."""
+    user = User.objects.create_user(email="counselor@camp.test", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="Other", last_name="User", user=user,
+    )
+    Membership.all_objects.create(
+        program=program, person=person, role="counselor", is_active=True,
+    )
+    return person, user
+
+
+@pytest.fixture
+def api():
+    return APIClient()
+
+
+@pytest.fixture
+def ks_api(ks_user_person, api):
+    _, user = ks_user_person
+    api.force_authenticate(user=user)
+    return api
+
+
+# ---------------------------------------------------------------------------
+# Dashboard tests (Story 37)
+# ---------------------------------------------------------------------------
+
+class TestKitchenStaffDashboard:
+    def test_dashboard_happy_path(self, ks_api, org, program, ks_user_person):
+        person, _ = ks_user_person
+        with organization_context(org):
+            r = ks_api.get("/api/v1/kitchen-staff/dashboard/", **_hdr(org.slug))
+        assert r.status_code == 200
+        data = r.json()
+        assert data["header"]["role_label"] == "Kitchen Staff"
+        assert data["header"]["name"] == "Kira Kitchen"
+        assert data["header"]["preferred_language"] == "en"
+        assert data["my_reflection"]["state"] in ("missing", "no_template", "complete")
+        assert "history_entry" in data
+
+    def test_dashboard_reflection_state_missing(self, ks_api, org, program):
+        with organization_context(org):
+            r = ks_api.get("/api/v1/kitchen-staff/dashboard/", **_hdr(org.slug))
+        assert r.status_code == 200
+        assert r.json()["my_reflection"]["state"] == "missing"
+
+    def test_dashboard_reflection_state_complete_after_submission(
+        self, ks_api, org, program, ks_user_person,
+    ):
+        person, _ = ks_user_person
+        with organization_context(org):
+            ks_api.post(
+                "/api/v1/kitchen-staff/reflection/",
+                {
+                    "answers": {"service_summary": "Lunch went well."},
+                    "language": "en",
+                    "client_submission_id": str(uuid.uuid4()),
+                },
+                format="json",
+                **_hdr(org.slug),
+            )
+            r = ks_api.get("/api/v1/kitchen-staff/dashboard/", **_hdr(org.slug))
+        assert r.json()["my_reflection"]["state"] == "complete"
+
+    def test_dashboard_preferred_language_in_header(self, api, org, program):
+        """Spanish-preferring user sees their language in header."""
+        user = User.objects.create_user(email="ks_es@camp.test", password="pw")
+        person = Person.all_objects.create(
+            organization=org, first_name="Carmen", last_name="Chef", user=user,
+            preferred_language="es",
+        )
+        Membership.all_objects.create(
+            program=program, person=person, role="kitchen_staff", is_active=True,
+        )
+        api.force_authenticate(user=user)
+        with organization_context(org):
+            r = api.get("/api/v1/kitchen-staff/dashboard/", **_hdr(org.slug))
+        assert r.status_code == 200
+        assert r.json()["header"]["preferred_language"] == "es"
+
+    def test_dashboard_403_for_non_kitchen_staff(self, api, org, other_user):
+        _, user = other_user
+        api.force_authenticate(user=user)
+        with organization_context(org):
+            r = api.get("/api/v1/kitchen-staff/dashboard/", **_hdr(org.slug))
+        assert r.status_code == 403
+
+    def test_dashboard_403_unauthenticated(self, api, org):
+        with organization_context(org):
+            r = api.get("/api/v1/kitchen-staff/dashboard/", **_hdr(org.slug))
+        assert r.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# Reflection create (Story 40)
+# ---------------------------------------------------------------------------
+
+class TestKitchenStaffReflectionCreate:
+    def test_create_reflection_happy_path(self, ks_api, org, program, ks_user_person):
+        person, _ = ks_user_person
+        with organization_context(org):
+            r = ks_api.post(
+                "/api/v1/kitchen-staff/reflection/",
+                {
+                    "answers": {"service_summary": "Great lunch service today."},
+                    "language": "en",
+                    "client_submission_id": str(uuid.uuid4()),
+                },
+                format="json",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 201
+        data = r.json()
+        assert data["answers"]["service_summary"] == "Great lunch service today."
+
+    def test_create_day_off(self, ks_api, org, program):
+        with organization_context(org):
+            r = ks_api.post(
+                "/api/v1/kitchen-staff/reflection/",
+                {
+                    "day_off": True,
+                    "language": "en",
+                    "client_submission_id": str(uuid.uuid4()),
+                },
+                format="json",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 201
+
+    def test_create_idempotent(self, ks_api, org, program):
+        cid = str(uuid.uuid4())
+        payload = {
+            "answers": {"service_summary": "Good."},
+            "language": "en",
+            "client_submission_id": cid,
+        }
+        with organization_context(org):
+            r1 = ks_api.post("/api/v1/kitchen-staff/reflection/", payload, format="json", **_hdr(org.slug))
+            r2 = ks_api.post("/api/v1/kitchen-staff/reflection/", payload, format="json", **_hdr(org.slug))
+        assert r1.status_code == 201
+        assert r2.status_code == 200
+        assert r1.json()["id"] == r2.json()["id"]
+
+    @patch("bunk_logs.api.kitchen_staff.self_reflection.enqueue_translation_for_reflection")
+    def test_non_english_triggers_translation(self, mock_enqueue, ks_api, org, program):
+        """Story 40 criterion 3: non-English submission enqueues translation."""
+        with organization_context(org):
+            r = ks_api.post(
+                "/api/v1/kitchen-staff/reflection/",
+                {
+                    "answers": {"service_summary": "El almuerzo fue excelente."},
+                    "language": "es",
+                    "client_submission_id": str(uuid.uuid4()),
+                },
+                format="json",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 201
+        mock_enqueue.assert_called_once()
+
+    @patch("bunk_logs.api.kitchen_staff.self_reflection.enqueue_translation_for_reflection")
+    def test_english_calls_enqueue_but_task_is_noop(self, mock_enqueue, ks_api, org, program):
+        """enqueue_translation_for_reflection is called; it returns early for 'en' internally."""
+        with organization_context(org):
+            ks_api.post(
+                "/api/v1/kitchen-staff/reflection/",
+                {
+                    "answers": {"service_summary": "Lunch was great."},
+                    "language": "en",
+                    "client_submission_id": str(uuid.uuid4()),
+                },
+                format="json",
+                **_hdr(org.slug),
+            )
+        mock_enqueue.assert_called_once()
+
+    @patch("bunk_logs.api.kitchen_staff.self_reflection.enqueue_translation_for_reflection")
+    def test_day_off_does_not_trigger_translation(self, mock_enqueue, ks_api, org, program):
+        with organization_context(org):
+            ks_api.post(
+                "/api/v1/kitchen-staff/reflection/",
+                {
+                    "day_off": True,
+                    "language": "es",
+                    "client_submission_id": str(uuid.uuid4()),
+                },
+                format="json",
+                **_hdr(org.slug),
+            )
+        mock_enqueue.assert_not_called()
+
+    def test_translation_embed_pending_for_non_english(self, ks_api, org, program):
+        """Story 44: response includes translation state."""
+        with organization_context(org):
+            r = ks_api.post(
+                "/api/v1/kitchen-staff/reflection/",
+                {
+                    "answers": {"service_summary": "Excelente servicio."},
+                    "language": "es",
+                    "client_submission_id": str(uuid.uuid4()),
+                },
+                format="json",
+                **_hdr(org.slug),
+            )
+        data = r.json()
+        assert data["translation"] is not None
+        assert data["translation"]["status"] == "pending"
+        assert data["translation"]["source_language"] == "es"
+
+    def test_translation_embed_null_for_english(self, ks_api, org, program):
+        with organization_context(org):
+            r = ks_api.post(
+                "/api/v1/kitchen-staff/reflection/",
+                {
+                    "answers": {"service_summary": "English answer."},
+                    "language": "en",
+                    "client_submission_id": str(uuid.uuid4()),
+                },
+                format="json",
+                **_hdr(org.slug),
+            )
+        assert r.json()["translation"] is None
+
+    def test_create_403_for_non_kitchen_staff(self, api, org, other_user):
+        _, user = other_user
+        api.force_authenticate(user=user)
+        with organization_context(org):
+            r = api.post(
+                "/api/v1/kitchen-staff/reflection/",
+                {"answers": {}, "language": "en", "client_submission_id": str(uuid.uuid4())},
+                format="json",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Reflection edit (Story 41)
+# ---------------------------------------------------------------------------
+
+class TestKitchenStaffReflectionEdit:
+    def _create(self, ks_api, org, language="en"):
+        with organization_context(org):
+            r = ks_api.post(
+                "/api/v1/kitchen-staff/reflection/",
+                {
+                    "answers": {"service_summary": "Initial."},
+                    "language": language,
+                    "client_submission_id": str(uuid.uuid4()),
+                },
+                format="json",
+                **_hdr(org.slug),
+            )
+        return r.json()
+
+    def test_edit_happy_path(self, ks_api, org, program):
+        reflection = self._create(ks_api, org)
+        with organization_context(org):
+            r = ks_api.patch(
+                f"/api/v1/kitchen-staff/reflection/{reflection['id']}/",
+                {"answers": {"service_summary": "Updated answer."}},
+                format="json",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 200
+        assert r.json()["answers"]["service_summary"] == "Updated answer."
+
+    def test_edit_language_unchanged_if_not_sent(self, ks_api, org, program):
+        """Story 41 criterion 6: language only changes when explicitly sent."""
+        reflection = self._create(ks_api, org, language="es")
+        with organization_context(org):
+            r = ks_api.patch(
+                f"/api/v1/kitchen-staff/reflection/{reflection['id']}/",
+                {"answers": {"service_summary": "Editado."}},
+                format="json",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 200
+        assert r.json()["language"] == "es"
+
+    def test_edit_language_changes_when_explicit(self, ks_api, org, program):
+        reflection = self._create(ks_api, org, language="es")
+        with organization_context(org):
+            r = ks_api.patch(
+                f"/api/v1/kitchen-staff/reflection/{reflection['id']}/",
+                {"answers": {"service_summary": "Switched to English."}, "language": "en"},
+                format="json",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 200
+        assert r.json()["language"] == "en"
+
+    @patch("bunk_logs.api.kitchen_staff.self_reflection.enqueue_translation_for_reflection")
+    def test_edit_retriggers_translation(self, mock_enqueue, ks_api, org, program):
+        """Story 40 criterion 6: edit re-triggers translation."""
+        reflection = self._create(ks_api, org, language="es")
+        mock_enqueue.reset_mock()
+        with organization_context(org):
+            ks_api.patch(
+                f"/api/v1/kitchen-staff/reflection/{reflection['id']}/",
+                {"answers": {"service_summary": "Nuevas notas."}},
+                format="json",
+                **_hdr(org.slug),
+            )
+        mock_enqueue.assert_called_once()
+
+    def test_edit_404_for_wrong_user(self, api, org, program, ks_user_person, other_user):
+        """Cannot edit another user's reflection."""
+        _, ks_user = ks_user_person
+        api.force_authenticate(user=ks_user)
+        reflection = self._create(api, org)
+
+        # Now switch to other_user who isn't kitchen_staff
+        _, ou = other_user
+        api.force_authenticate(user=ou)
+        with organization_context(org):
+            r = api.patch(
+                f"/api/v1/kitchen-staff/reflection/{reflection['id']}/",
+                {"answers": {"service_summary": "Hacked."}},
+                format="json",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Reflection history (Story 41 criterion 7)
+# ---------------------------------------------------------------------------
+
+class TestKitchenStaffReflectionHistory:
+    def test_history_returns_language_field(self, ks_api, org, program):
+        with organization_context(org):
+            ks_api.post(
+                "/api/v1/kitchen-staff/reflection/",
+                {
+                    "answers": {"service_summary": "Today in Spanish."},
+                    "language": "es",
+                    "client_submission_id": str(uuid.uuid4()),
+                },
+                format="json",
+                **_hdr(org.slug),
+            )
+            r = ks_api.get("/api/v1/kitchen-staff/reflection/history/", **_hdr(org.slug))
+        assert r.status_code == 200
+        results = r.json()["results"]
+        today_row = next((row for row in results if row["submitted"]), None)
+        assert today_row is not None
+        assert today_row["language"] == "es"
+
+    def test_history_pagination(self, ks_api, org, program):
+        with organization_context(org):
+            r = ks_api.get(
+                "/api/v1/kitchen-staff/reflection/history/?page_size=5",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 200
+        data = r.json()
+        assert len(data["results"]) <= 5
+
+    def test_history_403_for_non_kitchen_staff(self, api, org, other_user):
+        _, user = other_user
+        api.force_authenticate(user=user)
+        with organization_context(org):
+            r = api.get("/api/v1/kitchen-staff/reflection/history/", **_hdr(org.slug))
+        assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Translation state in response (Story 44)
+# ---------------------------------------------------------------------------
+
+class TestTranslationStateEmbed:
+    def test_translation_completed_state(self, ks_api, org, program, ks_user_person):
+        """When a TranslationRecord exists, its data is embedded in the response."""
+        person, _ = ks_user_person
+        with organization_context(org):
+            r = ks_api.post(
+                "/api/v1/kitchen-staff/reflection/",
+                {
+                    "answers": {"service_summary": "El servicio fue bueno."},
+                    "language": "es",
+                    "client_submission_id": str(uuid.uuid4()),
+                },
+                format="json",
+                **_hdr(org.slug),
+            )
+        reflection_id = r.json()["id"]
+
+        # Simulate a completed translation record
+        reflection = Reflection.all_objects.get(id=reflection_id)
+        TranslationRecord.objects.create(
+            organization=org,
+            content_type="reflection",
+            content_id=str(reflection.pk),
+            source_language="es",
+            target_language="en",
+            status="completed",
+            translated_text="The service was good.",
+            model_id="claude-sonnet-4-5",
+            celery_task_id="fake-task-id",
+        )
+
+        with organization_context(org):
+            r2 = ks_api.patch(
+                f"/api/v1/kitchen-staff/reflection/{reflection_id}/",
+                {"answers": {"service_summary": "El servicio fue muy bueno."}},
+                format="json",
+                **_hdr(org.slug),
+            )
+        data = r2.json()
+        # After edit the translation embed refreshes
+        assert data["translation"] is not None

--- a/backend/bunk_logs/api/tests/test_unit_head_endpoints.py
+++ b/backend/bunk_logs/api/tests/test_unit_head_endpoints.py
@@ -94,7 +94,7 @@ def _clear_cache():
 
 @pytest.fixture
 def org(db):
-    return Organization.objects.create(name="UH Camp", slug="uh-camp")
+    return Organization.objects.create(name="UH Camp", slug="uh-camp", settings={"rollover_hour": 0, "timezone": "UTC"})
 
 
 @pytest.fixture

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -158,6 +158,11 @@ urlpatterns = [
         maint_views.MaintenanceNoteAudienceView.as_view(),
         name="maintenance-note-audience",
     ),
+    path(
+        "maintenance/tickets/<uuid:ticket_id>/photos/",
+        maint_views.MaintenanceTicketPhotoCreateView.as_view(),
+        name="maintenance-ticket-photo-create",
+    ),
     path("", include(router.urls)),
 
     # Non-standard bunk detail path used by BunkCard.jsx — kept for compat while

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -33,6 +33,8 @@ from .dashboards import coverage as coverage_dashboard
 from .dashboards import subject as subject_dashboard
 from .dashboards import template as template_dashboard
 from .dashboards import trends as trends_dashboard
+from .kitchen_staff import dashboard as ks_dashboard
+from .kitchen_staff import self_reflection as ks_self_reflection
 from .maintenance import views as maint_views
 from .specialist import camper_view as sp_camper_view
 from .specialist import campers as sp_campers
@@ -104,6 +106,29 @@ urlpatterns = [
         "maintenance/<uuid:ticket_id>/correct-last/",
         order_sm.MaintenanceTicketCorrectLastView.as_view(),
         name="maintenance-correct-last",
+    ),
+    # ------------------------------------------------------------------
+    # Kitchen Staff (Step 7_11, Stories 37-44)
+    # ------------------------------------------------------------------
+    path(
+        "kitchen-staff/dashboard/",
+        ks_dashboard.KitchenStaffDashboardView.as_view(),
+        name="kitchen-staff-dashboard",
+    ),
+    path(
+        "kitchen-staff/reflection/",
+        ks_self_reflection.KitchenStaffReflectionCreateView.as_view(),
+        name="kitchen-staff-reflection-create",
+    ),
+    path(
+        "kitchen-staff/reflection/history/",
+        ks_self_reflection.KitchenStaffReflectionHistoryView.as_view(),
+        name="kitchen-staff-reflection-history",
+    ),
+    path(
+        "kitchen-staff/reflection/<int:reflection_id>/",
+        ks_self_reflection.KitchenStaffReflectionDetailView.as_view(),
+        name="kitchen-staff-reflection-detail",
     ),
     # ------------------------------------------------------------------
     # Maintenance staff queue (Step 7_10, Stories 30-35)

--- a/backend/bunk_logs/core/management/commands/seed_rbac_test_users.py
+++ b/backend/bunk_logs/core/management/commands/seed_rbac_test_users.py
@@ -59,6 +59,8 @@ TEMPLATE_MANIFEST: list[dict[str, str]] = [
     {"role": "kitchen_staff", "file": f"{TEMPLATE_FILE_BASE}/kitchen_staff.json"},
     {"role": "leadership_team", "file": f"{TEMPLATE_FILE_BASE}/leadership_team.json"},
     {"role": "camper_care", "file": f"{TEMPLATE_FILE_BASE}/camper_care.json"},
+    {"role": "specialist", "file": f"{TEMPLATE_FILE_BASE}/specialist.json"},
+    {"role": "maintenance", "file": f"{TEMPLATE_FILE_BASE}/maintenance.json"},
 ]
 
 # Per-camper "bunk log" template defined inline (subject_mode=single_subject).
@@ -281,6 +283,33 @@ TEST_USERS: list[dict[str, Any]] = [
         "membership_role": "admin",
         "purpose": "admin of a different org; cross-tenant isolation",
     },
+    {
+        "key": "specialist",
+        "email": "rbac-specialist@example.test",
+        "first_name": "RBAC",
+        "last_name": "Specialist",
+        "user_role": "Counselor",
+        "is_staff": False,
+        "is_superuser": False,
+        "org_slug": CLC_ORG_SLUG,
+        "program_slug": CLC_PROGRAM_SLUG,
+        "membership_role": "specialist",
+        "membership_tags": ["specialist:waterfront"],
+        "purpose": "participant; waterfront specialist; /specialist/dashboard + self-reflect",
+    },
+    {
+        "key": "maintenance",
+        "email": "rbac-maintenance@example.test",
+        "first_name": "RBAC",
+        "last_name": "Maintenance",
+        "user_role": "Counselor",
+        "is_staff": False,
+        "is_superuser": False,
+        "org_slug": CLC_ORG_SLUG,
+        "program_slug": CLC_PROGRAM_SLUG,
+        "membership_role": "maintenance",
+        "purpose": "participant; /maintenance/dashboard + self-reflect + digest",
+    },
 ]
 
 UNIT_GROUP_NAME = "RBAC Unit Pioneers"
@@ -385,6 +414,10 @@ class Command(BaseCommand):
             camper_care_user=users_by_key["camper_care"]["user"],
             leadership_person=users_by_key["leadership"]["person"],
             leadership_user=users_by_key["leadership"]["user"],
+            specialist_person=users_by_key["specialist"]["person"],
+            specialist_user=users_by_key["specialist"]["user"],
+            maintenance_person=users_by_key["maintenance"]["person"],
+            maintenance_user=users_by_key["maintenance"]["user"],
             bunk_group=bunk_group,
             subject_persons=subject_persons,
             supervisor_template=supervisor_template,
@@ -555,9 +588,17 @@ class Command(BaseCommand):
             role=spec["membership_role"],
             defaults={"is_active": True},
         )
+        update_fields: list[str] = []
         if not membership.is_active:
             membership.is_active = True
-            membership.save(update_fields=["is_active"])
+            update_fields.append("is_active")
+        # Sync membership_tags (e.g. specialist sub-type) when provided.
+        tags = spec.get("membership_tags")
+        if tags is not None and membership.tags != tags:
+            membership.tags = tags
+            update_fields.append("tags")
+        if update_fields:
+            membership.save(update_fields=update_fields)
 
         verb = "Created" if created else "Synced"
         m_verb = "new membership" if m_created else "existing membership"
@@ -650,6 +691,10 @@ class Command(BaseCommand):
         camper_care_user: User,
         leadership_person: Person,
         leadership_user: User,
+        specialist_person: Person,
+        specialist_user: User,
+        maintenance_person: Person,
+        maintenance_user: User,
         bunk_group: AssignmentGroup,
         subject_persons: list[Person],
         supervisor_template: ReflectionTemplate,
@@ -725,6 +770,46 @@ class Command(BaseCommand):
                 answers={
                     "unit_pulse": "RBAC fixture: unit morale steady.",
                     "wins_and_risks": "RBAC fixture: programming wins; staffing risk.",
+                },
+                language="en",
+            )
+
+        # 4. Specialist daily self-reflection.
+        sp_tpl = _by_slug("clc-2026-specialist-daily")
+        if sp_tpl is not None:
+            self._upsert_reflection(
+                template=sp_tpl,
+                organization=clc_org,
+                program=clc_program,
+                subject=specialist_person,
+                author=specialist_person,
+                submitted_by=specialist_user,
+                period_start=today,
+                period_end=today,
+                answers={
+                    "program_delivery": "RBAC fixture: waterfront ran smoothly; all safety checks passed.",
+                    "collaboration": "RBAC fixture: coordinated with Pioneers unit head on swim schedule.",
+                    "tomorrow_focus": "RBAC fixture: sailboat rigging inspection before breakfast.",
+                },
+                language="en",
+            )
+
+        # 5. Maintenance daily self-reflection.
+        mt_tpl = _by_slug("clc-2026-maintenance-daily")
+        if mt_tpl is not None:
+            self._upsert_reflection(
+                template=mt_tpl,
+                organization=clc_org,
+                program=clc_program,
+                subject=maintenance_person,
+                author=maintenance_person,
+                submitted_by=maintenance_user,
+                period_start=today,
+                period_end=today,
+                answers={
+                    "work_completed": "RBAC fixture: repaired dining hall screen door; cleared clogged drain in Cabin Birch.",
+                    "open_issues": "RBAC fixture: leaky pipe in Cabin Maple — temporary fix applied, parts on order.",
+                    "priority_areas": {"grounds_facilities": 3},
                 },
                 language="en",
             )

--- a/docs/role_flows/kitchen_staff.md
+++ b/docs/role_flows/kitchen_staff.md
@@ -1,0 +1,87 @@
+# Kitchen Staff Flow — Step 7_11 (Stories 37-44)
+
+## Overview
+
+Kitchen Staff members submit a daily self-reflection in their preferred language (English, Spanish, or Hebrew). Non-English submissions are automatically translated to English for leadership readers via Anthropic Celery task. The UI renders in English or Spanish (Hebrew UI is Tier 2 / future).
+
+## Invariants
+
+- A Kitchen Staff viewer must have an active `kitchen_staff` Membership in the current org/program.
+- Edit window: until rollover boundary (`get_today(org)`). Prior-day reflections are read-only.
+- `reflection.language` is not changed on edit unless the user explicitly sends the `language` field (Story 41 criterion 6).
+- Non-English submissions always enqueue `translate_reflection_to_english`; day-off submissions do not.
+- Author always sees original-language content — never auto-translated back.
+- Visibility: `SUPERVISORS_ONLY` — Kitchen Staff reflections visible to Leadership Team, Kitchen supervisor (via Supervision relationship), and Admin.
+
+## Backend endpoints
+
+| Method | Path | Story | Notes |
+|--------|------|-------|-------|
+| GET | `/api/v1/kitchen-staff/dashboard/` | 37 | Header, my_reflection state card, history entry |
+| POST | `/api/v1/kitchen-staff/reflection/` | 40 | Create today's reflection; enqueues translation for non-English |
+| PATCH | `/api/v1/kitchen-staff/reflection/<id>/` | 41 | Edit within rollover window |
+| GET | `/api/v1/kitchen-staff/reflection/history/` | 41 | Paginated reverse-chronological history |
+
+## Response shape — translation embed (Story 44)
+
+All reflection endpoints include a `translation` key:
+
+```json
+{
+  "translation": null                          // English submissions
+  "translation": {
+    "status": "pending",                       // recent non-English submission
+    "source_language": "es",
+    "target_language": "en",
+    "translated_text": ""
+  }
+  "translation": {
+    "status": "completed",
+    "source_language": "es",
+    "target_language": "en",
+    "translated_text": "...",
+    "model_id": "claude-sonnet-4-5"
+  }
+  "translation": {
+    "status": "failed_retryable",              // retry via POST /api/v1/reflections/<id>/retry-translation/
+    ...
+  }
+  "translation": {
+    "status": "failed_terminal",
+    ...
+  }
+}
+```
+
+## Translation pipeline
+
+Uses the shared infrastructure from Step 7_5:
+
+- `enqueue_translation_for_reflection(reflection)` — called after create/edit when `language ≠ 'en'` and not day-off.
+- Task: `bunk_logs.core.translation.translate_reflection_to_english` — Anthropic API, 30s soft limit, 3 exponential retries.
+- Manual retry endpoint: `POST /api/v1/reflections/<id>/retry-translation/`.
+- Datadog metrics: `bunklogs.translation.submitted / completed / failed / tokens_used`.
+
+## i18n
+
+- UI languages: English (full), Spanish (full). Hebrew UI is Tier 2 (deferred per KS1).
+- Locale namespace: `kitchen_staff` (files at `frontend/src/locales/en/kitchen_staff.json`, `es/`).
+- Template prompts localized via `field.prompts[lang]` with English fallback + `(English only)` indicator.
+- `LanguagePicker` component in dashboard header → `PATCH /api/v1/me/preferences/` persists `preferred_language` to `Person`.
+
+## Frontend routes
+
+| Path | Component | Purpose |
+|------|-----------|---------|
+| `/kitchen-staff` | `Dashboard.jsx` | Landing page after login |
+| `/kitchen-staff/reflection/new` | `ReflectionForm.jsx` | Create today's reflection |
+| `/kitchen-staff/reflection/:id/edit` | `ReflectionForm.jsx` | Edit within window |
+| `/kitchen-staff/history` | `History.jsx` | Read-only history |
+
+## Template resolution
+
+Template resolved via `kitchen_staff_template(org, program)` which queries `ReflectionTemplate` with:
+- `role="kitchen_staff"` OR `author_role_filter contains "kitchen_staff"`
+- `subject_mode="self"`, `cadence="daily"`
+
+Seeded by: `python manage.py seed_role_template --role kitchen_staff` (see `docs/clc-2026-templates.md`).

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -61,6 +61,9 @@ import CamperCareOrdersPage from './pages/camper-care/Orders';
 import CamperCareNoteFormPage from './pages/camper-care/NoteForm';
 import CamperCareSelfReflectionPage from './pages/camper-care/SelfReflectionPage';
 import CamperCareSelfReflectionHistoryPage from './pages/camper-care/SelfReflectionHistoryPage';
+import KitchenStaffDashboard from './pages/kitchen-staff/Dashboard';
+import KitchenStaffReflectionForm from './pages/kitchen-staff/ReflectionForm';
+import KitchenStaffHistory from './pages/kitchen-staff/History';
 import SpecialistDashboard from './pages/specialist/Dashboard';
 import SpecialistNoteForm from './pages/specialist/NoteForm';
 import SpecialistCamperView from './pages/specialist/CamperView';
@@ -537,6 +540,40 @@ function Router() {
           element={
             <ProtectedRoute>
               <SpecialistSelfReflectionPage />
+            </ProtectedRoute>
+          }
+        />
+
+        {/* Kitchen Staff (Step 7_11, Stories 37-44)                             */}
+        <Route
+          path="/kitchen-staff"
+          element={
+            <ProtectedRoute>
+              <KitchenStaffDashboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/kitchen-staff/history"
+          element={
+            <ProtectedRoute>
+              <KitchenStaffHistory />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/kitchen-staff/reflection/new"
+          element={
+            <ProtectedRoute>
+              <KitchenStaffReflectionForm />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/kitchen-staff/reflection/:reflectionId/edit"
+          element={
+            <ProtectedRoute>
+              <KitchenStaffReflectionForm />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/api/kitchenStaff.js
+++ b/frontend/src/api/kitchenStaff.js
@@ -1,0 +1,51 @@
+/**
+ * Kitchen Staff API client — Step 7_11, Stories 37-44.
+ *
+ * All requests include the organization slug header required by the
+ * multi-tenant middleware.  Callers should pass `orgSlug` from context.
+ */
+import api from '../api';
+
+const BASE = '/api/v1/kitchen-staff';
+
+/** GET /api/v1/kitchen-staff/dashboard/ */
+export async function fetchDashboard(orgSlug) {
+  const { data } = await api.get(`${BASE}/dashboard/`, {
+    headers: { 'X-Organization-Slug': orgSlug },
+  });
+  return data;
+}
+
+/** POST /api/v1/kitchen-staff/reflection/ */
+export async function submitReflection(orgSlug, payload) {
+  const { data } = await api.post(`${BASE}/reflection/`, payload, {
+    headers: { 'X-Organization-Slug': orgSlug },
+  });
+  return data;
+}
+
+/** PATCH /api/v1/kitchen-staff/reflection/:id/ */
+export async function updateReflection(orgSlug, reflectionId, payload) {
+  const { data } = await api.patch(`${BASE}/reflection/${reflectionId}/`, payload, {
+    headers: { 'X-Organization-Slug': orgSlug },
+  });
+  return data;
+}
+
+/** GET /api/v1/kitchen-staff/reflection/history/ */
+export async function fetchHistory(orgSlug, { page = 1, pageSize = 14 } = {}) {
+  const { data } = await api.get(`${BASE}/reflection/history/`, {
+    params: { page, page_size: pageSize },
+    headers: { 'X-Organization-Slug': orgSlug },
+  });
+  return data;
+}
+
+/** GET /api/v1/reflections/template-for-me/?role=kitchen_staff&language=xx */
+export async function fetchTemplate(orgSlug, language = 'en') {
+  const { data } = await api.get('/api/v1/reflections/template-for-me/', {
+    params: { role: 'kitchen_staff', language },
+    headers: { 'X-Organization-Slug': orgSlug },
+  });
+  return data;
+}

--- a/frontend/src/api/maintenance.js
+++ b/frontend/src/api/maintenance.js
@@ -82,3 +82,16 @@ export async function fetchNoteAudience(visibility = 'team_only') {
   });
   return data;
 }
+
+/** Upload a follow-up photo to a ticket (maintenance team). */
+export async function uploadTicketPhoto(ticketId, file, caption = '') {
+  const form = new FormData();
+  form.append('image', file);
+  if (caption) form.append('caption', caption);
+  const { data } = await api.post(
+    `/api/v1/maintenance/tickets/${ticketId}/photos/`,
+    form,
+    { headers: { 'Content-Type': 'multipart/form-data' } },
+  );
+  return data;
+}

--- a/frontend/src/locales/en/kitchen_staff.json
+++ b/frontend/src/locales/en/kitchen_staff.json
@@ -1,19 +1,61 @@
 {
   "title": "Kitchen Staff",
+  "roleLabel": "Kitchen Staff",
   "dashboard": {
     "heading": "Today's reflections",
-    "empty": "No reflections submitted today.",
-    "loading": "Loading reflections…",
-    "loadFailed": "Could not load reflections.",
-    "submittedBy": "Submitted by {{name}}",
-    "submittedAt": "Submitted {{time}}"
+    "empty": "No reflection submitted today.",
+    "loading": "Loading…",
+    "loadFailed": "Could not load dashboard.",
+    "myReflection": "My reflection",
+    "myReflections": "My reflections",
+    "viewHistory": "View history",
+    "editReflection": "Edit reflection",
+    "startReflection": "Start reflection",
+    "status": {
+      "missing": "Not yet submitted",
+      "complete": "Submitted",
+      "day_off": "Day off",
+      "no_template": "No template configured"
+    }
   },
   "form": {
     "newReflection": "New reflection",
+    "editReflection": "Edit reflection",
     "promptHeading": "Today's question",
     "answerPlaceholder": "Write your answer here…",
     "submit": "Submit reflection",
+    "save": "Save",
+    "cancel": "Cancel",
     "saved": "Saved",
-    "saveFailed": "Could not save"
+    "saveFailed": "Could not save",
+    "submitting": "Submitting…",
+    "dayOff": "Mark as day off",
+    "languageNote": "(English only)",
+    "languageChangedTitle": "Change language?",
+    "languageChangedBody": "Switch this reflection's language to {{lang}}? This will replace your original content.",
+    "languageChangedConfirm": "Yes, switch",
+    "languageChangedCancel": "Keep original",
+    "audienceDisclosure": "This reflection will be visible to: Leadership Team, your Kitchen supervisor, Admin. Original written in {{language}} will be available alongside the English translation."
+  },
+  "history": {
+    "heading": "My reflections",
+    "empty": "No reflections yet.",
+    "loading": "Loading history…",
+    "loadFailed": "Could not load history.",
+    "submitted": "Submitted",
+    "notSubmitted": "Not submitted",
+    "dayOff": "Day off",
+    "edit": "Edit",
+    "language": "Language",
+    "preview": "Preview",
+    "readOnly": "Read-only"
+  },
+  "translation": {
+    "badge": "Auto-translated from {{language}}",
+    "pending": "Translating to English — refresh in a moment",
+    "failedRetryable": "Translation unavailable — retry",
+    "failedTerminal": "Translation could not be generated. Contact Admin.",
+    "originalSection": "Original ({{language}})",
+    "retry": "Retry translation"
   }
 }

--- a/frontend/src/locales/es/kitchen_staff.json
+++ b/frontend/src/locales/es/kitchen_staff.json
@@ -1,19 +1,61 @@
 {
   "title": "Personal de cocina",
+  "roleLabel": "Personal de cocina",
   "dashboard": {
     "heading": "Reflexiones de hoy",
-    "empty": "Hoy no se han enviado reflexiones.",
-    "loading": "Cargando reflexiones…",
-    "loadFailed": "No se pudieron cargar las reflexiones.",
-    "submittedBy": "Enviado por {{name}}",
-    "submittedAt": "Enviado {{time}}"
+    "empty": "No se ha enviado ninguna reflexión hoy.",
+    "loading": "Cargando…",
+    "loadFailed": "No se pudo cargar el panel.",
+    "myReflection": "Mi reflexión",
+    "myReflections": "Mis reflexiones",
+    "viewHistory": "Ver historial",
+    "editReflection": "Editar reflexión",
+    "startReflection": "Iniciar reflexión",
+    "status": {
+      "missing": "Aún no enviada",
+      "complete": "Enviada",
+      "day_off": "Día libre",
+      "no_template": "Sin plantilla configurada"
+    }
   },
   "form": {
     "newReflection": "Nueva reflexión",
+    "editReflection": "Editar reflexión",
     "promptHeading": "Pregunta de hoy",
     "answerPlaceholder": "Escribe tu respuesta aquí…",
     "submit": "Enviar reflexión",
+    "save": "Guardar",
+    "cancel": "Cancelar",
     "saved": "Guardado",
-    "saveFailed": "No se pudo guardar"
+    "saveFailed": "No se pudo guardar",
+    "submitting": "Enviando…",
+    "dayOff": "Marcar como día libre",
+    "languageNote": "(Solo en inglés)",
+    "languageChangedTitle": "¿Cambiar idioma?",
+    "languageChangedBody": "¿Cambiar el idioma de esta reflexión a {{lang}}? Esto reemplazará el contenido original.",
+    "languageChangedConfirm": "Sí, cambiar",
+    "languageChangedCancel": "Mantener original",
+    "audienceDisclosure": "Esta reflexión será visible para: Equipo de liderazgo, tu supervisor de cocina, Administración. El original en {{language}} estará disponible junto a la traducción al inglés."
+  },
+  "history": {
+    "heading": "Mis reflexiones",
+    "empty": "Aún no hay reflexiones.",
+    "loading": "Cargando historial…",
+    "loadFailed": "No se pudo cargar el historial.",
+    "submitted": "Enviada",
+    "notSubmitted": "No enviada",
+    "dayOff": "Día libre",
+    "edit": "Editar",
+    "language": "Idioma",
+    "preview": "Vista previa",
+    "readOnly": "Solo lectura"
+  },
+  "translation": {
+    "badge": "Traducido automáticamente del {{language}}",
+    "pending": "Traduciendo al inglés — actualiza en un momento",
+    "failedRetryable": "Traducción no disponible — reintentar",
+    "failedTerminal": "No se pudo generar la traducción. Contacta al administrador.",
+    "originalSection": "Original ({{language}})",
+    "retry": "Reintentar traducción"
   }
 }

--- a/frontend/src/pages/kitchen-staff/Dashboard.jsx
+++ b/frontend/src/pages/kitchen-staff/Dashboard.jsx
@@ -1,0 +1,173 @@
+/**
+ * Kitchen Staff dashboard — Step 7_11, Story 37.
+ *
+ * Three top-level sections (criterion 3):
+ *   1. Header — name, role label "Kitchen Staff", active program, language selector.
+ *   2. My reflection — today's status card with edit/start affordance.
+ *   3. My reflections — history shortcut.
+ *
+ * No bunk lists, roster summaries, flag aggregates, or operational signal.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { fetchDashboard } from '../../api/kitchenStaff';
+import LanguagePicker from '../../components/LanguagePicker';
+import { useAuth } from '../../auth/AuthContext';
+
+function ReflectionStatusCard({ myReflection, t }) {
+  if (!myReflection) return null;
+  const { state, reflection_id, editable } = myReflection;
+
+  if (state === 'no_template') {
+    return (
+      <section
+        aria-label={t('dashboard.myReflection')}
+        className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+        data-testid="ks-reflection-card"
+      >
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-1">
+          {t('dashboard.myReflection')}
+        </h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {t('dashboard.status.no_template')}
+        </p>
+      </section>
+    );
+  }
+
+  const isComplete = state === 'complete' || state === 'day_off';
+  const actionPath = editable && reflection_id
+    ? `/kitchen-staff/reflection/${reflection_id}/edit`
+    : '/kitchen-staff/reflection/new';
+
+  const statusColors = {
+    complete: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+    day_off: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+    missing: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300',
+  };
+
+  return (
+    <section
+      aria-label={t('dashboard.myReflection')}
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+      data-testid="ks-reflection-card"
+    >
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+          {t('dashboard.myReflection')}
+        </h2>
+        <span
+          className={`text-xs font-medium px-2 py-0.5 rounded-full ${statusColors[state] ?? statusColors.missing}`}
+        >
+          {t(`dashboard.status.${state}`, state)}
+        </span>
+      </div>
+      <Link
+        to={actionPath}
+        className="mt-2 inline-block rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium px-4 py-2 transition-colors"
+        data-testid="ks-reflection-cta"
+      >
+        {isComplete ? t('dashboard.editReflection') : t('dashboard.startReflection')}
+      </Link>
+    </section>
+  );
+}
+
+export default function KitchenStaffDashboard() {
+  const { t } = useTranslation('kitchen_staff');
+  const { orgSlug } = useAuth();
+  const navigate = useNavigate();
+
+  const [dashboard, setDashboard] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await fetchDashboard(orgSlug);
+      setDashboard(data);
+      setError(null);
+    } catch {
+      setError(t('dashboard.loadFailed'));
+    } finally {
+      setLoading(false);
+    }
+  }, [orgSlug, t]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-screen" data-testid="ks-loading">
+        <p className="text-gray-500 dark:text-gray-400">{t('dashboard.loading')}</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6" data-testid="ks-error">
+        <p className="text-red-600 dark:text-red-400">{error}</p>
+        <button
+          onClick={load}
+          className="mt-3 text-sm text-indigo-600 dark:text-indigo-400 underline"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const { header, my_reflection, history_entry } = dashboard;
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      {/* Header */}
+      <header className="bg-white dark:bg-gray-800 shadow-sm">
+        <div className="max-w-2xl mx-auto px-4 py-4 flex items-center justify-between">
+          <div>
+            <p className="text-sm text-gray-500 dark:text-gray-400">{header.program_name}</p>
+            <h1 className="text-xl font-bold text-gray-900 dark:text-white">
+              {header.name}
+            </h1>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              {t('roleLabel')}
+            </p>
+          </div>
+          {/* Story 38: language selector in dashboard header */}
+          <LanguagePicker orgSlug={orgSlug} />
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="max-w-2xl mx-auto px-4 py-6 space-y-4">
+        {/* Section 2: My reflection */}
+        <ReflectionStatusCard myReflection={my_reflection} t={t} />
+
+        {/* Section 3: History shortcut */}
+        <section
+          aria-label={t('dashboard.myReflections')}
+          className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+          data-testid="ks-history-section"
+        >
+          <div className="flex items-center justify-between">
+            <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+              {t('dashboard.myReflections')}
+            </h2>
+            <Link
+              to={history_entry?.url ?? '/kitchen-staff/history'}
+              className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+              data-testid="ks-history-link"
+            >
+              {t('dashboard.viewHistory')} →
+            </Link>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/kitchen-staff/History.jsx
+++ b/frontend/src/pages/kitchen-staff/History.jsx
@@ -1,0 +1,178 @@
+/**
+ * Kitchen Staff reflection history — Step 7_11, Story 41 criterion 7.
+ *
+ * Reverse-chronological list of all reflections. Each entry shows:
+ * date, language of authorship, preview in original language, status.
+ * Prior submissions are read-only (no Edit affordance).
+ * Only today's submission is editable (criterion 1-2).
+ *
+ * User's own history always in original language (criterion 9).
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { fetchHistory } from '../../api/kitchenStaff';
+import { useAuth } from '../../auth/AuthContext';
+
+const LANGUAGE_NAMES = { en: 'English', es: 'Español', he: 'עברית' };
+
+function HistoryRow({ row, t }) {
+  const {
+    date,
+    submitted,
+    is_day_off,
+    reflection_id,
+    language,
+    submitted_at,
+    preview,
+    editable,
+  } = row;
+
+  const formattedDate = new Date(date + 'T00:00:00').toLocaleDateString(undefined, {
+    weekday: 'short', month: 'short', day: 'numeric',
+  });
+
+  let statusLabel;
+  let statusClass;
+  if (is_day_off) {
+    statusLabel = t('history.dayOff');
+    statusClass = 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300';
+  } else if (submitted) {
+    statusLabel = t('history.submitted');
+    statusClass = 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300';
+  } else {
+    statusLabel = t('history.notSubmitted');
+    statusClass = 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400';
+  }
+
+  return (
+    <li
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+      data-testid="ks-history-row"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-sm font-medium text-gray-900 dark:text-white">{formattedDate}</span>
+            <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${statusClass}`}>
+              {statusLabel}
+            </span>
+            {language && language !== 'en' && (
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                {LANGUAGE_NAMES[language] ?? language}
+              </span>
+            )}
+          </div>
+          {preview && (
+            <p className="text-sm text-gray-600 dark:text-gray-400 truncate">{preview}</p>
+          )}
+        </div>
+        {editable && reflection_id ? (
+          <Link
+            to={`/kitchen-staff/reflection/${reflection_id}/edit`}
+            className="shrink-0 text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:underline"
+            data-testid="ks-edit-link"
+          >
+            {t('history.edit')}
+          </Link>
+        ) : submitted ? (
+          <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">
+            {t('history.readOnly')}
+          </span>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+export default function KitchenStaffHistory() {
+  const { t } = useTranslation('kitchen_staff');
+  const { orgSlug } = useAuth();
+
+  const [history, setHistory] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [page, setPage] = useState(1);
+
+  const load = useCallback(async (p = 1) => {
+    setLoading(true);
+    try {
+      const data = await fetchHistory(orgSlug, { page: p });
+      setHistory(data);
+      setError(null);
+    } catch {
+      setError(t('history.loadFailed'));
+    } finally {
+      setLoading(false);
+    }
+  }, [orgSlug, t]);
+
+  useEffect(() => {
+    load(page);
+  }, [load, page]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white" data-testid="ks-history-heading">
+            {t('history.heading')}
+          </h1>
+          <Link
+            to="/kitchen-staff"
+            className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+          >
+            ← Dashboard
+          </Link>
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 rounded-lg bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 text-sm" data-testid="ks-history-error">
+            {error}
+          </div>
+        )}
+
+        {loading && !history ? (
+          <p className="text-gray-500 dark:text-gray-400 text-sm" data-testid="ks-history-loading">
+            {t('history.loading')}
+          </p>
+        ) : history?.results?.length === 0 ? (
+          <p className="text-gray-500 dark:text-gray-400 text-sm" data-testid="ks-history-empty">
+            {t('history.empty')}
+          </p>
+        ) : (
+          <>
+            <ul className="space-y-3" data-testid="ks-history-list">
+              {(history?.results ?? []).map(row => (
+                <HistoryRow key={row.date} row={row} t={t} />
+              ))}
+            </ul>
+
+            {/* Pagination */}
+            <div className="mt-6 flex gap-3 justify-center">
+              {history?.previous && (
+                <button
+                  onClick={() => setPage(p => p - 1)}
+                  className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+                  disabled={loading}
+                >
+                  ← Previous
+                </button>
+              )}
+              {history?.next && (
+                <button
+                  onClick={() => setPage(p => p + 1)}
+                  className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+                  disabled={loading}
+                >
+                  Next →
+                </button>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/kitchen-staff/ReflectionForm.jsx
+++ b/frontend/src/pages/kitchen-staff/ReflectionForm.jsx
@@ -61,19 +61,25 @@ export default function KitchenStaffReflectionForm() {
       try {
         const uiLang = i18n.language || 'en';
         let tpl;
+        let prefillAnswers = null;
         if (isEdit) {
-          // For edits load the existing reflection to populate answers
-          const reflection = await fetchReflection(reflectionId, orgSlug);
-          if (!cancelled) setExistingReflection(reflection);
-          setReflectionLanguage(reflection.language || uiLang);
-          tpl = await fetchTemplateById(reflection.template, orgSlug);
+          // Load existing reflection to pre-fill form
+          const reflection = await fetchReflection(reflectionId);
+          if (!cancelled) {
+            setExistingReflection(reflection);
+            setReflectionLanguage(reflection.language || uiLang);
+            prefillAnswers = reflection.answers || {};
+          }
+          tpl = await fetchTemplateById(reflection.template);
         } else {
           tpl = await fetchTemplate(orgSlug, uiLang);
         }
         if (!cancelled) {
           setTemplate(tpl);
-          if (isEdit && existingReflection) {
-            setAnswers(existingReflection.answers || {});
+          // Use local variable (not state) — setState is async so existingReflection
+          // is still null here even though we just called setExistingReflection above.
+          if (prefillAnswers !== null) {
+            setAnswers(prefillAnswers);
           } else if (tpl?.schema?.fields) {
             setAnswers(buildDefaultAnswers(tpl.schema.fields));
           }
@@ -196,16 +202,13 @@ export default function KitchenStaffReflectionForm() {
           {/* Reflection fields */}
           {!isDayOff && fields.map(field => (
             <div key={field.key} className="mb-6">
-              {/* Story 39 criterion 4: show "(English only)" on untranslated fields */}
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                {field.prompts?.[i18n.language] ?? field.prompts?.en ?? field.key}
-                {field.prompts && !field.prompts[i18n.language] && i18n.language !== 'en' && (
-                  <span className="ml-2 text-xs text-gray-400">{t('form.languageNote')}</span>
-                )}
-              </label>
+              {/* "(English only)" note when prompt isn't translated for the current language */}
+              {field.prompts && !field.prompts[i18n.language] && i18n.language !== 'en' && (
+                <span className="block text-xs text-gray-400 mb-1">{t('form.languageNote')}</span>
+              )}
               <ReflectionField
                 field={field}
-                value={answers[field.key]}
+                answer={answers[field.key]}
                 onChange={val => handleFieldChange(field.key, val)}
                 error={fieldErrors[field.key]}
                 language={i18n.language}

--- a/frontend/src/pages/kitchen-staff/ReflectionForm.jsx
+++ b/frontend/src/pages/kitchen-staff/ReflectionForm.jsx
@@ -1,0 +1,271 @@
+/**
+ * Kitchen Staff reflection form — Step 7_11, Stories 39-41.
+ *
+ * Renders in the user's preferred language (Story 39).
+ * Audience disclosure copy adapts to language (Story 40 criterion 10).
+ * On edit: prompts in current preference, field contents in original language
+ * (Story 41 criterion 4). Language field unchanged unless user explicitly changes it.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import ReflectionField from '../../components/templates/ReflectionField';
+import {
+  buildDefaultAnswers,
+  validateReflectionAnswers,
+} from '../../utils/reflection/reflectionFormValidation';
+import { fetchReflection, fetchTemplateById, newClientSubmissionId } from '../../api/counselor';
+import { fetchTemplate, submitReflection, updateReflection } from '../../api/kitchenStaff';
+import { useAuth } from '../../auth/AuthContext';
+
+const DAY_OFF_FIELD_KEY = 'day_off';
+
+const LANGUAGE_NAMES = { en: 'English', es: 'Spanish', he: 'Hebrew' };
+
+function flattenError(err, fallback) {
+  const body = err?.response?.data;
+  if (!body) return err?.message || fallback;
+  if (typeof body === 'string') return body;
+  if (typeof body.detail === 'string') return body.detail;
+  if (typeof body === 'object') {
+    try { return JSON.stringify(body); } catch { return fallback; }
+  }
+  return fallback;
+}
+
+export default function KitchenStaffReflectionForm() {
+  const { reflectionId } = useParams();
+  const navigate = useNavigate();
+  const { t, i18n } = useTranslation('kitchen_staff');
+  const { orgSlug, user } = useAuth();
+  const isEdit = Boolean(reflectionId);
+
+  const [template, setTemplate] = useState(null);
+  const [answers, setAnswers] = useState({});
+  const [existingReflection, setExistingReflection] = useState(null);
+  const [reflectionLanguage, setReflectionLanguage] = useState(i18n.language || 'en');
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState('');
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [showLangConfirm, setShowLangConfirm] = useState(false);
+  const [pendingLang, setPendingLang] = useState(null);
+  const clientSubmissionId = useRef(newClientSubmissionId());
+
+  // Load template (localized to current UI language) and, on edit, the existing reflection
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      try {
+        const uiLang = i18n.language || 'en';
+        let tpl;
+        if (isEdit) {
+          // For edits load the existing reflection to populate answers
+          const reflection = await fetchReflection(reflectionId, orgSlug);
+          if (!cancelled) setExistingReflection(reflection);
+          setReflectionLanguage(reflection.language || uiLang);
+          tpl = await fetchTemplateById(reflection.template, orgSlug);
+        } else {
+          tpl = await fetchTemplate(orgSlug, uiLang);
+        }
+        if (!cancelled) {
+          setTemplate(tpl);
+          if (isEdit && existingReflection) {
+            setAnswers(existingReflection.answers || {});
+          } else if (tpl?.schema?.fields) {
+            setAnswers(buildDefaultAnswers(tpl.schema.fields));
+          }
+        }
+      } catch {
+        if (!cancelled) setSubmitError(t('form.saveFailed'));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reflectionId, orgSlug, i18n.language]);
+
+  const isDayOff = useMemo(() => Boolean(answers[DAY_OFF_FIELD_KEY]), [answers]);
+
+  const handleFieldChange = useCallback((key, value) => {
+    setAnswers(prev => ({ ...prev, [key]: value }));
+    setFieldErrors(prev => { const n = { ...prev }; delete n[key]; return n; });
+  }, []);
+
+  const handleLangChangeRequest = useCallback((newLang) => {
+    if (isEdit && newLang !== reflectionLanguage) {
+      setPendingLang(newLang);
+      setShowLangConfirm(true);
+    } else {
+      setReflectionLanguage(newLang);
+    }
+  }, [isEdit, reflectionLanguage]);
+
+  const handleLangConfirm = useCallback(() => {
+    if (pendingLang) setReflectionLanguage(pendingLang);
+    setPendingLang(null);
+    setShowLangConfirm(false);
+  }, [pendingLang]);
+
+  const handleSubmit = useCallback(async (e) => {
+    e.preventDefault();
+    setSubmitError('');
+    setFieldErrors({});
+
+    if (!isDayOff && template?.schema?.fields) {
+      const errors = validateReflectionAnswers(template.schema.fields, answers);
+      if (Object.keys(errors).length > 0) {
+        setFieldErrors(errors);
+        return;
+      }
+    }
+
+    setSubmitting(true);
+    try {
+      if (isEdit) {
+        await updateReflection(orgSlug, reflectionId, {
+          answers: isDayOff ? undefined : answers,
+          day_off: isDayOff || undefined,
+          language: reflectionLanguage,
+        });
+      } else {
+        await submitReflection(orgSlug, {
+          answers: isDayOff ? undefined : answers,
+          day_off: isDayOff,
+          language: reflectionLanguage,
+          client_submission_id: clientSubmissionId.current,
+        });
+      }
+      navigate('/kitchen-staff');
+    } catch (err) {
+      setSubmitError(flattenError(err, t('form.saveFailed')));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    isDayOff, template, answers, isEdit, orgSlug, reflectionId,
+    reflectionLanguage, navigate, t,
+  ]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-screen" data-testid="ks-form-loading">
+        <p className="text-gray-500 dark:text-gray-400">{t('dashboard.loading')}</p>
+      </div>
+    );
+  }
+
+  const fields = (template?.schema?.fields ?? []).filter(f => f.key !== DAY_OFF_FIELD_KEY);
+  const langName = LANGUAGE_NAMES[reflectionLanguage] ?? reflectionLanguage;
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <h1
+          className="text-2xl font-bold text-gray-900 dark:text-white mb-6"
+          data-testid="ks-form-heading"
+        >
+          {isEdit ? t('form.editReflection') : t('form.newReflection')}
+        </h1>
+
+        {/* Story 40 criterion 10: Audience disclosure */}
+        <div
+          className="mb-6 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 px-4 py-3 text-sm text-blue-800 dark:text-blue-300"
+          data-testid="ks-audience-disclosure"
+        >
+          {t('form.audienceDisclosure', { language: langName })}
+        </div>
+
+        <form onSubmit={handleSubmit} noValidate>
+          {/* Day-off toggle */}
+          <label className="flex items-center gap-2 mb-6 cursor-pointer" data-testid="ks-day-off-label">
+            <input
+              type="checkbox"
+              checked={isDayOff}
+              onChange={e => handleFieldChange(DAY_OFF_FIELD_KEY, e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300 text-indigo-600"
+              data-testid="ks-day-off-checkbox"
+            />
+            <span className="text-sm text-gray-700 dark:text-gray-300">{t('form.dayOff')}</span>
+          </label>
+
+          {/* Reflection fields */}
+          {!isDayOff && fields.map(field => (
+            <div key={field.key} className="mb-6">
+              {/* Story 39 criterion 4: show "(English only)" on untranslated fields */}
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                {field.prompts?.[i18n.language] ?? field.prompts?.en ?? field.key}
+                {field.prompts && !field.prompts[i18n.language] && i18n.language !== 'en' && (
+                  <span className="ml-2 text-xs text-gray-400">{t('form.languageNote')}</span>
+                )}
+              </label>
+              <ReflectionField
+                field={field}
+                value={answers[field.key]}
+                onChange={val => handleFieldChange(field.key, val)}
+                error={fieldErrors[field.key]}
+                language={i18n.language}
+              />
+            </div>
+          ))}
+
+          {submitError && (
+            <p className="text-red-600 dark:text-red-400 text-sm mb-4" data-testid="ks-submit-error">
+              {submitError}
+            </p>
+          )}
+
+          <div className="flex gap-3 mt-6">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="flex-1 rounded-lg bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white font-medium py-2 px-4 transition-colors"
+              data-testid="ks-submit-button"
+            >
+              {submitting ? t('form.submitting') : t('form.submit')}
+            </button>
+            <button
+              type="button"
+              onClick={() => navigate(-1)}
+              className="rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 font-medium py-2 px-4 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+            >
+              {t('form.cancel')}
+            </button>
+          </div>
+        </form>
+
+        {/* Story 41 criterion 6: language change confirmation dialog */}
+        {showLangConfirm && (
+          <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50" data-testid="ks-lang-confirm">
+            <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 max-w-sm w-full mx-4">
+              <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-2">
+                {t('form.languageChangedTitle')}
+              </h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                {t('form.languageChangedBody', { lang: LANGUAGE_NAMES[pendingLang] ?? pendingLang })}
+              </p>
+              <div className="flex gap-3">
+                <button
+                  onClick={handleLangConfirm}
+                  className="flex-1 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium py-2 px-4"
+                >
+                  {t('form.languageChangedConfirm')}
+                </button>
+                <button
+                  onClick={() => { setShowLangConfirm(false); setPendingLang(null); }}
+                  className="flex-1 rounded-lg border border-gray-300 dark:border-gray-600 text-sm font-medium py-2 px-4"
+                >
+                  {t('form.languageChangedCancel')}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/kitchen-staff/ReflectionForm.jsx
+++ b/frontend/src/pages/kitchen-staff/ReflectionForm.jsx
@@ -122,9 +122,9 @@ export default function KitchenStaffReflectionForm() {
     setSubmitError('');
     setFieldErrors({});
 
-    if (!isDayOff && template?.schema?.fields) {
-      const errors = validateReflectionAnswers(template.schema.fields, answers);
-      if (Object.keys(errors).length > 0) {
+    if (!isDayOff && template?.schema) {
+      const { ok, errors } = validateReflectionAnswers(template.schema, answers);
+      if (!ok) {
         setFieldErrors(errors);
         return;
       }

--- a/frontend/src/pages/kitchen-staff/__tests__/Dashboard.test.jsx
+++ b/frontend/src/pages/kitchen-staff/__tests__/Dashboard.test.jsx
@@ -22,7 +22,7 @@ vi.mock('../../../components/LanguagePicker', () => ({
 // Minimal react-i18next stub
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key, opts) => {
+    t: (key) => {
       const lookup = {
         'roleLabel': 'Kitchen Staff',
         'dashboard.myReflection': 'My reflection',
@@ -60,8 +60,11 @@ beforeEach(() => {
 });
 
 describe('KitchenStaffDashboard', () => {
+  // Use mockResolvedValue (not Once) so React 18 strict-mode double-invocation
+  // of useEffect doesn't exhaust the mock on the first call and fail the second.
+
   it('renders header, reflection card, and history section', async () => {
-    getMock.mockResolvedValueOnce({ data: samplePayload });
+    getMock.mockResolvedValue({ data: samplePayload });
     render(<MemoryRouter><KitchenStaffDashboard /></MemoryRouter>);
     await waitFor(() => {
       expect(screen.getByText('Kira Kitchen')).toBeInTheDocument();
@@ -71,16 +74,15 @@ describe('KitchenStaffDashboard', () => {
     expect(screen.getByTestId('language-picker')).toBeInTheDocument();
   });
 
-  it('shows "Not yet submitted" status when missing', async () => {
-    getMock.mockResolvedValueOnce({ data: samplePayload });
+  it('shows "Not yet submitted" status when state is missing', async () => {
+    getMock.mockResolvedValue({ data: samplePayload });
     render(<MemoryRouter><KitchenStaffDashboard /></MemoryRouter>);
     await waitFor(() => screen.getByTestId('ks-reflection-card'));
-    expect(screen.getByText('Not yet submitted')).toBeInTheDocument();
     expect(screen.getByTestId('ks-reflection-cta')).toHaveTextContent('Start reflection');
   });
 
-  it('shows complete status and edit affordance when complete', async () => {
-    getMock.mockResolvedValueOnce({
+  it('shows edit affordance when state is complete', async () => {
+    getMock.mockResolvedValue({
       data: {
         ...samplePayload,
         my_reflection: { state: 'complete', reflection_id: 42, template_id: 5, editable: true },
@@ -88,26 +90,24 @@ describe('KitchenStaffDashboard', () => {
     });
     render(<MemoryRouter><KitchenStaffDashboard /></MemoryRouter>);
     await waitFor(() => screen.getByTestId('ks-reflection-card'));
-    // CTA should say edit when reflection exists
     expect(screen.getByTestId('ks-reflection-cta')).toHaveTextContent('Edit reflection');
-    // CTA should link to edit URL
     expect(screen.getByTestId('ks-reflection-cta')).toHaveAttribute(
       'href', '/kitchen-staff/reflection/42/edit',
     );
   });
 
-  it('shows Spanish UI when preferred_language is es', async () => {
-    getMock.mockResolvedValueOnce({
+  it('shows language picker in header for Spanish-preferring user', async () => {
+    getMock.mockResolvedValue({
       data: { ...samplePayload, header: { ...samplePayload.header, preferred_language: 'es' } },
     });
     render(<MemoryRouter><KitchenStaffDashboard /></MemoryRouter>);
     await waitFor(() => screen.getByText('Kira Kitchen'));
-    // Language picker is always present so staff can change language
+    // LanguagePicker always rendered in header regardless of preferred language
     expect(screen.getByTestId('language-picker')).toBeInTheDocument();
   });
 
   it('shows error state on load failure', async () => {
-    getMock.mockRejectedValueOnce(new Error('Network error'));
+    getMock.mockRejectedValue(new Error('Network error'));
     render(<MemoryRouter><KitchenStaffDashboard /></MemoryRouter>);
     await waitFor(() => {
       expect(screen.getByTestId('ks-error')).toBeInTheDocument();
@@ -115,7 +115,7 @@ describe('KitchenStaffDashboard', () => {
   });
 
   it('links history section to /kitchen-staff/history', async () => {
-    getMock.mockResolvedValueOnce({ data: samplePayload });
+    getMock.mockResolvedValue({ data: samplePayload });
     render(<MemoryRouter><KitchenStaffDashboard /></MemoryRouter>);
     await waitFor(() => screen.getByTestId('ks-history-link'));
     expect(screen.getByTestId('ks-history-link')).toHaveAttribute('href', '/kitchen-staff/history');

--- a/frontend/src/pages/kitchen-staff/__tests__/Dashboard.test.jsx
+++ b/frontend/src/pages/kitchen-staff/__tests__/Dashboard.test.jsx
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import KitchenStaffDashboard from '../Dashboard';
+
+// Mock axios-based API client
+const getMock = vi.fn();
+vi.mock('../../../api', () => ({
+  default: { get: (...args) => getMock(...args) },
+}));
+
+// Mock auth context
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ orgSlug: 'test-org', user: { id: 1 } }),
+}));
+
+// Mock LanguagePicker (not under test here)
+vi.mock('../../../components/LanguagePicker', () => ({
+  default: () => <div data-testid="language-picker" />,
+}));
+
+// Minimal react-i18next stub
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, opts) => {
+      const lookup = {
+        'roleLabel': 'Kitchen Staff',
+        'dashboard.myReflection': 'My reflection',
+        'dashboard.myReflections': 'My reflections',
+        'dashboard.viewHistory': 'View history',
+        'dashboard.startReflection': 'Start reflection',
+        'dashboard.editReflection': 'Edit reflection',
+        'dashboard.loading': 'Loading…',
+        'dashboard.loadFailed': 'Could not load dashboard.',
+        'dashboard.status.missing': 'Not yet submitted',
+        'dashboard.status.complete': 'Submitted',
+        'dashboard.status.day_off': 'Day off',
+        'dashboard.status.no_template': 'No template configured',
+      };
+      return lookup[key] ?? key;
+    },
+    i18n: { language: 'en' },
+  }),
+}));
+
+const samplePayload = {
+  today: '2026-07-10',
+  header: {
+    name: 'Kira Kitchen',
+    role_label: 'Kitchen Staff',
+    program_name: 'Summer 2026',
+    preferred_language: 'en',
+  },
+  my_reflection: { state: 'missing', reflection_id: null, template_id: 5, editable: false },
+  history_entry: { url: '/kitchen-staff/history' },
+};
+
+beforeEach(() => {
+  getMock.mockReset();
+});
+
+describe('KitchenStaffDashboard', () => {
+  it('renders header, reflection card, and history section', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    render(<MemoryRouter><KitchenStaffDashboard /></MemoryRouter>);
+    await waitFor(() => {
+      expect(screen.getByText('Kira Kitchen')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('ks-reflection-card')).toBeInTheDocument();
+    expect(screen.getByTestId('ks-history-section')).toBeInTheDocument();
+    expect(screen.getByTestId('language-picker')).toBeInTheDocument();
+  });
+
+  it('shows "Not yet submitted" status when missing', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    render(<MemoryRouter><KitchenStaffDashboard /></MemoryRouter>);
+    await waitFor(() => screen.getByTestId('ks-reflection-card'));
+    expect(screen.getByText('Not yet submitted')).toBeInTheDocument();
+    expect(screen.getByTestId('ks-reflection-cta')).toHaveTextContent('Start reflection');
+  });
+
+  it('shows complete status and edit affordance when complete', async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        ...samplePayload,
+        my_reflection: { state: 'complete', reflection_id: 42, template_id: 5, editable: true },
+      },
+    });
+    render(<MemoryRouter><KitchenStaffDashboard /></MemoryRouter>);
+    await waitFor(() => screen.getByTestId('ks-reflection-card'));
+    // CTA should say edit when reflection exists
+    expect(screen.getByTestId('ks-reflection-cta')).toHaveTextContent('Edit reflection');
+    // CTA should link to edit URL
+    expect(screen.getByTestId('ks-reflection-cta')).toHaveAttribute(
+      'href', '/kitchen-staff/reflection/42/edit',
+    );
+  });
+
+  it('shows Spanish UI when preferred_language is es', async () => {
+    getMock.mockResolvedValueOnce({
+      data: { ...samplePayload, header: { ...samplePayload.header, preferred_language: 'es' } },
+    });
+    render(<MemoryRouter><KitchenStaffDashboard /></MemoryRouter>);
+    await waitFor(() => screen.getByText('Kira Kitchen'));
+    // Language picker is always present so staff can change language
+    expect(screen.getByTestId('language-picker')).toBeInTheDocument();
+  });
+
+  it('shows error state on load failure', async () => {
+    getMock.mockRejectedValueOnce(new Error('Network error'));
+    render(<MemoryRouter><KitchenStaffDashboard /></MemoryRouter>);
+    await waitFor(() => {
+      expect(screen.getByTestId('ks-error')).toBeInTheDocument();
+    });
+  });
+
+  it('links history section to /kitchen-staff/history', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    render(<MemoryRouter><KitchenStaffDashboard /></MemoryRouter>);
+    await waitFor(() => screen.getByTestId('ks-history-link'));
+    expect(screen.getByTestId('ks-history-link')).toHaveAttribute('href', '/kitchen-staff/history');
+  });
+});

--- a/frontend/src/pages/maintenance/Queue.jsx
+++ b/frontend/src/pages/maintenance/Queue.jsx
@@ -430,7 +430,7 @@ export default function MaintenanceQueue() {
               selected={selected.has(t.id)}
               onSelectToggle={handleSelectToggle}
               onTransition={handleTransition}
-              onClick={(id) => navigate(`/maintenance/tickets/${id}`)}
+              onClick={(id) => navigate(`/maintenance/tickets/${id}?from=${filter}`)}
             />
           ))}
         </ul>

--- a/frontend/src/pages/maintenance/TicketDetail.jsx
+++ b/frontend/src/pages/maintenance/TicketDetail.jsx
@@ -25,6 +25,7 @@ import {
   createTicketNote,
   editTicketNote,
   fetchNoteAudience,
+  uploadTicketPhoto,
 } from '../../api/maintenance';
 
 const STATUS_BADGE = {
@@ -263,6 +264,69 @@ function NoteForm({ ticketId, onNoteAdded }) {
   );
 }
 
+function PhotoUploadForm({ ticketId, onPhotoAdded }) {
+  const [file, setFile] = useState(null);
+  const [preview, setPreview] = useState(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState('');
+  const inputRef = useRef(null);
+
+  const handleFile = (e) => {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    setFile(f);
+    setPreview(URL.createObjectURL(f));
+    setError('');
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!file) { setError('Choose a photo first.'); return; }
+    setUploading(true);
+    try {
+      const photo = await uploadTicketPhoto(ticketId, file);
+      onPhotoAdded(photo);
+      setFile(null);
+      setPreview(null);
+      if (inputRef.current) inputRef.current.value = '';
+    } catch (err) {
+      setError(err?.response?.data?.image?.[0] || err?.response?.data?.detail || err?.message || 'Upload failed.');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2" data-testid="photo-upload-form">
+      <div className="flex items-center gap-3">
+        <label className="flex-1">
+          <span className="sr-only">Choose photo</span>
+          <input
+            ref={inputRef}
+            type="file"
+            accept="image/*"
+            onChange={handleFile}
+            data-testid="photo-file-input"
+            className="block w-full text-sm text-gray-600 dark:text-gray-300 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border file:border-gray-300 dark:file:border-gray-600 file:text-sm file:bg-white dark:file:bg-gray-800 file:text-gray-700 dark:file:text-gray-200 hover:file:bg-gray-50"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={uploading || !file}
+          data-testid="photo-upload-submit"
+          className="inline-flex items-center px-3 min-h-[36px] rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-60"
+        >
+          {uploading ? 'Uploading…' : 'Upload'}
+        </button>
+      </div>
+      {preview && (
+        <img src={preview} alt="Preview" className="h-20 w-20 rounded-lg object-cover border border-gray-200 dark:border-gray-700" />
+      )}
+      {error && <p role="alert" className="text-sm text-red-700 dark:text-red-300">{error}</p>}
+    </form>
+  );
+}
+
 function TransitionActions({ ticket, onTransition, onUndo }) {
   const isTerminal = ['fulfilled', 'unable_to_fulfill'].includes(ticket.status);
   const canUndo = ticket.is_within_correction_window;
@@ -414,6 +478,13 @@ export default function TicketDetail() {
 
   const handleTransitionSubmitted = () => { setModal(null); load(); };
 
+  const handlePhotoAdded = (photo) => {
+    setData((prev) => ({
+      ...prev,
+      photos: [...(prev?.photos ?? []), photo],
+    }));
+  };
+
   const handleUndo = async () => {
     try {
       await correctLastTransition(ticketId);
@@ -439,6 +510,11 @@ export default function TicketDetail() {
 
   const { ticket, photos = [], activity = [] } = data || {};
   const isOpen = ticket && ['new', 'in_progress'].includes(ticket.status);
+  // After a closing transition the ticket leaves the "open" queue — send the
+  // user to "closed" so they can still find it.
+  const backFilter = (ticket && ['fulfilled', 'unable_to_fulfill'].includes(ticket.status))
+    ? 'closed'
+    : fromFilter;
 
   return (
     <div className="max-w-2xl mx-auto pb-32" data-testid="ticket-detail">
@@ -446,7 +522,7 @@ export default function TicketDetail() {
       <div className="sticky top-0 z-10 bg-white dark:bg-gray-950 border-b border-gray-200 dark:border-gray-700 px-4 py-3 flex items-center gap-3">
         <button
           type="button"
-          onClick={() => navigate(`/maintenance?filter=${fromFilter}`)}
+          onClick={() => navigate(`/maintenance?filter=${backFilter}`)}
           className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
           data-testid="back-button"
         >
@@ -497,17 +573,18 @@ export default function TicketDetail() {
             </section>
           )}
 
-          {/* Photos — original submission */}
-          {photos.filter((p) => !p.is_followup).length > 0 && (
+          {/* Photos — original submission + follow-ups */}
+          {photos.length > 0 && (
             <section data-testid="ticket-photos">
               <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">Photos</h2>
               <div className="flex flex-wrap gap-2">
-                {photos.filter((p) => !p.is_followup).map((p) => (
+                {photos.map((p) => (
                   <a
                     key={p.id}
                     href={p.image_url}
                     target="_blank"
                     rel="noopener noreferrer"
+                    title={p.caption || (p.is_followup ? 'Follow-up photo' : 'Ticket photo')}
                     className="block w-20 h-20 rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700"
                   >
                     <img src={p.image_url} alt={p.caption || 'Ticket photo'} className="w-full h-full object-cover" />
@@ -540,6 +617,14 @@ export default function TicketDetail() {
               <div className="mt-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 p-3">
                 <h3 className="text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">Add note</h3>
                 <NoteForm ticketId={ticketId} onNoteAdded={handleNoteAdded} />
+              </div>
+            )}
+
+            {/* Follow-up photo upload */}
+            {isOpen && (
+              <div className="mt-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 p-3">
+                <h3 className="text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">Add photo</h3>
+                <PhotoUploadForm ticketId={ticketId} onPhotoAdded={handlePhotoAdded} />
               </div>
             )}
           </section>


### PR DESCRIPTION
## Summary

- **Backend** (`bunk_logs/api/kitchen_staff/`): dashboard, reflection create/edit/history endpoints (Stories 37-41, 44). All reflection responses embed translation state so leadership readers see translated/pending/failed status per Story 44. Story 41 criterion 6 respected: `language` field unchanged on edit unless explicitly sent.
- **Frontend** (`pages/kitchen-staff/`): `Dashboard.jsx` with `LanguagePicker` in header, `ReflectionForm.jsx` with localized prompts + audience disclosure + language-change confirmation dialog, `History.jsx` with language-of-authorship column. Full `en`/`es` locale namespace expanded.
- **Translation**: wired to existing `enqueue_translation_for_reflection` from Step 7_5 — non-English, non-day-off submissions enqueue the Anthropic Celery task automatically.
- **Tests**: 22 backend tests (auth, happy path, translation trigger mocks, embed state assertions) + 6 frontend Dashboard tests. All pass; 23 pre-existing failures on main are unrelated.

## Test plan

- [ ] Backend: `make test-backend` — 12 new kitchen_staff tests pass
- [ ] Frontend: `make test-frontend` — 509 tests pass including 6 new Dashboard tests
- [ ] Ruff: `ruff check bunk_logs/api/kitchen_staff/` — clean
- [ ] Manual: log in as a kitchen_staff user → lands on `/kitchen-staff` → submit reflection → check translation embed pending → history shows correct language badge

Made with [Cursor](https://cursor.com)