### PR TITLE
feat(7_12): LT backend — dashboard, team, self-reflection, mark-attention

### DIFF
--- a/backend/bunk_logs/api/leadership_team/__init__.py
+++ b/backend/bunk_logs/api/leadership_team/__init__.py
@@ -1,0 +1,13 @@
+"""Leadership Team API endpoints (Step 7_12).
+
+Implements Stories 45-53. PR A delivers the supervision-driven dashboard,
+team dashboard, individual member reflection reader, self-reflection
+submit/edit, and the mark-attention primitive. PR B layers the LT-scoped
+template builder and assignment API on top; PR C adds the frontend.
+
+Visibility relies on the existing ``content_visibility`` primitive (Step
+7_1); supervision resolution uses ``Supervision.objects.team_members``
+(Step 7_3); attention badges reuse helpers from
+:mod:`api.unit_head.common` so the per-team card semantics stay
+consistent across role flows.
+"""

--- a/backend/bunk_logs/api/leadership_team/common.py
+++ b/backend/bunk_logs/api/leadership_team/common.py
@@ -1,0 +1,242 @@
+"""Shared helpers for Leadership Team endpoints (Step 7_12).
+
+Mirrors the structure of ``api/unit_head/common.py`` and
+``api/camper_care/common.py``: viewer resolution + supervision-driven
+team helpers + a thin period resolver for the biweekly LT self
+template.
+
+Key invariants
+--------------
+* Viewer must have an active ``leadership_team`` Membership AND the
+  ``program_lead`` capability (the latter is derived in ``Membership.save()``
+  via ``ROLE_TO_CAPABILITY`` — checking it here keeps the gate consistent
+  if the mapping changes).
+* "Teams I supervise" = ``Supervision.target_type='role_in_program'`` rows.
+* Period boundaries for non-daily cadences are anchored on the program
+  start_date so weekly / biweekly windows stay deterministic across
+  re-deploys and DST shifts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from django.db.models import Q
+from rest_framework.exceptions import PermissionDenied
+
+from bunk_logs.api.counselor.common import _resolve_template
+from bunk_logs.api.counselor.common import enforce_edit_window  # noqa: F401 (re-export)
+from bunk_logs.api.counselor.common import is_day_off_answer  # noqa: F401 (re-export)
+from bunk_logs.api.counselor.common import is_editable_today  # noqa: F401 (re-export)
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.models import Supervision
+from bunk_logs.core.time_utils import get_today
+
+if TYPE_CHECKING:
+    from bunk_logs.core.models import Organization
+    from bunk_logs.core.models import Program
+
+
+__all__ = [
+    "LT_SELF_TEMPLATE_SLUG",
+    "ViewerContext",
+    "leadership_team_self_template",
+    "resolve_period",
+    "supervised_role_supervisions",
+    "supervised_roles",
+    "team_membership_ids",
+    "team_memberships",
+    "viewer_or_403",
+]
+
+
+LT_SELF_TEMPLATE_SLUG = "leadership-team-self-reflection"
+
+
+@dataclass(frozen=True)
+class ViewerContext:
+    """Resolved request context for a Leadership Team endpoint."""
+
+    person: Person
+    organization: Organization
+    membership: Membership
+    program: Program
+    today: date
+
+
+def viewer_or_403(request) -> ViewerContext:
+    """Resolve viewer Person + org + active LT Membership, or raise 403.
+
+    LT endpoints require all of: organization context, an authenticated
+    user, a Person profile in that org, and at least one active
+    ``leadership_team`` Membership. We also defensively assert the
+    derived ``program_lead`` capability so a mis-seeded Membership row
+    that lost its mapping doesn't quietly grant LT access.
+    """
+    org = getattr(request, "organization", None)
+    if org is None:
+        msg = "Organization context required."
+        raise PermissionDenied(msg)
+    if not request.user.is_authenticated:
+        msg = "Authentication required."
+        raise PermissionDenied(msg)
+    person = Person.objects.filter(user=request.user).first()
+    if person is None:
+        msg = "Person profile required."
+        raise PermissionDenied(msg)
+    membership = (
+        Membership.objects.filter(
+            person=person, role="leadership_team", is_active=True,
+        )
+        .select_related("program", "program__organization")
+        .order_by("-created_at")
+        .first()
+    )
+    if membership is None or membership.capability != "program_lead":
+        msg = "Leadership Team role required."
+        raise PermissionDenied(msg)
+    return ViewerContext(
+        person=person,
+        organization=org,
+        membership=membership,
+        program=membership.program,
+        today=get_today(org),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Supervised teams (Stories 45 / 46 — LT2 explicit-supervision visibility)
+# ---------------------------------------------------------------------------
+
+
+def supervised_role_supervisions(
+    membership: Membership, *, today: date | None = None,
+) -> list[Supervision]:
+    """Active ``ROLE_IN_PROGRAM`` Supervision rows for the LT viewer.
+
+    Each row maps the LT to one (role, program) pair; multiple rows
+    cover multiple teams. We order by target_role so the per-team list
+    on the dashboard has a deterministic sort tie-breaker (after the
+    badge-priority sort that the dashboard applies).
+    """
+    return list(
+        Supervision.objects.active(today=today)
+        .for_supervisor(membership)
+        .filter(target_type=Supervision.TargetType.ROLE_IN_PROGRAM)
+        .select_related("target_program")
+        .order_by("target_role"),
+    )
+
+
+def supervised_roles(
+    membership: Membership, *, today: date | None = None,
+) -> list[tuple[str, int]]:
+    """List of ``(target_role, target_program_id)`` pairs."""
+    return [
+        (s.target_role, s.target_program_id)
+        for s in supervised_role_supervisions(membership, today=today)
+    ]
+
+
+def team_memberships(
+    membership: Membership, target_role: str, *, today: date | None = None,
+):
+    """Memberships forming the team for ``target_role`` (Story 46 c1)."""
+    return (
+        Supervision.objects.team_members(membership, target_role=target_role, today=today)
+        .select_related("person", "program")
+        .order_by("person__last_name", "person__first_name")
+    )
+
+
+def team_membership_ids(
+    membership: Membership, target_role: str, *, today: date | None = None,
+) -> set[int]:
+    return set(
+        team_memberships(membership, target_role, today=today).values_list("id", flat=True),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Template resolution
+# ---------------------------------------------------------------------------
+
+
+def leadership_team_self_template(
+    organization: Organization, program: Program,
+) -> ReflectionTemplate | None:
+    """Active LT self-reflection template, org-shadowing-global.
+
+    Picks the template targeting role=``leadership_team`` with
+    ``subject_mode='self'``. The cadence is whatever the org/program has
+    configured — default biweekly (see seed migration 0034) but
+    overridable per program (Story 50 c2). The org-shadow resolver
+    inherits the highest-version active row.
+    """
+    qs = ReflectionTemplate.all_objects.filter(
+        Q(role="leadership_team") | Q(author_role_filter__contains=["leadership_team"]),
+        subject_mode="self",
+    )
+    return _resolve_template(
+        qs, organization=organization, program_type=program.program_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Period resolution (Story 50 — cadence-driven period boundaries)
+# ---------------------------------------------------------------------------
+
+
+def resolve_period(
+    template: ReflectionTemplate, *, anchor: date, program: Program,
+) -> tuple[date, date]:
+    """Return ``(period_start, period_end)`` for ``anchor`` under a cadence.
+
+    * ``daily``: a single day.
+    * ``weekly``: Monday-anchored week containing ``anchor``.
+    * ``biweekly``: 14-day chunks anchored on ``program.start_date``;
+      falls back to a Monday-anchored fortnight if no program start.
+    * ``monthly``: calendar month containing ``anchor``.
+    * ``on_demand``: degenerate single-day window.
+
+    Deliberately deterministic so the edit-window check
+    (``period_start <= today <= period_end``) is consistent for any
+    viewer reading the same template at the same moment.
+    """
+    cadence = (template.cadence or "daily").lower()
+    if cadence in ("daily", "on_demand"):
+        return anchor, anchor
+    if cadence == "weekly":
+        start = anchor - timedelta(days=anchor.weekday())
+        return start, start + timedelta(days=6)
+    if cadence == "biweekly":
+        ref = program.start_date if (program and program.start_date) else (
+            anchor - timedelta(days=anchor.weekday())
+        )
+        delta_days = (anchor - ref).days
+        # Integer-floor toward the prior fortnight boundary even when
+        # anchor predates ref (negative delta).
+        period_index = delta_days // 14
+        start = ref + timedelta(days=period_index * 14)
+        return start, start + timedelta(days=13)
+    if cadence == "monthly":
+        start = anchor.replace(day=1)
+        # Last day = first of next month minus 1.
+        if start.month == 12:
+            next_first = start.replace(year=start.year + 1, month=1)
+        else:
+            next_first = start.replace(month=start.month + 1)
+        return start, next_first - timedelta(days=1)
+    # Unknown cadence — fail safe to single-day window.
+    return anchor, anchor
+
+
+def is_within_period(reflection_period_start: date, reflection_period_end: date,
+                     today: date) -> bool:
+    """Convenience: whether ``today`` falls within the reflection's period."""
+    return reflection_period_start <= today <= reflection_period_end

--- a/backend/bunk_logs/api/leadership_team/dashboard.py
+++ b/backend/bunk_logs/api/leadership_team/dashboard.py
@@ -1,0 +1,457 @@
+"""``GET /api/v1/leadership-team/dashboard/`` — Story 45.
+
+Returns per-team cards (one per ROLE_IN_PROGRAM supervision the LT
+viewer holds), an entry to the Bunks-and-Units side (Story 49), the
+LT's "My reflection" state for the current period, and a tiny
+templates-and-assignments summary (Stories 51, 53 — full list lives on
+its own page).
+
+Caching mirrors the UH/CC dashboards: 30s per (org, viewer, day).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.core.cache import cache
+
+if TYPE_CHECKING:
+    from datetime import date
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.api.counselor.common import camper_reflection_template
+from bunk_logs.api.counselor.common import is_day_off_answer
+from bunk_logs.api.counselor.common import latest_self_reflection
+from bunk_logs.api.unit_head.common import expected_by_passed
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import Note
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import Supervision
+
+from .common import leadership_team_self_template
+from .common import resolve_period
+from .common import supervised_role_supervisions
+from .common import team_memberships
+from .common import viewer_or_403
+
+DASHBOARD_CACHE_TTL_SECONDS = 30
+LOW_COMPLETION_THRESHOLD = 0.5  # Story 45 c5: <50% by configured time
+
+ATTENTION_BADGE_ORDER: tuple[str, ...] = (
+    "low_completion",
+    "concerning_ratings",
+    "sensitive_content",
+)
+
+
+def _cache_key(*, viewer_id: int, organization_id: int, today: date) -> str:
+    return f"leadership_team_dashboard:{organization_id}:{viewer_id}:{today.isoformat()}"
+
+
+class LeadershipTeamDashboardView(APIView):
+    """Supervised teams + bunks-and-units entry + self-reflection state."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer = ctx.person
+        org = ctx.organization
+        today = ctx.today
+
+        bypass = (request.query_params.get("nocache") or "").lower() in {"1", "true"}
+        cache_key = _cache_key(viewer_id=viewer.id, organization_id=org.id, today=today)
+        if not bypass:
+            cached = cache.get(cache_key)
+            if cached is not None:
+                return Response(cached)
+
+        teams_payload = _build_team_cards(ctx)
+        bunks_units = _build_bunks_units_summary(ctx)
+        self_section = _build_self_section(ctx)
+        templates_summary = _build_templates_summary(ctx)
+
+        payload = {
+            "today": today.isoformat(),
+            "teams": teams_payload,
+            "bunks_and_units": bunks_units,
+            "self_reflection": self_section,
+            "templates_and_assignments": templates_summary,
+        }
+        cache.set(cache_key, payload, DASHBOARD_CACHE_TTL_SECONDS)
+        return Response(payload)
+
+
+# ---------------------------------------------------------------------------
+# Per-team cards (Story 45 c3-c6)
+# ---------------------------------------------------------------------------
+
+
+def _build_team_cards(ctx) -> list[dict]:
+    """One card per ROLE_IN_PROGRAM supervision held by the LT viewer.
+
+    Each card carries member counts, today's completion, co-supervisor
+    names, and the attention badges in dashboard-sort order.
+    """
+    supervisions = supervised_role_supervisions(ctx.membership, today=ctx.today)
+    if not supervisions:
+        return []
+
+    expected_passed = expected_by_passed(ctx.organization, ctx.today)
+    cards: list[dict] = []
+    for supervision in supervisions:
+        role = supervision.target_role
+        program = supervision.target_program
+        memberships = team_memberships(ctx.membership, role, today=ctx.today)
+        member_count = memberships.count()
+        member_person_ids = list(memberships.values_list("person_id", flat=True))
+
+        completion, concerning = _team_completion(
+            organization=ctx.organization,
+            program=program,
+            target_role=role,
+            person_ids=member_person_ids,
+            today=ctx.today,
+        )
+
+        sensitive_count = _team_sensitive_notes_count(
+            organization=ctx.organization,
+            program=program,
+            today=ctx.today,
+            role=role,
+            person_ids=member_person_ids,
+        )
+
+        badges = _compute_team_badges(
+            completion=completion,
+            concerning=concerning,
+            sensitive_count=sensitive_count,
+            expected_passed=expected_passed,
+            low_completion_threshold=LOW_COMPLETION_THRESHOLD,
+        )
+
+        co_supervisors = list(
+            Supervision.objects.co_supervisors(supervision, today=ctx.today)
+            .select_related("supervisor_membership__person"),
+        )
+
+        cards.append({
+            "team_role": role,
+            "team_role_label": dict(_role_labels()).get(role, role.replace("_", " ").title()),
+            "program_id": program.id if program else None,
+            "program_name": program.name if program else None,
+            "member_count": member_count,
+            "completion": completion,
+            "co_supervisors": [
+                {
+                    "membership_id": s.supervisor_membership_id,
+                    "person_name": _person_brief(s.supervisor_membership.person),
+                }
+                for s in co_supervisors
+                if s.supervisor_membership and s.supervisor_membership.person
+            ],
+            "badges": badges,
+        })
+
+    cards.sort(key=_team_card_sort_key)
+    return cards
+
+
+def _team_completion(
+    *, organization, program, target_role: str, person_ids: list[int], today: date,
+) -> tuple[dict, bool]:
+    """Today's submission count vs expected for a team.
+
+    Returns ``(completion_dict, has_concerning_rating)``. The concerning
+    rating flag fires when any answer in any submission equals the
+    template's lowest scale value (Story 45 c5 — LT4).
+    """
+    if not person_ids:
+        return {"submitted": 0, "expected": 0}, False
+
+    # Resolve the team's active self-reflection template for the given role.
+    # Org-shadows-global resolver; cadence is whatever the template carries.
+    template = _team_template_for_role(organization, program, target_role)
+    if template is None:
+        return {"submitted": 0, "expected": len(person_ids)}, False
+
+    period_start, period_end = resolve_period(
+        template, anchor=today, program=program,
+    )
+
+    reflections = list(
+        Reflection.all_objects.filter(
+            template=template,
+            subject_id__in=person_ids,
+            period_start=period_start,
+            period_end=period_end,
+            is_complete=True,
+        ),
+    )
+    submitted_subject_ids = {r.subject_id for r in reflections}
+
+    concerning = _has_concerning_rating(template, reflections)
+    return (
+        {"submitted": len(submitted_subject_ids), "expected": len(person_ids)},
+        concerning,
+    )
+
+
+def _team_template_for_role(organization, program, target_role: str):
+    """Active self-reflection template for ``target_role`` in this program."""
+    from bunk_logs.api.counselor.common import _resolve_template
+    from bunk_logs.core.models import ReflectionTemplate
+
+    qs = ReflectionTemplate.all_objects.filter(
+        role=target_role, subject_mode="self",
+    )
+    return _resolve_template(
+        qs, organization=organization, program_type=program.program_type if program else None,
+    )
+
+
+def _has_concerning_rating(template, reflections) -> bool:
+    """True iff any answer == ``min(scale)`` of any scored field in ``template``."""
+    from bunk_logs.core.reflection_scores import iter_scored_fields
+    from bunk_logs.core.reflection_scores import resolve_rating_cells
+
+    if not reflections:
+        return False
+    scale_mins: dict[str, int] = {}
+    for field, label, _scale_max in iter_scored_fields(template):
+        scale = field.get("scale")
+        if isinstance(scale, list) and scale:
+            try:
+                scale_mins[label] = int(scale[0])
+            except (TypeError, ValueError):
+                continue
+    if not scale_mins:
+        return False
+    schema_fields = (template.schema or {}).get("fields") or []
+    field_by_key = {
+        f["key"]: f for f in schema_fields
+        if isinstance(f, dict) and isinstance(f.get("key"), str)
+    }
+    for r in reflections:
+        for label, min_val in scale_mins.items():
+            field_key = label.split("__", 1)[0]
+            field = field_by_key.get(field_key)
+            if field is None:
+                continue
+            cells = resolve_rating_cells(field, r.answers or {})
+            value = cells.get(label)
+            if value is not None and value <= min_val:
+                return True
+    return False
+
+
+def _team_sensitive_notes_count(
+    *, organization, program, today: date, role: str, person_ids: list[int],
+) -> int:
+    """Sensitive Specialist / Camper-Care notes about team members today.
+
+    LT3 visibility for sensitive content extends to LT supervisors only
+    when the content is in their supervised scope. We use the union of
+    the supervised team's person ids as the scope for this card.
+    Counting sensitive notes about LT members themselves is unusual but
+    not impossible; the count is most meaningful for teams of campers /
+    counselors that LT supervises transitively. Today the scope is
+    direct-team; further transitive expansion is deferred.
+    """
+    if not person_ids:
+        return 0
+    return (
+        Note.all_objects.filter(
+            organization=organization,
+            program=program,
+            subject_id__in=person_ids,
+            is_sensitive=True,
+            note_type__in=[
+                Note.NoteType.SPECIALIST, Note.NoteType.CAMPER_CARE,
+            ],
+            created_at__date=today,
+        ).count()
+    )
+
+
+def _compute_team_badges(
+    *, completion: dict, concerning: bool, sensitive_count: int,
+    expected_passed: bool, low_completion_threshold: float,
+) -> list[str]:
+    """Compute attention badges in dashboard-sort order for one team card."""
+    badges: list[str] = []
+    expected = completion.get("expected") or 0
+    submitted = completion.get("submitted") or 0
+    if expected_passed and expected:
+        ratio = submitted / expected
+        if ratio < low_completion_threshold:
+            badges.append("low_completion")
+    if concerning:
+        badges.append("concerning_ratings")
+    if sensitive_count > 0:
+        badges.append("sensitive_content")
+    return badges
+
+
+def _team_card_sort_key(card: dict) -> tuple:
+    """Story 45 c6 sort order.
+
+    Badged cards first, in ATTENTION_BADGE_ORDER priority of the
+    HIGHEST badge. Within the same band, alphabetical by team role
+    (case-insensitive). Unbadged cards come last, also alphabetical.
+    """
+    badges = card.get("badges") or []
+    name_key = (card.get("team_role") or "").casefold()
+    if not badges:
+        return (1, 99, name_key)
+    priority = min(
+        (ATTENTION_BADGE_ORDER.index(b) for b in badges if b in ATTENTION_BADGE_ORDER),
+        default=99,
+    )
+    return (0, priority, name_key)
+
+
+# ---------------------------------------------------------------------------
+# Bunks-and-units summary (Story 49 entry)
+# ---------------------------------------------------------------------------
+
+
+def _build_bunks_units_summary(ctx) -> dict:
+    """Org-wide unit + bunk counts plus today's completion."""
+    org = ctx.organization
+    program = ctx.program
+    today = ctx.today
+
+    units = list(
+        AssignmentGroup.objects.filter(
+            program=program, group_type="unit", is_active=True,
+        ).order_by("name"),
+    )
+    bunks = list(
+        AssignmentGroup.objects.filter(
+            program=program, group_type="bunk", is_active=True,
+        ),
+    )
+    camper_template = camper_reflection_template(org, program)
+    submitted = 0
+    expected = 0
+    if camper_template and bunks:
+        # Expected = active subjects across all bunks (today's roster).
+        from bunk_logs.core.models import AssignmentGroupMembership
+        subject_ids = list(
+            AssignmentGroupMembership.objects.filter(
+                group__in=bunks, role_in_group="subject", is_active=True,
+            ).values_list("person_id", flat=True),
+        )
+        expected = len(subject_ids)
+        submitted = (
+            Reflection.all_objects.filter(
+                template=camper_template,
+                assignment_group__in=bunks,
+                subject_id__in=subject_ids,
+                period_start=today,
+                period_end=today,
+                is_complete=True,
+            ).values("subject_id").distinct().count()
+        )
+    return {
+        "unit_count": len(units),
+        "bunk_count": len(bunks),
+        "completion": {"submitted": submitted, "expected": expected},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Self-reflection section (Story 50)
+# ---------------------------------------------------------------------------
+
+
+def _build_self_section(ctx) -> dict:
+    template = leadership_team_self_template(ctx.organization, ctx.program)
+    if template is None:
+        return {
+            "state": "missing",
+            "reflection_id": None,
+            "template_id": None,
+            "editable": False,
+            "period_start": None,
+            "period_end": None,
+        }
+    period_start, period_end = resolve_period(
+        template, anchor=ctx.today, program=ctx.program,
+    )
+    existing = latest_self_reflection(
+        ctx.person, template, period_start, period_end,
+    )
+    state = "missing"
+    reflection_id = None
+    editable = period_start <= ctx.today <= period_end
+    if existing is not None:
+        state = "day_off" if is_day_off_answer(existing) else "complete"
+        reflection_id = existing.id
+    return {
+        "state": state,
+        "reflection_id": reflection_id,
+        "template_id": template.id,
+        "editable": editable,
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+        "cadence": template.cadence,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Templates-and-assignments summary (Stories 51, 53)
+# ---------------------------------------------------------------------------
+
+
+def _build_templates_summary(ctx) -> dict:
+    """Tiny "Templates & assignments" preview for the dashboard.
+
+    PR A keeps this minimal — just counts of templates the viewer
+    authored / can clone. PR B fills in the full library + active
+    assignment counts.
+    """
+    from bunk_logs.core.models import ReflectionTemplate
+
+    owned = ReflectionTemplate.objects.filter(
+        organization=ctx.organization,
+        metadata__contains={"created_by_membership_id": ctx.membership.id},
+    ).count() if _template_metadata_supported() else 0
+    return {
+        "owned_template_count": owned,
+        "assignment_count": 0,  # filled in PR B
+    }
+
+
+def _template_metadata_supported() -> bool:
+    """Whether ReflectionTemplate has the LT-builder ``metadata`` column.
+
+    PR A doesn't add the column yet — PR B does. The dashboard accepts
+    that ``owned_template_count`` is 0 until then; this keeps the API
+    shape stable across PRs.
+    """
+    from bunk_logs.core.models import ReflectionTemplate
+    return "metadata" in {f.name for f in ReflectionTemplate._meta.get_fields()}
+
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+
+
+def _role_labels() -> list[tuple[str, str]]:
+    from bunk_logs.core.models import Membership
+    return list(Membership.ROLES)
+
+
+def _person_brief(person) -> str:
+    if person is None:
+        return ""
+    name = (person.preferred_name or person.first_name or "").strip()
+    last_initial = (person.last_name or "").strip()[:1]
+    if name and last_initial:
+        return f"{name} {last_initial}."
+    return name or last_initial or ""

--- a/backend/bunk_logs/api/leadership_team/mark_attention.py
+++ b/backend/bunk_logs/api/leadership_team/mark_attention.py
@@ -1,0 +1,125 @@
+"""``POST /api/v1/leadership-team/reflections/<id>/mark-attention/`` — Story 46 c5.
+
+Places a :class:`ReflectionAttentionMarker` on a reflection authored by
+a team member the LT viewer supervises. The marker is visible to the
+viewer and to co-supervisors (Supervisions sharing the same
+``ROLE_IN_PROGRAM`` target), but does NOT mutate the reflection or
+notify the author.
+
+A subsequent POST by the same marker_membership is idempotent — we
+``update_or_create`` keyed on ``(reflection, marker_membership)`` so
+repeated taps don't pile up duplicate rows. The optional ``note``
+captures the supervisor's reason and replaces the previous note when
+re-marking.
+
+DELETE removes the viewer's own marker (un-mark). DELETE by other
+supervisors is rejected with 403 so one LT cannot quietly suppress a
+peer's attention flag.
+"""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+from rest_framework import status
+from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.filters import reflections_visible_for_user
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionAttentionMarker
+
+from .common import viewer_or_403
+
+
+class _MarkAttentionSerializer(serializers.Serializer):
+    note = serializers.CharField(required=False, allow_blank=True, max_length=500)
+
+
+class LeadershipTeamMarkAttentionView(APIView):
+    """Mark / unmark a reflection as needing attention."""
+
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["post", "delete", "head", "options"]
+
+    def post(self, request, reflection_id: int, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        reflection = _get_visible_reflection(request, ctx, reflection_id)
+
+        ser = _MarkAttentionSerializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        note = (ser.validated_data.get("note") or "").strip()
+
+        marker, created = ReflectionAttentionMarker.all_objects.update_or_create(
+            reflection=reflection,
+            marker_membership=ctx.membership,
+            defaults={
+                "organization": ctx.organization,
+                "note": note,
+            },
+        )
+        audit_module.created(
+            ctx.membership, marker,
+            after_state={
+                "reflection_id": reflection.id,
+                "note": note,
+            },
+            content_type="reflection_attention_marker",
+        )
+        return Response({
+            "id": marker.id,
+            "reflection_id": reflection.id,
+            "marker_membership_id": ctx.membership.id,
+            "note": marker.note,
+            "created": created,
+            "created_at": marker.created_at.isoformat(),
+        }, status=status.HTTP_201_CREATED if created else status.HTTP_200_OK)
+
+    def delete(self, request, reflection_id: int, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        reflection = _get_visible_reflection(request, ctx, reflection_id)
+
+        marker = ReflectionAttentionMarker.all_objects.filter(
+            reflection=reflection, marker_membership=ctx.membership,
+        ).first()
+        if marker is None:
+            msg = "No attention marker to remove."
+            raise NotFound(msg)
+        before = {"reflection_id": reflection.id, "note": marker.note}
+        marker.delete()
+        audit_module.deactivated(
+            ctx.membership, reflection,
+            before_state=before,
+            content_type="reflection_attention_marker",
+            reason="attention marker removed",
+        )
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+def _get_visible_reflection(request, ctx, reflection_id: int) -> Reflection:
+    """Resolve a reflection the LT viewer is allowed to flag.
+
+    Visibility uses the standard ``RoleVisibilityFilterBackend`` query
+    so we don't accidentally widen the audience by relying on
+    supervision alone. A reflection the LT cannot read cannot be
+    flagged either.
+    """
+    reflection = (
+        Reflection.all_objects.filter(id=reflection_id, organization=ctx.organization)
+        .select_related("template", "author", "program")
+        .first()
+    )
+    if reflection is None:
+        msg = "Reflection not found."
+        raise NotFound(msg)
+    visible = reflections_visible_for_user(
+        request.user,
+        Reflection.all_objects.filter(id=reflection_id),
+    )
+    if not visible.exists():
+        msg = "You may not flag this reflection."
+        raise PermissionDenied(msg)
+    return reflection

--- a/backend/bunk_logs/api/leadership_team/member_reflection.py
+++ b/backend/bunk_logs/api/leadership_team/member_reflection.py
@@ -1,0 +1,315 @@
+"""``GET /api/v1/leadership-team/teams/<team_role>/members/<membership_id>/reflection/``.
+
+Story 47 — individual reflection reader for one team member.
+
+Read-only. Pulls the most-recent reflection for the period, the trend
+graph data over the configured window (default 14 days for daily
+cadence, 8 periods for non-daily), and the visibility-filtered
+reflection payload using the shared
+:func:`api.unit_head.camper_dashboard.build_camper_dashboard_payload`
+trend helpers.
+
+LT readers see translation embeds for non-English content via the
+existing reflection serializer (Story 44); they may NOT edit, comment,
+or read prior edit history — only "Edited [time]" indicator (Story
+47 c5).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from datetime import timedelta
+from typing import Any
+
+from django.utils.dateparse import parse_date
+from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.api.counselor.common import person_display_name
+from bunk_logs.core.filters import reflections_visible_for_user
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionAttentionMarker
+from bunk_logs.core.models import TranslationRecord
+from bunk_logs.core.reflection_scores import iter_scored_fields
+from bunk_logs.core.reflection_scores import resolve_rating_cells
+
+from .common import resolve_period
+from .common import team_memberships
+from .common import viewer_or_403
+from .dashboard import _team_template_for_role
+from .team_dashboard import _ensure_supervised
+
+
+class LeadershipTeamMemberReflectionView(APIView):
+    """One team member's reflection for a period, with trend graph + meta."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, team_role: str, membership_id: int, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        _ensure_supervised(ctx, team_role)
+
+        # Verify the membership is on the team.
+        team = list(team_memberships(ctx.membership, team_role, today=ctx.today))
+        member = next((m for m in team if m.id == membership_id), None)
+        if member is None:
+            msg = "This member is not on the supervised team."
+            raise NotFound(msg)
+        person = member.person
+        if person is None:
+            msg = "Member has no Person profile."
+            raise NotFound(msg)
+
+        template = _team_template_for_role(ctx.organization, ctx.program, team_role)
+        period_raw = request.query_params.get("period")
+        anchor = _parse_date_param(period_raw, default=ctx.today)
+        if anchor > ctx.today:
+            msg = "Future periods are not selectable."
+            raise ValidationError(msg)
+
+        if template is None:
+            return Response({
+                "header": _header(person, member, period=None, language_pref=person.preferred_language),
+                "metadata": None,
+                "content": None,
+                "trend": {"series": [], "scale_max": 5, "period": None},
+                "attention_markers": [],
+            })
+
+        period_start, period_end = resolve_period(
+            template, anchor=anchor, program=ctx.program,
+        )
+
+        # Visibility-filtered current-period reflection (most recent).
+        current_qs = (
+            Reflection.all_objects.filter(
+                template=template,
+                subject=person,
+                period_start=period_start,
+                period_end=period_end,
+                is_complete=True,
+            )
+            .select_related("author", "template")
+        )
+        reflection = (
+            reflections_visible_for_user(request.user, current_qs)
+            .order_by("-submitted_at")
+            .first()
+        )
+        content = _serialize_reflection(reflection, template) if reflection else None
+        trend_payload = _build_trend(
+            request=request, template=template, person=person,
+            anchor=anchor, program=ctx.program,
+        )
+
+        marker_rows: list[dict] = []
+        if reflection is not None:
+            marker_rows = [
+                {
+                    "id": marker.id,
+                    "marker_membership_id": marker.marker_membership_id,
+                    "person_name": person_display_name(marker.marker_membership.person)
+                                   if marker.marker_membership and marker.marker_membership.person else "",
+                    "note": marker.note,
+                    "created_at": marker.created_at.isoformat(),
+                }
+                for marker in ReflectionAttentionMarker.objects.filter(
+                    reflection=reflection,
+                ).select_related("marker_membership__person").order_by("-created_at")
+            ]
+
+        return Response({
+            "header": _header(
+                person, member,
+                period={"start": period_start.isoformat(),
+                        "end": period_end.isoformat(),
+                        "cadence": template.cadence},
+                language_pref=person.preferred_language,
+            ),
+            "metadata": _metadata(reflection),
+            "content": content,
+            "trend": trend_payload,
+            "attention_markers": marker_rows,
+        })
+
+
+# ---------------------------------------------------------------------------
+# Payload helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_date_param(raw: str | None, *, default: date) -> date:
+    if not raw:
+        return default
+    parsed = parse_date(raw)
+    if parsed is None:
+        msg = "Invalid 'period' parameter; expected YYYY-MM-DD."
+        raise ValidationError(msg)
+    return parsed
+
+
+def _header(person, membership: Membership, *, period, language_pref: str) -> dict:
+    return {
+        "person": {
+            "id": person.id,
+            "name": person_display_name(person),
+            "first_name": person.first_name,
+            "last_name": person.last_name,
+            "preferred_name": person.preferred_name,
+        },
+        "role": membership.role,
+        "membership_id": membership.id,
+        "language_preference": language_pref,
+        "period": period,
+    }
+
+
+def _metadata(reflection: Reflection | None) -> dict | None:
+    if reflection is None:
+        return None
+    edited = (
+        reflection.updated_at is not None
+        and reflection.submitted_at is not None
+        and (reflection.updated_at - reflection.submitted_at).total_seconds() > 1
+    )
+    return {
+        "reflection_id": reflection.id,
+        "submitted_at": reflection.submitted_at.isoformat() if reflection.submitted_at else None,
+        "last_edited_at": reflection.updated_at.isoformat() if edited else None,
+        "language_of_authorship": reflection.language,
+        "team_visibility": reflection.team_visibility,
+    }
+
+
+def _serialize_reflection(reflection: Reflection, template) -> dict:
+    """Render answers in template field order with translation embed."""
+    answers = reflection.answers or {}
+    fields_out: list[dict[str, Any]] = []
+    for f in (template.schema or {}).get("fields") or []:
+        if not isinstance(f, dict):
+            continue
+        key = f.get("key")
+        if not isinstance(key, str):
+            continue
+        fields_out.append({
+            "key": key,
+            "type": f.get("type"),
+            "dashboard_role": f.get("dashboard_role"),
+            "prompts": f.get("prompts") or {},
+            "scale_labels": f.get("scale_labels") or {},
+            "scale": f.get("scale"),
+            "categories": f.get("categories") or [],
+            "options": f.get("options") or [],
+            "answer": answers.get(key),
+        })
+    translation = None
+    if reflection.language != "en":
+        record = TranslationRecord.latest_for("reflection", reflection.pk)
+        if record is None:
+            translation = {
+                "status": "pending",
+                "source_language": reflection.language,
+                "target_language": "en",
+                "translated_text": "",
+            }
+        else:
+            translation = {
+                "id": str(record.id),
+                "status": record.status,
+                "source_language": record.source_language,
+                "target_language": record.target_language,
+                "translated_text": record.translated_text,
+            }
+    return {
+        "fields": fields_out,
+        "translation": translation,
+    }
+
+
+def _build_trend(
+    *, request, template, person, anchor: date, program,
+) -> dict:
+    """Trend payload over the configured window.
+
+    Default windows (Story 47 c1):
+    * daily cadence -> last 14 days inclusive.
+    * non-daily cadences -> last 8 periods inclusive.
+    """
+    cadence = (template.cadence or "daily").lower()
+    if cadence == "daily":
+        period_end = anchor
+        period_start = anchor - timedelta(days=13)
+        periods = [
+            (period_start + timedelta(days=i), period_start + timedelta(days=i))
+            for i in range(14)
+        ]
+    else:
+        # Walk back N periods of the same cadence.
+        periods = []
+        cursor = anchor
+        for _ in range(8):
+            ps, pe = resolve_period(template, anchor=cursor, program=program)
+            periods.append((ps, pe))
+            cursor = ps - timedelta(days=1)
+        periods.reverse()
+        period_start, period_end = periods[0][0], periods[-1][1]
+
+    qs = (
+        Reflection.all_objects.filter(
+            template=template,
+            subject=person,
+            period_start__gte=period_start,
+            period_end__lte=period_end,
+            is_complete=True,
+        )
+        .order_by("period_end", "submitted_at")
+    )
+    reflections = list(reflections_visible_for_user(request.user, qs))
+
+    by_period: dict[tuple[date, date], Reflection] = {}
+    for r in reflections:
+        key = (r.period_start, r.period_end)
+        existing = by_period.get(key)
+        if existing is None or r.submitted_at > existing.submitted_at:
+            by_period[key] = r
+
+    series: list[dict[str, Any]] = []
+    scale_max_overall = 5
+    for field, label, sm in iter_scored_fields(template):
+        scale_max_overall = max(scale_max_overall, sm)
+        points: list[dict[str, Any]] = []
+        for ps, pe in periods:
+            r = by_period.get((ps, pe))
+            value: float | None = None
+            reflection_id = None
+            if r is not None:
+                cells = resolve_rating_cells(field, r.answers or {})
+                value = cells.get(label)
+                reflection_id = r.id
+            points.append({
+                "period_start": ps.isoformat(),
+                "period_end": pe.isoformat(),
+                "value": round(value, 2) if value is not None else None,
+                "reflection_id": reflection_id,
+            })
+        series.append({
+            "label": label,
+            "field_key": field.get("key"),
+            "field_type": field.get("type"),
+            "scale_max": sm,
+            "points": points,
+        })
+
+    return {
+        "series": series,
+        "scale_max": scale_max_overall,
+        "period": {
+            "start": period_start.isoformat(),
+            "end": period_end.isoformat(),
+            "cadence": cadence,
+        },
+    }

--- a/backend/bunk_logs/api/leadership_team/self_reflection.py
+++ b/backend/bunk_logs/api/leadership_team/self_reflection.py
@@ -1,0 +1,224 @@
+"""LT self-reflection write + edit endpoints — Story 50.
+
+POST  /api/v1/leadership-team/self-reflection/                — submit
+PATCH /api/v1/leadership-team/self-reflection/<id>/           — edit within period
+
+Differences from the kitchen / counselor / UH self-reflection modules:
+
+* Template is ``leadership-team-self-reflection`` (biweekly by default).
+* Edit window is the current period, not a single rollover day — we
+  enforce ``period_start <= today <= period_end`` instead of
+  ``is_editable_today``.
+* The ``is_private`` payload toggle restricts visibility to the
+  author + Admin only by mapping to
+  ``Reflection.TeamVisibility.SUPERVISORS_ONLY`` AND marking the row
+  ``is_sensitive=True``. That combination flips the visibility model
+  to the sensitive-variant audience for ``LEADERSHIP_TEAM_SELF_REFLECTION``
+  ({admin} only) per ``content_visibility._SENSITIVE_AUDIENCES``.
+
+Notes on history:
+* The dashboard reads "current period" state; a paginated history list
+  endpoint lands in PR B with the broader templates + responses surface.
+"""
+
+from __future__ import annotations
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
+from rest_framework import status
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.api.counselor.common import find_existing_by_client_submission_id
+from bunk_logs.api.counselor.responses import reflection_response
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import reflection_snapshot
+from bunk_logs.core.models import validate_reflection_answers
+from bunk_logs.core.translation import enqueue_translation_for_reflection
+
+from .common import leadership_team_self_template
+from .common import resolve_period
+from .common import viewer_or_403
+from .serializers import LTSelfReflectionCreateSerializer
+from .serializers import LTSelfReflectionUpdateSerializer
+
+
+def _validate_answers_for_template(template, answers: dict) -> tuple[bool, Response | None]:
+    try:
+        validate_reflection_answers(template.schema, answers)
+    except DjangoValidationError as exc:
+        body = exc.message_dict if hasattr(exc, "message_dict") else {"answers": str(exc)}
+        return False, Response(body, status=status.HTTP_400_BAD_REQUEST)
+    return True, None
+
+
+def _enforce_period(reflection: Reflection, today) -> None:
+    if reflection.period_start <= today <= reflection.period_end:
+        return
+    msg = "This reflection can no longer be edited (the period has closed)."
+    raise PermissionDenied(msg)
+
+
+def _bust_dashboard_cache(org_id: int, viewer_id: int, today) -> None:
+    from django.core.cache import cache
+    cache.delete(f"leadership_team_dashboard:{org_id}:{viewer_id}:{today.isoformat()}")
+
+
+class LeadershipTeamSelfReflectionCreateView(APIView):
+    """POST an LT self-reflection for the current period (Story 50)."""
+
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["post", "head", "options"]
+
+    def post(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer, org, today = ctx.person, ctx.organization, ctx.today
+
+        ser = LTSelfReflectionCreateSerializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        payload = ser.validated_data
+
+        template = leadership_team_self_template(org, ctx.program)
+        if template is None:
+            msg = "No Leadership Team self-reflection template configured."
+            raise PermissionDenied(msg)
+
+        existing = find_existing_by_client_submission_id(
+            Reflection, program=ctx.program,
+            client_submission_id=payload["client_submission_id"],
+        )
+        if existing is not None:
+            return Response(reflection_response(existing), status=status.HTTP_200_OK)
+
+        period_start, period_end = resolve_period(
+            template, anchor=today, program=ctx.program,
+        )
+
+        answers = dict(payload.get("answers") or {})
+        ok, err = _validate_answers_for_template(template, answers)
+        if not ok:
+            return err
+
+        is_private = bool(payload.get("is_private"))
+        team_visibility = (
+            Reflection.TeamVisibility.SUPERVISORS_ONLY
+            if is_private
+            else Reflection.TeamVisibility.TEAM
+        )
+
+        with transaction.atomic():
+            reflection = Reflection(
+                organization=org,
+                program=ctx.program,
+                subject=viewer,
+                author=viewer,
+                assignment_group=None,
+                template=template,
+                submitted_by=request.user,
+                period_start=period_start,
+                period_end=period_end,
+                answers=answers,
+                language=payload["language"],
+                team_visibility=team_visibility,
+                is_sensitive=is_private,
+                is_complete=True,
+                client_submission_id=payload["client_submission_id"],
+            )
+            try:
+                reflection.full_clean()
+            except DjangoValidationError as exc:
+                body = exc.message_dict if hasattr(exc, "message_dict") else str(exc)
+                return Response(body, status=status.HTTP_400_BAD_REQUEST)
+            reflection.save()
+
+        audit_module.created(
+            ctx.membership, reflection,
+            after_state=reflection_snapshot(reflection),
+            content_type="reflection",
+        )
+        enqueue_translation_for_reflection(reflection)
+        _bust_dashboard_cache(org.id, viewer.id, today)
+        return Response(reflection_response(reflection), status=status.HTTP_201_CREATED)
+
+
+class LeadershipTeamSelfReflectionDetailView(APIView):
+    """PATCH an LT self-reflection within its period (Story 50 c7)."""
+
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["patch", "head", "options"]
+
+    def patch(self, request, reflection_id: int, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        viewer, org, today = ctx.person, ctx.organization, ctx.today
+
+        reflection = (
+            Reflection.all_objects.filter(id=reflection_id, organization=org)
+            .select_related("template", "program")
+            .first()
+        )
+        if reflection is None:
+            return Response(
+                {"detail": "Reflection not found."}, status=status.HTTP_404_NOT_FOUND,
+            )
+        if reflection.author_id != viewer.id or reflection.subject_id != viewer.id:
+            msg = "You can only edit your own self-reflection."
+            raise PermissionDenied(msg)
+        _enforce_period(reflection, today)
+
+        ser = LTSelfReflectionUpdateSerializer(data=request.data, partial=True)
+        ser.is_valid(raise_exception=True)
+        payload = ser.validated_data
+
+        before = reflection_snapshot(reflection)
+
+        if "answers" in payload:
+            answers = dict(payload["answers"])
+            ok, err = _validate_answers_for_template(reflection.template, answers)
+            if not ok:
+                return err
+        else:
+            answers = reflection.answers
+
+        language = payload.get("language", reflection.language)
+        reflection.answers = answers
+        reflection.language = language
+
+        if "is_private" in payload:
+            is_private = bool(payload["is_private"])
+            reflection.team_visibility = (
+                Reflection.TeamVisibility.SUPERVISORS_ONLY
+                if is_private
+                else Reflection.TeamVisibility.TEAM
+            )
+            reflection.is_sensitive = is_private
+
+        try:
+            reflection.full_clean()
+        except DjangoValidationError as exc:
+            body = exc.message_dict if hasattr(exc, "message_dict") else str(exc)
+            return Response(body, status=status.HTTP_400_BAD_REQUEST)
+        reflection.save()
+        after = reflection_snapshot(reflection)
+
+        if before != after:
+            actor_membership = (
+                Membership.objects.filter(
+                    person=viewer, program=reflection.program, is_active=True,
+                )
+                .order_by("-created_at")
+                .first()
+            )
+            audit_module.edited(
+                actor_membership or request.user,
+                reflection, before, after,
+                content_type="reflection",
+            )
+        if before.get("answers") != after.get("answers") or before.get("language") != after.get("language"):
+            enqueue_translation_for_reflection(reflection)
+
+        _bust_dashboard_cache(org.id, viewer.id, today)
+        return Response(reflection_response(reflection), status=status.HTTP_200_OK)

--- a/backend/bunk_logs/api/leadership_team/serializers.py
+++ b/backend/bunk_logs/api/leadership_team/serializers.py
@@ -1,0 +1,30 @@
+"""DRF serializers for LT write endpoints."""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+
+class LTSelfReflectionCreateSerializer(serializers.Serializer):
+    answers = serializers.JSONField(required=False)
+    language = serializers.CharField(max_length=10, default="en")
+    is_private = serializers.BooleanField(default=False)
+    client_submission_id = serializers.UUIDField()
+
+    def validate(self, attrs):
+        if not attrs.get("answers"):
+            msg = {"answers": "answers is required."}
+            raise serializers.ValidationError(msg)
+        return attrs
+
+
+class LTSelfReflectionUpdateSerializer(serializers.Serializer):
+    answers = serializers.JSONField(required=False)
+    language = serializers.CharField(max_length=10, required=False)
+    is_private = serializers.BooleanField(required=False)
+
+    def validate(self, attrs):
+        if not attrs:
+            msg = "At least one field must be provided."
+            raise serializers.ValidationError(msg)
+        return attrs

--- a/backend/bunk_logs/api/leadership_team/team_dashboard.py
+++ b/backend/bunk_logs/api/leadership_team/team_dashboard.py
@@ -1,0 +1,319 @@
+"""``GET /api/v1/leadership-team/teams/<team_role>/`` — Story 46.
+
+Per-team dashboard for one team the LT viewer supervises:
+
+* Header: team name, supervisors, member count, current period, date.
+* Submission status: grouped submitted / not submitted / day-off counts
+  + per-member status rows.
+* Flagged reflections: current-period low ratings (concerning) +
+  user-flagged ``ReflectionAttentionMarker`` rows.
+* Member list: row per active team member with status + one-line
+  preview.
+
+Date selector defaults to current period; navigating to a prior
+period adjusts ``period_start``/``period_end`` per the team's template
+cadence. Future dates are rejected.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.utils.dateparse import parse_date
+
+if TYPE_CHECKING:
+    from datetime import date
+from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.api.counselor.common import person_display_name
+from bunk_logs.core.filters import reflections_visible_for_user
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionAttentionMarker
+from bunk_logs.core.models import Supervision
+
+from .common import resolve_period
+from .common import team_memberships
+from .common import viewer_or_403
+from .dashboard import _team_template_for_role
+
+
+class LeadershipTeamTeamDashboardView(APIView):
+    """Team dashboard payload for one supervised role."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, team_role: str, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        _ensure_supervised(ctx, team_role)
+
+        target_date = _parse_date_param(
+            request.query_params.get("date"), default=ctx.today,
+        )
+        if target_date > ctx.today:
+            msg = "Future dates are not selectable."
+            raise ValidationError(msg)
+
+        memberships = list(team_memberships(ctx.membership, team_role, today=target_date))
+        template = _team_template_for_role(ctx.organization, ctx.program, team_role)
+        if template is None:
+            period_start, period_end = target_date, target_date
+        else:
+            period_start, period_end = resolve_period(
+                template, anchor=target_date, program=ctx.program,
+            )
+
+        # Pull current-period reflections for the team in one query,
+        # then map back per member.
+        reflections_qs = Reflection.all_objects.none()
+        person_ids = [m.person_id for m in memberships if m.person_id]
+        if template is not None and person_ids:
+            reflections_qs = Reflection.all_objects.filter(
+                template=template,
+                subject_id__in=person_ids,
+                period_start=period_start,
+                period_end=period_end,
+                is_complete=True,
+            ).select_related("author", "template")
+        visible_reflections = list(
+            reflections_visible_for_user(request.user, reflections_qs)
+            if template is not None else [],
+        )
+        latest_by_subject: dict[int, Reflection] = {}
+        for r in visible_reflections:
+            existing = latest_by_subject.get(r.subject_id)
+            if existing is None or r.submitted_at > existing.submitted_at:
+                latest_by_subject[r.subject_id] = r
+
+        # Per-row attention-marker counts for current period.
+        marker_counts: dict[int, int] = {}
+        if visible_reflections:
+            from collections import Counter
+            rows = ReflectionAttentionMarker.objects.filter(
+                reflection_id__in=[r.id for r in visible_reflections],
+            ).values_list("reflection_id", flat=True)
+            marker_counts = Counter(rows)
+
+        # Co-supervisors of THIS team — used in the header.
+        supervision = (
+            Supervision.objects.active(today=target_date)
+            .for_supervisor(ctx.membership)
+            .filter(target_type=Supervision.TargetType.ROLE_IN_PROGRAM, target_role=team_role)
+            .first()
+        )
+        co_supervisors = []
+        if supervision:
+            co_supervisors = list(
+                Supervision.objects.co_supervisors(supervision, today=target_date)
+                .select_related("supervisor_membership__person"),
+            )
+
+        members_payload = _build_member_rows(
+            memberships=memberships,
+            latest_by_subject=latest_by_subject,
+            marker_counts=marker_counts,
+        )
+        submission_status = _summarize_status(members_payload)
+        flagged = _build_flagged_section(
+            memberships=memberships,
+            latest_by_subject=latest_by_subject,
+            template=template,
+            marker_counts=marker_counts,
+        )
+
+        return Response({
+            "header": {
+                "team_role": team_role,
+                "team_role_label": dict(Membership.ROLES).get(
+                    team_role, team_role.replace("_", " ").title(),
+                ),
+                "program": {
+                    "id": ctx.program.id,
+                    "name": ctx.program.name,
+                },
+                "member_count": len(memberships),
+                "supervisors": _supervisors_payload(ctx, supervision, co_supervisors),
+                "period": {
+                    "start": period_start.isoformat(),
+                    "end": period_end.isoformat(),
+                    "cadence": template.cadence if template else None,
+                },
+                "date": target_date.isoformat(),
+            },
+            "submission_status": submission_status,
+            "flagged": flagged,
+            "members": members_payload,
+        })
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_supervised(ctx, team_role: str) -> None:
+    """Raise 403 / 404 if the viewer doesn't supervise ``team_role``."""
+    qs = (
+        Supervision.objects.active(today=ctx.today)
+        .for_supervisor(ctx.membership)
+        .filter(
+            target_type=Supervision.TargetType.ROLE_IN_PROGRAM,
+            target_role=team_role,
+        )
+    )
+    if not qs.exists():
+        if team_role not in dict(Membership.ROLES):
+            msg = f"Unknown team role: {team_role!r}."
+            raise NotFound(msg)
+        msg = "You do not supervise this team."
+        raise PermissionDenied(msg)
+
+
+def _parse_date_param(raw: str | None, *, default: date) -> date:
+    if not raw:
+        return default
+    parsed = parse_date(raw)
+    if parsed is None:
+        msg = "Invalid 'date' parameter; expected YYYY-MM-DD."
+        raise ValidationError(msg)
+    return parsed
+
+
+def _supervisors_payload(ctx, supervision, co_supervisors) -> list[dict]:
+    """LT viewer + co-supervisors as compact name dicts."""
+    out: list[dict] = [{
+        "membership_id": ctx.membership.id,
+        "person_name": person_display_name(ctx.person),
+        "is_viewer": True,
+    }]
+    for s in co_supervisors:
+        member = s.supervisor_membership
+        if member is None or member.person is None:
+            continue
+        out.append({
+            "membership_id": member.id,
+            "person_name": person_display_name(member.person),
+            "is_viewer": False,
+        })
+    return out
+
+
+def _build_member_rows(
+    *, memberships, latest_by_subject: dict[int, Reflection],
+    marker_counts: dict[int, int],
+) -> list[dict]:
+    """One row per active team member with status, preview, marker count."""
+    rows: list[dict] = []
+    for m in memberships:
+        person = m.person
+        r = latest_by_subject.get(m.person_id)
+        rows.append({
+            "membership_id": m.id,
+            "person_id": person.id if person else None,
+            "person_name": person_display_name(person) if person else "",
+            "language_preference": (person.preferred_language if person else "en"),
+            "status": _row_status(r),
+            "reflection_id": r.id if r else None,
+            "submitted_at": r.submitted_at.isoformat() if r and r.submitted_at else None,
+            "language_of_authorship": r.language if r else None,
+            "preview": _preview_from_reflection(r),
+            "attention_marker_count": marker_counts.get(r.id, 0) if r else 0,
+        })
+    rows.sort(key=lambda row: (row["status"] != "not_submitted",
+                               row["person_name"].casefold()))
+    return rows
+
+
+def _row_status(reflection: Reflection | None) -> str:
+    if reflection is None:
+        return "not_submitted"
+    answers = reflection.answers or {}
+    if answers.get("day_off"):
+        return "day_off"
+    return "submitted"
+
+
+def _preview_from_reflection(r: Reflection | None) -> str:
+    if r is None or not r.answers:
+        return ""
+    for value in r.answers.values():
+        if isinstance(value, str) and value.strip():
+            text = value.strip()
+            return text if len(text) <= 120 else text[:119] + "\u2026"
+    return ""
+
+
+def _summarize_status(rows: list[dict]) -> dict:
+    submitted = sum(1 for r in rows if r["status"] == "submitted")
+    day_off = sum(1 for r in rows if r["status"] == "day_off")
+    not_submitted = sum(1 for r in rows if r["status"] == "not_submitted")
+    return {
+        "submitted": submitted,
+        "day_off": day_off,
+        "not_submitted": not_submitted,
+        "total": len(rows),
+    }
+
+
+def _build_flagged_section(
+    *, memberships, latest_by_subject, template, marker_counts,
+) -> list[dict]:
+    """Reflections with low ratings OR attention markers (current period)."""
+    if not latest_by_subject:
+        return []
+    flagged: list[dict] = []
+    person_by_id = {m.person_id: m.person for m in memberships if m.person_id}
+
+    # Scale-min check for concerning ratings.
+    scale_mins: dict[str, int] = {}
+    if template is not None:
+        from bunk_logs.core.reflection_scores import iter_scored_fields
+        for field, label, _ in iter_scored_fields(template):
+            scale = field.get("scale")
+            if isinstance(scale, list) and scale:
+                try:
+                    scale_mins[label] = int(scale[0])
+                except (TypeError, ValueError):
+                    continue
+        schema_fields = (template.schema or {}).get("fields") or []
+        field_by_key = {
+            f["key"]: f for f in schema_fields
+            if isinstance(f, dict) and isinstance(f.get("key"), str)
+        }
+    else:
+        field_by_key = {}
+
+    from bunk_logs.core.reflection_scores import resolve_rating_cells
+
+    for subject_id, r in latest_by_subject.items():
+        reasons: list[str] = []
+        if marker_counts.get(r.id):
+            reasons.append("needs_attention")
+        for label, min_val in scale_mins.items():
+            field_key = label.split("__", 1)[0]
+            field = field_by_key.get(field_key)
+            if field is None:
+                continue
+            cells = resolve_rating_cells(field, r.answers or {})
+            value = cells.get(label)
+            if value is not None and value <= min_val:
+                reasons.append("low_rating")
+                break
+        if not reasons:
+            continue
+        person = person_by_id.get(subject_id)
+        flagged.append({
+            "reflection_id": r.id,
+            "person_name": person_display_name(person) if person else "",
+            "reasons": reasons,
+            "submitted_at": r.submitted_at.isoformat() if r.submitted_at else None,
+            "language_of_authorship": r.language,
+            "preview": _preview_from_reflection(r),
+        })
+    flagged.sort(key=lambda row: row["submitted_at"] or "", reverse=True)
+    return flagged

--- a/backend/bunk_logs/api/tests/conftest.py
+++ b/backend/bunk_logs/api/tests/conftest.py
@@ -234,3 +234,66 @@ def _ensure_kitchen_staff_self_reflection_template(db):
             "program_type": None,
         },
     )
+
+
+_LEADERSHIP_TEAM_SELF_REFLECTION_SCHEMA = {
+    "fields": [
+        {
+            "key": "overall_period",
+            "type": "single_rating",
+            "required": False,
+            "scale": [1, 5],
+            "prompts": {"en": "How did the period feel overall?"},
+            "dashboard_role": "primary_rating",
+        },
+        {
+            "key": "wins",
+            "type": "text_list",
+            "required": False,
+            "prompts": {"en": "What went well?"},
+            "dashboard_role": "wins",
+        },
+        {
+            "key": "improvements",
+            "type": "text_list",
+            "required": False,
+            "prompts": {"en": "What needs more attention?"},
+            "dashboard_role": "improvements",
+        },
+        {
+            "key": "concern",
+            "type": "textarea",
+            "required": False,
+            "prompts": {"en": "Anything to flag?"},
+            "dashboard_role": "open_concern",
+        },
+    ],
+}
+
+
+@pytest.fixture(autouse=True)
+def _ensure_leadership_team_self_reflection_template(db):
+    """Re-seed the LT self-reflection template before every test (Step 7_12)."""
+    ReflectionTemplate.all_objects.update_or_create(
+        organization=None,
+        slug="leadership-team-self-reflection",
+        version=1,
+        defaults={
+            "name": "Leadership Team Self-Reflection",
+            "description": "Auto-seeded for tests via api/tests/conftest.py.",
+            "cadence": "biweekly",
+            "schema": _LEADERSHIP_TEAM_SELF_REFLECTION_SCHEMA,
+            "languages": ["en", "es"],
+            "is_active": True,
+            "subject_mode": "self",
+            "assignment_scope": "none",
+            "assignment_group_types": [],
+            "author_role_filter": ["leadership_team"],
+            "subject_role_filter": [],
+            "required_per_subject_per_period": 1,
+            "subject_visible": False,
+            "supports_privacy": True,
+            "role": "leadership_team",
+            "program_type": None,
+        },
+    )

--- a/backend/bunk_logs/api/tests/test_leadership_team_endpoints.py
+++ b/backend/bunk_logs/api/tests/test_leadership_team_endpoints.py
@@ -1,0 +1,560 @@
+"""Tests for ``/api/v1/leadership-team/*`` (Step 7_12 PR A, Stories 45-47, 50).
+
+Covers:
+
+* Supervision-driven dashboard (Story 45) — supervised teams card list,
+  attention badges, sort order, bunks-and-units summary, self section.
+* Team dashboard (Story 46) — period selector, member rows, flagged
+  reflections, marker-count integration.
+* Member reflection reader (Story 47) — visibility filter, trend
+  payload, translation embed shape.
+* Self-reflection submit + edit (Story 50) — biweekly period
+  resolution, privacy toggle audience change, idempotency,
+  edit-window enforcement.
+* Mark-attention POST + DELETE (Story 46 c5) — idempotency, co-supervisor
+  visibility, permission gate.
+
+Visibility / RBAC specifics around sensitive content are covered by
+the content-visibility unit tests; here we focus on the LT-specific
+composition.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from datetime import timedelta
+from uuid import uuid4
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionAttentionMarker
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.models import Supervision
+
+User = get_user_model()
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(
+        name="LT Camp", slug="lt-camp",
+        settings={"rollover_hour": 0, "timezone": "UTC"},
+    )
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org, name="LT Camp Summer 2026", slug="lt-summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1), end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def lt_user():
+    return User.objects.create_user(email="lt@lt.test", password="pw")
+
+
+@pytest.fixture
+def lt_person(org, lt_user):
+    return Person.all_objects.create(
+        organization=org, first_name="Riley", last_name="Park", user=lt_user,
+    )
+
+
+@pytest.fixture
+def lt_membership(program, lt_person):
+    return Membership.all_objects.create(
+        program=program, person=lt_person, role="leadership_team", is_active=True,
+    )
+
+
+def _create_team_member(org, program, role: str, first: str, last: str):
+    """Create a Person + active Membership in the given role."""
+    p = Person.all_objects.create(organization=org, first_name=first, last_name=last)
+    Membership.all_objects.create(
+        program=program, person=p, role=role, is_active=True,
+    )
+    return p
+
+
+@pytest.fixture
+def kitchen_team(org, program):
+    return [
+        _create_team_member(org, program, "kitchen_staff", "Alice", "Romero"),
+        _create_team_member(org, program, "kitchen_staff", "Bo", "Singer"),
+    ]
+
+
+@pytest.fixture
+def lt_supervises_kitchen(lt_membership, program):
+    """LT supervises the kitchen_staff role in program."""
+    return Supervision.all_objects.create(
+        supervisor_membership=lt_membership,
+        target_type=Supervision.TargetType.ROLE_IN_PROGRAM,
+        target_role="kitchen_staff",
+        target_program=program,
+        start_date=date(2026, 1, 1),
+    )
+
+
+def _client(user, org):
+    c = APIClient()
+    c.force_authenticate(user=user)
+    c.credentials(HTTP_X_ORGANIZATION_SLUG=org.slug)
+    return c
+
+
+def _today_in_org(org):
+    from bunk_logs.core.time_utils import get_today
+    return get_today(org)
+
+
+# ---------------------------------------------------------------------------
+# Dashboard — Story 45
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_dashboard_requires_lt_membership(org, lt_user):
+    """Authenticated user without an LT Membership gets 403."""
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/leadership-team/dashboard/?nocache=1")
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_dashboard_lists_supervised_teams_only(
+    org, lt_user, lt_membership, kitchen_team, lt_supervises_kitchen, program,
+):
+    """Story 45 c3 — one card per ROLE_IN_PROGRAM supervision; others excluded."""
+    # Add a counselor team not under supervision.
+    _create_team_member(org, program, "counselor", "Casey", "Lee")
+
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/leadership-team/dashboard/?nocache=1")
+    assert resp.status_code == 200
+    body = resp.json()
+    team_roles = [t["team_role"] for t in body["teams"]]
+    assert team_roles == ["kitchen_staff"]
+    card = body["teams"][0]
+    assert card["member_count"] == 2
+    assert card["program_name"] == program.name
+
+
+@pytest.mark.django_db
+def test_dashboard_low_completion_badge_after_expected_by(
+    org, lt_user, lt_membership, kitchen_team, lt_supervises_kitchen, program,
+):
+    """Story 45 c5 — low_completion fires when ratio < 0.5 after expected_by."""
+    # Move expected-by hour to past so the gate fires (default 18:00 local).
+    org.settings = {"rollover_hour": 0, "timezone": "UTC",
+                    "dashboards": {"expected_by_hour": 0}}
+    org.save()
+
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/leadership-team/dashboard/?nocache=1")
+    body = resp.json()
+    badges = body["teams"][0]["badges"]
+    assert "low_completion" in badges
+
+
+@pytest.mark.django_db
+def test_dashboard_includes_self_section(
+    org, lt_user, lt_membership, lt_person, program,
+):
+    """Story 50 — self_reflection section shows missing + period bounds."""
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/leadership-team/dashboard/?nocache=1")
+    body = resp.json()
+    self_section = body["self_reflection"]
+    assert self_section["state"] == "missing"
+    assert self_section["editable"] is True
+    assert self_section["cadence"] == "biweekly"
+    # Period start/end span 14 days.
+    ps = date.fromisoformat(self_section["period_start"])
+    pe = date.fromisoformat(self_section["period_end"])
+    assert (pe - ps).days == 13
+
+
+# ---------------------------------------------------------------------------
+# Team dashboard — Story 46
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_team_dashboard_requires_supervised_role(
+    org, lt_user, lt_membership, lt_supervises_kitchen,
+):
+    """Story 46 — unsupervised role returns 403."""
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/leadership-team/teams/counselor/")
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_team_dashboard_member_status_grouping(
+    org, lt_user, lt_membership, kitchen_team, lt_supervises_kitchen, program,
+):
+    """Story 46 c1 — submitted / not submitted / day-off counts + rows."""
+    template = ReflectionTemplate.all_objects.get(
+        slug="kitchen-staff-self-reflection",
+    )
+    today = _today_in_org(org)
+    # First member submits a normal reflection.
+    Reflection.all_objects.create(
+        organization=org, program=program, template=template,
+        subject=kitchen_team[0], author=kitchen_team[0],
+        period_start=today, period_end=today,
+        answers={"service_summary": "Smooth lunch."},
+        is_complete=True,
+    )
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/leadership-team/teams/kitchen_staff/")
+    assert resp.status_code == 200
+    body = resp.json()
+    status_summary = body["submission_status"]
+    assert status_summary == {
+        "submitted": 1, "day_off": 0, "not_submitted": 1, "total": 2,
+    }
+    statuses = sorted(r["status"] for r in body["members"])
+    assert statuses == ["not_submitted", "submitted"]
+
+
+@pytest.mark.django_db
+def test_team_dashboard_rejects_future_date(
+    org, lt_user, lt_membership, lt_supervises_kitchen,
+):
+    today = _today_in_org(org)
+    future = (today + timedelta(days=1)).isoformat()
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.get(f"/api/v1/leadership-team/teams/kitchen_staff/?date={future}")
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Member reflection reader — Story 47
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_member_reflection_returns_visible_payload(
+    org, lt_user, lt_membership, kitchen_team, lt_supervises_kitchen, program,
+):
+    """Story 47 — payload includes header, content, trend structure."""
+    template = ReflectionTemplate.all_objects.get(
+        slug="kitchen-staff-self-reflection",
+    )
+    today = _today_in_org(org)
+    Reflection.all_objects.create(
+        organization=org, program=program, template=template,
+        subject=kitchen_team[0], author=kitchen_team[0],
+        period_start=today, period_end=today,
+        answers={"service_summary": "Smooth lunch."},
+        is_complete=True,
+    )
+    member_membership = Membership.all_objects.get(
+        person=kitchen_team[0], program=program, role="kitchen_staff",
+    )
+
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.get(
+            f"/api/v1/leadership-team/teams/kitchen_staff/members/"
+            f"{member_membership.id}/reflection/",
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["header"]["person"]["first_name"] == "Alice"
+    assert body["metadata"]["reflection_id"]
+    assert body["content"]["fields"]
+    # Trend payload always returns a structure; kitchen template has no
+    # scored fields so series is empty — that's expected.
+    assert "series" in body["trend"]
+    assert body["trend"]["period"]["cadence"] == "daily"
+
+
+@pytest.mark.django_db
+def test_member_reflection_rejects_non_team_membership(
+    org, lt_user, lt_membership, lt_supervises_kitchen, program,
+):
+    """A membership that isn't on the supervised team returns 404."""
+    counselor = _create_team_member(org, program, "counselor", "Pat", "Lee")
+    membership = Membership.all_objects.get(
+        person=counselor, program=program, role="counselor",
+    )
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.get(
+            f"/api/v1/leadership-team/teams/kitchen_staff/members/"
+            f"{membership.id}/reflection/",
+        )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Self-reflection — Story 50
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_self_reflection_post_creates_with_biweekly_period(
+    org, lt_user, lt_membership, lt_person, program,
+):
+    today = _today_in_org(org)
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/leadership-team/self-reflection/",
+            data={
+                "answers": {"overall_period": 4},
+                "language": "en",
+                "client_submission_id": str(uuid4()),
+            },
+            format="json",
+        )
+    assert resp.status_code == 201
+    body = resp.json()
+    ps = date.fromisoformat(body["period_start"])
+    pe = date.fromisoformat(body["period_end"])
+    assert ps <= today <= pe
+    assert (pe - ps).days == 13
+
+
+@pytest.mark.django_db
+def test_self_reflection_private_toggle_marks_sensitive(
+    org, lt_user, lt_membership, lt_person, program,
+):
+    """Story 50 c11 — is_private maps to is_sensitive + SUPERVISORS_ONLY."""
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/leadership-team/self-reflection/",
+            data={
+                "answers": {"overall_period": 5},
+                "language": "en",
+                "is_private": True,
+                "client_submission_id": str(uuid4()),
+            },
+            format="json",
+        )
+    assert resp.status_code == 201
+    reflection_id = resp.json()["id"]
+    row = Reflection.all_objects.get(id=reflection_id)
+    assert row.is_sensitive is True
+    assert row.team_visibility == Reflection.TeamVisibility.SUPERVISORS_ONLY
+
+
+@pytest.mark.django_db
+def test_self_reflection_post_idempotent_on_client_submission_id(
+    org, lt_user, lt_membership, lt_person, program,
+):
+    """Replays return the same row with HTTP 200 instead of duplicating."""
+    csid = str(uuid4())
+    c = _client(lt_user, org)
+    with organization_context(org):
+        first = c.post(
+            "/api/v1/leadership-team/self-reflection/",
+            data={
+                "answers": {"overall_period": 3},
+                "language": "en",
+                "client_submission_id": csid,
+            },
+            format="json",
+        )
+        second = c.post(
+            "/api/v1/leadership-team/self-reflection/",
+            data={
+                "answers": {"overall_period": 3},
+                "language": "en",
+                "client_submission_id": csid,
+            },
+            format="json",
+        )
+    assert first.status_code == 201
+    assert second.status_code == 200
+    assert first.json()["id"] == second.json()["id"]
+
+
+@pytest.mark.django_db
+def test_self_reflection_patch_within_period(
+    org, lt_user, lt_membership, lt_person, program,
+):
+    """Story 50 c7 — edits allowed within current period."""
+    c = _client(lt_user, org)
+    with organization_context(org):
+        first = c.post(
+            "/api/v1/leadership-team/self-reflection/",
+            data={
+                "answers": {"overall_period": 3},
+                "language": "en",
+                "client_submission_id": str(uuid4()),
+            },
+            format="json",
+        )
+        rid = first.json()["id"]
+        patched = c.patch(
+            f"/api/v1/leadership-team/self-reflection/{rid}/",
+            data={"answers": {"overall_period": 5}},
+            format="json",
+        )
+    assert patched.status_code == 200
+    assert patched.json()["answers"]["overall_period"] == 5
+
+
+@pytest.mark.django_db
+def test_self_reflection_patch_outside_period_is_forbidden(
+    org, lt_user, lt_membership, lt_person, program,
+):
+    """Story 50 c7 — once the period closes, edits 403."""
+    template = ReflectionTemplate.all_objects.get(
+        slug="leadership-team-self-reflection",
+    )
+    old_start = date(2024, 1, 1)
+    old_end = old_start + timedelta(days=13)
+    reflection = Reflection.all_objects.create(
+        organization=org, program=program, template=template,
+        subject=lt_person, author=lt_person,
+        period_start=old_start, period_end=old_end,
+        answers={"overall_period": 3},
+        is_complete=True,
+    )
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.patch(
+            f"/api/v1/leadership-team/self-reflection/{reflection.id}/",
+            data={"answers": {"overall_period": 5}},
+            format="json",
+        )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Mark attention — Story 46 c5
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_mark_attention_creates_and_is_idempotent(
+    org, lt_user, lt_membership, kitchen_team, lt_supervises_kitchen, program,
+):
+    template = ReflectionTemplate.all_objects.get(
+        slug="kitchen-staff-self-reflection",
+    )
+    today = _today_in_org(org)
+    reflection = Reflection.all_objects.create(
+        organization=org, program=program, template=template,
+        subject=kitchen_team[0], author=kitchen_team[0],
+        period_start=today, period_end=today,
+        answers={"service_summary": "Smooth lunch."},
+        is_complete=True,
+    )
+    c = _client(lt_user, org)
+    with organization_context(org):
+        first = c.post(
+            f"/api/v1/leadership-team/reflections/{reflection.id}/mark-attention/",
+            data={"note": "Follow up tomorrow."}, format="json",
+        )
+        second = c.post(
+            f"/api/v1/leadership-team/reflections/{reflection.id}/mark-attention/",
+            data={"note": "Follow up tomorrow."}, format="json",
+        )
+    assert first.status_code == 201
+    assert second.status_code == 200
+    assert first.json()["id"] == second.json()["id"]
+    assert ReflectionAttentionMarker.all_objects.filter(
+        reflection=reflection,
+    ).count() == 1
+
+
+@pytest.mark.django_db
+def test_mark_attention_delete_removes_own_marker(
+    org, lt_user, lt_membership, kitchen_team, lt_supervises_kitchen, program,
+):
+    template = ReflectionTemplate.all_objects.get(
+        slug="kitchen-staff-self-reflection",
+    )
+    today = _today_in_org(org)
+    reflection = Reflection.all_objects.create(
+        organization=org, program=program, template=template,
+        subject=kitchen_team[0], author=kitchen_team[0],
+        period_start=today, period_end=today,
+        answers={"service_summary": "Smooth lunch."},
+        is_complete=True,
+    )
+    c = _client(lt_user, org)
+    with organization_context(org):
+        c.post(
+            f"/api/v1/leadership-team/reflections/{reflection.id}/mark-attention/",
+            data={}, format="json",
+        )
+        del_resp = c.delete(
+            f"/api/v1/leadership-team/reflections/{reflection.id}/mark-attention/",
+        )
+    assert del_resp.status_code == 204
+    assert not ReflectionAttentionMarker.all_objects.filter(
+        reflection=reflection,
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_mark_attention_rejects_invisible_reflection(
+    org, lt_user, lt_membership, program,
+):
+    """An LT cannot flag a reflection they cannot read (visibility gate).
+
+    Another LT's *private* self-reflection has the {admin}-only
+    sensitive audience — the viewer LT is neither author nor admin so
+    visibility filter excludes it.
+    """
+    other_lt_person = Person.all_objects.create(
+        organization=org, first_name="Other", last_name="LT",
+    )
+    Membership.all_objects.create(
+        program=program, person=other_lt_person, role="leadership_team",
+        is_active=True,
+    )
+    lt_template = ReflectionTemplate.all_objects.get(
+        slug="leadership-team-self-reflection",
+    )
+    today = _today_in_org(org)
+    reflection = Reflection.all_objects.create(
+        organization=org, program=program, template=lt_template,
+        subject=other_lt_person, author=other_lt_person,
+        period_start=today, period_end=today,
+        answers={"overall_period": 3},
+        team_visibility=Reflection.TeamVisibility.SUPERVISORS_ONLY,
+        is_sensitive=True,
+        is_complete=True,
+    )
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.post(
+            f"/api/v1/leadership-team/reflections/{reflection.id}/mark-attention/",
+            data={}, format="json",
+        )
+    assert resp.status_code == 403

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -35,6 +35,11 @@ from .dashboards import template as template_dashboard
 from .dashboards import trends as trends_dashboard
 from .kitchen_staff import dashboard as ks_dashboard
 from .kitchen_staff import self_reflection as ks_self_reflection
+from .leadership_team import dashboard as lt_dashboard
+from .leadership_team import mark_attention as lt_mark_attention
+from .leadership_team import member_reflection as lt_member_reflection
+from .leadership_team import self_reflection as lt_self_reflection
+from .leadership_team import team_dashboard as lt_team_dashboard
 from .maintenance import views as maint_views
 from .specialist import camper_view as sp_camper_view
 from .specialist import campers as sp_campers
@@ -474,6 +479,40 @@ urlpatterns = [
         "specialist/self-reflection/<int:reflection_id>/",
         sp_self_reflection.SpecialistSelfReflectionDetailView.as_view(),
         name="specialist-self-reflection-detail",
+    ),
+
+    # ------------------------------------------------------------------
+    # Leadership Team (Step 7_12, Stories 45-53)
+    # ------------------------------------------------------------------
+    path(
+        "leadership-team/dashboard/",
+        lt_dashboard.LeadershipTeamDashboardView.as_view(),
+        name="leadership-team-dashboard",
+    ),
+    path(
+        "leadership-team/teams/<str:team_role>/",
+        lt_team_dashboard.LeadershipTeamTeamDashboardView.as_view(),
+        name="leadership-team-team-dashboard",
+    ),
+    path(
+        "leadership-team/teams/<str:team_role>/members/<int:membership_id>/reflection/",
+        lt_member_reflection.LeadershipTeamMemberReflectionView.as_view(),
+        name="leadership-team-member-reflection",
+    ),
+    path(
+        "leadership-team/reflections/<int:reflection_id>/mark-attention/",
+        lt_mark_attention.LeadershipTeamMarkAttentionView.as_view(),
+        name="leadership-team-mark-attention",
+    ),
+    path(
+        "leadership-team/self-reflection/",
+        lt_self_reflection.LeadershipTeamSelfReflectionCreateView.as_view(),
+        name="leadership-team-self-reflection-create",
+    ),
+    path(
+        "leadership-team/self-reflection/<int:reflection_id>/",
+        lt_self_reflection.LeadershipTeamSelfReflectionDetailView.as_view(),
+        name="leadership-team-self-reflection-detail",
     ),
 ]
 

--- a/backend/bunk_logs/core/migrations/0033_reflectionattentionmarker.py
+++ b/backend/bunk_logs/core/migrations/0033_reflectionattentionmarker.py
@@ -1,0 +1,74 @@
+"""Add ReflectionAttentionMarker model (Step 7_12 PR A — Story 46 c5).
+
+Net-new table. Markers are placed by supervisor Memberships against
+Reflection rows and are visible to the placing supervisor plus any
+co-supervisors. The reflection itself is not mutated.
+"""
+
+import django.db.models.deletion
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0032_seed_camper_care_self_reflection_template"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ReflectionAttentionMarker",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("note", models.TextField(blank=True, default="")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "marker_membership",
+                    models.ForeignKey(
+                        help_text="Supervisor Membership that placed the marker.",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="attention_markers_placed",
+                        to="core.membership",
+                    ),
+                ),
+                (
+                    "organization",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="reflection_attention_markers",
+                        to="core.organization",
+                    ),
+                ),
+                (
+                    "reflection",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="attention_markers",
+                        to="core.reflection",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+                "indexes": [
+                    models.Index(
+                        fields=["reflection", "created_at"],
+                        name="core_reflec_reflect_82d2c2_idx",
+                    ),
+                    models.Index(
+                        fields=["marker_membership", "created_at"],
+                        name="core_reflec_marker__a7c2e0_idx",
+                    ),
+                ],
+                "unique_together": {("reflection", "marker_membership")},
+            },
+        ),
+    ]

--- a/backend/bunk_logs/core/migrations/0033_reflectionattentionmarker.py
+++ b/backend/bunk_logs/core/migrations/0033_reflectionattentionmarker.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    models.AutoField(
+                    models.BigAutoField(
                         auto_created=True,
                         primary_key=True,
                         serialize=False,
@@ -61,11 +61,11 @@ class Migration(migrations.Migration):
                 "indexes": [
                     models.Index(
                         fields=["reflection", "created_at"],
-                        name="core_reflec_reflect_82d2c2_idx",
+                        name="core_reflec_reflect_577903_idx",
                     ),
                     models.Index(
                         fields=["marker_membership", "created_at"],
-                        name="core_reflec_marker__a7c2e0_idx",
+                        name="core_reflec_marker__e89c3f_idx",
                     ),
                 ],
                 "unique_together": {("reflection", "marker_membership")},

--- a/backend/bunk_logs/core/migrations/0034_seed_leadership_team_self_reflection_template.py
+++ b/backend/bunk_logs/core/migrations/0034_seed_leadership_team_self_reflection_template.py
@@ -1,0 +1,119 @@
+"""Seed the global Leadership Team self-reflection ReflectionTemplate (Step 7_12 PR A).
+
+Targets the ``leadership_team`` Membership role. Differs from the other
+role flows in two ways:
+
+* ``cadence='biweekly'`` per Story 50 c2 (default biweekly, configurable per program).
+* ``supports_privacy=True`` per Story 50 c11 — the private toggle restricts
+  the reflection to author + Admin only (sensitive variant of the
+  ``leadership_team_self_reflection`` content type).
+
+English + Spanish prompts are seeded so the form renders in either
+language out of the box.
+"""
+
+from django.db import migrations
+
+SLUG = "leadership-team-self-reflection"
+NAME = "Leadership Team Self-Reflection"
+LANGUAGES = ["en", "es"]
+
+
+def _schema() -> dict:
+    return {
+        "fields": [
+            {
+                "key": "overall_period",
+                "type": "single_rating",
+                "required": False,
+                "scale": [1, 5],
+                "scale_labels": {
+                    "en": ["Difficult", "Tough", "OK", "Good", "Great"],
+                    "es": ["Difícil", "Duro", "Regular", "Bueno", "Excelente"],
+                },
+                "dashboard_role": "primary_rating",
+                "prompts": {
+                    "en": "How did the last two weeks feel overall?",
+                    "es": "¿Cómo se sintieron las últimas dos semanas en general?",
+                },
+            },
+            {
+                "key": "wins",
+                "type": "text_list",
+                "required": False,
+                "prompts": {
+                    "en": "What went well across the teams you supervise?",
+                    "es": "¿Qué salió bien en los equipos que supervisas?",
+                },
+                "dashboard_role": "wins",
+            },
+            {
+                "key": "improvements",
+                "type": "text_list",
+                "required": False,
+                "prompts": {
+                    "en": "What needs more attention next period?",
+                    "es": "¿Qué necesita más atención el próximo período?",
+                },
+                "dashboard_role": "improvements",
+            },
+            {
+                "key": "concern",
+                "type": "textarea",
+                "required": False,
+                "prompts": {
+                    "en": "Anything to flag for your leadership peers or admin?",
+                    "es": "¿Algo que quieras compartir con tus pares de liderazgo o administración?",
+                },
+                "dashboard_role": "open_concern",
+            },
+        ],
+    }
+
+
+def _seed_template(apps, schema_editor):
+    ReflectionTemplate = apps.get_model("core", "ReflectionTemplate")
+    ReflectionTemplate.objects.update_or_create(
+        organization=None,
+        slug=SLUG,
+        version=1,
+        defaults={
+            "name": NAME,
+            "description": (
+                "Biweekly self-reflection for Leadership Team members. "
+                "Supports the per-submission private toggle (Story 50 c11) "
+                "which restricts visibility to the author plus org Admin."
+            ),
+            "cadence": "biweekly",
+            "schema": _schema(),
+            "languages": LANGUAGES,
+            "is_active": True,
+            "subject_mode": "self",
+            "assignment_scope": "none",
+            "assignment_group_types": [],
+            "author_role_filter": ["leadership_team"],
+            "subject_role_filter": [],
+            "required_per_subject_per_period": 1,
+            "subject_visible": False,
+            "supports_privacy": True,
+            "role": "leadership_team",
+            "program_type": None,
+        },
+    )
+
+
+def _remove_template(apps, schema_editor):
+    ReflectionTemplate = apps.get_model("core", "ReflectionTemplate")
+    ReflectionTemplate.objects.filter(
+        organization__isnull=True, slug=SLUG, version=1,
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0033_reflectionattentionmarker"),
+    ]
+
+    operations = [
+        migrations.RunPython(_seed_template, reverse_code=_remove_template),
+    ]

--- a/backend/bunk_logs/core/models.py
+++ b/backend/bunk_logs/core/models.py
@@ -2563,3 +2563,54 @@ class TranslationRecord(models.Model):
             .order_by("-created_at")
             .first()
         )
+
+
+# ---------------------------------------------------------------------------
+# Leadership Team — attention markers (Step 7_12)
+# ---------------------------------------------------------------------------
+
+
+class ReflectionAttentionMarker(models.Model):
+    """Per-supervisor "needs attention" annotation on a Reflection (Story 46 c5).
+
+    Markers are visible to the supervisor who placed them AND to anyone
+    sharing a same-target Supervision (co-supervisor scope). They do NOT
+    mutate the reflection itself and do NOT notify the author. The
+    canonical product spec is ``docs/user_stories/07_leadership_team/STORIES.md``.
+    """
+
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="reflection_attention_markers",
+    )
+    reflection = models.ForeignKey(
+        Reflection,
+        on_delete=models.CASCADE,
+        related_name="attention_markers",
+    )
+    marker_membership = models.ForeignKey(
+        Membership,
+        on_delete=models.CASCADE,
+        related_name="attention_markers_placed",
+        help_text="Supervisor Membership that placed the marker.",
+    )
+    note = models.TextField(blank=True, default="")
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    objects = OrgScopedManager()
+    all_objects = models.Manager()  # noqa: DJ012
+
+    class Meta:
+        unique_together = [("reflection", "marker_membership")]
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["reflection", "created_at"]),
+            models.Index(fields=["marker_membership", "created_at"]),
+        ]
+
+    def __str__(self) -> str:
+        return (
+            f"attention marker on reflection:{self.reflection_id} "
+            f"by membership:{self.marker_membership_id}"
+        )

--- a/backend/bunk_logs/core/test_multitenancy.py
+++ b/backend/bunk_logs/core/test_multitenancy.py
@@ -127,13 +127,14 @@ def test_reflection_template_includes_global_for_org(org_alpha):
         schema={"fields": [_field_schema("x")]},
     )
     with organization_context(org_alpha):
-        # Global role templates from migrations 0029/0030/0032 are always
-        # present; exclude them so this test stays focused on org/global
-        # scoping.
+        # Global role templates from migrations 0029/0030/0032/0034 are
+        # always present; exclude them so this test stays focused on
+        # org/global scoping.
         seeded_global_slugs = (
             "counselor-self-reflection",
             "unit-head-self-reflection",
             "camper-care-self-reflection",
+            "leadership-team-self-reflection",
         )
         ids = set(
             ReflectionTemplate.objects.exclude(slug__in=seeded_global_slugs)


### PR DESCRIPTION
## Summary

PR **A of 3** for Step 7_12 (Leadership Team Flow). Stories 45-47, 50, plus the `ReflectionAttentionMarker` foundation for Story 46 c5.

- LT dashboard with per-team cards, bunks-and-units summary, my-reflection state, and a templates-and-assignments preview (filled out in PR B).
- Per-team dashboard with submission status, flagged reflections, and member rows.
- Read-only per-member reflection reader with trend graph + translation embed.
- Biweekly LT self-reflection (POST + PATCH) with a `Private` toggle that maps to `team_visibility=supervisors_only` + `is_sensitive=true`.
- `ReflectionAttentionMarker` model + POST/DELETE endpoints — marker rows do not mutate the reflection or notify the author.
- Attention condition helpers: low_completion, concerning_ratings, sensitive_content.

## What's new

| Layer | Detail |
|-------|--------|
| Models | `ReflectionAttentionMarker` (FKs to Reflection / marker_membership / org, unique on (reflection, marker_membership)) |
| API | `/api/v1/leadership-team/dashboard/`, `/teams/<role>/`, `/teams/<role>/members/<id>/reflection/`, `/self-reflection/[<id>/]`, `/reflections/<id>/mark-attention/` |
| Permissions | `viewer_or_403` requires `role=leadership_team` AND `program_lead` capability |
| Seed | New `leadership-team-self-reflection` global template (biweekly cadence, supports privacy) |

## Test plan

- [x] Backend test suite green locally (`make test-backend`)
- [x] LT-specific endpoint tests cover: 403 for non-LT, supervised-team isolation, idempotent self-reflection via `client_submission_id`, attention marker visibility chain, sensitive-private vs visible reflection check
- [x] `test_multitenancy` updated to ignore the new global LT template seed

## Migration safety

`0033_reflectionattentionmarker` adds one additive table — no backfills, no column changes on existing tables. Safe to roll forward and reverse.

## Out of scope (handled by follow-ups)

- Template builder API, assignments, responses, CSV, seed extension — PR B
- LT frontend pages, sidebar entry, docs — PR C

🧱 Stack: this PR → PR B → PR C

Made with [Cursor](https://cursor.com)