### PR TITLE
feat(7_12): LT frontend — pages, template builder UI, responses, docs

### DIFF
--- a/docs/role_flows/leadership_team.md
+++ b/docs/role_flows/leadership_team.md
@@ -1,0 +1,173 @@
+# Leadership Team Flow — Step 7_12 (Stories 45-53)
+
+## Overview
+
+The Leadership Team (LT) is the program-leadership layer above unit
+heads, camper care, kitchen, specialists, etc. They supervise multiple
+role-based teams, file their own biweekly reflection, and design the
+reflection templates the rest of the program fills out.
+
+The flow combines three surfaces:
+
+1. **Dashboards** — Story 45 LT overview, Story 46 per-team, Story 47
+   per-member.
+2. **Self-reflection** — Story 50 LT biweekly with optional Private
+   toggle.
+3. **Template builder + assignments + responses** — Stories 51-53.
+
+## Invariants
+
+- LT viewers must have an active Membership with `role="leadership_team"`
+  AND the `program_lead` capability set on the user. The shared
+  `viewer_or_403(request)` helper enforces both.
+- LT users see content based on **supervision**, not transitive role
+  inheritance: a viewer who supervises `kitchen_staff` for program X
+  may *not* see another program's kitchen team.
+- Sensitive notes (Specialist / Camper Care, `is_sensitive=True`) are
+  visible to LT only when the subject is inside the LT's supervised
+  scope.
+- The LT self-reflection's "Private" toggle maps to
+  `team_visibility=supervisors_only` + `is_sensitive=True`, so the row
+  is visible only to the author and admins.
+- Templates have a tri-state lifecycle (`draft` / `published` /
+  `archived`). Only `published` can be assigned and collect responses;
+  `archived` is preserved read-only.
+
+## Backend endpoints
+
+| Method | Path | Story |
+|--------|------|-------|
+| GET | `/api/v1/leadership-team/dashboard/` | 45 |
+| GET | `/api/v1/leadership-team/teams/<team_role>/` | 46 |
+| GET | `/api/v1/leadership-team/teams/<team_role>/members/<id>/reflection/` | 47 |
+| GET | `/api/v1/leadership-team/teams/<team_role>/aggregate/export/` | 48 |
+| POST/DELETE | `/api/v1/leadership-team/reflections/<id>/mark-attention/` | 46 c5 |
+| POST/PATCH | `/api/v1/leadership-team/self-reflection/[<id>/]` | 50 |
+| GET/POST | `/api/v1/leadership-team/templates/` | 51 |
+| GET/PATCH | `/api/v1/leadership-team/templates/<id>/` | 51 |
+| POST | `/api/v1/leadership-team/templates/<id>/publish/` | 51 |
+| POST | `/api/v1/leadership-team/templates/<id>/clone/` | 51 |
+| POST | `/api/v1/leadership-team/templates/<id>/archive/` | 51 |
+| GET/POST | `/api/v1/leadership-team/assignments/` | 52 |
+| PATCH/DELETE | `/api/v1/leadership-team/assignments/<id>/` | 52 |
+| GET | `/api/v1/leadership-team/templates/<id>/responses/` | 53 |
+| GET | `/api/v1/leadership-team/templates/<id>/responses/export/` | 53 c7 |
+
+## Supervision query model (Story 45 c3)
+
+A LT viewer's "supervised teams" are the active `Supervision` rows
+where:
+
+- `supervisor_membership = <LT membership>`
+- `target_type = "role_in_program"`
+- `target_program = <ctx.program>`
+- (no `expires_at` or `expires_at >= today`)
+
+For each such supervision, `team_members(lt, role, today=today)`
+returns active Memberships in that role for the same program.
+`Supervision.objects.co_supervisors(supervision)` returns peer LTs who
+also supervise that role.
+
+## Attention conditions (Story 45 c5)
+
+Per-team-card badges fire in order:
+
+1. `low_completion` — `< 50%` of expected reflections submitted by the
+   program's `expected_by_time` (default 18:00 local).
+2. `concerning_ratings` — any answer in any submission equals the
+   minimum of the scale on any scored field.
+3. `sensitive_content` — any `Note` with `is_sensitive=True` from
+   `specialist` / `camper_care` authors about a current team member,
+   for the current period.
+
+## Mark-for-attention (Story 46 c5)
+
+LT viewers (and any user who can see the reflection) may flag a
+reflection via `POST .../reflections/<id>/mark-attention/`. The flag is
+stored on a separate `ReflectionAttentionMarker` row — it does not
+mutate the reflection or notify the author. Co-supervisors see the
+flag; other LTs not in the supervision chain do not.
+
+## Template lifecycle (Story 51)
+
+```
+            ┌────────┐  publish  ┌────────────┐  archive  ┌──────────┐
+   create → │  draft │ ────────▶ │  published │ ────────▶ │ archived │
+            └────────┘           └────────────┘           └──────────┘
+                 ▲    edit-in-place                            │
+                 │    (PATCH)                                  │
+                 └─────────────────────────────────────────────┘
+                          clone (always allowed)
+```
+
+- `draft` → `published`: requires per-language prompts on every field
+  and unique keys. The endpoint returns a 409 with `warnings` if any
+  validation fails so the UI can surface them inline.
+- `published` → new version: PATCHing a `published` template that has
+  reflections automatically creates a new row with `parent_template`
+  set. Pass `?force_new_version=true` to opt in explicitly.
+- `archived` is terminal — reflections are preserved as read-only.
+
+## Assignments + conflict resolution (Story 52)
+
+`TemplateAssignment` is the link between a template and its audience
+for a given window. Three target types:
+
+| target_type | payload | dynamic? |
+|-------------|---------|----------|
+| `role` | `{role: "kitchen_staff"}` | yes — auto-includes new memberships |
+| `tag_group` | `{tag: "kitchen-lead"}` | yes — based on `Membership.tags` |
+| `individuals` | `{membership_ids: [...]}` | no — static snapshot |
+
+Creating an assignment that overlaps an existing one (same template +
+target identifiers) returns 409 with a `conflicts` list. The caller
+must resubmit with one of:
+
+- `replace` — ends prior assignment(s) the day before `start_date` and
+  sets `replaces` FK on the new row.
+- `run_both` — creates the new assignment without touching the old.
+- `cancel` — backend returns 200 OK without creating anything.
+
+Once any reflection has been submitted under an assignment, only
+`end_date` is mutable (Story 52 c4/c9).
+
+## CSV exports
+
+Two export endpoints, both `audit.export()`-logged:
+
+- **Team aggregate** (`/teams/<role>/aggregate/export/`): row per
+  reflection for that team's active template version with translated
+  text alongside the original (Story 48 c5/c6, LT13).
+- **Template responses** (`/templates/<id>/responses/export/`):
+  individual or aggregate row format selected by `?tab=`.
+
+CSV columns include: period, language_of_authorship, author name,
+subject name (for self-reflections this equals author), answers (one
+column per scored field key), and a translated_text column for
+non-English rows.
+
+## Frontend pages
+
+| Route | Component |
+|-------|-----------|
+| `/leadership-team` | `Dashboard.jsx` |
+| `/leadership-team/teams/:teamRole` | `TeamDashboard.jsx` |
+| `/leadership-team/teams/:teamRole/members/:membershipId` | `MemberReflection.jsx` |
+| `/leadership-team/self-reflection[/...]` | `SelfReflectionPage.jsx` |
+| `/leadership-team/templates` | `TemplateLibrary.jsx` |
+| `/leadership-team/templates/new` and `/leadership-team/templates/:id` | `TemplateBuilder/TemplateBuilderPage.jsx` |
+| `/leadership-team/templates/:id/responses` | `Responses.jsx` |
+
+Sidebar entry is gated on `program_lead` capability. Inline English
+copy is used throughout per lean-mode policy; i18n wrapping is deferred
+to a separate PR.
+
+## Deliberate non-goals
+
+- No conditional/branching logic, calculated fields, file upload,
+  multi-page templates, skip logic, translation-request workflow,
+  approval workflow, or cross-org template library (all Tier 2).
+- No removal of the legacy `/dashboards/team` route — deferred to
+  step 7_16.
+- No new chart library — the trend graph reuses the existing visual
+  conventions in the codebase.

--- a/docs/template_builder.md
+++ b/docs/template_builder.md
@@ -1,0 +1,105 @@
+# LT Template Builder — Tier 1 (Step 7_12, Story 51)
+
+The LT-scoped template builder lives at
+`/leadership-team/templates/new` and `/leadership-team/templates/:id`
+in the frontend and `/api/v1/leadership-team/templates/...` on the
+backend. It deliberately exposes a narrower surface than the admin
+template editor so Tier 1 customers can self-serve without admin
+review.
+
+## Tier 1 field types
+
+| Type | UI control | Notes |
+|------|-----------|-------|
+| `text` | single-line input | bounded by `max_length` (default 200) |
+| `textarea` | multi-line textarea | bounded by `max_length` (default 1000) |
+| `text_list` | repeated text entries | `min_items` / `max_items` |
+| `single_choice` | radio group | requires `options[]` |
+| `multiple_choice` | checkbox group | requires `options[]` |
+| `rating_group` | matrix of categories × scale | requires `categories[]` + `scale` |
+
+Tier 2 controls (conditional / calculated / file upload / multi-page /
+skip logic / approval workflow) are intentionally absent from this
+builder; they remain admin-only.
+
+## Lifecycle states
+
+```
+draft  → (publish)  → published  → (archive) → archived
+   ↑           edit-in-place (PATCH) ↻             │
+   └─────────  clone (always works)  ──────────────┘
+```
+
+- **draft**: PATCH edits the row in place; the version stays at the
+  initial value. Anyone with `program_lead` capability who supervises a
+  team in the program can view + edit it.
+- **published**: PATCH a published template that already has any
+  Reflections submitted under it creates a new row with
+  `parent_template` set (preserving historical answers against the old
+  version). Pass `?force_new_version=true` to make the new-version
+  fork explicit.
+- **archived**: terminal state — reflections stay readable but no new
+  responses can be collected. Cannot transition back to `published`;
+  use **Clone** to start a new draft from an archived template.
+
+## Versioning rules
+
+`ReflectionTemplate.version` increments on every new fork:
+
+- `parent_template_id IS NULL` for the v1 row.
+- Each subsequent version has `parent_template_id` = the prior version's
+  pk. Walking the chain to the root gives the full version history.
+- Within an `organization` + `slug`, exactly one row may be
+  `is_active=True` at a time. Older versions are deactivated when a
+  newer version is published.
+- Reflections always store their `template_id` directly so existing
+  responses keep pointing at the version that was active when they
+  were submitted.
+
+## Publishing validation
+
+`POST .../templates/<id>/publish/` runs:
+
+1. Every field key is unique.
+2. Every required field has a prompt in every declared language
+   (`languages[]`).
+3. `single_choice` / `multiple_choice` have at least one option each.
+4. `rating_group` has at least one category and a valid `scale`.
+
+Failures are returned as a 409 with a `warnings` array so the builder
+can render them inline next to the offending field.
+
+## Language gap behavior
+
+The builder surfaces a "language gap" indicator next to any field
+whose prompt is empty for an enabled language. Publishing is blocked
+while gaps exist for **required** fields, but optional fields with
+gaps publish with a soft warning. Fallback at runtime is the first
+non-empty translation, so a missing translation degrades to English
+rather than rendering an empty prompt.
+
+## Clone semantics
+
+`POST .../templates/<id>/clone/` always produces a brand new draft:
+
+- New `slug` (`<original-slug>-copy-<n>`).
+- `version` resets to 1.
+- `parent_template` is `NULL` — the clone is NOT a new version of the
+  source template.
+- All schema content (fields, prompts, options, categories) is
+  deep-copied.
+
+Use Clone when you want to fork a template for a different role or
+program; use the PATCH-on-published flow when you want to keep the
+slug and produce a new version of the same template.
+
+## Roll-out checklist
+
+For every new tier-1 customer:
+
+1. Seed the global LT9 base templates via
+   `python manage.py seed_role_template --status published`.
+2. Confirm the customer's LT memberships have `program_lead` in their
+   `capabilities` JSON.
+3. Sample-publish one template per role inside an LT account.
+4. Verify the team dashboards render the expected member roster.

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -64,6 +64,13 @@ import CamperCareSelfReflectionHistoryPage from './pages/camper-care/SelfReflect
 import KitchenStaffDashboard from './pages/kitchen-staff/Dashboard';
 import KitchenStaffReflectionForm from './pages/kitchen-staff/ReflectionForm';
 import KitchenStaffHistory from './pages/kitchen-staff/History';
+import LeadershipTeamDashboard from './pages/leadership-team/Dashboard';
+import LeadershipTeamTeamDashboard from './pages/leadership-team/TeamDashboard';
+import LeadershipTeamMemberReflection from './pages/leadership-team/MemberReflection';
+import LeadershipTeamSelfReflectionPage from './pages/leadership-team/SelfReflectionPage';
+import LeadershipTeamTemplateLibrary from './pages/leadership-team/TemplateLibrary';
+import LeadershipTeamTemplateBuilderPage from './pages/leadership-team/TemplateBuilder/TemplateBuilderPage';
+import LeadershipTeamResponses from './pages/leadership-team/Responses';
 import SpecialistDashboard from './pages/specialist/Dashboard';
 import SpecialistNoteForm from './pages/specialist/NoteForm';
 import SpecialistCamperView from './pages/specialist/CamperView';
@@ -574,6 +581,80 @@ function Router() {
           element={
             <ProtectedRoute>
               <KitchenStaffReflectionForm />
+            </ProtectedRoute>
+          }
+        />
+
+        {/* Leadership Team (Step 7_12, Stories 45-53) */}
+        <Route
+          path="/leadership-team"
+          element={
+            <ProtectedRoute>
+              <LeadershipTeamDashboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/leadership-team/teams/:teamRole"
+          element={
+            <ProtectedRoute>
+              <LeadershipTeamTeamDashboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/leadership-team/teams/:teamRole/members/:membershipId"
+          element={
+            <ProtectedRoute>
+              <LeadershipTeamMemberReflection />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/leadership-team/self-reflection"
+          element={
+            <ProtectedRoute>
+              <LeadershipTeamSelfReflectionPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/leadership-team/self-reflection/:reflectionId/edit"
+          element={
+            <ProtectedRoute>
+              <LeadershipTeamSelfReflectionPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/leadership-team/templates"
+          element={
+            <ProtectedRoute>
+              <LeadershipTeamTemplateLibrary />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/leadership-team/templates/new"
+          element={
+            <ProtectedRoute>
+              <LeadershipTeamTemplateBuilderPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/leadership-team/templates/:id"
+          element={
+            <ProtectedRoute>
+              <LeadershipTeamTemplateBuilderPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/leadership-team/templates/:id/responses"
+          element={
+            <ProtectedRoute>
+              <LeadershipTeamResponses />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/api/leadershipTeam.js
+++ b/frontend/src/api/leadershipTeam.js
@@ -1,0 +1,176 @@
+/**
+ * Leadership Team API client — Step 7_12 PRs A + B (Stories 45-53).
+ *
+ * Mirrors ``api/kitchenStaff.js`` shape: every call accepts an
+ * ``orgSlug`` and injects ``X-Organization-Slug`` so the multi-tenant
+ * middleware resolves the right org.
+ */
+import api from '../api';
+
+const BASE = '/api/v1/leadership-team';
+
+const headers = (orgSlug) => ({ 'X-Organization-Slug': orgSlug });
+
+// ---------------------------------------------------------------------------
+// Dashboards (Stories 45-47)
+// ---------------------------------------------------------------------------
+
+export async function fetchDashboard(orgSlug) {
+  const { data } = await api.get(`${BASE}/dashboard/`, { headers: headers(orgSlug) });
+  return data;
+}
+
+export async function fetchTeamDashboard(orgSlug, teamRole, { date } = {}) {
+  const { data } = await api.get(`${BASE}/teams/${teamRole}/`, {
+    params: date ? { date } : {},
+    headers: headers(orgSlug),
+  });
+  return data;
+}
+
+export async function fetchMemberReflection(orgSlug, teamRole, membershipId, { period } = {}) {
+  const { data } = await api.get(
+    `${BASE}/teams/${teamRole}/members/${membershipId}/reflection/`,
+    { params: period ? { period } : {}, headers: headers(orgSlug) },
+  );
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Self-reflection (Story 50)
+// ---------------------------------------------------------------------------
+
+export async function submitSelfReflection(orgSlug, payload) {
+  const { data } = await api.post(`${BASE}/self-reflection/`, payload, {
+    headers: headers(orgSlug),
+  });
+  return data;
+}
+
+export async function updateSelfReflection(orgSlug, reflectionId, payload) {
+  const { data } = await api.patch(`${BASE}/self-reflection/${reflectionId}/`, payload, {
+    headers: headers(orgSlug),
+  });
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Mark-attention (Story 46 c5)
+// ---------------------------------------------------------------------------
+
+export async function markAttention(orgSlug, reflectionId, { note = '' } = {}) {
+  const { data } = await api.post(
+    `${BASE}/reflections/${reflectionId}/mark-attention/`,
+    { note },
+    { headers: headers(orgSlug) },
+  );
+  return data;
+}
+
+export async function unmarkAttention(orgSlug, reflectionId) {
+  await api.delete(`${BASE}/reflections/${reflectionId}/mark-attention/`, {
+    headers: headers(orgSlug),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Template builder (Story 51)
+// ---------------------------------------------------------------------------
+
+export async function listTemplates(orgSlug, { status, role } = {}) {
+  const { data } = await api.get(`${BASE}/templates/`, {
+    params: { status, role },
+    headers: headers(orgSlug),
+  });
+  return data;
+}
+
+export async function getTemplate(orgSlug, id) {
+  const { data } = await api.get(`${BASE}/templates/${id}/`, { headers: headers(orgSlug) });
+  return data;
+}
+
+export async function createTemplate(orgSlug, payload) {
+  const { data } = await api.post(`${BASE}/templates/`, payload, { headers: headers(orgSlug) });
+  return data;
+}
+
+export async function patchTemplate(orgSlug, id, payload, { forceNewVersion = false } = {}) {
+  const { data } = await api.patch(`${BASE}/templates/${id}/`, payload, {
+    params: forceNewVersion ? { force_new_version: 'true' } : {},
+    headers: headers(orgSlug),
+  });
+  return data;
+}
+
+export async function publishTemplate(orgSlug, id) {
+  const { data } = await api.post(`${BASE}/templates/${id}/publish/`, {}, {
+    headers: headers(orgSlug),
+  });
+  return data;
+}
+
+export async function cloneTemplate(orgSlug, id) {
+  const { data } = await api.post(`${BASE}/templates/${id}/clone/`, {}, {
+    headers: headers(orgSlug),
+  });
+  return data;
+}
+
+export async function archiveTemplate(orgSlug, id) {
+  const { data } = await api.post(`${BASE}/templates/${id}/archive/`, {}, {
+    headers: headers(orgSlug),
+  });
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Assignments (Story 52)
+// ---------------------------------------------------------------------------
+
+export async function listAssignments(orgSlug, { template } = {}) {
+  const { data } = await api.get(`${BASE}/assignments/`, {
+    params: template ? { template } : {},
+    headers: headers(orgSlug),
+  });
+  return data;
+}
+
+export async function createAssignment(orgSlug, payload) {
+  const { data } = await api.post(`${BASE}/assignments/`, payload, {
+    headers: headers(orgSlug),
+  });
+  return data;
+}
+
+export async function patchAssignment(orgSlug, id, payload) {
+  const { data } = await api.patch(`${BASE}/assignments/${id}/`, payload, {
+    headers: headers(orgSlug),
+  });
+  return data;
+}
+
+export async function cancelAssignment(orgSlug, id) {
+  await api.delete(`${BASE}/assignments/${id}/`, { headers: headers(orgSlug) });
+}
+
+// ---------------------------------------------------------------------------
+// Responses (Story 53)
+// ---------------------------------------------------------------------------
+
+export async function fetchResponses(orgSlug, templateId, params = {}) {
+  const { data } = await api.get(`${BASE}/templates/${templateId}/responses/`, {
+    params,
+    headers: headers(orgSlug),
+  });
+  return data;
+}
+
+export function exportResponsesUrl(templateId, params = {}) {
+  const qs = new URLSearchParams(params).toString();
+  return `${BASE}/templates/${templateId}/responses/export/${qs ? `?${qs}` : ''}`;
+}
+
+export function exportTeamAggregateUrl(teamRole) {
+  return `${BASE}/teams/${teamRole}/aggregate/export/`;
+}

--- a/frontend/src/pages/leadership-team/AssignmentDialog.jsx
+++ b/frontend/src/pages/leadership-team/AssignmentDialog.jsx
@@ -1,0 +1,308 @@
+/**
+ * LT Assignment Dialog — Step 7_12, Story 52.
+ *
+ * Modal-style form for creating a TemplateAssignment. Caller controls
+ * the open/close state; on success it calls ``onCreated(assignment)``.
+ * Handles 409 conflicts inline by surfacing the conflict list and
+ * collecting a ``conflict_resolution`` choice before retrying.
+ */
+
+import { useCallback, useState } from 'react';
+import { createAssignment } from '../../api/leadershipTeam';
+import { useAuth } from '../../auth/AuthContext';
+
+const TARGET_TYPES = [
+  { value: 'role', label: 'Role' },
+  { value: 'individuals', label: 'Individuals' },
+  { value: 'tag_group', label: 'Tag group' },
+];
+
+const ROLE_OPTIONS = [
+  'counselor', 'junior_counselor', 'specialist', 'general_counselor',
+  'unit_head', 'leadership_team', 'kitchen_staff', 'maintenance',
+  'housekeeping', 'camper_care', 'health_center', 'madrich', 'faculty',
+];
+
+const CADENCE_OVERRIDES = ['', 'daily', 'weekly', 'biweekly', 'monthly', 'on_demand'];
+
+const CONFLICT_CHOICES = [
+  { value: 'replace', label: 'Replace existing (end prior assignment)' },
+  { value: 'run_both', label: 'Run both' },
+  { value: 'cancel', label: 'Cancel — keep prior, do not create' },
+];
+
+export default function AssignmentDialog({ template, onClose, onCreated }) {
+  const { orgSlug } = useAuth();
+  const [targetType, setTargetType] = useState('role');
+  const [role, setRole] = useState(template?.role ?? 'counselor');
+  const [membershipIds, setMembershipIds] = useState('');
+  const [tag, setTag] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [cadenceOverride, setCadenceOverride] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [conflicts, setConflicts] = useState([]);
+  const [resolution, setResolution] = useState('');
+
+  const buildPayload = useCallback(() => {
+    const target_payload = (() => {
+      if (targetType === 'role') return { role };
+      if (targetType === 'individuals') {
+        const ids = membershipIds
+          .split(',')
+          .map((s) => parseInt(s.trim(), 10))
+          .filter((n) => Number.isFinite(n));
+        return { membership_ids: ids };
+      }
+      return { tag };
+    })();
+    const body = {
+      template: template?.id,
+      target_type: targetType,
+      target_payload,
+      start_date: startDate,
+    };
+    if (endDate) body.end_date = endDate;
+    if (cadenceOverride) body.cadence_override = cadenceOverride;
+    return body;
+  }, [targetType, role, membershipIds, tag, startDate, endDate, cadenceOverride, template]);
+
+  const submit = async () => {
+    setError('');
+    if (!template?.id) { setError('Choose a template first.'); return; }
+    if (!startDate) { setError('Start date is required.'); return; }
+    if (targetType === 'role' && !role) { setError('Pick a role.'); return; }
+    if (targetType === 'individuals' && !membershipIds.trim()) {
+      setError('Enter at least one membership ID.');
+      return;
+    }
+    if (targetType === 'tag_group' && !tag.trim()) {
+      setError('Enter a tag.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const payload = buildPayload();
+      if (conflicts.length > 0) {
+        if (!resolution) {
+          setError('Pick how to resolve the conflict.');
+          setSubmitting(false);
+          return;
+        }
+        payload.conflict_resolution = resolution;
+      }
+      const data = await createAssignment(orgSlug, payload);
+      if (onCreated) onCreated(data);
+      onClose?.();
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 409) {
+        const body = err.response.data ?? {};
+        setConflicts(body.conflicts ?? []);
+        setError(body.detail ?? 'There is a conflicting assignment.');
+        setResolution('');
+      } else {
+        const detail = err?.response?.data?.detail
+          ?? err?.response?.data?.errors
+          ?? 'Failed to create assignment.';
+        setError(typeof detail === 'string' ? detail : JSON.stringify(detail));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center px-4"
+      data-testid="lt-assignment-dialog"
+    >
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg max-w-lg w-full p-5 max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+            Assign template
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm text-gray-500 hover:text-gray-700"
+            data-testid="lt-assignment-close"
+          >
+            ✕
+          </button>
+        </div>
+
+        <p className="text-sm text-gray-600 dark:text-gray-300 mb-3">
+          {template?.name} <span className="text-xs">v{template?.version}</span>
+        </p>
+
+        <div className="space-y-3">
+          <div className="flex gap-2" role="tablist" data-testid="lt-assignment-target-tabs">
+            {TARGET_TYPES.map((t) => (
+              <button
+                key={t.value}
+                type="button"
+                role="tab"
+                aria-selected={targetType === t.value}
+                onClick={() => setTargetType(t.value)}
+                className={`text-sm px-3 py-1 rounded-md ${
+                  targetType === t.value
+                    ? 'bg-indigo-600 text-white'
+                    : 'border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300'
+                }`}
+                data-testid={`lt-assignment-target-${t.value}`}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+
+          {targetType === 'role' && (
+            <label className="block text-sm text-gray-700 dark:text-gray-300">
+              Role
+              <select
+                value={role}
+                onChange={(e) => setRole(e.target.value)}
+                className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
+                data-testid="lt-assignment-role"
+              >
+                {ROLE_OPTIONS.map((r) => <option key={r} value={r}>{r}</option>)}
+              </select>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                Membership in this role auto-includes future additions while the assignment is active.
+              </p>
+            </label>
+          )}
+
+          {targetType === 'individuals' && (
+            <label className="block text-sm text-gray-700 dark:text-gray-300">
+              Membership IDs (comma-separated)
+              <input
+                type="text"
+                value={membershipIds}
+                onChange={(e) => setMembershipIds(e.target.value)}
+                placeholder="123, 456"
+                className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
+                data-testid="lt-assignment-individuals"
+              />
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                Static snapshot — added members later need a new assignment.
+              </p>
+            </label>
+          )}
+
+          {targetType === 'tag_group' && (
+            <label className="block text-sm text-gray-700 dark:text-gray-300">
+              Membership tag
+              <input
+                type="text"
+                value={tag}
+                onChange={(e) => setTag(e.target.value)}
+                placeholder="e.g. kitchen-lead"
+                className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
+                data-testid="lt-assignment-tag"
+              />
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                Dynamic — any membership with this tag is included.
+              </p>
+            </label>
+          )}
+
+          <div className="flex gap-3">
+            <label className="flex-1 text-sm text-gray-700 dark:text-gray-300">
+              Start date
+              <input
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
+                data-testid="lt-assignment-start"
+              />
+            </label>
+            <label className="flex-1 text-sm text-gray-700 dark:text-gray-300">
+              End date (optional)
+              <input
+                type="date"
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+                className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
+                data-testid="lt-assignment-end"
+              />
+            </label>
+          </div>
+
+          <label className="block text-sm text-gray-700 dark:text-gray-300">
+            Cadence override (optional)
+            <select
+              value={cadenceOverride}
+              onChange={(e) => setCadenceOverride(e.target.value)}
+              className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
+              data-testid="lt-assignment-cadence"
+            >
+              {CADENCE_OVERRIDES.map((c) => (
+                <option key={c} value={c}>{c || 'inherit from template'}</option>
+              ))}
+            </select>
+          </label>
+
+          {conflicts.length > 0 && (
+            <div
+              className="rounded-md border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 p-3 text-sm text-amber-900 dark:text-amber-200"
+              data-testid="lt-assignment-conflicts"
+            >
+              <p className="font-medium mb-1">Conflicting assignments:</p>
+              <ul className="list-disc list-inside text-xs space-y-0.5 mb-2">
+                {conflicts.map((c) => (
+                  <li key={c.id}>
+                    #{c.id}: {c.start_date} – {c.end_date ?? '∞'} ({c.target_type})
+                  </li>
+                ))}
+              </ul>
+              <fieldset className="space-y-1" role="radiogroup">
+                {CONFLICT_CHOICES.map((c) => (
+                  <label key={c.value} className="flex items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      name="lt-conflict-resolution"
+                      value={c.value}
+                      checked={resolution === c.value}
+                      onChange={() => setResolution(c.value)}
+                      data-testid={`lt-conflict-${c.value}`}
+                    />
+                    {c.label}
+                  </label>
+                ))}
+              </fieldset>
+            </div>
+          )}
+
+          {error && (
+            <p className="text-red-600 dark:text-red-400 text-sm" data-testid="lt-assignment-error">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 mt-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 px-3 py-1.5"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={submitting}
+            className="text-sm rounded-md bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white px-3 py-1.5"
+            data-testid="lt-assignment-submit"
+          >
+            {submitting ? 'Creating…' : 'Create assignment'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/leadership-team/Dashboard.jsx
+++ b/frontend/src/pages/leadership-team/Dashboard.jsx
@@ -1,0 +1,290 @@
+/**
+ * Leadership Team dashboard — Step 7_12, Story 45.
+ *
+ * Per-team cards (one per ROLE_IN_PROGRAM supervision the LT viewer
+ * holds), a bunks-and-units summary entry, the LT's own self-reflection
+ * card, and a templates-and-assignments preview.
+ *
+ * Each team card is rendered from the dashboard payload returned by the
+ * backend; if the call fails altogether the page surfaces a retry CTA.
+ * Card-level retry is unnecessary here because the backend batches
+ * everything into a single request — keeps the surface simple.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchDashboard } from '../../api/leadershipTeam';
+import { useAuth } from '../../auth/AuthContext';
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+const BADGE_META = {
+  low_completion: {
+    label: 'Low completion',
+    className: 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-100',
+  },
+  concerning_ratings: {
+    label: 'Concerning ratings',
+    className: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+  },
+  sensitive_content: {
+    label: 'Sensitive notes',
+    className: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+  },
+};
+
+function Badge({ kind }) {
+  const meta = BADGE_META[kind] || {
+    label: kind,
+    className: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200',
+  };
+  return (
+    <span
+      data-testid={`lt-badge-${kind}`}
+      className={`text-xs font-medium px-2 py-0.5 rounded-full ${meta.className}`}
+    >
+      {meta.label}
+    </span>
+  );
+}
+
+function TeamCard({ card }) {
+  const { team_role, team_role_label, member_count, completion, co_supervisors, badges } = card;
+  return (
+    <li
+      data-testid={`lt-team-card-${team_role}`}
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm"
+    >
+      <Link
+        to={`/leadership-team/teams/${team_role}`}
+        className="block px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h3 className="font-semibold text-gray-900 dark:text-white truncate">
+              {team_role_label}
+            </h3>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              {member_count} {member_count === 1 ? 'member' : 'members'}
+            </p>
+            {co_supervisors?.length > 0 && (
+              <p className="text-xs text-gray-600 dark:text-gray-300 mt-1 truncate">
+                with {co_supervisors.map((c) => c.person_name).join(', ')}
+              </p>
+            )}
+          </div>
+          <div className="text-right shrink-0">
+            <p className="text-sm font-medium text-gray-900 dark:text-white">
+              {completion.submitted} / {completion.expected}
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">submitted today</p>
+          </div>
+        </div>
+        {badges?.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mt-2">
+            {badges.map((b) => (
+              <Badge key={b} kind={b} />
+            ))}
+          </div>
+        )}
+      </Link>
+    </li>
+  );
+}
+
+function SelfReflectionCard({ self }) {
+  if (!self || self.state === 'missing') {
+    return (
+      <section
+        aria-label="My reflection"
+        className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+        data-testid="lt-self-card"
+      >
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-1">
+          My reflection
+        </h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          No reflection template is configured for your role yet.
+        </p>
+      </section>
+    );
+  }
+  const isComplete = self.state === 'complete' || self.state === 'day_off';
+  const actionPath = self.reflection_id
+    ? `/leadership-team/self-reflection/${self.reflection_id}/edit`
+    : '/leadership-team/self-reflection';
+  const statusColors = {
+    complete: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+    day_off: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+    missing: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300',
+  };
+  return (
+    <section
+      aria-label="My reflection"
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+      data-testid="lt-self-card"
+    >
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white">My reflection</h2>
+        <span
+          className={`text-xs font-medium px-2 py-0.5 rounded-full ${statusColors[self.state] ?? statusColors.missing}`}
+        >
+          {self.state.replace('_', ' ')}
+        </span>
+      </div>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+        Period {self.period_start} → {self.period_end} ({self.cadence})
+      </p>
+      <Link
+        to={actionPath}
+        className="mt-2 inline-block rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium px-4 py-2 transition-colors"
+        data-testid="lt-self-cta"
+      >
+        {isComplete ? 'Edit reflection' : 'Start reflection'}
+      </Link>
+    </section>
+  );
+}
+
+function BunksUnitsCard({ summary }) {
+  if (!summary) return null;
+  return (
+    <section
+      aria-label="Bunks and units"
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+      data-testid="lt-bunks-units-card"
+    >
+      <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-2">
+        Bunks &amp; units
+      </h2>
+      <div className="flex flex-wrap gap-4 text-sm text-gray-700 dark:text-gray-300">
+        <span data-testid="lt-bu-units">{summary.unit_count} units</span>
+        <span data-testid="lt-bu-bunks">{summary.bunk_count} bunks</span>
+        <span data-testid="lt-bu-completion">
+          {summary.completion.submitted}/{summary.completion.expected} bunk logs today
+        </span>
+      </div>
+    </section>
+  );
+}
+
+function TemplatesCard({ summary }) {
+  if (!summary) return null;
+  return (
+    <section
+      aria-label="Templates and assignments"
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+      data-testid="lt-templates-card"
+    >
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+          Templates &amp; assignments
+        </h2>
+        <Link
+          to="/leadership-team/templates"
+          className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+          data-testid="lt-templates-link"
+        >
+          Open library →
+        </Link>
+      </div>
+      <p className="text-sm text-gray-700 dark:text-gray-300">
+        {summary.owned_template_count} template{summary.owned_template_count === 1 ? '' : 's'} you authored
+      </p>
+    </section>
+  );
+}
+
+export default function LeadershipTeamDashboard() {
+  const { orgSlug } = useAuth();
+  const [dashboard, setDashboard] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await fetchDashboard(orgSlug);
+      setDashboard(data);
+      setError(null);
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 403) {
+        setError('Your account does not have Leadership Team access.');
+      } else {
+        setError('Failed to load the Leadership Team dashboard.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [orgSlug]);
+
+  useEffect(() => {
+    load();
+    const id = setInterval(load, REFRESH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-screen" data-testid="lt-loading">
+        <p className="text-gray-500 dark:text-gray-400">Loading…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6" data-testid="lt-error">
+        <p className="text-red-600 dark:text-red-400">{error}</p>
+        <button
+          onClick={load}
+          className="mt-3 text-sm text-indigo-600 dark:text-indigo-400 underline"
+          type="button"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const teams = dashboard?.teams ?? [];
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <header className="bg-white dark:bg-gray-800 shadow-sm">
+        <div className="max-w-3xl mx-auto px-4 py-4">
+          <h1 className="text-xl font-bold text-gray-900 dark:text-white">Leadership Team</h1>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            {dashboard.today}
+          </p>
+        </div>
+      </header>
+      <main className="max-w-3xl mx-auto px-4 py-6 space-y-4">
+        <SelfReflectionCard self={dashboard.self_reflection} />
+
+        <section aria-label="Supervised teams" data-testid="lt-teams-section">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-2">
+            My teams
+          </h2>
+          {teams.length === 0 ? (
+            <div
+              className="rounded-xl border border-dashed border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 text-sm text-gray-500 dark:text-gray-400"
+              data-testid="lt-teams-empty"
+            >
+              You don&apos;t currently supervise any role-based teams in this program.
+            </div>
+          ) : (
+            <ul className="space-y-2" data-testid="lt-teams-list">
+              {teams.map((card) => (
+                <TeamCard key={card.team_role} card={card} />
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <BunksUnitsCard summary={dashboard.bunks_and_units} />
+        <TemplatesCard summary={dashboard.templates_and_assignments} />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/leadership-team/MemberReflection.jsx
+++ b/frontend/src/pages/leadership-team/MemberReflection.jsx
@@ -1,0 +1,334 @@
+/**
+ * LT Member Reflection — Step 7_12, Story 47.
+ *
+ * Read-only view of one team member's most recent reflection plus a
+ * trend graph over the configured window. LT may mark a reflection as
+ * "needs attention" but cannot edit, comment, or peek at edit history
+ * (only an "Edited" indicator).
+ *
+ * Trend display: ASCII-style stacked bars from existing color-grid
+ * conventions; per the plan we intentionally do NOT add a new chart
+ * dependency in this PR.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import {
+  fetchMemberReflection,
+  markAttention,
+  unmarkAttention,
+} from '../../api/leadershipTeam';
+import { useAuth } from '../../auth/AuthContext';
+
+function FieldRow({ field }) {
+  const prompt = field.prompts?.en ?? field.key;
+  const answer = field.answer;
+  if (field.type === 'rating_group' || field.type === 'single_rating') {
+    const cells = answer && typeof answer === 'object' ? answer : {};
+    return (
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-gray-900 dark:text-white">{prompt}</p>
+        <div className="flex flex-wrap gap-2 text-xs text-gray-700 dark:text-gray-300">
+          {Object.entries(cells).map(([k, v]) => (
+            <span key={k} className="rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5">
+              {k}: {String(v)}
+            </span>
+          ))}
+        </div>
+      </div>
+    );
+  }
+  if (Array.isArray(answer)) {
+    return (
+      <div>
+        <p className="text-sm font-medium text-gray-900 dark:text-white">{prompt}</p>
+        <ul className="list-disc list-inside text-sm text-gray-800 dark:text-gray-200">
+          {answer.map((a, i) => <li key={i}>{String(a)}</li>)}
+        </ul>
+      </div>
+    );
+  }
+  return (
+    <div>
+      <p className="text-sm font-medium text-gray-900 dark:text-white">{prompt}</p>
+      <p className="text-sm text-gray-800 dark:text-gray-200 whitespace-pre-wrap">
+        {answer === null || answer === undefined || answer === '' ? '—' : String(answer)}
+      </p>
+    </div>
+  );
+}
+
+function TrendSeries({ series }) {
+  if (!series?.length) {
+    return (
+      <p className="text-sm text-gray-500 dark:text-gray-400" data-testid="lt-trend-empty">
+        No scored fields to plot.
+      </p>
+    );
+  }
+  return (
+    <div className="space-y-3" data-testid="lt-trend">
+      {series.map((s) => (
+        <div key={s.label} data-testid={`lt-trend-series-${s.label}`}>
+          <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+            {s.label}
+          </p>
+          <div className="flex items-end gap-1 h-12">
+            {s.points.map((p, i) => {
+              const h = p.value == null ? 0 : (p.value / s.scale_max) * 100;
+              return (
+                <span
+                  key={`${p.period_start}-${i}`}
+                  title={`${p.period_start}: ${p.value ?? '—'}`}
+                  className={`flex-1 rounded-sm ${p.value == null ? 'bg-gray-200 dark:bg-gray-700' : 'bg-indigo-500 dark:bg-indigo-400'}`}
+                  style={{ height: `${Math.max(h, 4)}%` }}
+                  data-testid={`lt-trend-bar-${s.label}-${i}`}
+                />
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function LeadershipTeamMemberReflection() {
+  const { teamRole, membershipId } = useParams();
+  const { orgSlug } = useAuth();
+
+  const [payload, setPayload] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [actionPending, setActionPending] = useState(false);
+  const [showFlagForm, setShowFlagForm] = useState(false);
+  const [flagNote, setFlagNote] = useState('');
+
+  const load = useCallback(async () => {
+    try {
+      const data = await fetchMemberReflection(orgSlug, teamRole, membershipId);
+      setPayload(data);
+      setError(null);
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 403) setError('You cannot view this reflection.');
+      else if (status === 404) setError('Member or team not found.');
+      else setError('Failed to load member reflection.');
+    } finally {
+      setLoading(false);
+    }
+  }, [orgSlug, teamRole, membershipId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleMark = async () => {
+    const reflectionId = payload?.metadata?.reflection_id;
+    if (!reflectionId) return;
+    setActionPending(true);
+    try {
+      await markAttention(orgSlug, reflectionId, { note: flagNote });
+      setShowFlagForm(false);
+      setFlagNote('');
+      await load();
+    } catch {
+      setError('Failed to mark for attention.');
+    } finally {
+      setActionPending(false);
+    }
+  };
+
+  const handleUnmark = async () => {
+    const reflectionId = payload?.metadata?.reflection_id;
+    if (!reflectionId) return;
+    setActionPending(true);
+    try {
+      await unmarkAttention(orgSlug, reflectionId);
+      await load();
+    } catch {
+      setError('Failed to remove your flag.');
+    } finally {
+      setActionPending(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-screen" data-testid="lt-member-loading">
+        <p className="text-gray-500 dark:text-gray-400">Loading…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6" data-testid="lt-member-error">
+        <p className="text-red-600 dark:text-red-400">{error}</p>
+        <Link
+          to={`/leadership-team/teams/${teamRole}`}
+          className="mt-3 inline-block text-sm text-indigo-600 dark:text-indigo-400 underline"
+        >
+          Back to team
+        </Link>
+      </div>
+    );
+  }
+
+  const { header, metadata, content, trend, attention_markers } = payload;
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <header className="bg-white dark:bg-gray-800 shadow-sm">
+        <div className="max-w-3xl mx-auto px-4 py-4">
+          <Link
+            to={`/leadership-team/teams/${teamRole}`}
+            className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+          >
+            ← Back to team
+          </Link>
+          <h1 className="text-xl font-bold text-gray-900 dark:text-white mt-2">
+            {header.person.name}
+          </h1>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            {header.role} ·{' '}
+            {header.period ? (
+              <>Period {header.period.start} → {header.period.end} ({header.period.cadence})</>
+            ) : (
+              'No template configured'
+            )}
+          </p>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-4 py-6 space-y-4">
+        {!metadata ? (
+          <section
+            className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+            data-testid="lt-member-empty"
+          >
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              No reflection has been submitted for this period.
+            </p>
+          </section>
+        ) : (
+          <>
+            <section
+              className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+              data-testid="lt-member-metadata"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="text-xs text-gray-500 dark:text-gray-400 space-y-0.5">
+                  <p>Submitted {metadata.submitted_at}</p>
+                  {metadata.last_edited_at && <p>Edited {metadata.last_edited_at}</p>}
+                  <p>Language: {metadata.language_of_authorship}</p>
+                </div>
+                <div className="shrink-0">
+                  {attention_markers?.length > 0 ? (
+                    <button
+                      type="button"
+                      onClick={handleUnmark}
+                      disabled={actionPending}
+                      className="text-xs rounded-md border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200 px-2 py-1 hover:bg-amber-100"
+                      data-testid="lt-mark-attention-toggle"
+                    >
+                      Clear my flag
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setShowFlagForm(true)}
+                      disabled={actionPending}
+                      className="text-xs rounded-md border border-amber-300 dark:border-amber-700 bg-white dark:bg-gray-900 text-amber-800 dark:text-amber-200 px-2 py-1 hover:bg-amber-50"
+                      data-testid="lt-mark-attention-toggle"
+                    >
+                      Mark for attention
+                    </button>
+                  )}
+                </div>
+              </div>
+              {showFlagForm && (
+                <div
+                  className="mt-3 rounded-md border border-amber-200 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 p-3"
+                  data-testid="lt-mark-attention-form"
+                >
+                  <textarea
+                    value={flagNote}
+                    onChange={(e) => setFlagNote(e.target.value)}
+                    placeholder="Optional context for co-supervisors"
+                    className="w-full text-sm rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-800"
+                    rows={2}
+                    data-testid="lt-mark-attention-note"
+                  />
+                  <div className="flex gap-2 mt-2 justify-end">
+                    <button
+                      type="button"
+                      onClick={() => { setShowFlagForm(false); setFlagNote(''); }}
+                      className="text-xs px-2 py-1 rounded-md border border-gray-300 dark:border-gray-600"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleMark}
+                      disabled={actionPending}
+                      className="text-xs px-2 py-1 rounded-md bg-amber-600 hover:bg-amber-700 text-white"
+                      data-testid="lt-mark-attention-submit"
+                    >
+                      Mark
+                    </button>
+                  </div>
+                </div>
+              )}
+              {attention_markers?.length > 0 && (
+                <ul className="mt-3 space-y-1 text-xs text-gray-700 dark:text-gray-300">
+                  {attention_markers.map((m) => (
+                    <li key={m.id} data-testid={`lt-marker-${m.id}`}>
+                      <span className="font-medium">{m.person_name}</span> flagged on {m.created_at}
+                      {m.note && <span className="block text-gray-500 dark:text-gray-400">{m.note}</span>}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            {content?.translation && (
+              <section className="rounded-xl border border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/20 p-3 text-xs text-blue-800 dark:text-blue-200">
+                {content.translation.status === 'pending'
+                  ? `Translation from ${content.translation.source_language} → en is pending.`
+                  : (
+                    <>
+                      <p className="font-medium mb-1">
+                        Translation ({content.translation.source_language} → en)
+                      </p>
+                      <p className="whitespace-pre-wrap">{content.translation.translated_text}</p>
+                    </>
+                  )}
+              </section>
+            )}
+
+            <section
+              className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 space-y-4"
+              data-testid="lt-member-content"
+            >
+              {content?.fields?.map((f) => <FieldRow key={f.key} field={f} />)}
+            </section>
+          </>
+        )}
+
+        <section
+          className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+          data-testid="lt-member-trend"
+        >
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-2">
+            Trend
+          </h2>
+          {trend?.period && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+              {trend.period.start} → {trend.period.end} ({trend.period.cadence})
+            </p>
+          )}
+          <TrendSeries series={trend?.series ?? []} />
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/leadership-team/Responses.jsx
+++ b/frontend/src/pages/leadership-team/Responses.jsx
@@ -1,0 +1,360 @@
+/**
+ * LT Template Responses — Step 7_12, Story 53.
+ *
+ * Two tabs:
+ *   • Individual — paginated rows (period, author, language, answers)
+ *     with filters: date range, respondent, language, rating_le,
+ *     has_free_text.
+ *   • Aggregate — counts, language distribution, avg-per-dimension
+ *     with version-validity markers (Story 48 c1).
+ *
+ * CSV download buttons hit the LT export endpoints (Story 53 c7) which
+ * the browser fetches with cookie auth like other Django downloads.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
+import {
+  exportResponsesUrl,
+  fetchResponses,
+  getTemplate,
+} from '../../api/leadershipTeam';
+import { useAuth } from '../../auth/AuthContext';
+
+function fmtDate(d) { return d || '—'; }
+
+function IndividualTab({ payload, params, setParams }) {
+  const rows = payload?.results ?? [];
+  const page = payload?.page ?? 1;
+  const pageSize = payload?.page_size ?? 25;
+  const total = payload?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  const setParam = (k, v) => {
+    const next = new URLSearchParams(params);
+    if (v) next.set(k, v); else next.delete(k);
+    if (k !== 'page') next.delete('page');
+    setParams(next, { replace: true });
+  };
+
+  return (
+    <>
+      <section
+        className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3 flex flex-wrap gap-2 items-end"
+        aria-label="Filters"
+        data-testid="lt-responses-filters"
+      >
+        <label className="text-xs text-gray-700 dark:text-gray-300">
+          From
+          <input
+            type="date"
+            value={params.get('date_from') || ''}
+            onChange={(e) => setParam('date_from', e.target.value)}
+            className="block mt-1 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
+            data-testid="lt-responses-date-from"
+          />
+        </label>
+        <label className="text-xs text-gray-700 dark:text-gray-300">
+          To
+          <input
+            type="date"
+            value={params.get('date_to') || ''}
+            onChange={(e) => setParam('date_to', e.target.value)}
+            className="block mt-1 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
+          />
+        </label>
+        <label className="text-xs text-gray-700 dark:text-gray-300">
+          Language
+          <select
+            value={params.get('language') || ''}
+            onChange={(e) => setParam('language', e.target.value)}
+            className="block mt-1 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
+            data-testid="lt-responses-lang"
+          >
+            <option value="">all</option>
+            <option value="en">en</option>
+            <option value="es">es</option>
+            <option value="he">he</option>
+          </select>
+        </label>
+        <label className="text-xs text-gray-700 dark:text-gray-300">
+          Rating ≤
+          <input
+            type="number"
+            value={params.get('rating_le') || ''}
+            onChange={(e) => setParam('rating_le', e.target.value)}
+            className="block mt-1 w-20 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
+            data-testid="lt-responses-rating-le"
+          />
+        </label>
+        <label className="text-xs text-gray-700 dark:text-gray-300 flex items-center gap-1 mt-4">
+          <input
+            type="checkbox"
+            checked={params.get('has_free_text') === '1'}
+            onChange={(e) => setParam('has_free_text', e.target.checked ? '1' : '')}
+            data-testid="lt-responses-free-text"
+          />
+          Has free text
+        </label>
+      </section>
+
+      {rows.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-6" data-testid="lt-responses-empty">
+          No reflections match these filters.
+        </p>
+      ) : (
+        <ul className="space-y-2" data-testid="lt-responses-rows">
+          {rows.map((r) => (
+            <li
+              key={r.id}
+              className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3"
+              data-testid={`lt-responses-row-${r.id}`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-gray-900 dark:text-white">
+                    {r.author?.name ?? 'Unknown'}{' '}
+                    {r.subject?.name && r.subject?.id !== r.author?.id && (
+                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                        about {r.subject.name}
+                      </span>
+                    )}
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    Period {fmtDate(r.period_start)} → {fmtDate(r.period_end)} · {r.language} · v{r.template_version}
+                  </p>
+                </div>
+                <Link
+                  to={`/reflections/${r.id}`}
+                  className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline shrink-0"
+                >
+                  Open →
+                </Link>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {totalPages > 1 && (
+        <div
+          className="flex items-center gap-2 justify-end text-sm"
+          data-testid="lt-responses-pagination"
+        >
+          <button
+            type="button"
+            disabled={page <= 1}
+            onClick={() => setParam('page', String(page - 1))}
+            className="rounded-md border border-gray-300 dark:border-gray-600 px-2 py-1 disabled:opacity-40 text-gray-700 dark:text-gray-300"
+          >
+            Prev
+          </button>
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            Page {page} / {totalPages}
+          </span>
+          <button
+            type="button"
+            disabled={page >= totalPages}
+            onClick={() => setParam('page', String(page + 1))}
+            className="rounded-md border border-gray-300 dark:border-gray-600 px-2 py-1 disabled:opacity-40 text-gray-700 dark:text-gray-300"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
+function AggregateTab({ payload }) {
+  if (!payload) return null;
+  const dims = payload.avg_per_dimension ?? [];
+  const langDist = payload.language_distribution ?? {};
+  const volume = payload.response_volume_per_period ?? [];
+  return (
+    <div className="space-y-4">
+      <div
+        className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+        data-testid="lt-responses-summary"
+      >
+        <p className="text-sm text-gray-700 dark:text-gray-300">
+          <span className="font-semibold text-gray-900 dark:text-white">{payload.total_responses}</span> responses
+        </p>
+      </div>
+
+      <div
+        className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+        data-testid="lt-responses-avg"
+      >
+        <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-2">
+          Average per dimension
+        </h3>
+        {dims.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">No scored fields.</p>
+        ) : (
+          <ul className="space-y-1 text-sm">
+            {dims.map((d) => (
+              <li key={d.key} className="flex justify-between" data-testid={`lt-responses-dim-${d.key}`}>
+                <span className="text-gray-700 dark:text-gray-300">
+                  {d.key}
+                  <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">
+                    versions: {(d.versions ?? []).join(', ') || '—'}
+                  </span>
+                </span>
+                <span className="text-gray-900 dark:text-white font-medium">
+                  {d.avg == null ? '—' : d.avg.toFixed(2)}
+                  <span className="text-xs text-gray-500 dark:text-gray-400 ml-1">({d.count})</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
+        <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-2">
+          Language distribution
+        </h3>
+        <ul className="text-sm space-y-1">
+          {Object.entries(langDist).map(([lang, count]) => (
+            <li key={lang} className="flex justify-between text-gray-700 dark:text-gray-300">
+              <span>{lang}</span>
+              <span>{count}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
+        <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-2">
+          Volume per period
+        </h3>
+        <ul className="text-xs space-y-0.5">
+          {volume.map((v) => (
+            <li key={v.period_start} className="flex justify-between text-gray-700 dark:text-gray-300">
+              <span>{v.period_start}</span>
+              <span>{v.count}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default function LeadershipTeamResponses() {
+  const { id } = useParams();
+  const { orgSlug } = useAuth();
+  const [params, setParams] = useSearchParams();
+  const tab = (params.get('tab') || 'individual').toLowerCase();
+
+  const [template, setTemplate] = useState(null);
+  const [payload, setPayload] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const filtersDeps = useMemo(() => params.toString(), [params]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function run() {
+      setLoading(true);
+      setError('');
+      try {
+        const [tpl, data] = await Promise.all([
+          getTemplate(orgSlug, id),
+          fetchResponses(orgSlug, id, Object.fromEntries(new URLSearchParams(filtersDeps).entries())),
+        ]);
+        if (cancelled) return;
+        setTemplate(tpl);
+        setPayload(data);
+      } catch (err) {
+        if (cancelled) return;
+        if (err?.response?.status === 403) setError('You cannot view these responses.');
+        else if (err?.response?.status === 404) setError('Template not found.');
+        else setError('Failed to load responses.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    run();
+    return () => { cancelled = true; };
+  }, [orgSlug, id, filtersDeps]);
+
+  const switchTab = (next) => {
+    const updated = new URLSearchParams(params);
+    updated.set('tab', next);
+    updated.delete('page');
+    setParams(updated, { replace: true });
+  };
+
+  const exportHref = exportResponsesUrl(id, Object.fromEntries(params.entries()));
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <header className="bg-white dark:bg-gray-800 shadow-sm">
+        <div className="max-w-5xl mx-auto px-4 py-4">
+          <Link
+            to="/leadership-team/templates"
+            className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+          >
+            ← Template library
+          </Link>
+          <div className="flex items-center justify-between gap-3 mt-2">
+            <div>
+              <h1 className="text-xl font-bold text-gray-900 dark:text-white">
+                {template?.name ?? 'Responses'}
+              </h1>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                {template?.role} · v{template?.version}
+              </p>
+            </div>
+            <a
+              href={exportHref}
+              className="rounded-lg border border-gray-300 dark:border-gray-600 text-sm font-medium px-3 py-1.5 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
+              data-testid="lt-responses-export"
+            >
+              Export CSV
+            </a>
+          </div>
+
+          <div className="mt-3 flex gap-2 border-b border-gray-200 dark:border-gray-700">
+            {['individual', 'aggregate'].map((t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => switchTab(t)}
+                aria-current={tab === t ? 'page' : undefined}
+                className={`text-sm px-3 py-2 -mb-px border-b-2 ${
+                  tab === t
+                    ? 'border-indigo-600 text-indigo-600 dark:text-indigo-400'
+                    : 'border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900'
+                }`}
+                data-testid={`lt-responses-tab-${t}`}
+              >
+                {t === 'individual' ? 'Individual' : 'Aggregate'}
+              </button>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-5xl mx-auto px-4 py-6 space-y-4">
+        {loading && (
+          <p className="text-sm text-gray-500 dark:text-gray-400" data-testid="lt-responses-loading">
+            Loading…
+          </p>
+        )}
+        {error && (
+          <p className="text-red-600 dark:text-red-400 text-sm" data-testid="lt-responses-error">
+            {error}
+          </p>
+        )}
+        {!loading && !error && tab === 'individual' && (
+          <IndividualTab payload={payload} params={params} setParams={setParams} />
+        )}
+        {!loading && !error && tab === 'aggregate' && <AggregateTab payload={payload} />}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/leadership-team/SelfReflectionPage.jsx
+++ b/frontend/src/pages/leadership-team/SelfReflectionPage.jsx
@@ -1,0 +1,237 @@
+/**
+ * LT Self-Reflection form — Step 7_12, Story 50.
+ *
+ * Biweekly cadence by default. Supports a "Private" toggle that sets
+ * ``is_private=true`` server-side, which the backend translates to
+ * ``team_visibility=supervisors_only`` + ``is_sensitive=true`` so only
+ * the author and admins can see the row.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import ReflectionField from '../../components/templates/ReflectionField';
+import {
+  buildDefaultAnswers,
+  validateReflectionAnswers,
+} from '../../utils/reflection/reflectionFormValidation';
+import {
+  fetchReflection,
+  fetchTemplateById,
+  newClientSubmissionId,
+} from '../../api/counselor';
+import {
+  fetchDashboard,
+  submitSelfReflection,
+  updateSelfReflection,
+} from '../../api/leadershipTeam';
+import { useAuth } from '../../auth/AuthContext';
+
+const DAY_OFF_FIELD_KEY = 'day_off';
+
+function flattenError(err, fallback) {
+  const body = err?.response?.data;
+  if (!body) return err?.message || fallback;
+  if (typeof body === 'string') return body;
+  if (typeof body.detail === 'string') return body.detail;
+  if (typeof body === 'object') {
+    try { return JSON.stringify(body); } catch { return fallback; }
+  }
+  return fallback;
+}
+
+export default function LeadershipTeamSelfReflectionPage() {
+  const { reflectionId: editIdParam } = useParams();
+  const navigate = useNavigate();
+  const { orgSlug } = useAuth();
+  const isEdit = Boolean(editIdParam);
+
+  const [template, setTemplate] = useState(null);
+  const [answers, setAnswers] = useState({});
+  const [language, setLanguage] = useState('en');
+  const [isPrivate, setIsPrivate] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState({});
+  const clientSubmissionId = useRef(newClientSubmissionId());
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const dashboard = await fetchDashboard(orgSlug);
+      const selfMeta = dashboard?.self_reflection;
+      if (!selfMeta?.template_id) {
+        setError('No Leadership Team reflection template is configured.');
+        return;
+      }
+      const tpl = await fetchTemplateById(selfMeta.template_id);
+      setTemplate(tpl);
+
+      if (isEdit) {
+        const reflection = await fetchReflection(editIdParam);
+        const ans = reflection.answers || {};
+        setAnswers(ans);
+        setLanguage(reflection.language || 'en');
+        setIsPrivate(reflection.team_visibility === 'supervisors_only' || Boolean(reflection.is_sensitive));
+      } else if (selfMeta.reflection_id) {
+        navigate(`/leadership-team/self-reflection/${selfMeta.reflection_id}/edit`, { replace: true });
+        return;
+      } else {
+        setAnswers(buildDefaultAnswers(tpl.schema));
+      }
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 403) setError('You do not have Leadership Team access.');
+      else setError(flattenError(err, 'Could not load the reflection form.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [orgSlug, isEdit, editIdParam, navigate]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const isDayOff = useMemo(() => Boolean(answers[DAY_OFF_FIELD_KEY]), [answers]);
+
+  const updateAnswer = (key, value) => {
+    setAnswers((prev) => ({ ...prev, [key]: value }));
+    setFieldErrors((prev) => { const next = { ...prev }; delete next[key]; return next; });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    if (!template) return;
+    if (!isDayOff) {
+      const { ok, errors } = validateReflectionAnswers(template.schema, answers);
+      if (!ok) {
+        setFieldErrors(errors);
+        return;
+      }
+    }
+    setSubmitting(true);
+    try {
+      const payload = {
+        answers: isDayOff ? undefined : answers,
+        day_off: isDayOff || undefined,
+        language,
+        is_private: isPrivate || undefined,
+      };
+      if (isEdit) {
+        await updateSelfReflection(orgSlug, editIdParam, payload);
+      } else {
+        await submitSelfReflection(orgSlug, {
+          ...payload,
+          client_submission_id: clientSubmissionId.current,
+        });
+      }
+      navigate('/leadership-team');
+    } catch (err) {
+      setError(flattenError(err, 'Could not save the reflection.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-screen" data-testid="lt-self-loading">
+        <p className="text-gray-500 dark:text-gray-400">Loading…</p>
+      </div>
+    );
+  }
+
+  if (error && !template) {
+    return (
+      <div className="p-6" data-testid="lt-self-error">
+        <p className="text-red-600 dark:text-red-400">{error}</p>
+        <Link
+          to="/leadership-team"
+          className="mt-3 inline-block text-sm text-indigo-600 dark:text-indigo-400 underline"
+        >
+          Back to LT dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  const fields = (template?.schema?.fields ?? []).filter(f => f.key !== DAY_OFF_FIELD_KEY);
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <Link
+          to="/leadership-team"
+          className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+        >
+          ← Back to LT dashboard
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white mt-2 mb-6">
+          {isEdit ? 'Edit Leadership reflection' : 'New Leadership reflection'}
+        </h1>
+
+        <form onSubmit={handleSubmit} noValidate>
+          <label className="flex items-center gap-2 mb-4 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={isDayOff}
+              onChange={(e) => updateAnswer(DAY_OFF_FIELD_KEY, e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300"
+              data-testid="lt-self-day-off"
+            />
+            <span className="text-sm text-gray-700 dark:text-gray-300">Day off</span>
+          </label>
+
+          {!isDayOff && fields.map((field) => (
+            <div key={field.key} className="mb-6">
+              <ReflectionField
+                field={field}
+                answer={answers[field.key]}
+                onChange={(v) => updateAnswer(field.key, v)}
+                error={fieldErrors[field.key]}
+                language={language}
+              />
+            </div>
+          ))}
+
+          <label className="flex items-center gap-2 mb-4 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={isPrivate}
+              onChange={(e) => setIsPrivate(e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300"
+              data-testid="lt-self-private"
+            />
+            <span className="text-sm text-gray-700 dark:text-gray-300">
+              Private — only admins and I can see this
+            </span>
+          </label>
+
+          {error && (
+            <p className="text-red-600 dark:text-red-400 text-sm mb-3" data-testid="lt-self-submit-error">
+              {error}
+            </p>
+          )}
+
+          <div className="flex gap-3">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="flex-1 rounded-lg bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white font-medium py-2 px-4"
+              data-testid="lt-self-submit"
+            >
+              {submitting ? 'Saving…' : isEdit ? 'Save changes' : 'Submit reflection'}
+            </button>
+            <button
+              type="button"
+              onClick={() => navigate(-1)}
+              className="rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 font-medium py-2 px-4"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/leadership-team/TeamDashboard.jsx
+++ b/frontend/src/pages/leadership-team/TeamDashboard.jsx
@@ -1,0 +1,319 @@
+/**
+ * LT Team Dashboard — Step 7_12, Story 46 + Story 48 toggle.
+ *
+ * Per-supervised-team page: submission status, flagged reflections,
+ * member rows. Tapping a member row navigates to MemberReflection.
+ * The date selector defaults to the current period; future dates are
+ * rejected by the backend with 400.
+ *
+ * Story 48 c5/c6: aggregate-CSV download button hits the export URL on
+ * the server.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
+import {
+  exportTeamAggregateUrl,
+  fetchTeamDashboard,
+} from '../../api/leadershipTeam';
+import { useAuth } from '../../auth/AuthContext';
+
+const STATUS_META = {
+  submitted: {
+    label: 'Submitted',
+    className: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
+  },
+  day_off: {
+    label: 'Day off',
+    className: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
+  },
+  not_submitted: {
+    label: 'Not submitted',
+    className: 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-100',
+  },
+};
+
+const REASON_LABELS = {
+  needs_attention: 'Needs attention',
+  low_rating: 'Low rating',
+};
+
+function StatusPill({ status }) {
+  const meta = STATUS_META[status] ?? STATUS_META.not_submitted;
+  return (
+    <span
+      data-testid={`lt-status-${status}`}
+      className={`text-xs font-medium px-2 py-0.5 rounded-full ${meta.className}`}
+    >
+      {meta.label}
+    </span>
+  );
+}
+
+export default function LeadershipTeamTeamDashboard() {
+  const { teamRole } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { orgSlug } = useAuth();
+  const dateParam = searchParams.get('date') || '';
+  const filterStatus = searchParams.get('filter') || 'all';
+
+  const [payload, setPayload] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetchTeamDashboard(orgSlug, teamRole, {
+        date: dateParam || undefined,
+      });
+      setPayload(data);
+      setError(null);
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 403) setError('You do not supervise this team.');
+      else if (status === 404) setError('Unknown team role.');
+      else setError('Failed to load the team dashboard.');
+    } finally {
+      setLoading(false);
+    }
+  }, [orgSlug, teamRole, dateParam]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const filteredMembers = useMemo(() => {
+    const rows = payload?.members ?? [];
+    if (filterStatus === 'all') return rows;
+    return rows.filter((m) => m.status === filterStatus);
+  }, [payload, filterStatus]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-screen" data-testid="lt-team-loading">
+        <p className="text-gray-500 dark:text-gray-400">Loading…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6" data-testid="lt-team-error">
+        <p className="text-red-600 dark:text-red-400">{error}</p>
+        <Link
+          to="/leadership-team"
+          className="mt-3 inline-block text-sm text-indigo-600 dark:text-indigo-400 underline"
+        >
+          Back to LT dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  const { header, submission_status, flagged } = payload;
+
+  const onDateChange = (e) => {
+    const value = e.target.value;
+    const next = new URLSearchParams(searchParams);
+    if (value) next.set('date', value);
+    else next.delete('date');
+    setSearchParams(next, { replace: true });
+  };
+
+  const onFilterChange = (value) => {
+    const next = new URLSearchParams(searchParams);
+    if (value === 'all') next.delete('filter');
+    else next.set('filter', value);
+    setSearchParams(next, { replace: true });
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <header className="bg-white dark:bg-gray-800 shadow-sm">
+        <div className="max-w-3xl mx-auto px-4 py-4">
+          <Link
+            to="/leadership-team"
+            className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+          >
+            ← Back to LT dashboard
+          </Link>
+          <div className="flex items-start justify-between gap-3 mt-2">
+            <div>
+              <h1 className="text-xl font-bold text-gray-900 dark:text-white">
+                {header.team_role_label}
+              </h1>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                {header.program.name} · {header.member_count} members
+              </p>
+              {header.supervisors?.length > 0 && (
+                <p className="text-xs text-gray-600 dark:text-gray-300 mt-1">
+                  Supervisors: {header.supervisors.map((s) => s.person_name).join(', ')}
+                </p>
+              )}
+            </div>
+            <a
+              href={exportTeamAggregateUrl(teamRole)}
+              className="rounded-lg border border-gray-300 dark:border-gray-600 text-sm font-medium px-3 py-1.5 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
+              data-testid="lt-team-export"
+            >
+              Export CSV
+            </a>
+          </div>
+
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <label className="text-sm text-gray-700 dark:text-gray-300">
+              Date{' '}
+              <input
+                type="date"
+                value={dateParam || header.date}
+                onChange={onDateChange}
+                max={header.date}
+                className="ml-1 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
+                data-testid="lt-team-date"
+              />
+            </label>
+            {header.period && (
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                Period {header.period.start} → {header.period.end} ({header.period.cadence})
+              </span>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-4 py-6 space-y-4">
+        <section
+          aria-label="Submission status"
+          className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+          data-testid="lt-team-status"
+        >
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-2">
+            Submission status
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {['all', 'submitted', 'not_submitted', 'day_off'].map((s) => {
+              const count = s === 'all'
+                ? submission_status.total
+                : (submission_status[s] ?? 0);
+              const active = filterStatus === s;
+              return (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => onFilterChange(s)}
+                  className={`text-xs px-2 py-1 rounded-full border ${
+                    active
+                      ? 'bg-indigo-600 text-white border-indigo-600'
+                      : 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300'
+                  }`}
+                  data-testid={`lt-filter-${s}`}
+                >
+                  {s === 'all' ? 'All' : STATUS_META[s].label} ({count})
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        {flagged?.length > 0 && (
+          <section
+            aria-label="Flagged reflections"
+            className="rounded-xl border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 p-4"
+            data-testid="lt-team-flagged"
+          >
+            <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-2">
+              Flagged reflections
+            </h2>
+            <ul className="space-y-2">
+              {flagged.map((row) => (
+                <li
+                  key={row.reflection_id}
+                  className="flex items-start justify-between gap-3"
+                  data-testid={`lt-flagged-${row.reflection_id}`}
+                >
+                  <div className="min-w-0">
+                    <p className="font-medium text-gray-900 dark:text-white text-sm">
+                      {row.person_name}
+                    </p>
+                    {row.preview && (
+                      <p className="text-xs text-gray-700 dark:text-gray-300 truncate mt-0.5">
+                        {row.preview}
+                      </p>
+                    )}
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {row.reasons.map((r) => (
+                        <span
+                          key={r}
+                          className="text-xs bg-amber-200 text-amber-900 dark:bg-amber-700 dark:text-amber-50 rounded-full px-2 py-0.5"
+                        >
+                          {REASON_LABELS[r] ?? r}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                  <Link
+                    to={`/reflections/${row.reflection_id}`}
+                    className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline shrink-0"
+                  >
+                    Open →
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        <section aria-label="Members" data-testid="lt-team-members">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-2">
+            Members
+          </h2>
+          {filteredMembers.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 text-sm text-gray-500 dark:text-gray-400">
+              No members match this filter.
+            </div>
+          ) : (
+            <ul className="space-y-2">
+              {filteredMembers.map((m) => (
+                <li
+                  key={m.membership_id}
+                  className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900"
+                  data-testid={`lt-member-row-${m.membership_id}`}
+                >
+                  <Link
+                    to={`/leadership-team/teams/${teamRole}/members/${m.membership_id}`}
+                    className="block px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <p className="font-medium text-gray-900 dark:text-white truncate">
+                            {m.person_name}
+                          </p>
+                          <StatusPill status={m.status} />
+                        </div>
+                        {m.preview && (
+                          <p className="text-xs text-gray-600 dark:text-gray-300 mt-1 truncate">
+                            {m.preview}
+                          </p>
+                        )}
+                      </div>
+                      {m.attention_marker_count > 0 && (
+                        <span
+                          className="shrink-0 text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200 rounded-full px-2 py-0.5"
+                          data-testid={`lt-marker-count-${m.membership_id}`}
+                        >
+                          {m.attention_marker_count} flag{m.attention_marker_count === 1 ? '' : 's'}
+                        </span>
+                      )}
+                    </div>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/leadership-team/TemplateBuilder/TemplateBuilderPage.jsx
+++ b/frontend/src/pages/leadership-team/TemplateBuilder/TemplateBuilderPage.jsx
@@ -1,0 +1,764 @@
+/**
+ * LT Template Builder — Step 7_12, Story 51.
+ *
+ * Tier 1 field types only: text, textarea, text_list, single_choice,
+ * multiple_choice, rating_group. The builder uses the LT-scoped API
+ * (``/api/v1/leadership-team/templates/``) which permits any LT
+ * viewer; admins also see these templates via the existing admin
+ * surface and can step in if needed.
+ *
+ * Edit-while-draft is in place; once responses exist, PATCH auto-
+ * creates a new version (parent_template chain). Publish runs a
+ * server-side validation pass for prompts/keys and surfaces warnings
+ * inline.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import ReflectionField from '../../../components/templates/ReflectionField';
+import {
+  archiveTemplate,
+  cloneTemplate,
+  createTemplate,
+  getTemplate,
+  patchTemplate,
+  publishTemplate,
+} from '../../../api/leadershipTeam';
+import { useAuth } from '../../../auth/AuthContext';
+
+const TIER_1_TYPES = [
+  { value: 'text', label: 'Short text' },
+  { value: 'textarea', label: 'Long text' },
+  { value: 'text_list', label: 'Text list' },
+  { value: 'single_choice', label: 'Single choice' },
+  { value: 'multiple_choice', label: 'Multiple choice' },
+  { value: 'rating_group', label: 'Rating group' },
+];
+
+const SUPPORTED_LANGUAGES = ['en', 'es', 'he'];
+
+let _localUid = 0;
+const newLocalId = () => `lt_fid_${++_localUid}`;
+
+function defaultsFor(type, lang = 'en') {
+  const base = { _id: newLocalId(), type, key: '', required: true };
+  if (type === 'rating_group' || type === 'single_rating') {
+    return {
+      ...base,
+      prompts: { [lang]: '' },
+      scale: [1, 5],
+      scale_labels: { [lang]: ['1', '2', '3', '4', '5'] },
+      categories: [],
+    };
+  }
+  if (type === 'single_choice' || type === 'multiple_choice') {
+    return { ...base, prompts: { [lang]: '' }, options: [] };
+  }
+  if (type === 'text_list') {
+    return { ...base, prompts: { [lang]: '' }, min_items: 0, max_items: 5 };
+  }
+  return { ...base, prompts: { [lang]: '' }, max_length: type === 'textarea' ? 1000 : 200 };
+}
+
+function addLocalIds(fields) {
+  return (fields || []).map((f) => ({ ...f, _id: f._id || newLocalId() }));
+}
+
+function stripLocalIds(fields) {
+  return (fields || []).map(({ _id, ...rest }) => rest);
+}
+
+function clientValidate(template, fields) {
+  const issues = [];
+  const seenKeys = new Set();
+  const languages = template.languages?.length ? template.languages : ['en'];
+  fields.forEach((f, idx) => {
+    const loc = `Field ${idx + 1}`;
+    if (!f.key?.trim()) issues.push(`${loc}: key is required.`);
+    else if (seenKeys.has(f.key)) issues.push(`${loc}: duplicate key "${f.key}".`);
+    else seenKeys.add(f.key);
+    for (const lang of languages) {
+      if (!f.prompts?.[lang]) issues.push(`${loc}: missing "${lang}" prompt.`);
+    }
+    if ((f.type === 'single_choice' || f.type === 'multiple_choice') && !(f.options?.length > 0)) {
+      issues.push(`${loc}: add at least one option.`);
+    }
+    if (f.type === 'rating_group' && !(f.categories?.length > 0)) {
+      issues.push(`${loc}: add at least one category.`);
+    }
+  });
+  return issues;
+}
+
+function FieldEditor({ field, languages, onChange, onRemove }) {
+  const update = (patch) => onChange({ ...field, ...patch });
+  const updatePrompt = (lang, value) =>
+    update({ prompts: { ...(field.prompts || {}), [lang]: value } });
+
+  return (
+    <div
+      className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3"
+      data-testid={`lt-fld-${field._id}`}
+    >
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <div className="flex items-center gap-2">
+          <select
+            value={field.type}
+            onChange={(e) => update({ type: e.target.value })}
+            className="text-sm rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700"
+            data-testid={`lt-fld-type-${field._id}`}
+          >
+            {TIER_1_TYPES.map((t) => (
+              <option key={t.value} value={t.value}>{t.label}</option>
+            ))}
+          </select>
+          <input
+            type="text"
+            value={field.key}
+            onChange={(e) => update({ key: e.target.value })}
+            placeholder="field_key"
+            className="text-sm rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700"
+            data-testid={`lt-fld-key-${field._id}`}
+          />
+          <label className="text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={!!field.required}
+              onChange={(e) => update({ required: e.target.checked })}
+            />
+            required
+          </label>
+        </div>
+        <button
+          type="button"
+          onClick={onRemove}
+          className="text-xs rounded-md border border-red-300 text-red-600 hover:bg-red-50 px-2 py-1"
+          data-testid={`lt-fld-remove-${field._id}`}
+        >
+          Remove
+        </button>
+      </div>
+
+      <div className="space-y-2">
+        {languages.map((lang) => (
+          <label key={lang} className="block text-xs text-gray-700 dark:text-gray-300">
+            Prompt ({lang})
+            <input
+              type="text"
+              value={field.prompts?.[lang] ?? ''}
+              onChange={(e) => updatePrompt(lang, e.target.value)}
+              className="mt-1 w-full text-sm rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700"
+              data-testid={`lt-fld-prompt-${field._id}-${lang}`}
+            />
+          </label>
+        ))}
+
+        {(field.type === 'single_choice' || field.type === 'multiple_choice') && (
+          <OptionsEditor
+            options={field.options || []}
+            languages={languages}
+            onChange={(options) => update({ options })}
+            fieldId={field._id}
+          />
+        )}
+
+        {field.type === 'rating_group' && (
+          <CategoriesEditor
+            categories={field.categories || []}
+            languages={languages}
+            onChange={(categories) => update({ categories })}
+            fieldId={field._id}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function OptionsEditor({ options, languages, onChange, fieldId }) {
+  const addOption = () => onChange([
+    ...options,
+    { key: '', labels: Object.fromEntries(languages.map((l) => [l, ''])) },
+  ]);
+  const updateOption = (idx, patch) => onChange(options.map((o, i) => i === idx ? { ...o, ...patch } : o));
+  const removeOption = (idx) => onChange(options.filter((_, i) => i !== idx));
+  return (
+    <div className="space-y-1">
+      <p className="text-xs font-medium text-gray-700 dark:text-gray-300">Options</p>
+      {options.map((o, idx) => (
+        <div key={idx} className="flex gap-2 items-center" data-testid={`lt-opt-${fieldId}-${idx}`}>
+          <input
+            type="text"
+            value={o.key}
+            onChange={(e) => updateOption(idx, { key: e.target.value })}
+            placeholder="option_key"
+            className="text-xs rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 w-32"
+          />
+          {languages.map((lang) => (
+            <input
+              key={lang}
+              type="text"
+              value={o.labels?.[lang] ?? ''}
+              onChange={(e) => updateOption(idx, { labels: { ...(o.labels || {}), [lang]: e.target.value } })}
+              placeholder={`label (${lang})`}
+              className="text-xs rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 flex-1"
+            />
+          ))}
+          <button
+            type="button"
+            onClick={() => removeOption(idx)}
+            className="text-xs text-red-600 hover:underline"
+          >
+            Remove
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={addOption}
+        className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline"
+        data-testid={`lt-opt-add-${fieldId}`}
+      >
+        + Add option
+      </button>
+    </div>
+  );
+}
+
+function CategoriesEditor({ categories, languages, onChange, fieldId }) {
+  const add = () => onChange([
+    ...categories,
+    { key: '', labels: Object.fromEntries(languages.map((l) => [l, ''])) },
+  ]);
+  const update = (idx, patch) => onChange(categories.map((c, i) => i === idx ? { ...c, ...patch } : c));
+  const remove = (idx) => onChange(categories.filter((_, i) => i !== idx));
+  return (
+    <div className="space-y-1">
+      <p className="text-xs font-medium text-gray-700 dark:text-gray-300">Categories</p>
+      {categories.map((c, idx) => (
+        <div key={idx} className="flex gap-2 items-center" data-testid={`lt-cat-${fieldId}-${idx}`}>
+          <input
+            type="text"
+            value={c.key}
+            onChange={(e) => update(idx, { key: e.target.value })}
+            placeholder="category_key"
+            className="text-xs rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 w-32"
+          />
+          {languages.map((lang) => (
+            <input
+              key={lang}
+              type="text"
+              value={c.labels?.[lang] ?? ''}
+              onChange={(e) => update(idx, { labels: { ...(c.labels || {}), [lang]: e.target.value } })}
+              placeholder={`label (${lang})`}
+              className="text-xs rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 flex-1"
+            />
+          ))}
+          <button
+            type="button"
+            onClick={() => remove(idx)}
+            className="text-xs text-red-600 hover:underline"
+          >
+            Remove
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={add}
+        className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline"
+        data-testid={`lt-cat-add-${fieldId}`}
+      >
+        + Add category
+      </button>
+    </div>
+  );
+}
+
+function PreviewPane({ template, fields, previewLanguage }) {
+  return (
+    <div className="space-y-4">
+      {fields.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400" data-testid="lt-builder-preview-empty">
+          Add a field to see a preview.
+        </p>
+      ) : (
+        fields.map((field) => (
+          <div key={field._id} data-testid={`lt-preview-${field._id}`}>
+            <ReflectionField
+              field={field}
+              answer={undefined}
+              onChange={() => {}}
+              language={previewLanguage}
+            />
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+export default function TemplateBuilderPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const { orgSlug } = useAuth();
+  const isEdit = Boolean(id);
+
+  const [template, setTemplate] = useState({
+    name: '',
+    role: 'leadership_team',
+    languages: ['en'],
+    cadence: 'biweekly',
+    status: 'draft',
+    schema: { fields: [] },
+    is_active: true,
+    version: 1,
+  });
+  const [fields, setFields] = useState([]);
+  const [loading, setLoading] = useState(isEdit);
+  const [error, setError] = useState('');
+  const [warnings, setWarnings] = useState([]);
+  const [saving, setSaving] = useState(false);
+  const [previewLanguage, setPreviewLanguage] = useState('en');
+  const [dirty, setDirty] = useState(false);
+  const [showForceVersion, setShowForceVersion] = useState(false);
+  const dirtyRef = useRef(false);
+  dirtyRef.current = dirty;
+
+  const load = useCallback(async () => {
+    if (!isEdit) return;
+    setLoading(true);
+    try {
+      const data = await getTemplate(orgSlug, id);
+      setTemplate({
+        id: data.id,
+        name: data.name ?? '',
+        role: data.role ?? 'leadership_team',
+        languages: data.languages?.length ? data.languages : ['en'],
+        cadence: data.cadence ?? 'biweekly',
+        status: data.status ?? (data.is_active ? 'published' : 'archived'),
+        schema: data.schema ?? { fields: [] },
+        is_active: data.is_active,
+        version: data.version ?? 1,
+        slug: data.slug,
+      });
+      setFields(addLocalIds(data.schema?.fields ?? []));
+      setPreviewLanguage(data.languages?.[0] ?? 'en');
+    } catch (err) {
+      if (err?.response?.status === 403) setError('You cannot edit this template.');
+      else setError('Failed to load template.');
+    } finally {
+      setLoading(false);
+    }
+  }, [isEdit, orgSlug, id]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const updateTemplate = (patch) => {
+    setTemplate((prev) => ({ ...prev, ...patch }));
+    setDirty(true);
+  };
+
+  const updateFields = (next) => {
+    setFields(next);
+    setDirty(true);
+  };
+
+  const onAddField = (type) => {
+    updateFields([...fields, defaultsFor(type, template.languages[0] ?? 'en')]);
+  };
+
+  const onFieldChange = (idx, next) => {
+    updateFields(fields.map((f, i) => i === idx ? next : f));
+  };
+
+  const onFieldRemove = (idx) => {
+    updateFields(fields.filter((_, i) => i !== idx));
+  };
+
+  const move = (idx, direction) => {
+    const target = idx + direction;
+    if (target < 0 || target >= fields.length) return;
+    const next = [...fields];
+    [next[idx], next[target]] = [next[target], next[idx]];
+    updateFields(next);
+  };
+
+  const validationIssues = useMemo(
+    () => clientValidate(template, fields),
+    [template, fields],
+  );
+
+  const buildPayload = () => ({
+    name: template.name,
+    role: template.role,
+    languages: template.languages,
+    cadence: template.cadence,
+    schema: { fields: stripLocalIds(fields) },
+  });
+
+  const save = async ({ forceNewVersion = false } = {}) => {
+    setError('');
+    setWarnings([]);
+    if (validationIssues.length > 0) {
+      setError(validationIssues.join(' · '));
+      return null;
+    }
+    setSaving(true);
+    try {
+      const payload = buildPayload();
+      if (isEdit) {
+        const data = await patchTemplate(orgSlug, id, payload, { forceNewVersion });
+        if (data?.warnings?.length) setWarnings(data.warnings);
+        if (data?.id && data.id !== Number(id)) {
+          navigate(`/leadership-team/templates/${data.id}`);
+          return data;
+        }
+        await load();
+        setDirty(false);
+        return data;
+      }
+      const created = await createTemplate(orgSlug, payload);
+      if (created?.id) {
+        navigate(`/leadership-team/templates/${created.id}`);
+      }
+      return created;
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 409) {
+        setShowForceVersion(true);
+        setError(err?.response?.data?.detail ?? 'Responses exist on this template — confirm a new version.');
+        return null;
+      }
+      const detail = err?.response?.data?.errors
+        ?? err?.response?.data?.detail
+        ?? 'Failed to save template.';
+      setError(Array.isArray(detail) ? detail.join(' · ') : (typeof detail === 'string' ? detail : JSON.stringify(detail)));
+      return null;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const doPublish = async () => {
+    if (dirtyRef.current) {
+      const saved = await save();
+      if (!saved) return;
+    }
+    setSaving(true);
+    setError('');
+    setWarnings([]);
+    try {
+      const data = await publishTemplate(orgSlug, id);
+      if (data?.warnings?.length) setWarnings(data.warnings);
+      await load();
+    } catch (err) {
+      if (err?.response?.status === 409) {
+        setWarnings(err.response.data?.warnings ?? []);
+        setError('Resolve warnings before publishing.');
+      } else {
+        setError(err?.response?.data?.detail ?? 'Publish failed.');
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const doArchive = async () => {
+    setSaving(true);
+    try {
+      await archiveTemplate(orgSlug, id);
+      navigate('/leadership-team/templates');
+    } catch (err) {
+      setError(err?.response?.data?.detail ?? 'Archive failed.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const doClone = async () => {
+    setSaving(true);
+    try {
+      const cloned = await cloneTemplate(orgSlug, id);
+      if (cloned?.id) navigate(`/leadership-team/templates/${cloned.id}`);
+    } catch (err) {
+      setError(err?.response?.data?.detail ?? 'Clone failed.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-screen" data-testid="lt-builder-loading">
+        <p className="text-gray-500 dark:text-gray-400">Loading…</p>
+      </div>
+    );
+  }
+
+  const status = template.status ?? 'draft';
+  const isPublished = status === 'published';
+  const isArchived = status === 'archived';
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <header className="bg-white dark:bg-gray-800 shadow-sm sticky top-0 z-10">
+        <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between gap-3">
+          <div className="flex-1 min-w-0">
+            <Link
+              to="/leadership-team/templates"
+              className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+            >
+              ← Template library
+            </Link>
+            <div className="flex items-center gap-2 mt-1">
+              <input
+                type="text"
+                value={template.name}
+                onChange={(e) => updateTemplate({ name: e.target.value })}
+                placeholder="Template name"
+                disabled={isArchived}
+                className="text-lg font-semibold text-gray-900 dark:text-white bg-transparent border-b border-gray-200 dark:border-gray-700 focus:outline-none flex-1 min-w-0"
+                data-testid="lt-builder-name"
+              />
+              <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200">
+                {status} v{template.version}
+              </span>
+            </div>
+          </div>
+          <div className="flex gap-2 shrink-0">
+            <button
+              type="button"
+              onClick={() => save()}
+              disabled={saving || isArchived}
+              className="text-sm rounded-lg bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white px-3 py-1.5"
+              data-testid="lt-builder-save"
+            >
+              {saving ? 'Saving…' : isEdit ? 'Save' : 'Save draft'}
+            </button>
+            {isEdit && !isPublished && !isArchived && (
+              <button
+                type="button"
+                onClick={doPublish}
+                disabled={saving}
+                className="text-sm rounded-lg bg-green-600 hover:bg-green-700 disabled:opacity-50 text-white px-3 py-1.5"
+                data-testid="lt-builder-publish"
+              >
+                Publish
+              </button>
+            )}
+            {isEdit && isPublished && (
+              <button
+                type="button"
+                onClick={doArchive}
+                disabled={saving}
+                className="text-sm rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 px-3 py-1.5"
+                data-testid="lt-builder-archive"
+              >
+                Archive
+              </button>
+            )}
+            {isEdit && (
+              <button
+                type="button"
+                onClick={doClone}
+                disabled={saving}
+                className="text-sm rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 px-3 py-1.5"
+                data-testid="lt-builder-clone"
+              >
+                Clone
+              </button>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-6xl mx-auto px-4 py-6 grid grid-cols-1 lg:grid-cols-12 gap-4">
+        <section className="lg:col-span-3 space-y-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">Settings</h2>
+          <label className="block text-sm text-gray-700 dark:text-gray-300">
+            Role
+            <select
+              value={template.role}
+              onChange={(e) => updateTemplate({ role: e.target.value })}
+              disabled={isArchived}
+              className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
+              data-testid="lt-builder-role"
+            >
+              {[
+                'counselor', 'specialist', 'unit_head', 'leadership_team',
+                'kitchen_staff', 'maintenance', 'housekeeping', 'camper_care',
+                'health_center', 'madrich', 'general_counselor', 'faculty',
+              ].map((r) => <option key={r} value={r}>{r}</option>)}
+            </select>
+          </label>
+          <label className="block text-sm text-gray-700 dark:text-gray-300">
+            Cadence
+            <select
+              value={template.cadence}
+              onChange={(e) => updateTemplate({ cadence: e.target.value })}
+              disabled={isArchived}
+              className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
+              data-testid="lt-builder-cadence"
+            >
+              {['daily', 'weekly', 'biweekly', 'monthly', 'on_demand'].map((c) => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </label>
+          <fieldset className="border border-gray-200 dark:border-gray-700 rounded-md p-2">
+            <legend className="text-xs text-gray-500 dark:text-gray-400 px-1">Languages</legend>
+            {SUPPORTED_LANGUAGES.map((lang) => (
+              <label key={lang} className="flex items-center gap-1 text-sm text-gray-700 dark:text-gray-300">
+                <input
+                  type="checkbox"
+                  checked={template.languages.includes(lang)}
+                  disabled={isArchived}
+                  onChange={(e) => {
+                    const next = e.target.checked
+                      ? [...new Set([...template.languages, lang])]
+                      : template.languages.filter((l) => l !== lang);
+                    updateTemplate({ languages: next.length ? next : ['en'] });
+                  }}
+                  data-testid={`lt-builder-lang-${lang}`}
+                />
+                {lang}
+              </label>
+            ))}
+          </fieldset>
+          <label className="block text-sm text-gray-700 dark:text-gray-300">
+            Preview language
+            <select
+              value={previewLanguage}
+              onChange={(e) => setPreviewLanguage(e.target.value)}
+              className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
+              data-testid="lt-builder-preview-lang"
+            >
+              {template.languages.map((lang) => (
+                <option key={lang} value={lang}>{lang}</option>
+              ))}
+            </select>
+          </label>
+        </section>
+
+        <section className="lg:col-span-5 space-y-3" aria-label="Fields">
+          <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
+            <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-2">
+              Fields
+            </h2>
+            <div className="flex flex-wrap gap-1 mb-3">
+              {TIER_1_TYPES.map((t) => (
+                <button
+                  key={t.value}
+                  type="button"
+                  onClick={() => onAddField(t.value)}
+                  disabled={isArchived}
+                  className="text-xs rounded-md border border-gray-300 dark:border-gray-600 px-2 py-1 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+                  data-testid={`lt-builder-add-${t.value}`}
+                >
+                  + {t.label}
+                </button>
+              ))}
+            </div>
+            <div className="space-y-2" data-testid="lt-builder-fields">
+              {fields.map((field, idx) => (
+                <div key={field._id} className="flex items-stretch gap-1">
+                  <div className="flex flex-col gap-1 shrink-0">
+                    <button
+                      type="button"
+                      onClick={() => move(idx, -1)}
+                      disabled={idx === 0 || isArchived}
+                      className="text-xs rounded border border-gray-300 dark:border-gray-600 px-1 text-gray-500 disabled:opacity-30"
+                      data-testid={`lt-builder-up-${field._id}`}
+                      aria-label="Move up"
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => move(idx, 1)}
+                      disabled={idx === fields.length - 1 || isArchived}
+                      className="text-xs rounded border border-gray-300 dark:border-gray-600 px-1 text-gray-500 disabled:opacity-30"
+                      data-testid={`lt-builder-down-${field._id}`}
+                      aria-label="Move down"
+                    >
+                      ↓
+                    </button>
+                  </div>
+                  <div className="flex-1">
+                    <FieldEditor
+                      field={field}
+                      languages={template.languages}
+                      onChange={(next) => onFieldChange(idx, next)}
+                      onRemove={() => onFieldRemove(idx)}
+                    />
+                  </div>
+                </div>
+              ))}
+              {fields.length === 0 && (
+                <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-6" data-testid="lt-builder-empty">
+                  No fields yet — add one above.
+                </p>
+              )}
+            </div>
+          </div>
+
+          {validationIssues.length > 0 && (
+            <div
+              className="rounded-md border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 p-2 text-xs text-amber-900 dark:text-amber-200"
+              data-testid="lt-builder-issues"
+            >
+              <p className="font-medium mb-1">Issues:</p>
+              <ul className="list-disc list-inside space-y-0.5">
+                {validationIssues.map((iss) => <li key={iss}>{iss}</li>)}
+              </ul>
+            </div>
+          )}
+
+          {warnings.length > 0 && (
+            <div
+              className="rounded-md border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 p-2 text-xs text-amber-900 dark:text-amber-200"
+              data-testid="lt-builder-warnings"
+            >
+              <p className="font-medium mb-1">Warnings:</p>
+              <ul className="list-disc list-inside space-y-0.5">
+                {warnings.map((w) => <li key={w}>{w}</li>)}
+              </ul>
+            </div>
+          )}
+
+          {error && (
+            <div
+              className="rounded-md border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20 p-2 text-xs text-red-700 dark:text-red-300"
+              data-testid="lt-builder-error"
+            >
+              {error}
+              {showForceVersion && (
+                <button
+                  type="button"
+                  onClick={() => { setShowForceVersion(false); save({ forceNewVersion: true }); }}
+                  className="ml-2 text-xs rounded-md bg-red-600 hover:bg-red-700 text-white px-2 py-1"
+                  data-testid="lt-builder-force-version"
+                >
+                  Create new version
+                </button>
+              )}
+            </div>
+          )}
+        </section>
+
+        <section
+          className="lg:col-span-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+          aria-label="Preview"
+          data-testid="lt-builder-preview"
+        >
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-base font-semibold text-gray-900 dark:text-white">Preview</h2>
+            <span className="text-xs text-gray-500 dark:text-gray-400">{previewLanguage}</span>
+          </div>
+          <PreviewPane template={template} fields={fields} previewLanguage={previewLanguage} />
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/leadership-team/TemplateLibrary.jsx
+++ b/frontend/src/pages/leadership-team/TemplateLibrary.jsx
@@ -1,0 +1,252 @@
+/**
+ * LT Template Library — Step 7_12, Story 51 entrypoint.
+ *
+ * Lists templates the LT viewer + their co-supervisors can see, with
+ * filters by status / role and quick actions (open, publish, clone,
+ * archive, view responses). The detail / edit surface lives in
+ * ``TemplateBuilderPage``; clone calls the LT clone endpoint and
+ * redirects to the new draft.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import {
+  archiveTemplate,
+  cloneTemplate,
+  listTemplates,
+  publishTemplate,
+} from '../../api/leadershipTeam';
+import { useAuth } from '../../auth/AuthContext';
+
+const STATUS_OPTIONS = [
+  { value: '', label: 'All' },
+  { value: 'draft', label: 'Draft' },
+  { value: 'published', label: 'Published' },
+  { value: 'archived', label: 'Archived' },
+];
+
+const ROLE_OPTIONS = [
+  '', 'counselor', 'junior_counselor', 'specialist', 'general_counselor',
+  'unit_head', 'leadership_team', 'kitchen_staff', 'maintenance',
+  'housekeeping', 'camper_care', 'health_center', 'madrich', 'faculty',
+];
+
+function statusBadge(status) {
+  const map = {
+    draft: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200',
+    published: 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300',
+    archived: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300',
+  };
+  return map[status] ?? map.archived;
+}
+
+export default function LeadershipTeamTemplateLibrary() {
+  const navigate = useNavigate();
+  const { orgSlug } = useAuth();
+  const [templates, setTemplates] = useState([]);
+  const [statusFilter, setStatusFilter] = useState('');
+  const [roleFilter, setRoleFilter] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [actionPending, setActionPending] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await listTemplates(orgSlug, {
+        status: statusFilter || undefined,
+        role: roleFilter || undefined,
+      });
+      const rows = Array.isArray(data?.results) ? data.results
+        : Array.isArray(data) ? data : [];
+      setTemplates(rows);
+    } catch (err) {
+      if (err?.response?.status === 403) setError('You do not have LT access.');
+      else setError('Failed to load templates.');
+    } finally {
+      setLoading(false);
+    }
+  }, [orgSlug, statusFilter, roleFilter]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const doAction = async (id, action) => {
+    setActionPending(id);
+    try {
+      if (action === 'publish') {
+        await publishTemplate(orgSlug, id);
+      } else if (action === 'archive') {
+        await archiveTemplate(orgSlug, id);
+      } else if (action === 'clone') {
+        const cloned = await cloneTemplate(orgSlug, id);
+        if (cloned?.id) navigate(`/leadership-team/templates/${cloned.id}`);
+        return;
+      }
+      await load();
+    } catch (err) {
+      const detail = err?.response?.data?.detail
+        ?? err?.response?.data?.errors?.[0]
+        ?? `Failed to ${action} template.`;
+      setError(typeof detail === 'string' ? detail : JSON.stringify(detail));
+    } finally {
+      setActionPending(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <header className="bg-white dark:bg-gray-800 shadow-sm">
+        <div className="max-w-5xl mx-auto px-4 py-4 flex items-center justify-between">
+          <div>
+            <Link
+              to="/leadership-team"
+              className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+            >
+              ← Back to LT dashboard
+            </Link>
+            <h1 className="text-xl font-bold text-gray-900 dark:text-white mt-2">
+              Templates
+            </h1>
+          </div>
+          <Link
+            to="/leadership-team/templates/new"
+            className="rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium px-3 py-1.5"
+            data-testid="lt-templates-new"
+          >
+            New template
+          </Link>
+        </div>
+      </header>
+
+      <main className="max-w-5xl mx-auto px-4 py-6 space-y-4">
+        <section
+          className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3 flex flex-wrap gap-3"
+          aria-label="Filters"
+        >
+          <label className="text-sm text-gray-700 dark:text-gray-300">
+            Status{' '}
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value)}
+              className="ml-1 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
+              data-testid="lt-tpl-status-filter"
+            >
+              {STATUS_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm text-gray-700 dark:text-gray-300">
+            Role{' '}
+            <select
+              value={roleFilter}
+              onChange={(e) => setRoleFilter(e.target.value)}
+              className="ml-1 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
+              data-testid="lt-tpl-role-filter"
+            >
+              {ROLE_OPTIONS.map((r) => (
+                <option key={r} value={r}>{r ? r.replace('_', ' ') : 'All'}</option>
+              ))}
+            </select>
+          </label>
+        </section>
+
+        {error && (
+          <p className="text-red-600 dark:text-red-400 text-sm" data-testid="lt-tpl-error">
+            {error}
+          </p>
+        )}
+
+        {loading ? (
+          <p className="text-gray-500 dark:text-gray-400 text-sm" data-testid="lt-tpl-loading">
+            Loading…
+          </p>
+        ) : templates.length === 0 ? (
+          <div
+            className="rounded-xl border border-dashed border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 p-6 text-center text-sm text-gray-500 dark:text-gray-400"
+            data-testid="lt-tpl-empty"
+          >
+            No templates match the current filters.
+          </div>
+        ) : (
+          <ul className="space-y-2" data-testid="lt-tpl-list">
+            {templates.map((tpl) => (
+              <li
+                key={tpl.id}
+                className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3"
+                data-testid={`lt-tpl-row-${tpl.id}`}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <Link
+                        to={`/leadership-team/templates/${tpl.id}`}
+                        className="font-medium text-gray-900 dark:text-white hover:underline"
+                      >
+                        {tpl.name}
+                      </Link>
+                      <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${statusBadge(tpl.status)}`}>
+                        {tpl.status} v{tpl.version}
+                      </span>
+                      {tpl.role && (
+                        <span className="text-xs text-gray-500 dark:text-gray-400">
+                          {tpl.role.replace('_', ' ')}
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                      {tpl.languages?.join(', ') ?? 'en'} · {tpl.cadence ?? 'daily'}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0 flex-wrap">
+                    {tpl.status === 'draft' && (
+                      <button
+                        type="button"
+                        onClick={() => doAction(tpl.id, 'publish')}
+                        disabled={actionPending === tpl.id}
+                        className="text-xs rounded-md bg-indigo-600 hover:bg-indigo-700 text-white px-2 py-1"
+                        data-testid={`lt-tpl-publish-${tpl.id}`}
+                      >
+                        Publish
+                      </button>
+                    )}
+                    {tpl.status === 'published' && (
+                      <>
+                        <Link
+                          to={`/leadership-team/templates/${tpl.id}/responses`}
+                          className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline"
+                          data-testid={`lt-tpl-responses-${tpl.id}`}
+                        >
+                          Responses
+                        </Link>
+                        <button
+                          type="button"
+                          onClick={() => doAction(tpl.id, 'archive')}
+                          disabled={actionPending === tpl.id}
+                          className="text-xs rounded-md border border-gray-300 dark:border-gray-600 px-2 py-1 text-gray-700 dark:text-gray-300"
+                          data-testid={`lt-tpl-archive-${tpl.id}`}
+                        >
+                          Archive
+                        </button>
+                      </>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => doAction(tpl.id, 'clone')}
+                      disabled={actionPending === tpl.id}
+                      className="text-xs rounded-md border border-gray-300 dark:border-gray-600 px-2 py-1 text-gray-700 dark:text-gray-300"
+                      data-testid={`lt-tpl-clone-${tpl.id}`}
+                    >
+                      Clone
+                    </button>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/leadership-team/__tests__/AssignmentDialog.test.jsx
+++ b/frontend/src/pages/leadership-team/__tests__/AssignmentDialog.test.jsx
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import AssignmentDialog from '../AssignmentDialog';
+
+const postMock = vi.fn();
+vi.mock('../../../api', () => ({
+  default: { post: (...args) => postMock(...args) },
+}));
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ orgSlug: 'test-org' }),
+}));
+
+beforeEach(() => { postMock.mockReset(); });
+
+const template = { id: 9, name: 'Kitchen weekly', version: 2, role: 'kitchen_staff' };
+
+describe('AssignmentDialog', () => {
+  it('submits a role-targeted assignment and calls onCreated', async () => {
+    postMock.mockResolvedValue({ data: { id: 1, target_type: 'role' } });
+    const onCreated = vi.fn();
+    const onClose = vi.fn();
+    render(<AssignmentDialog template={template} onClose={onClose} onCreated={onCreated} />);
+
+    fireEvent.change(screen.getByTestId('lt-assignment-start'), {
+      target: { value: '2026-07-12' },
+    });
+    fireEvent.click(screen.getByTestId('lt-assignment-submit'));
+    await waitFor(() => expect(onCreated).toHaveBeenCalled());
+    expect(postMock).toHaveBeenCalledTimes(1);
+    const [, body] = postMock.mock.calls[0];
+    expect(body.target_type).toBe('role');
+    expect(body.target_payload).toEqual({ role: 'kitchen_staff' });
+  });
+
+  it('renders the conflict picker and resubmits with conflict_resolution=replace', async () => {
+    postMock.mockRejectedValueOnce({
+      response: {
+        status: 409,
+        data: {
+          detail: 'Assignment conflict requires conflict_resolution.',
+          conflicts: [{ id: 99, start_date: '2026-06-01', end_date: null, target_type: 'role' }],
+        },
+      },
+    });
+    postMock.mockResolvedValueOnce({ data: { id: 12 } });
+    const onCreated = vi.fn();
+    render(<AssignmentDialog template={template} onCreated={onCreated} onClose={() => {}} />);
+    fireEvent.change(screen.getByTestId('lt-assignment-start'), {
+      target: { value: '2026-07-12' },
+    });
+    fireEvent.click(screen.getByTestId('lt-assignment-submit'));
+    await waitFor(() => expect(screen.getByTestId('lt-assignment-conflicts')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('lt-conflict-replace'));
+    fireEvent.click(screen.getByTestId('lt-assignment-submit'));
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith({ id: 12 }));
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(postMock.mock.calls[1][1].conflict_resolution).toBe('replace');
+  });
+
+  it('shows a validation error when start_date is missing', async () => {
+    render(<AssignmentDialog template={template} onCreated={() => {}} onClose={() => {}} />);
+    fireEvent.click(screen.getByTestId('lt-assignment-submit'));
+    await waitFor(() => expect(screen.getByTestId('lt-assignment-error')).toBeInTheDocument());
+    expect(postMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/leadership-team/__tests__/Dashboard.test.jsx
+++ b/frontend/src/pages/leadership-team/__tests__/Dashboard.test.jsx
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import LeadershipTeamDashboard from '../Dashboard';
+
+const getMock = vi.fn();
+vi.mock('../../../api', () => ({
+  default: { get: (...args) => getMock(...args) },
+}));
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ orgSlug: 'test-org', user: { id: 1 } }),
+}));
+
+const sample = {
+  today: '2026-07-10',
+  teams: [
+    {
+      team_role: 'kitchen_staff',
+      team_role_label: 'Kitchen Staff',
+      program_id: 1,
+      program_name: 'Summer',
+      member_count: 4,
+      completion: { submitted: 2, expected: 4 },
+      co_supervisors: [{ membership_id: 9, person_name: 'Co-LT' }],
+      badges: ['low_completion'],
+    },
+  ],
+  bunks_and_units: {
+    unit_count: 3,
+    bunk_count: 12,
+    completion: { submitted: 10, expected: 12 },
+  },
+  self_reflection: {
+    state: 'missing',
+    reflection_id: null,
+    template_id: 50,
+    editable: true,
+    period_start: '2026-07-06',
+    period_end: '2026-07-19',
+    cadence: 'biweekly',
+  },
+  templates_and_assignments: { owned_template_count: 2, assignment_count: 0 },
+};
+
+beforeEach(() => { getMock.mockReset(); });
+
+describe('LeadershipTeamDashboard', () => {
+  it('renders teams, self-reflection card, bunks/units, and templates sections', async () => {
+    getMock.mockResolvedValue({ data: sample });
+    render(<MemoryRouter><LeadershipTeamDashboard /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByTestId('lt-teams-list')).toBeInTheDocument());
+    expect(screen.getByTestId('lt-team-card-kitchen_staff')).toBeInTheDocument();
+    expect(screen.getByTestId('lt-badge-low_completion')).toBeInTheDocument();
+    expect(screen.getByTestId('lt-self-card')).toBeInTheDocument();
+    expect(screen.getByTestId('lt-bunks-units-card')).toBeInTheDocument();
+    expect(screen.getByTestId('lt-templates-card')).toBeInTheDocument();
+    expect(screen.getByText(/2 templates you authored/)).toBeInTheDocument();
+  });
+
+  it('surfaces an access error when the API returns 403', async () => {
+    getMock.mockRejectedValue({ response: { status: 403 } });
+    render(<MemoryRouter><LeadershipTeamDashboard /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByTestId('lt-error')).toBeInTheDocument());
+    expect(screen.getByText(/Leadership Team access/)).toBeInTheDocument();
+  });
+
+  it('shows an empty-state when the viewer supervises no teams', async () => {
+    getMock.mockResolvedValue({ data: { ...sample, teams: [] } });
+    render(<MemoryRouter><LeadershipTeamDashboard /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByTestId('lt-teams-empty')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/pages/leadership-team/__tests__/MemberReflection.test.jsx
+++ b/frontend/src/pages/leadership-team/__tests__/MemberReflection.test.jsx
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import LeadershipTeamMemberReflection from '../MemberReflection';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: (...args) => postMock(...args),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ orgSlug: 'test-org' }),
+}));
+
+const payload = {
+  header: {
+    person: { id: 11, name: 'Asha Cook', first_name: 'Asha', last_name: 'Cook', preferred_name: 'Asha' },
+    role: 'kitchen_staff',
+    membership_id: 21,
+    language_preference: 'en',
+    period: { start: '2026-07-06', end: '2026-07-12', cadence: 'weekly' },
+  },
+  metadata: {
+    reflection_id: 100,
+    submitted_at: '2026-07-10T08:00:00Z',
+    last_edited_at: null,
+    language_of_authorship: 'en',
+    team_visibility: 'org_default',
+  },
+  content: {
+    fields: [
+      { key: 'mood', type: 'single_rating', prompts: { en: 'Mood' }, answer: { mood: 4 }, scale: [1, 5] },
+      { key: 'notes', type: 'textarea', prompts: { en: 'Anything else?' }, answer: 'Things went well today' },
+    ],
+    translation: null,
+  },
+  trend: {
+    series: [
+      {
+        label: 'mood',
+        field_key: 'mood',
+        field_type: 'single_rating',
+        scale_max: 5,
+        points: [
+          { period_start: '2026-06-29', period_end: '2026-07-05', value: 3, reflection_id: 99 },
+          { period_start: '2026-07-06', period_end: '2026-07-12', value: 4, reflection_id: 100 },
+        ],
+      },
+    ],
+    scale_max: 5,
+    period: { start: '2026-06-29', end: '2026-07-12', cadence: 'weekly' },
+  },
+  attention_markers: [],
+};
+
+beforeEach(() => { getMock.mockReset(); postMock.mockReset(); });
+
+function renderAt(route) {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <Routes>
+        <Route
+          path="/leadership-team/teams/:teamRole/members/:membershipId"
+          element={<LeadershipTeamMemberReflection />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('LeadershipTeamMemberReflection', () => {
+  it('renders the reflection content and trend series', async () => {
+    getMock.mockResolvedValue({ data: payload });
+    renderAt('/leadership-team/teams/kitchen_staff/members/21');
+    await waitFor(() => expect(screen.getByText('Asha Cook')).toBeInTheDocument());
+    expect(screen.getByText('Things went well today')).toBeInTheDocument();
+    expect(screen.getByTestId('lt-trend-series-mood')).toBeInTheDocument();
+  });
+
+  it('opens the flag form and POSTs to mark-attention', async () => {
+    getMock.mockResolvedValue({ data: payload });
+    postMock.mockResolvedValue({ data: { id: 7 } });
+    renderAt('/leadership-team/teams/kitchen_staff/members/21');
+    await waitFor(() => screen.getByTestId('lt-mark-attention-toggle'));
+    fireEvent.click(screen.getByTestId('lt-mark-attention-toggle'));
+    fireEvent.change(screen.getByTestId('lt-mark-attention-note'), { target: { value: 'check in next week' } });
+    fireEvent.click(screen.getByTestId('lt-mark-attention-submit'));
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    expect(postMock.mock.calls[0][0]).toMatch(/reflections\/100\/mark-attention/);
+    expect(postMock.mock.calls[0][1]).toEqual({ note: 'check in next week' });
+  });
+});

--- a/frontend/src/pages/leadership-team/__tests__/Responses.test.jsx
+++ b/frontend/src/pages/leadership-team/__tests__/Responses.test.jsx
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import LeadershipTeamResponses from '../Responses';
+
+const getMock = vi.fn();
+vi.mock('../../../api', () => ({
+  default: { get: (...args) => getMock(...args) },
+}));
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ orgSlug: 'test-org' }),
+}));
+
+const templatePayload = { id: 7, name: 'KS Weekly', version: 1, role: 'kitchen_staff' };
+
+const individualPayload = {
+  tab: 'individual',
+  template: { id: 7, slug: 'ks-weekly' },
+  total: 1,
+  page: 1,
+  page_size: 25,
+  results: [
+    {
+      id: 401,
+      period_start: '2026-07-06',
+      period_end: '2026-07-12',
+      language: 'en',
+      author: { id: 33, name: 'Asha Cook' },
+      subject: { id: 33, name: 'Asha Cook' },
+      template_version: 1,
+      answers: { mood: 4 },
+    },
+  ],
+};
+
+const aggregatePayload = {
+  tab: 'aggregate',
+  total_responses: 2,
+  response_volume_per_period: [{ period_start: '2026-07-06', count: 2 }],
+  language_distribution: { en: 2 },
+  avg_per_dimension: [
+    { key: 'mood', avg: 4.5, count: 2, versions: [1] },
+  ],
+};
+
+beforeEach(() => { getMock.mockReset(); });
+
+function renderAt(route) {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <Routes>
+        <Route path="/leadership-team/templates/:id/responses" element={<LeadershipTeamResponses />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('LeadershipTeamResponses', () => {
+  it('renders the individual tab with a row per reflection', async () => {
+    getMock.mockImplementation((url) => {
+      if (url.includes('/responses/')) return Promise.resolve({ data: individualPayload });
+      return Promise.resolve({ data: templatePayload });
+    });
+    renderAt('/leadership-team/templates/7/responses');
+    await waitFor(() => expect(screen.getByTestId('lt-responses-row-401')).toBeInTheDocument());
+    expect(screen.getByText('Asha Cook')).toBeInTheDocument();
+    expect(screen.getByTestId('lt-responses-export')).toHaveAttribute('href', expect.stringContaining('/responses/export/'));
+  });
+
+  it('switches to the aggregate tab and shows per-dimension averages', async () => {
+    getMock.mockImplementation((url, { params } = {}) => {
+      if (!url.includes('/responses/')) return Promise.resolve({ data: templatePayload });
+      if (params?.tab === 'aggregate') return Promise.resolve({ data: aggregatePayload });
+      return Promise.resolve({ data: individualPayload });
+    });
+    renderAt('/leadership-team/templates/7/responses');
+    await waitFor(() => screen.getByTestId('lt-responses-row-401'));
+    fireEvent.click(screen.getByTestId('lt-responses-tab-aggregate'));
+    await waitFor(() => expect(screen.getByTestId('lt-responses-dim-mood')).toBeInTheDocument());
+    expect(screen.getByText('4.50')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/leadership-team/__tests__/TeamDashboard.test.jsx
+++ b/frontend/src/pages/leadership-team/__tests__/TeamDashboard.test.jsx
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import LeadershipTeamTeamDashboard from '../TeamDashboard';
+
+const getMock = vi.fn();
+vi.mock('../../../api', () => ({
+  default: { get: (...args) => getMock(...args) },
+}));
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ orgSlug: 'test-org', user: { id: 1 } }),
+}));
+
+const samplePayload = {
+  header: {
+    team_role: 'kitchen_staff',
+    team_role_label: 'Kitchen Staff',
+    program: { id: 1, name: 'Summer 2026' },
+    member_count: 3,
+    supervisors: [{ membership_id: 1, person_name: 'Lou LT', is_viewer: true }],
+    period: { start: '2026-07-06', end: '2026-07-12', cadence: 'weekly' },
+    date: '2026-07-10',
+  },
+  submission_status: { submitted: 1, day_off: 1, not_submitted: 1, total: 3 },
+  flagged: [],
+  members: [
+    {
+      membership_id: 11, person_id: 21, person_name: 'Asha Cook',
+      language_preference: 'en', status: 'submitted', reflection_id: 100,
+      submitted_at: '2026-07-10T08:00:00Z', language_of_authorship: 'en',
+      preview: 'good day', attention_marker_count: 0,
+    },
+    {
+      membership_id: 12, person_id: 22, person_name: 'Ben Cook',
+      language_preference: 'en', status: 'not_submitted', reflection_id: null,
+      submitted_at: null, language_of_authorship: null,
+      preview: '', attention_marker_count: 0,
+    },
+    {
+      membership_id: 13, person_id: 23, person_name: 'Cami Cook',
+      language_preference: 'en', status: 'day_off', reflection_id: 102,
+      submitted_at: '2026-07-10T07:00:00Z', language_of_authorship: 'en',
+      preview: '', attention_marker_count: 2,
+    },
+  ],
+};
+
+beforeEach(() => { getMock.mockReset(); });
+
+function renderAt(route) {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <Routes>
+        <Route path="/leadership-team/teams/:teamRole" element={<LeadershipTeamTeamDashboard />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('LeadershipTeamTeamDashboard', () => {
+  it('renders header, status, and member rows', async () => {
+    getMock.mockResolvedValue({ data: samplePayload });
+    renderAt('/leadership-team/teams/kitchen_staff');
+    await waitFor(() => expect(screen.getByText('Kitchen Staff')).toBeInTheDocument());
+    expect(screen.getByTestId('lt-member-row-11')).toBeInTheDocument();
+    expect(screen.getByTestId('lt-marker-count-13')).toHaveTextContent('2 flags');
+  });
+
+  it('filters member rows by status when a filter chip is clicked', async () => {
+    getMock.mockResolvedValue({ data: samplePayload });
+    renderAt('/leadership-team/teams/kitchen_staff');
+    await waitFor(() => screen.getByTestId('lt-team-members'));
+    fireEvent.click(screen.getByTestId('lt-filter-not_submitted'));
+    await waitFor(() => {
+      expect(screen.getByTestId('lt-member-row-12')).toBeInTheDocument();
+      expect(screen.queryByTestId('lt-member-row-11')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows a permission error if the API returns 403', async () => {
+    getMock.mockRejectedValue({ response: { status: 403 } });
+    renderAt('/leadership-team/teams/kitchen_staff');
+    await waitFor(() => expect(screen.getByTestId('lt-team-error')).toBeInTheDocument());
+    expect(screen.getByText(/do not supervise/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/leadership-team/__tests__/TemplateBuilder.test.jsx
+++ b/frontend/src/pages/leadership-team/__tests__/TemplateBuilder.test.jsx
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import TemplateBuilderPage from '../TemplateBuilder/TemplateBuilderPage';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+const patchMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: (...args) => postMock(...args),
+    patch: (...args) => patchMock(...args),
+  },
+}));
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ orgSlug: 'test-org' }),
+}));
+
+vi.mock('../../../components/templates/ReflectionField', () => ({
+  default: ({ field }) => (
+    <div data-testid={`stub-field-${field.key || 'unset'}`}>{field.prompts?.en ?? ''}</div>
+  ),
+}));
+
+beforeEach(() => {
+  getMock.mockReset();
+  postMock.mockReset();
+  patchMock.mockReset();
+});
+
+function renderNew() {
+  return render(
+    <MemoryRouter initialEntries={['/leadership-team/templates/new']}>
+      <Routes>
+        <Route path="/leadership-team/templates/new" element={<TemplateBuilderPage />} />
+        <Route path="/leadership-team/templates/:id" element={<div data-testid="builder-redirect" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('TemplateBuilderPage', () => {
+  it('lets the LT user add a text field and post the new draft', async () => {
+    postMock.mockResolvedValue({ data: { id: 99 } });
+    renderNew();
+    fireEvent.change(screen.getByTestId('lt-builder-name'), { target: { value: 'New LT template' } });
+    fireEvent.click(screen.getByTestId('lt-builder-add-text'));
+    const keyInput = await screen.findByText(/Prompt \(en\)/);
+    expect(keyInput).toBeInTheDocument();
+    // Fill the first added field
+    const keyField = screen.getAllByPlaceholderText('field_key')[0];
+    fireEvent.change(keyField, { target: { value: 'reflection_summary' } });
+    const promptField = screen.getAllByRole('textbox').find(
+      (el) => el !== keyField && el !== screen.getByTestId('lt-builder-name'),
+    );
+    fireEvent.change(promptField, { target: { value: 'How was your week?' } });
+    fireEvent.click(screen.getByTestId('lt-builder-save'));
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    expect(postMock.mock.calls[0][1].schema.fields[0].key).toBe('reflection_summary');
+  });
+
+  it('flags missing prompts as a validation issue before save', async () => {
+    renderNew();
+    fireEvent.click(screen.getByTestId('lt-builder-add-text'));
+    fireEvent.click(screen.getByTestId('lt-builder-save'));
+    await waitFor(() => expect(screen.getByTestId('lt-builder-issues')).toBeInTheDocument());
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it('lists Tier 1 field types in the add menu and not Tier 2', () => {
+    renderNew();
+    expect(screen.getByTestId('lt-builder-add-text')).toBeInTheDocument();
+    expect(screen.getByTestId('lt-builder-add-textarea')).toBeInTheDocument();
+    expect(screen.getByTestId('lt-builder-add-text_list')).toBeInTheDocument();
+    expect(screen.getByTestId('lt-builder-add-single_choice')).toBeInTheDocument();
+    expect(screen.getByTestId('lt-builder-add-multiple_choice')).toBeInTheDocument();
+    expect(screen.getByTestId('lt-builder-add-rating_group')).toBeInTheDocument();
+    expect(screen.queryByTestId('lt-builder-add-yes_no')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('lt-builder-add-date')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('lt-builder-add-number')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/partials/Sidebar.jsx
+++ b/frontend/src/partials/Sidebar.jsx
@@ -139,6 +139,7 @@ function Sidebar({
 
   const canSupervise = hasCapability(user, SUPERVISOR_PLUS) || isSuperAdmin(user);
   const canSeeDashboards = hasCapability(user, PROGRAM_LEAD_PLUS) || isSuperAdmin(user);
+  const canSeeLeadershipTeam = hasCapability(user, PROGRAM_LEAD_PLUS) || isSuperAdmin(user);
   const canAdmin = hasCapability(user, 'admin') || isSuperAdmin(user);
   const canSeeLegacy = canAdmin;
   const canFileReflection = REFLECTION_FORM_ROLES.includes(user.role);
@@ -209,6 +210,21 @@ function Sidebar({
                 icon={IconAlert}
               />
             </Section>
+          )}
+
+          {canSeeLeadershipTeam && (
+            <CollapsibleSection
+              heading="Leadership Team"
+              activeWhen={
+                pathname === '/leadership-team' || pathname.startsWith('/leadership-team/')
+              }
+              icon={IconGrid}
+              setSidebarExpanded={setSidebarExpanded}
+            >
+              <SubItem to="/leadership-team" label="Overview" end />
+              <SubItem to="/leadership-team/templates" label="Templates" />
+              <SubItem to="/leadership-team/self-reflection" label="My reflection" />
+            </CollapsibleSection>
           )}
 
           {canSeeDashboards && (


### PR DESCRIPTION
## Summary

PR **C of 3** for Step 7_12 (Leadership Team Flow). Stories 45-53 frontend + docs.

- 7 LT pages (Dashboard, TeamDashboard, MemberReflection, SelfReflectionPage, TemplateLibrary, TemplateBuilder, Responses) plus an AssignmentDialog component.
- `api/leadershipTeam.js` axios client covering the full PR A + PR B surface, with the multi-tenant `X-Organization-Slug` header.
- Router wiring for 9 new routes under `/leadership-team`.
- Sidebar entry gated on the `program_lead` capability.
- 16 integration tests across 6 test files.
- Two new docs: `docs/role_flows/leadership_team.md` (endpoints, supervision model, attention conditions, template lifecycle) and `docs/template_builder.md` (Tier 1 scope, versioning, language gap behavior).

🔗 **Builds on:** [PR B](https://github.com/pantheonsteve/BunkLogs/pull/107). Merge order: A → B → C.

## Template builder UX

Tier 1 field types only: `text`, `textarea`, `text_list`, `single_choice`, `multiple_choice`, `rating_group`. The 3-pane layout keeps Settings (role / cadence / languages), the Field list with inline editors, and a live preview that reuses the existing `ReflectionField` renderer (so what the LT user sees in preview is what the respondent sees).

When PATCHing a published template with responses, the backend returns 409 with `forceNewVersion` semantics — the builder surfaces a \"Create new version\" button to resubmit with `?force_new_version=true`.

## Assignment dialog

Tab-based target picker (role / individuals / tag_group) with backend-driven conflict resolution: a 409 surfaces the conflict list inline and the LT user picks `replace` / `run_both` / `cancel` before resubmitting.

## i18n

Per CLAUDE.md lean-mode policy, copy is inline English in this PR. `t()` wrapping is deferred to a single dedicated i18n PR. The eslint `i18next/no-literal-string` rule still emits warnings (no errors) — these are expected.

## Test plan

- [x] All 523 frontend tests pass (`npx vitest run`)
- [x] 16 LT-specific tests cover dashboards, team dashboard, member reflection, assignment dialog conflict path, responses tab switch, and Tier-1-only field menu
- [x] `npx eslint --quiet` clean (no errors) on the new files
- [x] Production build succeeds (`npx vite build`)

## Manual smoke

After this stack merges, the recommended manual smoke pass:

1. Log in as an LT user with `program_lead` capability.
2. Open `/leadership-team` → expect per-team cards for any supervised roles.
3. Click into a team → submission status + member rows render.
4. Click a member → trend graph renders + the mark-for-attention flow works.
5. Open `/leadership-team/templates/new` → save a draft → publish → assign to a role with overlap → confirm 409 → choose `replace` → confirm prior assignment ends day before.

## Out of scope

- Removal of the legacy `/dashboards/team` route (deferred to 7_16)
- `t()` wrapping of new LT copy (deferred to a dedicated i18n PR)
- New chart library (we deliberately reuse existing visualization conventions)

🧱 Stack: PR A → PR B → this PR

Made with [Cursor](https://cursor.com)