### PR TITLE
fix: LT template builder save + list (slug + response shape)

### DIFF
--- a/frontend/src/pages/leadership-team/TemplateBuilder/TemplateBuilderPage.jsx
+++ b/frontend/src/pages/leadership-team/TemplateBuilder/TemplateBuilderPage.jsx
@@ -40,6 +40,28 @@ const SUPPORTED_LANGUAGES = ['en', 'es', 'he'];
 let _localUid = 0;
 const newLocalId = () => `lt_fid_${++_localUid}`;
 
+/**
+ * Derive a Django SlugField-friendly slug from a human name.
+ *
+ * The LT builder hides slugs from the LT user; we pick one for them
+ * so the POST body always carries one (the backend rejects missing
+ * slug with 400). A short base36 timestamp suffix avoids accidentally
+ * appending a "v2" to someone else's template that happened to share
+ * the same kebab-cased name in the same org.
+ */
+function deriveSlug(name) {
+  const base = (name || '')
+    .toString()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80) || 'lt-template';
+  const suffix = Date.now().toString(36).slice(-6);
+  return `${base}-${suffix}`;
+}
+
 function defaultsFor(type, lang = 'en') {
   const base = { _id: newLocalId(), type, key: '', required: true };
   if (type === 'rating_group' || type === 'single_rating') {
@@ -72,6 +94,7 @@ function clientValidate(template, fields) {
   const issues = [];
   const seenKeys = new Set();
   const languages = template.languages?.length ? template.languages : ['en'];
+  if (!template.name?.trim()) issues.push('Template name is required.');
   fields.forEach((f, idx) => {
     const loc = `Field ${idx + 1}`;
     if (!f.key?.trim()) issues.push(`${loc}: key is required.`);
@@ -389,13 +412,21 @@ export default function TemplateBuilderPage() {
     [template, fields],
   );
 
-  const buildPayload = () => ({
-    name: template.name,
-    role: template.role,
-    languages: template.languages,
-    cadence: template.cadence,
-    schema: { fields: stripLocalIds(fields) },
-  });
+  const buildPayload = () => {
+    const payload = {
+      name: template.name,
+      role: template.role,
+      languages: template.languages,
+      cadence: template.cadence,
+      schema: { fields: stripLocalIds(fields) },
+    };
+    if (!isEdit) {
+      payload.slug = template.slug || deriveSlug(template.name);
+    } else if (template.slug) {
+      payload.slug = template.slug;
+    }
+    return payload;
+  };
 
   const save = async ({ forceNewVersion = false } = {}) => {
     setError('');

--- a/frontend/src/pages/leadership-team/TemplateLibrary.jsx
+++ b/frontend/src/pages/leadership-team/TemplateLibrary.jsx
@@ -58,7 +58,8 @@ export default function LeadershipTeamTemplateLibrary() {
         status: statusFilter || undefined,
         role: roleFilter || undefined,
       });
-      const rows = Array.isArray(data?.results) ? data.results
+      const rows = Array.isArray(data?.templates) ? data.templates
+        : Array.isArray(data?.results) ? data.results
         : Array.isArray(data) ? data : [];
       setTemplates(rows);
     } catch (err) {

--- a/frontend/src/pages/leadership-team/__tests__/TemplateBuilder.test.jsx
+++ b/frontend/src/pages/leadership-team/__tests__/TemplateBuilder.test.jsx
@@ -59,7 +59,12 @@ describe('TemplateBuilderPage', () => {
     fireEvent.change(promptField, { target: { value: 'How was your week?' } });
     fireEvent.click(screen.getByTestId('lt-builder-save'));
     await waitFor(() => expect(postMock).toHaveBeenCalled());
-    expect(postMock.mock.calls[0][1].schema.fields[0].key).toBe('reflection_summary');
+    const body = postMock.mock.calls[0][1];
+    expect(body.schema.fields[0].key).toBe('reflection_summary');
+    expect(body.name).toBe('New LT template');
+    // Slug must be derived client-side so the backend doesn't 400 on
+    // missing slug (the LT builder UI never asks the user for one).
+    expect(body.slug).toMatch(/^new-lt-template-[a-z0-9]+$/);
   });
 
   it('flags missing prompts as a validation issue before save', async () => {

--- a/frontend/src/pages/leadership-team/__tests__/TemplateLibrary.test.jsx
+++ b/frontend/src/pages/leadership-team/__tests__/TemplateLibrary.test.jsx
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import TemplateLibrary from '../TemplateLibrary';
+
+const getMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ orgSlug: 'test-org' }),
+}));
+
+beforeEach(() => {
+  getMock.mockReset();
+});
+
+function renderLib() {
+  return render(
+    <MemoryRouter initialEntries={['/leadership-team/templates']}>
+      <TemplateLibrary />
+    </MemoryRouter>,
+  );
+}
+
+describe('LeadershipTeamTemplateLibrary', () => {
+  it('renders templates from the {templates: [...]} response shape', async () => {
+    // Backend (POST and GET on /api/v1/leadership-team/templates/) returns
+    // `{ templates: [...] }`, NOT `{ results: [...] }`. Regression guard
+    // for the silent-empty-list bug where the page rendered "no templates
+    // match" right after a successful create.
+    getMock.mockResolvedValue({
+      data: {
+        templates: [
+          {
+            id: 7,
+            name: 'Kitchen Daily',
+            status: 'draft',
+            version: 1,
+            role: 'kitchen_staff',
+            languages: ['en'],
+            cadence: 'daily',
+          },
+        ],
+      },
+    });
+    renderLib();
+    await waitFor(() => expect(screen.getByTestId('lt-tpl-row-7')).toBeInTheDocument());
+    expect(screen.getByText('Kitchen Daily')).toBeInTheDocument();
+    expect(screen.getByText(/draft v1/)).toBeInTheDocument();
+  });
+
+  it('shows the empty state when the org has no templates', async () => {
+    getMock.mockResolvedValue({ data: { templates: [] } });
+    renderLib();
+    await waitFor(() => expect(screen.getByTestId('lt-tpl-empty')).toBeInTheDocument());
+  });
+
+  it('surfaces a 403 as a friendly error', async () => {
+    getMock.mockRejectedValue({ response: { status: 403 } });
+    renderLib();
+    await waitFor(() => expect(screen.getByTestId('lt-tpl-error')).toBeInTheDocument());
+    expect(screen.getByTestId('lt-tpl-error')).toHaveTextContent(/LT access/i);
+  });
+});


### PR DESCRIPTION
## Summary

Two silent failures that together prevented the Leadership Team template builder from being usable end-to-end:

**1. Save returned 400.** `POST /api/v1/leadership-team/templates/` requires both `name` **and** `slug` (matching `ReflectionTemplate.slug = SlugField`), but the builder UI deliberately hides slugs from the LT user. Every create attempt was rejected with `400 "name and slug are required."`

The frontend now derives the slug client-side from the human-typed name:
- Kebab-case the ASCII-folded name (≤80 chars)
- Append a short base36 timestamp suffix so two LT users picking the same name in the same org don't silently chain as v1/v2 of the same slug
- Surface a clean "Template name is required" client-side validation message instead of bouncing off a server 400

PATCH (edit) is unchanged: the existing slug on the loaded template is preserved.

**2. New templates didn't show up in the library.** `GET /api/v1/leadership-team/templates/` returns the list under `{templates: [...]}`, but `TemplateLibrary.jsx` was reading `data.results` / `data` (the DRF pagination conventions) and silently falling through to `[]`. The page rendered "No templates match the current filters" even right after a successful save.

The reader now accepts `data.templates` first, with the other shapes as fallbacks.

## Test plan

- [x] `vitest` — 16 existing LT integration tests still pass
- [x] New `TemplateBuilder` assertion: derived slug is in the POST body
- [x] New `TemplateLibrary.test.jsx` (3 tests): `{templates: [...]}` shape renders rows, empty state, 403 → friendly error message — this is the regression guard the silent-empty bug would have failed on
- [x] `eslint` clean for `src/pages/leadership-team/`
- [ ] Manual: open `/leadership-team/templates/new`, type a name, click Save → 201 + redirect; navigate to `/leadership-team/templates` and confirm the new draft is in the list