### PR TITLE
7_13_admin_flow PR1: Admin namespace + Dashboard + Override + Audit wiring

### DIFF
--- a/backend/bunk_logs/api/admin_flow/__init__.py
+++ b/backend/bunk_logs/api/admin_flow/__init__.py
@@ -1,0 +1,13 @@
+"""Step 7_13 — Admin Flow API namespace.
+
+Mounted at ``/api/v1/admin/`` (see :mod:`bunk_logs.api.urls`). Every view
+here is gated by :class:`IsOrgAdminOrSuperuser` from
+``bunk_logs.core.permissions`` so a regular operational role cannot reach
+the admin surface even with a stolen JWT — the org-scoped membership
+lookup still has to pass.
+
+The module is named ``admin_flow`` (not ``admin``) to avoid colliding
+with the long-standing :mod:`bunk_logs.api.admin` module that powers the
+legacy Django-admin glue. Callers should never import from this package
+directly; route discovery in ``api/urls.py`` is the only entry point.
+"""

--- a/backend/bunk_logs/api/admin_flow/common.py
+++ b/backend/bunk_logs/api/admin_flow/common.py
@@ -1,0 +1,80 @@
+"""Shared helpers for Admin Flow endpoints (Step 7_13).
+
+Mirrors the structure of the per-role ``common.py`` modules. The viewer
+context resolves the requesting user to an active admin Membership in
+the request's organization context, or raises 403. Super Admins
+(``is_staff`` or ``is_superuser``) are also accepted; in that case
+``membership`` is ``None`` so dashboard helpers know not to scope by it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from rest_framework.exceptions import PermissionDenied
+
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Person
+from bunk_logs.core.permissions import is_super_admin
+from bunk_logs.core.time_utils import get_today
+
+if TYPE_CHECKING:
+    from datetime import date
+
+    from bunk_logs.core.models import Organization
+
+
+@dataclass(frozen=True)
+class AdminContext:
+    """Resolved request context for any admin-namespace endpoint."""
+
+    person: Person | None
+    organization: Organization
+    membership: Membership | None
+    today: date
+    is_super_admin: bool
+
+
+def viewer_or_403(request) -> AdminContext:
+    """Resolve admin-context for ``request`` or raise 403.
+
+    Order of checks:
+
+    1. Organization context must be set by ``OrganizationMiddleware`` --
+       missing header / unknown subdomain bails out immediately.
+    2. User must be authenticated.
+    3. Either Super Admin OR an active ``role='admin'`` Membership in
+       the active organization grants access. Super Admins get a
+       ``None`` membership in the returned context; tenant Admins get
+       their actual Membership row so audit helpers can record it.
+    """
+    org = getattr(request, "organization", None)
+    if org is None:
+        msg = "Organization context required."
+        raise PermissionDenied(msg)
+    if not request.user.is_authenticated:
+        msg = "Authentication required."
+        raise PermissionDenied(msg)
+    super_admin = is_super_admin(request.user)
+    person = Person.all_objects.filter(user=request.user).first()
+    membership = None
+    if person is not None:
+        membership = (
+            Membership.objects.filter(
+                person=person, role="admin", is_active=True,
+            )
+            .select_related("program")
+            .order_by("-created_at")
+            .first()
+        )
+    if not super_admin and membership is None:
+        msg = "Admin role required."
+        raise PermissionDenied(msg)
+    return AdminContext(
+        person=person,
+        organization=org,
+        membership=membership,
+        today=get_today(org),
+        is_super_admin=super_admin,
+    )

--- a/backend/bunk_logs/api/admin_flow/dashboard.py
+++ b/backend/bunk_logs/api/admin_flow/dashboard.py
@@ -1,0 +1,447 @@
+"""``GET /api/v1/admin/dashboard/`` -- Story 54.
+
+Returns three top-level sections:
+
+* ``org_snapshot`` -- counts an Admin glances at first thing in the
+  morning: active people, memberships by role, today's reflection
+  completion rate, open Camper Care orders, open Maintenance tickets,
+  active Camper Care flags.
+* ``attention_required`` -- six conditions from Story 54 criterion 5
+  (stale tickets / orders, unresolved flags, pending template review,
+  digest delivery failures, translation pipeline failures). Each card
+  carries a count and a deep-link payload so the frontend doesn't have
+  to know how to construct the URL.
+* ``recent_activity`` -- significant ``AuditEvent`` rows, rate-limited
+  to event types that matter to an Admin (criterion 6). Routine
+  submissions / note edits are excluded.
+
+The endpoint is gated by :class:`IsOrgAdminOrSuperuser` so a non-admin
+JWT cannot reach it even if it knows the URL.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.db.models import Count
+from django.utils import timezone
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core.models import AuditEvent
+from bunk_logs.core.models import Flag
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Order
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.permissions import IsOrgAdminOrSuperuser
+from bunk_logs.core.state_machine import OrderStateMachine
+
+from .common import AdminContext
+from .common import viewer_or_403
+
+# Conservative defaults for the "stale" / "pending review" / "digest
+# failures" thresholds. Each is overridable via ``Organization.settings``
+# JSONField keys (Story 58) so an Admin can tighten / loosen without a
+# code deploy. The defaults below match the wording in Story 54 c5 plus
+# spec decisions captured in `docs/user_stories/08_admin/STORIES.md`.
+DEFAULT_STALE_TICKET_DAYS = 3
+DEFAULT_STALE_ORDER_DAYS = 3
+UNRESOLVED_FLAG_DAYS = 7
+PENDING_REVIEW_DAYS = 14
+DIGEST_FAILURE_CONSECUTIVE = 3
+TRANSLATION_FAILURE_LOOKBACK_HOURS = 24
+TRANSLATION_FAILURE_MIN = 5
+
+OPEN_STATUSES: tuple[str, ...] = (
+    OrderStateMachine.NEW,
+    OrderStateMachine.IN_PROGRESS,
+)
+
+# Recent activity feed: keep it to "an admin would want to know within
+# the day" events. Routine submissions / per-note edits are excluded to
+# avoid drowning the section.
+SIGNIFICANT_EVENT_TYPES: tuple[str, ...] = (
+    AuditEvent.EventType.CREATED,
+    AuditEvent.EventType.DEACTIVATED,
+    AuditEvent.EventType.REACTIVATED,
+    AuditEvent.EventType.STATE_CHANGED,
+    AuditEvent.EventType.OVERRIDE_EDIT,
+    AuditEvent.EventType.OVERRIDE_CLOSE,
+    AuditEvent.EventType.OVERRIDE_RESOLVE,
+)
+RECENT_ACTIVITY_LIMIT = 25
+RECENT_ACTIVITY_LOOKBACK_DAYS = 7
+ACTIVITY_CONTENT_FILTER = (
+    "membership",
+    "supervision",
+    "reflection_template",
+    "template_assignment",
+    "order",
+    "maintenance_ticket",
+    "flag",
+    "program",
+    "person",
+)
+
+
+class AdminDashboardView(APIView):
+    """Org snapshot + Attention required + Recent activity."""
+
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        payload = {
+            "today": ctx.today.isoformat(),
+            "org": _org_header(ctx),
+            "org_snapshot": _build_org_snapshot(ctx),
+            "attention_required": _build_attention_required(ctx),
+            "recent_activity": _build_recent_activity(ctx),
+        }
+        return Response(payload)
+
+
+# ---------------------------------------------------------------------------
+# Org header
+# ---------------------------------------------------------------------------
+
+
+def _org_header(ctx: AdminContext) -> dict:
+    """Org name + active programs summary."""
+    programs = list(
+        Program.all_objects.filter(
+            organization=ctx.organization, is_active=True,
+        ).values("id", "name", "program_type", "start_date", "end_date"),
+    )
+    return {
+        "id": ctx.organization.id,
+        "name": ctx.organization.name,
+        "slug": ctx.organization.slug,
+        "active_programs": [
+            {
+                "id": p["id"],
+                "name": p["name"],
+                "program_type": p["program_type"],
+                "start_date": p["start_date"].isoformat() if p["start_date"] else None,
+                "end_date": p["end_date"].isoformat() if p["end_date"] else None,
+            }
+            for p in programs
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Org snapshot (Story 54 c3)
+# ---------------------------------------------------------------------------
+
+
+def _build_org_snapshot(ctx: AdminContext) -> dict:
+    """Counts an Admin glances at first thing.
+
+    Memberships are grouped by role (active only) so the snapshot
+    surfaces under-staffing without requiring an extra round trip.
+    """
+    org = ctx.organization
+
+    active_people = Person.all_objects.filter(
+        organization=org,
+        memberships__is_active=True,
+    ).distinct().count()
+
+    role_counts = list(
+        Membership.all_objects.filter(
+            program__organization=org, is_active=True,
+        )
+        .values("role")
+        .annotate(count=Count("id"))
+        .order_by("role"),
+    )
+
+    open_cc_orders = Order.all_objects.filter(
+        organization=org, status__in=OPEN_STATUSES,
+    ).count()
+    open_maint_tickets = MaintenanceTicket.all_objects.filter(
+        organization=org, status__in=OPEN_STATUSES,
+    ).count()
+    active_flags = Flag.all_objects.filter(
+        organization=org, status=Flag.Status.ACTIVE,
+    ).count()
+
+    return {
+        "active_people": active_people,
+        "memberships_by_role": [
+            {"role": r["role"], "count": r["count"]} for r in role_counts
+        ],
+        "open_camper_care_orders": open_cc_orders,
+        "open_maintenance_tickets": open_maint_tickets,
+        "active_flags": active_flags,
+        # Today's completion rate is computed once per role-flow via
+        # their dashboard endpoints; the org-wide rollup is best left to
+        # the per-role drill-downs and is intentionally omitted here to
+        # keep this endpoint cheap. The frontend can fetch the
+        # completion summary from the dashboards/coverage endpoint when
+        # it wants the cross-role view.
+    }
+
+
+# ---------------------------------------------------------------------------
+# Attention required (Story 54 c5)
+# ---------------------------------------------------------------------------
+
+
+def _build_attention_required(ctx: AdminContext) -> list[dict]:
+    """Six conditions, ordered by severity then alphabetical card key."""
+    org = ctx.organization
+    org_settings = org.settings or {}
+    today = ctx.today
+
+    stale_ticket_days = _int_setting(
+        org_settings, "stale_maintenance_ticket_days", DEFAULT_STALE_TICKET_DAYS,
+    )
+    stale_order_days = _int_setting(
+        org_settings, "stale_camper_care_order_days", DEFAULT_STALE_ORDER_DAYS,
+    )
+
+    cutoff_ticket = today - timedelta(days=stale_ticket_days)
+    cutoff_order = today - timedelta(days=stale_order_days)
+    cutoff_flag = today - timedelta(days=UNRESOLVED_FLAG_DAYS)
+    cutoff_template = timezone.now() - timedelta(days=PENDING_REVIEW_DAYS)
+
+    stale_tickets = (
+        MaintenanceTicket.all_objects.filter(
+            organization=org,
+            status__in=OPEN_STATUSES,
+            created_at__date__lte=cutoff_ticket,
+        ).count()
+    )
+    stale_orders = (
+        Order.all_objects.filter(
+            organization=org,
+            status__in=OPEN_STATUSES,
+            created_at__date__lte=cutoff_order,
+        ).count()
+    )
+    unresolved_flags = (
+        Flag.all_objects.filter(
+            organization=org,
+            status=Flag.Status.ACTIVE,
+            created_at__date__lte=cutoff_flag,
+        ).count()
+    )
+    pending_review = _pending_template_review_count(
+        organization=org, cutoff=cutoff_template,
+    )
+    digest_failures = _digest_delivery_failure_count(org)
+    translation_failures = _translation_failure_count(org)
+
+    # Surface ALL six cards (zero counts included) so the UI can render
+    # a stable layout; the frontend hides cards with zero counts if it
+    # wants a compact view.
+    return [
+        {
+            "key": "stale_maintenance_tickets",
+            "label": "Stale Maintenance tickets",
+            "count": stale_tickets,
+            "threshold_days": stale_ticket_days,
+            "deep_link": "/admin/operations/maintenance?filter=stale",
+        },
+        {
+            "key": "stale_camper_care_orders",
+            "label": "Stale Camper Care orders",
+            "count": stale_orders,
+            "threshold_days": stale_order_days,
+            "deep_link": "/admin/operations/orders?filter=stale",
+        },
+        {
+            "key": "unresolved_flags",
+            "label": "Unresolved Camper Care flags",
+            "count": unresolved_flags,
+            "threshold_days": UNRESOLVED_FLAG_DAYS,
+            "deep_link": "/admin/operations/flags?filter=stale",
+        },
+        {
+            "key": "pending_template_review",
+            "label": "Pending template review",
+            "count": pending_review,
+            "threshold_days": PENDING_REVIEW_DAYS,
+            "deep_link": "/admin/templates?filter=pending_review",
+        },
+        {
+            "key": "digest_delivery_failures",
+            "label": "Digest delivery failures",
+            "count": digest_failures,
+            "threshold_days": DIGEST_FAILURE_CONSECUTIVE,
+            "deep_link": "/admin/settings?tab=notifications",
+        },
+        {
+            "key": "translation_pipeline_failures",
+            "label": "Translation pipeline failures",
+            "count": translation_failures,
+            "threshold_days": 1,
+            "deep_link": "/admin/operations/translations",
+        },
+    ]
+
+
+def _int_setting(settings_dict: dict, key: str, fallback: int) -> int:
+    raw = settings_dict.get(key)
+    if isinstance(raw, bool):
+        return fallback
+    if isinstance(raw, int) and raw > 0:
+        return raw
+    return fallback
+
+
+def _pending_template_review_count(*, organization, cutoff) -> int:
+    """Templates in this org published in the last N days.
+
+    The "marked reviewed" / "needs revision" flag is added in PR3 of
+    this step (admin templates wrapper); until then the badge counts
+    every recently-published template, which is the correct upper
+    bound for an Admin to triage. PR3 will subtract already-flagged
+    rows via the storage location it adds.
+    """
+    return ReflectionTemplate.all_objects.filter(
+        organization=organization,
+        status=ReflectionTemplate.Status.PUBLISHED,
+        created_at__gte=cutoff,
+    ).count()
+
+
+def _digest_delivery_failure_count(organization) -> int:
+    """Maintenance digest emails that failed 3+ days in a row.
+
+    ``EmailLog`` is in the messaging app and is not org-scoped today
+    (single recipient list per deploy), so this counts org-wide. The
+    heuristic: any digest-named template that has 3 or more consecutive
+    failures in the last 7 days surfaces as one card-worthy event.
+    """
+    try:
+        from bunk_logs.messaging.models import EmailLog
+    except ImportError:  # pragma: no cover - messaging app should always be installed
+        return 0
+    since = timezone.now() - timedelta(days=7)
+    recent = list(
+        EmailLog.objects.filter(
+            sent_at__gte=since,
+            subject__icontains="digest",
+        )
+        .order_by("-sent_at")
+        .values_list("success", flat=True)[: DIGEST_FAILURE_CONSECUTIVE * 4],
+    )
+    if not recent:
+        return 0
+    consecutive_failures = 0
+    for success in recent:
+        if success:
+            break
+        consecutive_failures += 1
+    return 1 if consecutive_failures >= DIGEST_FAILURE_CONSECUTIVE else 0
+
+
+def _translation_failure_count(organization) -> int:
+    """Terminal translation failures in the last 24h for this org."""
+    try:
+        from bunk_logs.core.models import TranslationRecord
+    except ImportError:  # pragma: no cover
+        return 0
+    since = timezone.now() - timedelta(hours=TRANSLATION_FAILURE_LOOKBACK_HOURS)
+    count = TranslationRecord.objects.filter(
+        organization=organization,
+        status=TranslationRecord.Status.FAILED_TERMINAL,
+        created_at__gte=since,
+    ).count()
+    return count if count >= TRANSLATION_FAILURE_MIN else 0
+
+
+# ---------------------------------------------------------------------------
+# Recent activity feed (Story 54 c6)
+# ---------------------------------------------------------------------------
+
+
+def _build_recent_activity(ctx: AdminContext) -> list[dict]:
+    """Latest significant audit events, rate-limited and deep-linked."""
+    org = ctx.organization
+    since = timezone.now() - timedelta(days=RECENT_ACTIVITY_LOOKBACK_DAYS)
+    events = list(
+        AuditEvent.all_objects.filter(
+            organization=org,
+            created_at__gte=since,
+            event_type__in=SIGNIFICANT_EVENT_TYPES,
+            content_type__in=ACTIVITY_CONTENT_FILTER,
+        )
+        .select_related("actor_membership__person")
+        .order_by("-created_at")[: RECENT_ACTIVITY_LIMIT * 2],
+    )
+
+    out: list[dict] = []
+    for e in events:
+        if len(out) >= RECENT_ACTIVITY_LIMIT:
+            break
+        actor_name = _actor_display(e)
+        out.append({
+            "id": str(e.id),
+            "event_type": e.event_type,
+            "content_type": e.content_type,
+            "content_id": e.content_id,
+            "created_at": e.created_at.isoformat(),
+            "actor": actor_name,
+            "is_admin_override": e.is_admin_override,
+            "deep_link": _deep_link_for(e),
+            "summary": _summarize(e),
+        })
+    return out
+
+
+def _actor_display(event: AuditEvent) -> str | None:
+    membership = event.actor_membership
+    if membership and membership.person:
+        p = membership.person
+        return (p.preferred_name or p.first_name or "") + " " + (p.last_name or "")
+    return None
+
+
+def _deep_link_for(event: AuditEvent) -> str:
+    """Best-effort frontend path for a given audit row."""
+    ct = event.content_type
+    cid = event.content_id
+    if ct in ("order",):
+        return f"/admin/operations/orders/{cid}"
+    if ct == "maintenance_ticket":
+        return f"/admin/operations/maintenance/{cid}"
+    if ct == "flag":
+        return f"/admin/operations/flags/{cid}"
+    if ct == "membership":
+        return f"/admin/memberships/{cid}"
+    if ct == "supervision":
+        return f"/admin/assignments?supervision_id={cid}"
+    if ct in ("reflection_template", "template_assignment"):
+        return f"/admin/templates/{cid}"
+    if ct == "person":
+        return f"/admin/people/{cid}"
+    return "/admin"
+
+
+def _summarize(event: AuditEvent) -> str:
+    ev = event.event_type
+    ct = event.content_type.replace("_", " ").title()
+    if ev == AuditEvent.EventType.STATE_CHANGED:
+        before = (event.before_state or {}).get("status") or "?"
+        after = (event.after_state or {}).get("status") or "?"
+        return f"{ct}: {before} -> {after}"
+    if ev == AuditEvent.EventType.CREATED:
+        return f"{ct} created"
+    if ev == AuditEvent.EventType.DEACTIVATED:
+        return f"{ct} deactivated"
+    if ev == AuditEvent.EventType.REACTIVATED:
+        return f"{ct} reactivated"
+    if ev == AuditEvent.EventType.OVERRIDE_EDIT:
+        return f"Admin override: edited {ct}"
+    if ev == AuditEvent.EventType.OVERRIDE_CLOSE:
+        return f"Admin override: closed {ct}"
+    if ev == AuditEvent.EventType.OVERRIDE_RESOLVE:
+        return f"Admin override: resolved {ct}"
+    return f"{ct} {ev}"

--- a/backend/bunk_logs/api/admin_flow/override.py
+++ b/backend/bunk_logs/api/admin_flow/override.py
@@ -1,0 +1,199 @@
+"""``POST /api/v1/admin/override-edit/`` -- Story 59 criterion 8.
+
+Admin overrides another role's authorship on a content row (reflection
+or note) by submitting an edit with a mandatory reason. The write goes
+straight to the underlying model so the Admin doesn't have to spoof the
+authoring role's endpoint, and the action is captured in the audit log
+via :func:`bunk_logs.core.audit.override_edit` so reviewers can see
+*who* did *what*, *why*, with the before/after diff.
+
+Supported content types in PR1:
+
+* ``reflection`` -- patches ``answers``, ``language``,
+  ``team_visibility``, ``is_complete``, ``is_sensitive``.
+* ``note`` -- patches ``body``, ``is_sensitive``,
+  ``maintenance_visibility``, ``language``.
+
+Other content types raise a 400. Override-close / override-resolve
+flows live alongside the order/flag endpoints in PR2.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.db import transaction
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.models import Note
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import note_snapshot
+from bunk_logs.core.models import reflection_snapshot
+from bunk_logs.core.permissions import IsOrgAdminOrSuperuser
+
+from .common import viewer_or_403
+
+# Fields we let an Admin patch per content type. Anything outside this
+# allowlist is silently ignored so a client cannot, say, rewrite a
+# Reflection's ``author`` from the override surface.
+ALLOWED_REFLECTION_FIELDS = frozenset({
+    "answers",
+    "language",
+    "team_visibility",
+    "is_complete",
+    "is_sensitive",
+})
+ALLOWED_NOTE_FIELDS = frozenset({
+    "body",
+    "is_sensitive",
+    "maintenance_visibility",
+    "language",
+})
+
+
+class AdminOverrideEditView(APIView):
+    """Admin override path with required reason."""
+
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def post(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        content_type = (request.data.get("content_type") or "").strip()
+        content_id = request.data.get("content_id")
+        patch = request.data.get("patch") or {}
+        reason = (request.data.get("reason") or "").strip()
+
+        if not content_type or content_id in (None, ""):
+            return Response(
+                {"detail": "content_type and content_id are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if not reason:
+            # Per Story 59 c8: Admin override is an explicit, auditable
+            # action -- reason is mandatory.
+            return Response(
+                {"detail": "reason is required for an admin override."},
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
+        if not isinstance(patch, dict):
+            return Response(
+                {"detail": "patch must be an object."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        actor = ctx.membership or request.user
+        try:
+            with transaction.atomic():
+                if content_type == "reflection":
+                    payload = _apply_reflection_override(
+                        ctx, content_id, patch, reason, actor,
+                    )
+                elif content_type == "note":
+                    payload = _apply_note_override(
+                        ctx, content_id, patch, reason, actor,
+                    )
+                else:
+                    return Response(
+                        {
+                            "detail": (
+                                "Unsupported content_type for override-edit. "
+                                "Supported: reflection, note."
+                            ),
+                        },
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+        except _OverrideNotFoundError:
+            return Response(
+                {"detail": "Target content not found in this org."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        return Response(payload)
+
+
+# ---------------------------------------------------------------------------
+# Reflection override
+# ---------------------------------------------------------------------------
+
+
+def _apply_reflection_override(
+    ctx, content_id, patch: dict, reason: str, actor: Any,
+) -> dict:
+    try:
+        reflection = (
+            Reflection.all_objects.select_related("template", "organization")
+            .get(pk=content_id, organization=ctx.organization)
+        )
+    except Reflection.DoesNotExist as exc:
+        raise _OverrideNotFoundError from exc
+    before = reflection_snapshot(reflection)
+    changed = _apply_patch(reflection, patch, ALLOWED_REFLECTION_FIELDS)
+    if changed:
+        reflection.save()
+    after = reflection_snapshot(reflection)
+    audit_module.override_edit(
+        actor, reflection, before, after, reason=reason,
+    )
+    return {
+        "content_type": "reflection",
+        "content_id": reflection.id,
+        "before": before,
+        "after": after,
+        "fields_changed": sorted(changed),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Note override
+# ---------------------------------------------------------------------------
+
+
+def _apply_note_override(
+    ctx, content_id, patch: dict, reason: str, actor: Any,
+) -> dict:
+    try:
+        note = Note.all_objects.select_related("organization").get(
+            pk=content_id, organization=ctx.organization,
+        )
+    except Note.DoesNotExist as exc:
+        raise _OverrideNotFoundError from exc
+    before = note_snapshot(note)
+    changed = _apply_patch(note, patch, ALLOWED_NOTE_FIELDS)
+    if changed:
+        note.save()
+    after = note_snapshot(note)
+    audit_module.override_edit(
+        actor, note, before, after, reason=reason,
+    )
+    return {
+        "content_type": "note",
+        "content_id": note.id,
+        "before": before,
+        "after": after,
+        "fields_changed": sorted(changed),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _apply_patch(instance, patch: dict, allowed: frozenset) -> set[str]:
+    """Set allowed fields from ``patch`` on ``instance``; return the set we touched."""
+    changed: set[str] = set()
+    for key, value in patch.items():
+        if key not in allowed:
+            continue
+        current = getattr(instance, key, None)
+        if current == value:
+            continue
+        setattr(instance, key, value)
+        changed.add(key)
+    return changed
+
+
+class _OverrideNotFoundError(Exception):
+    """Internal sentinel for the not-found branches."""

--- a/backend/bunk_logs/api/admin_flow/urls.py
+++ b/backend/bunk_logs/api/admin_flow/urls.py
@@ -1,0 +1,31 @@
+"""URL patterns for the Admin Flow namespace.
+
+Mounted at ``/api/v1/admin/`` from :mod:`bunk_logs.api.urls`.
+"""
+
+from __future__ import annotations
+
+from django.urls import path
+
+from bunk_logs.api.audit import AuditEventViewSet
+
+from .dashboard import AdminDashboardView
+from .override import AdminOverrideEditView
+
+# Reuse the existing AuditEventViewSet so /admin/audit/ shares the
+# audit-view meta-event and pagination behaviour with /audit/. The
+# admin-flow path is the canonical one for Story 59; the bare /audit/
+# path stays for backward compatibility with existing PRs that already
+# wire to it.
+_audit_list = AuditEventViewSet.as_view({"get": "list"})
+_audit_by_actor = AuditEventViewSet.as_view({"get": "by_actor"})
+_audit_admin_overrides = AuditEventViewSet.as_view({"get": "admin_overrides"})
+
+
+urlpatterns = [
+    path("dashboard/", AdminDashboardView.as_view(), name="admin-dashboard"),
+    path("override-edit/", AdminOverrideEditView.as_view(), name="admin-override-edit"),
+    path("audit/", _audit_list, name="admin-audit"),
+    path("audit/by-actor/", _audit_by_actor, name="admin-audit-by-actor"),
+    path("audit/admin-overrides/", _audit_admin_overrides, name="admin-audit-admin-overrides"),
+]

--- a/backend/bunk_logs/api/tests/test_admin_flow.py
+++ b/backend/bunk_logs/api/tests/test_admin_flow.py
@@ -1,0 +1,480 @@
+"""API tests for Step 7_13 PR1 -- Admin Flow dashboard / override / audit.
+
+Covers:
+
+* ``GET /api/v1/admin/dashboard/`` -- payload shape, attention cards,
+  recent activity filter, auth gate.
+* ``POST /api/v1/admin/override-edit/`` -- required-reason validation,
+  before/after diff captured in audit, support for reflections and
+  notes, cross-org isolation.
+* ``GET /api/v1/admin/audit/`` -- meta-audit event written when the
+  admin opens a content trail.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import AuditEvent
+from bunk_logs.core.models import Flag
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Note
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.state_machine import OrderStateMachine
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def _hdr(slug: str) -> dict:
+    return {"HTTP_X_ORGANIZATION_SLUG": slug}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def api() -> APIClient:
+    return APIClient()
+
+
+@pytest.fixture
+def org():
+    return Organization.objects.create(name="Admin Flow Org", slug="adminflow")
+
+
+@pytest.fixture
+def other_org():
+    return Organization.objects.create(name="Other Admin Flow", slug="adminflow-other")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="Admin Flow Org Summer",
+        slug="adminflow-summer",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def other_program(other_org):
+    return Program.all_objects.create(
+        organization=other_org,
+        name="Other Admin Flow Summer",
+        slug="other-adminflow-summer",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def admin_user(org, program):
+    u = User.objects.create_user(email="admin@example.com", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="Ada", last_name="Min", user=u,
+    )
+    Membership.all_objects.create(
+        program=program, person=person, role="admin", is_active=True,
+    )
+    return u
+
+
+@pytest.fixture
+def admin_membership(admin_user):
+    person = Person.all_objects.get(user=admin_user)
+    return Membership.all_objects.get(person=person, role="admin")
+
+
+@pytest.fixture
+def non_admin_user(org, program):
+    u = User.objects.create_user(email="counselor@example.com", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="Carl", last_name="Counselor", user=u,
+    )
+    Membership.all_objects.create(
+        program=program, person=person, role="counselor", is_active=True,
+    )
+    return u
+
+
+@pytest.fixture
+def cc_membership(org, program):
+    person = Person.all_objects.create(
+        organization=org, first_name="Cl", last_name="Care",
+    )
+    return Membership.all_objects.create(
+        program=program, person=person, role="camper_care", is_active=True,
+    )
+
+
+@pytest.fixture
+def subject(org):
+    return Person.all_objects.create(
+        organization=org, first_name="Sub", last_name="Ject",
+    )
+
+
+@pytest.fixture
+def reflection_template(org):
+    return ReflectionTemplate.all_objects.create(
+        organization=org,
+        program_type="summer_camp",
+        role="counselor",
+        name="Counselor self",
+        slug="counselor-self",
+        cadence="daily",
+        schema={"fields": [{"key": "summary", "label": "Summary", "type": "long_text", "prompts": {"en": "How was today?"}}]},
+        languages=["en"],
+        subject_mode="self",
+    )
+
+
+@pytest.fixture
+def reflection(org, program, reflection_template, subject):
+    return Reflection.all_objects.create(
+        organization=org,
+        program=program,
+        template=reflection_template,
+        subject=subject,
+        author=subject,
+        period_start=date(2026, 7, 1),
+        period_end=date(2026, 7, 1),
+        answers={"summary": "great day"},
+        language="en",
+        is_complete=True,
+    )
+
+
+@pytest.fixture
+def note(org, program, subject, cc_membership):
+    return Note.all_objects.create(
+        organization=org,
+        program=program,
+        subject=subject,
+        author=cc_membership.person,
+        note_type=Note.NoteType.CAMPER_CARE,
+        body="Subject needed a quiet break.",
+        is_sensitive=False,
+        category=Note.Category.SOCIAL,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dashboard
+# ---------------------------------------------------------------------------
+
+
+class TestAdminDashboard:
+    def test_unauthenticated_blocked(self, api, org):
+        r = api.get("/api/v1/admin/dashboard/", **_hdr(org.slug))
+        assert r.status_code in (401, 403)
+
+    def test_non_admin_blocked(self, api, org, non_admin_user):
+        api.force_authenticate(user=non_admin_user)
+        with organization_context(org):
+            r = api.get("/api/v1/admin/dashboard/", **_hdr(org.slug))
+        assert r.status_code == 403
+
+    def test_admin_payload_shape(
+        self, api, org, program, admin_user,
+    ):
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.get("/api/v1/admin/dashboard/", **_hdr(org.slug))
+        assert r.status_code == 200, r.content
+        body = r.json()
+        assert "today" in body
+        assert body["org"]["slug"] == org.slug
+        assert isinstance(body["org_snapshot"], dict)
+        assert isinstance(body["attention_required"], list)
+        # All six attention card keys present (zero counts allowed).
+        keys = {c["key"] for c in body["attention_required"]}
+        assert keys == {
+            "stale_maintenance_tickets",
+            "stale_camper_care_orders",
+            "unresolved_flags",
+            "pending_template_review",
+            "digest_delivery_failures",
+            "translation_pipeline_failures",
+        }
+        assert isinstance(body["recent_activity"], list)
+
+    def test_active_people_count(
+        self, api, org, program, admin_user, cc_membership,
+    ):
+        # cc_membership creates a second active person beyond the admin
+        # fixture; ensure counts include both.
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.get("/api/v1/admin/dashboard/", **_hdr(org.slug))
+        snapshot = r.json()["org_snapshot"]
+        assert snapshot["active_people"] >= 2
+
+    def test_attention_stale_maintenance_ticket_fires(
+        self, api, org, program, admin_user,
+    ):
+        with organization_context(org):
+            ticket = MaintenanceTicket.objects.create(
+                organization=org, program=program,
+                status=OrderStateMachine.NEW,
+            )
+            # Simulate the ticket being 10 days old (> default 3-day threshold).
+            MaintenanceTicket.all_objects.filter(pk=ticket.pk).update(
+                created_at=timezone.now() - timedelta(days=10),
+            )
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.get("/api/v1/admin/dashboard/", **_hdr(org.slug))
+        cards = {c["key"]: c["count"] for c in r.json()["attention_required"]}
+        assert cards["stale_maintenance_tickets"] == 1
+
+    def test_attention_unresolved_flag_fires(
+        self, api, org, program, admin_user, subject, cc_membership,
+    ):
+        with organization_context(org):
+            flag = Flag.objects.create(
+                organization=org, program=program,
+                subject_camper=subject,
+                raised_by_membership=cc_membership,
+                flagged_for_role="camper_care",
+            )
+            Flag.all_objects.filter(pk=flag.pk).update(
+                created_at=timezone.now() - timedelta(days=10),
+            )
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.get("/api/v1/admin/dashboard/", **_hdr(org.slug))
+        cards = {c["key"]: c["count"] for c in r.json()["attention_required"]}
+        assert cards["unresolved_flags"] == 1
+
+    def test_recent_activity_excludes_routine_edits(
+        self, api, org, program, admin_user, admin_membership, reflection,
+    ):
+        # A routine edit on a reflection should NOT show up in recent
+        # activity (filtered out by content_type). An override on the
+        # same reflection SHOULD show up.
+        with organization_context(org):
+            audit_module.edited(
+                admin_membership, reflection,
+                {"answers": {"summary": "a"}},
+                {"answers": {"summary": "b"}},
+            )
+            audit_module.override_edit(
+                admin_membership, reflection,
+                {"answers": {"summary": "b"}},
+                {"answers": {"summary": "c"}},
+                reason="correction requested by family",
+            )
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.get("/api/v1/admin/dashboard/", **_hdr(org.slug))
+        activity = r.json()["recent_activity"]
+        # Reflection edits/overrides are excluded -- the activity feed
+        # focuses on operational events (orders, tickets, memberships,
+        # supervisions, etc.).
+        ev_types = {e["event_type"] for e in activity}
+        # Routine "edited" reflection content_type isn't in ACTIVITY_CONTENT_FILTER
+        # so neither event should appear.
+        assert "edited" not in ev_types or all(
+            e["content_type"] != "reflection" for e in activity
+        )
+
+
+# ---------------------------------------------------------------------------
+# Override-edit
+# ---------------------------------------------------------------------------
+
+
+class TestAdminOverrideEdit:
+    URL = "/api/v1/admin/override-edit/"
+
+    def test_non_admin_blocked(self, api, org, non_admin_user, reflection):
+        api.force_authenticate(user=non_admin_user)
+        with organization_context(org):
+            r = api.post(self.URL, {
+                "content_type": "reflection",
+                "content_id": str(reflection.id),
+                "patch": {"answers": {"summary": "x"}},
+                "reason": "rewrite",
+            }, format="json", **_hdr(org.slug))
+        assert r.status_code == 403
+
+    def test_missing_reason_returns_422(self, api, org, admin_user, reflection):
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.post(self.URL, {
+                "content_type": "reflection",
+                "content_id": str(reflection.id),
+                "patch": {"answers": {"summary": "x"}},
+                "reason": "   ",
+            }, format="json", **_hdr(org.slug))
+        assert r.status_code == 422
+
+    def test_missing_content_returns_400(self, api, org, admin_user):
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.post(self.URL, {
+                "content_type": "",
+                "content_id": "",
+                "reason": "x",
+            }, format="json", **_hdr(org.slug))
+        assert r.status_code == 400
+
+    def test_unsupported_content_type_returns_400(self, api, org, admin_user):
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.post(self.URL, {
+                "content_type": "supervision",
+                "content_id": "1",
+                "patch": {},
+                "reason": "x",
+            }, format="json", **_hdr(org.slug))
+        assert r.status_code == 400
+
+    def test_reflection_override_writes_audit_with_before_after(
+        self, api, org, admin_user, reflection,
+    ):
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.post(self.URL, {
+                "content_type": "reflection",
+                "content_id": str(reflection.id),
+                "patch": {"answers": {"summary": "rewritten by admin"}},
+                "reason": "Camper asked to remove identifying detail",
+            }, format="json", **_hdr(org.slug))
+        assert r.status_code == 200, r.content
+        body = r.json()
+        assert body["before"]["answers"] == {"summary": "great day"}
+        assert body["after"]["answers"] == {"summary": "rewritten by admin"}
+        # AuditEvent is recorded with is_admin_override=True
+        evts = AuditEvent.all_objects.filter(
+            content_type="reflection",
+            content_id=str(reflection.id),
+            event_type=AuditEvent.EventType.OVERRIDE_EDIT,
+        )
+        assert evts.count() == 1
+        evt = evts.first()
+        assert evt.is_admin_override is True
+        assert evt.reason_note == "Camper asked to remove identifying detail"
+        assert evt.before_state["answers"] == {"summary": "great day"}
+        assert evt.after_state["answers"] == {"summary": "rewritten by admin"}
+
+    def test_note_override_updates_body(self, api, org, admin_user, note):
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.post(self.URL, {
+                "content_type": "note",
+                "content_id": str(note.id),
+                "patch": {"body": "Redacted by Admin"},
+                "reason": "Reviewed for sensitive identifiers",
+            }, format="json", **_hdr(org.slug))
+        assert r.status_code == 200, r.content
+        note.refresh_from_db()
+        assert note.body == "Redacted by Admin"
+        assert AuditEvent.all_objects.filter(
+            content_type="note",
+            content_id=str(note.id),
+            event_type=AuditEvent.EventType.OVERRIDE_EDIT,
+        ).exists()
+
+    def test_cross_org_target_returns_404(
+        self, api, org, other_org, other_program, admin_user,
+    ):
+        # Reflection in another org should not be reachable.
+        with organization_context(other_org):
+            tpl = ReflectionTemplate.all_objects.create(
+                organization=other_org,
+                program_type="summer_camp",
+                role="counselor",
+                name="Other tpl",
+                slug="other-tpl",
+                cadence="daily",
+                schema={"fields": [{"key": "k", "label": "K", "type": "long_text", "prompts": {"en": "?"}}]},
+                languages=["en"],
+                subject_mode="self",
+            )
+            person = Person.all_objects.create(
+                organization=other_org, first_name="A", last_name="B",
+            )
+            other_ref = Reflection.all_objects.create(
+                organization=other_org, program=other_program, template=tpl,
+                subject=person, author=person,
+                period_start=date(2026, 7, 1), period_end=date(2026, 7, 1),
+                answers={"k": "v"}, is_complete=True,
+            )
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.post(self.URL, {
+                "content_type": "reflection",
+                "content_id": str(other_ref.id),
+                "patch": {"answers": {"k": "v2"}},
+                "reason": "no",
+            }, format="json", **_hdr(org.slug))
+        assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Admin audit pass-through
+# ---------------------------------------------------------------------------
+
+
+class TestAdminAuditPassthrough:
+    def test_meta_audit_written_via_admin_path(
+        self, api, org, admin_user, admin_membership, reflection,
+    ):
+        with organization_context(org):
+            audit_module.created(admin_membership, reflection)
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.get(
+                "/api/v1/admin/audit/",
+                {"content_type": "reflection", "content_id": str(reflection.id)},
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 200
+        view_events = AuditEvent.all_objects.filter(
+            event_type=AuditEvent.EventType.AUDIT_VIEW,
+            content_type="reflection",
+            content_id=str(reflection.id),
+        )
+        assert view_events.count() == 1
+
+    def test_admin_overrides_listing(
+        self, api, org, admin_user, admin_membership, reflection,
+    ):
+        with organization_context(org):
+            audit_module.override_edit(
+                admin_membership, reflection,
+                {"answers": {"summary": "a"}},
+                {"answers": {"summary": "b"}},
+                reason="cleanup",
+            )
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.get(
+                "/api/v1/admin/audit/admin-overrides/",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 200
+        body = r.json()
+        assert any(e["event_type"] == "override_edit" for e in body)

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -174,6 +174,10 @@ urlpatterns = [
     ),
     path("", include(router.urls)),
 
+    # Step 7_13 — Admin Flow namespace (mounted under /api/v1/admin/).
+    # See bunk_logs/api/admin_flow/__init__.py for the package layout.
+    path("admin/", include("bunk_logs.api.admin_flow.urls")),
+
     # Non-standard bunk detail path used by BunkCard.jsx — kept for compat while
     # callers are migrated to the standard /bunks/{id}/ route
     path("bunk/<str:id>/", views.BunkViewSet.as_view({"get": "retrieve"}), name="bunk-detail-compat"),

--- a/docs/role_flows/admin.md
+++ b/docs/role_flows/admin.md
@@ -1,0 +1,158 @@
+# Admin Flow — Step 7_13 (Stories 54-60)
+
+## Overview
+
+The Admin role owns org-wide configuration, oversight, and override
+authority. Admin lands on a Story 54 home dashboard, has full read-as
+access to every operational role surface (Story 59 c1), maintains
+People + Memberships + Programs + Settings (Stories 55, 56, 58), and
+can author / oversee reflection templates (Story 57).
+
+This file is the running reference for the Admin namespace. PR1 lands
+the foundation (dashboard + override path + audit access + viewing
+banner). PR2 + PR3 fill in People / Assignments / Programs / Settings /
+Global search / Templates wrapper.
+
+## Invariants
+
+- Every admin endpoint goes through `IsOrgAdminOrSuperuser`
+  (`backend/bunk_logs/core/permissions/drf.py`). Reaching `/api/v1/admin/*`
+  without an active `role="admin"` Membership in the active org returns
+  403, even with a valid JWT.
+- Super Admins (`is_staff` or `is_superuser`) get the same access; the
+  admin-context helper records `is_super_admin=True` so audit rows can
+  show "no membership" actor when needed.
+- All edits that target another role's content go through the override
+  path (`POST /admin/override-edit/`). The reason note is mandatory and
+  the action is captured as `OVERRIDE_EDIT` so reviewers can see who
+  did what and why.
+- Reading an audit trail is itself audited (`AUDIT_VIEW`) per Story 59
+  criterion 10.
+
+## Backend endpoints (PR1)
+
+| Method | Path | Story |
+|--------|------|-------|
+| GET | `/api/v1/admin/dashboard/` | 54 |
+| POST | `/api/v1/admin/override-edit/` | 59 c8 |
+| GET | `/api/v1/admin/audit/?content_type=&content_id=` | 59 c9 |
+| GET | `/api/v1/admin/audit/by-actor/?membership_id=` | 7_4 |
+| GET | `/api/v1/admin/audit/admin-overrides/?since=` | 7_4 |
+
+Each path lives in `backend/bunk_logs/api/admin_flow/` (the package is
+named `admin_flow` to avoid clashing with the
+`bunk_logs/api/admin.py` stub the Django app system already loads).
+
+### `GET /api/v1/admin/dashboard/`
+
+Returns the Story 54 home payload:
+
+```json
+{
+  "today": "2026-07-15",
+  "org": { "id": 1, "name": "...", "slug": "...", "active_programs": [...] },
+  "org_snapshot": {
+    "active_people": 87,
+    "memberships_by_role": [{ "role": "counselor", "count": 32 }, ...],
+    "open_camper_care_orders": 4,
+    "open_maintenance_tickets": 2,
+    "active_flags": 1
+  },
+  "attention_required": [{ "key": "...", "label": "...", "count": 0, ... }, ...],
+  "recent_activity": [{ "id": "...", "event_type": "...", "summary": "...", ... }]
+}
+```
+
+Six attention conditions are always present (zero counts allowed) so the
+frontend can render a stable grid:
+
+1. `stale_maintenance_tickets` — open older than the
+   `stale_maintenance_ticket_days` org setting (default 3).
+2. `stale_camper_care_orders` — open older than the
+   `stale_camper_care_order_days` org setting (default 3).
+3. `unresolved_flags` — active flags older than 7 days.
+4. `pending_template_review` — templates published in the last 14 days
+   (the per-template Reviewed / Needs revision flag lands in PR3).
+5. `digest_delivery_failures` — Maintenance digest emails that failed 3
+   consecutive sends in the last 7 days.
+6. `translation_pipeline_failures` — 5 or more `TranslationRecord`
+   rows in `failed_terminal` state in the last 24h.
+
+Recent activity is the latest 25 significant `AuditEvent` rows from the
+last 7 days, filtered to operational content types (orders, tickets,
+flags, memberships, supervisions, templates, programs, people). Routine
+reflection / note edits are deliberately excluded to keep the feed
+useful.
+
+### `POST /api/v1/admin/override-edit/`
+
+PR1 supports `content_type` of `reflection` or `note`. PR2 extends with
+order / ticket / flag overrides (those have dedicated state-machine
+paths). Request body:
+
+```json
+{
+  "content_type": "reflection",
+  "content_id": "<uuid or int>",
+  "patch": { "answers": { ... } },
+  "reason": "Required, non-empty"
+}
+```
+
+- Missing / blank reason → 422.
+- Missing content fields → 400.
+- Cross-org target → 404 (the row is invisible to this Admin).
+- Allowed reflection fields: `answers`, `language`, `team_visibility`,
+  `is_complete`, `is_sensitive`.
+- Allowed note fields: `body`, `is_sensitive`, `maintenance_visibility`,
+  `language`.
+
+The endpoint writes an `OVERRIDE_EDIT` AuditEvent with the captured
+before / after snapshot via
+`bunk_logs.core.audit.override_edit`.
+
+### `/api/v1/admin/audit/...`
+
+Mounts the existing `AuditEventViewSet` under the admin namespace so the
+frontend can use one consistent path for audit reads. The per-content
+trail call (`GET /admin/audit/?content_type=&content_id=`) writes the
+required `AUDIT_VIEW` meta-event on every fetch.
+
+## Frontend (PR1)
+
+| Route | Component |
+|-------|-----------|
+| `/admin` | `pages/admin/Dashboard.jsx` (Story 54) |
+| `/admin/dashboard` | same component, explicit path |
+| `/admin/hub` | legacy `pages/admin/AdminHub.jsx` (kept for bookmarks) |
+
+`AdminLayout` continues to wrap every `/admin/*` route with sidebar +
+header. The default `/admin` index used to render the `AdminHub` cards;
+PR1 swaps it for the Story 54 dashboard so an Admin lands on the
+home view that matches the spec. The hub is still reachable at
+`/admin/hub`.
+
+### Shared components
+
+- `components/admin/AdminViewingBanner.jsx` — Story 59 c2 "Viewing as
+  Admin" chip. Mounted in PR1 on `MaintenanceTicketDetail.jsx`;
+  PR2 wires it into the other operational detail surfaces.
+- `components/admin/EditAsAdminButton.jsx` — Story 59 c8 override
+  affordance. Opens a modal with a required reason textarea, posts to
+  `/api/v1/admin/override-edit/`, surfaces the AuditEvent through the
+  existing `AuditTrail` panel.
+- `components/AuditTrail.jsx` + `EditedIndicator.jsx` from Step 7_4
+  are wired into the maintenance ticket detail in PR1 as the
+  representative example. PR2 wires the remaining reflection / note /
+  flag detail pages.
+
+## Out of scope for PR1
+
+- People / Assignments / Programs / Settings CRUD (PR2)
+- Global search (PR3)
+- Bulk Person import UI + invitation flow (PR3)
+- Templates wrapper + Mark Reviewed / Needs revision flag (PR3)
+- Admin self-reflection card (deferred — already supported via the
+  shared self-reflection pipeline once an Admin template is assigned)
+- Cross-org Admin (Decision A1 — not a customer-facing role)
+- Performance indexes for FTS (Step 7_17)

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -31,6 +31,7 @@ import TeamDashboardPage from './pages/TeamDashboardPage';
 import WellnessDashboardPage from './pages/WellnessDashboardPage';
 import MembershipManagementPage from './pages/MembershipManagementPage';
 import AdminHub from './pages/admin/AdminHub';
+import AdminDashboardV2 from './pages/admin/Dashboard';
 import TemplateListPage from './pages/admin/templates/TemplateListPage';
 import TemplateEditorPage from './pages/admin/templates/TemplateEditorPage';
 import TemplateNewPage from './pages/admin/templates/TemplateNewPage';
@@ -780,7 +781,26 @@ function Router() {
             index
             element={
               <AdminRoute>
+                <AdminDashboardV2 />
+              </AdminRoute>
+            }
+          />
+          {/* The legacy hub stays reachable at /admin/hub so anyone with a
+              bookmark still lands on a working surface. The default
+              /admin route now shows the Story 54 home dashboard. */}
+          <Route
+            path="hub"
+            element={
+              <AdminRoute>
                 <AdminHub />
+              </AdminRoute>
+            }
+          />
+          <Route
+            path="dashboard"
+            element={
+              <AdminRoute>
+                <AdminDashboardV2 />
               </AdminRoute>
             }
           />

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -1,0 +1,30 @@
+import api from '../api';
+
+/**
+ * Step 7_13 — Admin Flow API client.
+ *
+ * Wraps the endpoints under `/api/v1/admin/`. Each helper returns the
+ * raw payload (no transformation) so component code stays the source
+ * of truth for shape interpretation.
+ */
+export const ADMIN_BASE = '/api/v1/admin';
+
+export async function fetchAdminDashboard() {
+  const resp = await api.get(`${ADMIN_BASE}/dashboard/`);
+  return resp?.data ?? null;
+}
+
+export async function postAdminOverrideEdit({
+  contentType,
+  contentId,
+  patch,
+  reason,
+}) {
+  const resp = await api.post(`${ADMIN_BASE}/override-edit/`, {
+    content_type: contentType,
+    content_id: contentId,
+    patch,
+    reason,
+  });
+  return resp?.data ?? null;
+}

--- a/frontend/src/components/admin/AdminViewingBanner.jsx
+++ b/frontend/src/components/admin/AdminViewingBanner.jsx
@@ -1,0 +1,31 @@
+import { useAuth } from '../../auth/AuthContext';
+import isSuperAdmin from '../../utils/auth/isSuperAdmin';
+
+/**
+ * Step 7_13 — Story 59 criterion 2.
+ *
+ * Renders a "Viewing as Admin — [role label]" header strip when an
+ * Admin / Super Admin opens an operational role's dashboard or detail
+ * view. Pass `roleLabel` for the role-specific copy ("Camper Care",
+ * "Counselor", etc.); the banner stays out of the DOM for non-admin
+ * viewers so callers can drop it anywhere without conditionals.
+ *
+ * Visual treatment is deliberately subtle (small amber chip) so it
+ * doesn't interfere with the underlying role surface while still being
+ * obvious enough that an Admin doesn't forget they're cross-viewing.
+ */
+export default function AdminViewingBanner({ roleLabel }) {
+  const { user } = useAuth();
+  const isAdmin = isSuperAdmin(user) || user?.role?.toLowerCase() === 'admin';
+  if (!isAdmin) return null;
+  return (
+    <div
+      data-testid="admin-viewing-banner"
+      role="status"
+      className="px-3 py-1.5 mb-3 inline-flex items-center gap-2 rounded-md border border-amber-300 bg-amber-50 text-amber-900 text-xs dark:bg-amber-900/30 dark:border-amber-700 dark:text-amber-100"
+    >
+      <span className="font-semibold uppercase tracking-wide">Viewing as Admin</span>
+      {roleLabel ? <span>— {roleLabel}</span> : null}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/EditAsAdminButton.jsx
+++ b/frontend/src/components/admin/EditAsAdminButton.jsx
@@ -1,0 +1,192 @@
+import { useState } from 'react';
+import api from '../../api';
+import { useAuth } from '../../auth/AuthContext';
+import isSuperAdmin from '../../utils/auth/isSuperAdmin';
+
+/**
+ * Step 7_13 — Story 59 criterion 8.
+ *
+ * Explicit "Edit as Admin" affordance for content the Admin doesn't
+ * own. Opens a modal that requires a non-empty reason note, then
+ * POSTs `/api/v1/admin/override-edit/` with the patch payload. The
+ * backend writes an `override_edit` AuditEvent with the reason so the
+ * action is reviewable from the audit trail.
+ *
+ * Props:
+ *   contentType   "reflection" | "note" — anything else the backend
+ *                 rejects; PR2/PR3 extend the supported types.
+ *   contentId     PK of the row being overridden.
+ *   patchBuilder  Optional function returning the patch object. When
+ *                 omitted, the modal renders a JSON textarea so the
+ *                 caller can plug in a richer editor later without a
+ *                 component refactor (most callers should supply
+ *                 `patchBuilder`).
+ *   onSaved       Optional callback fired after a successful override
+ *                 with the API response body.
+ *   label         Button label override. Defaults to "Edit as Admin".
+ */
+export default function EditAsAdminButton({
+  contentType,
+  contentId,
+  patchBuilder,
+  onSaved,
+  label = 'Edit as Admin',
+  className = '',
+}) {
+  const { user } = useAuth();
+  const isAdmin = isSuperAdmin(user) || user?.role?.toLowerCase() === 'admin';
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState('');
+  const [rawPatch, setRawPatch] = useState('{}');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  if (!isAdmin) return null;
+
+  const resetState = () => {
+    setReason('');
+    setRawPatch('{}');
+    setError('');
+    setSaving(false);
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+    if (!reason.trim()) {
+      setError('Reason is required.');
+      return;
+    }
+    let patch;
+    if (typeof patchBuilder === 'function') {
+      try {
+        patch = patchBuilder();
+      } catch (err) {
+        setError(err?.message || 'Failed to build patch.');
+        return;
+      }
+    } else {
+      try {
+        patch = JSON.parse(rawPatch || '{}');
+      } catch {
+        setError('Patch must be valid JSON.');
+        return;
+      }
+    }
+    setSaving(true);
+    try {
+      const resp = await api.post('/api/v1/admin/override-edit/', {
+        content_type: contentType,
+        content_id: contentId,
+        reason,
+        patch,
+      });
+      if (typeof onSaved === 'function') {
+        onSaved(resp?.data);
+      }
+      setOpen(false);
+      resetState();
+    } catch (err) {
+      const detail = err?.response?.data?.detail || err?.message || 'Override failed.';
+      setError(detail);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="edit-as-admin-button"
+        onClick={() => setOpen(true)}
+        className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium border border-red-300 bg-red-50 text-red-800 hover:bg-red-100 dark:bg-red-900/20 dark:border-red-700 dark:text-red-100 ${className}`}
+      >
+        {label}
+      </button>
+      {open && (
+        <div
+          data-testid="edit-as-admin-modal"
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={(e) => {
+            if (e.target === e.currentTarget && !saving) {
+              setOpen(false);
+              resetState();
+            }
+          }}
+        >
+          <form
+            onSubmit={handleSubmit}
+            className="w-full max-w-md rounded-xl bg-white dark:bg-gray-900 p-5 shadow-lg border border-gray-200 dark:border-gray-700"
+          >
+            <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-1">
+              Edit as Admin
+            </h2>
+            <p className="text-sm text-gray-600 dark:text-gray-300 mb-3">
+              This action is recorded in the audit trail with your reason.
+            </p>
+            <label className="block text-xs font-medium text-gray-700 dark:text-gray-200 mb-1" htmlFor="override-reason">
+              Reason
+              <span className="text-red-600 ml-0.5" aria-hidden>*</span>
+            </label>
+            <textarea
+              id="override-reason"
+              data-testid="edit-as-admin-reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={3}
+              aria-required="true"
+              className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 p-2 text-sm"
+            />
+            {!patchBuilder && (
+              <>
+                <label className="block text-xs font-medium text-gray-700 dark:text-gray-200 mb-1 mt-3" htmlFor="override-patch">
+                  Patch (JSON)
+                </label>
+                <textarea
+                  id="override-patch"
+                  data-testid="edit-as-admin-patch"
+                  value={rawPatch}
+                  onChange={(e) => setRawPatch(e.target.value)}
+                  rows={5}
+                  className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 p-2 text-sm font-mono"
+                />
+              </>
+            )}
+            {error && (
+              <p
+                data-testid="edit-as-admin-error"
+                className="mt-2 text-sm text-red-700 dark:text-red-300"
+              >
+                {error}
+              </p>
+            )}
+            <div className="mt-4 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setOpen(false);
+                  resetState();
+                }}
+                disabled={saving}
+                className="text-sm text-gray-600 dark:text-gray-300 hover:underline"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={saving}
+                data-testid="edit-as-admin-submit"
+                className="inline-flex items-center px-3 py-1.5 rounded-md text-sm font-medium bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
+              >
+                {saving ? 'Saving…' : 'Override and save'}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/admin/__tests__/AdminViewingBanner.test.jsx
+++ b/frontend/src/components/admin/__tests__/AdminViewingBanner.test.jsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+import { useAuth } from '../../../auth/AuthContext';
+import AdminViewingBanner from '../AdminViewingBanner';
+
+describe('AdminViewingBanner', () => {
+  it('renders nothing for non-admin viewers', () => {
+    useAuth.mockReturnValue({ user: { role: 'counselor', is_staff: false } });
+    const { container } = render(<AdminViewingBanner roleLabel="Counselor" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders for the legacy admin role', () => {
+    useAuth.mockReturnValue({ user: { role: 'Admin' } });
+    render(<AdminViewingBanner roleLabel="Maintenance" />);
+    expect(screen.getByTestId('admin-viewing-banner')).toBeInTheDocument();
+    expect(screen.getByText(/Maintenance/i)).toBeInTheDocument();
+  });
+
+  it('renders for Super Admins (is_staff)', () => {
+    useAuth.mockReturnValue({ user: { role: 'unit_head', is_staff: true } });
+    render(<AdminViewingBanner roleLabel="Unit Head" />);
+    expect(screen.getByTestId('admin-viewing-banner')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/admin/__tests__/EditAsAdminButton.test.jsx
+++ b/frontend/src/components/admin/__tests__/EditAsAdminButton.test.jsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('../../../api', () => ({
+  default: { post: vi.fn() },
+}));
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+import api from '../../../api';
+import { useAuth } from '../../../auth/AuthContext';
+import EditAsAdminButton from '../EditAsAdminButton';
+
+beforeEach(() => {
+  api.post.mockReset();
+  useAuth.mockReset();
+});
+
+describe('EditAsAdminButton', () => {
+  it('renders nothing for non-admin viewers', () => {
+    useAuth.mockReturnValue({ user: { role: 'counselor' } });
+    const { container } = render(
+      <EditAsAdminButton contentType="reflection" contentId="abc" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('requires a reason before submitting', async () => {
+    useAuth.mockReturnValue({ user: { role: 'admin' } });
+    render(<EditAsAdminButton contentType="reflection" contentId="abc" patchBuilder={() => ({ answers: { x: 1 } })} />);
+    fireEvent.click(screen.getByTestId('edit-as-admin-button'));
+    fireEvent.click(screen.getByTestId('edit-as-admin-submit'));
+    expect(await screen.findByTestId('edit-as-admin-error')).toHaveTextContent(/reason is required/i);
+    expect(api.post).not.toHaveBeenCalled();
+  });
+
+  it('posts to /admin/override-edit/ and calls onSaved on success', async () => {
+    useAuth.mockReturnValue({ user: { is_staff: true } });
+    api.post.mockResolvedValue({ data: { ok: true } });
+    const onSaved = vi.fn();
+    render(
+      <EditAsAdminButton
+        contentType="reflection"
+        contentId="abc"
+        onSaved={onSaved}
+        patchBuilder={() => ({ answers: { x: 1 } })}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('edit-as-admin-button'));
+    fireEvent.change(screen.getByTestId('edit-as-admin-reason'), {
+      target: { value: 'parent requested redaction' },
+    });
+    fireEvent.click(screen.getByTestId('edit-as-admin-submit'));
+    await waitFor(() => expect(api.post).toHaveBeenCalled());
+    expect(api.post).toHaveBeenCalledWith(
+      '/api/v1/admin/override-edit/',
+      expect.objectContaining({
+        content_type: 'reflection',
+        content_id: 'abc',
+        reason: 'parent requested redaction',
+        patch: { answers: { x: 1 } },
+      }),
+    );
+    expect(onSaved).toHaveBeenCalledWith({ ok: true });
+  });
+});

--- a/frontend/src/pages/admin/Dashboard.jsx
+++ b/frontend/src/pages/admin/Dashboard.jsx
@@ -1,0 +1,279 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchAdminDashboard } from '../../api/admin';
+
+/**
+ * Step 7_13 PR1 — Admin home dashboard (Story 54).
+ *
+ * Sections per Story 54 criterion 3:
+ *   - Org header (name, date, active programs)
+ *   - Org snapshot (counts)
+ *   - Attention required (6 conditions)
+ *   - Recent activity (significant audit events)
+ *
+ * Visually distinct from operational role dashboards — uses a wider
+ * grid + sharper section dividers so an Admin can tell they're on the
+ * meta-view, not a per-team surface.
+ *
+ * Per-role drill-downs (People / Assignments / Templates / Settings /
+ * search) are added in PR2 + PR3.
+ */
+const REFRESH_INTERVAL_MS = 120_000;
+
+const ATTENTION_TINT = {
+  stale_maintenance_tickets: 'border-amber-300 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-700',
+  stale_camper_care_orders: 'border-amber-300 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-700',
+  unresolved_flags: 'border-red-300 bg-red-50 dark:bg-red-900/20 dark:border-red-700',
+  pending_template_review: 'border-indigo-300 bg-indigo-50 dark:bg-indigo-900/20 dark:border-indigo-700',
+  digest_delivery_failures: 'border-red-300 bg-red-50 dark:bg-red-900/20 dark:border-red-700',
+  translation_pipeline_failures: 'border-red-300 bg-red-50 dark:bg-red-900/20 dark:border-red-700',
+};
+
+function formatDate(iso) {
+  if (!iso) return '';
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function formatTime(iso) {
+  if (!iso) return '';
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+function OrgHeader({ org, today }) {
+  if (!org) return null;
+  return (
+    <header
+      data-testid="admin-dashboard-header"
+      className="mb-6 border-b border-gray-200 dark:border-gray-700 pb-4"
+    >
+      <div className="flex flex-wrap items-baseline gap-3">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+          {org.name}
+        </h1>
+        <span className="text-sm text-gray-500 dark:text-gray-400">
+          {formatDate(today)}
+        </span>
+      </div>
+      {org.active_programs?.length > 0 && (
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+          {org.active_programs.length} active program{org.active_programs.length === 1 ? '' : 's'}
+          {': '}
+          {org.active_programs.map((p) => p.name).join(', ')}
+        </p>
+      )}
+    </header>
+  );
+}
+
+function SnapshotCard({ label, value }) {
+  return (
+    <div
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3"
+      data-testid={`admin-snapshot-${label.replace(/\s+/g, '-').toLowerCase()}`}
+    >
+      <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {label}
+      </p>
+      <p className="mt-1 text-2xl font-semibold text-gray-900 dark:text-white">
+        {value ?? 0}
+      </p>
+    </div>
+  );
+}
+
+function OrgSnapshot({ snapshot }) {
+  if (!snapshot) return null;
+  return (
+    <section data-testid="admin-snapshot" className="mb-6">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300 mb-2">
+        Org snapshot
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        <SnapshotCard label="Active people" value={snapshot.active_people} />
+        <SnapshotCard label="Open CC orders" value={snapshot.open_camper_care_orders} />
+        <SnapshotCard label="Open maintenance" value={snapshot.open_maintenance_tickets} />
+        <SnapshotCard label="Active flags" value={snapshot.active_flags} />
+      </div>
+      {snapshot.memberships_by_role?.length > 0 && (
+        <div className="mt-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3">
+          <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+            Memberships by role
+          </p>
+          <ul className="flex flex-wrap gap-x-5 gap-y-1 text-sm text-gray-800 dark:text-gray-100">
+            {snapshot.memberships_by_role.map((row) => (
+              <li key={row.role} data-testid={`admin-role-${row.role}`}>
+                <span className="font-medium">{row.count}</span>{' '}
+                <span className="text-gray-600 dark:text-gray-400">{row.role}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function AttentionRequired({ cards }) {
+  if (!cards?.length) return null;
+  return (
+    <section data-testid="admin-attention" className="mb-6">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300 mb-2">
+        Attention required
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {cards.map((card) => (
+          <Link
+            key={card.key}
+            to={card.deep_link || '/admin'}
+            data-testid={`admin-attention-${card.key}`}
+            className={`block rounded-xl border px-4 py-3 hover:shadow-md ${ATTENTION_TINT[card.key] || 'border-gray-200 bg-white dark:bg-gray-900 dark:border-gray-700'}`}
+          >
+            <div className="flex items-baseline justify-between gap-2">
+              <p className="text-sm font-medium text-gray-900 dark:text-white">
+                {card.label}
+              </p>
+              <span className="text-2xl font-semibold text-gray-900 dark:text-white">
+                {card.count}
+              </span>
+            </div>
+            {card.threshold_days != null && (
+              <p className="mt-1 text-xs text-gray-600 dark:text-gray-300">
+                Threshold: {card.threshold_days} day{card.threshold_days === 1 ? '' : 's'}
+              </p>
+            )}
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function RecentActivity({ events }) {
+  return (
+    <section data-testid="admin-activity" className="mb-6">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300 mb-2">
+        Recent activity
+      </h2>
+      {!events?.length ? (
+        <p data-testid="admin-activity-empty" className="text-sm italic text-gray-500 dark:text-gray-400">
+          No significant activity in the last 7 days.
+        </p>
+      ) : (
+        <ul className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 divide-y divide-gray-100 dark:divide-gray-800">
+          {events.map((event) => (
+            <li
+              key={event.id}
+              data-testid={`admin-activity-${event.id}`}
+              data-admin-override={event.is_admin_override ? 'true' : 'false'}
+              className="px-4 py-2.5 text-sm"
+            >
+              <div className="flex items-center justify-between gap-3 flex-wrap">
+                <Link
+                  to={event.deep_link || '/admin'}
+                  className="font-medium text-gray-900 dark:text-white hover:underline"
+                >
+                  {event.summary}
+                </Link>
+                <time className="text-xs text-gray-500 dark:text-gray-400" dateTime={event.created_at}>
+                  {formatTime(event.created_at)}
+                </time>
+              </div>
+              {event.actor && (
+                <p className="text-xs text-gray-600 dark:text-gray-300 mt-0.5">
+                  by {event.actor}
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function Navigation() {
+  return (
+    <section data-testid="admin-navigation" className="mb-6">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300 mb-2">
+        Manage
+      </h2>
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+        <Link to="/admin/memberships" className="rounded-xl border border-gray-200 bg-white dark:bg-gray-900 dark:border-gray-700 px-4 py-3 hover:shadow-md">
+          <p className="text-sm font-medium text-gray-900 dark:text-white">Memberships</p>
+        </Link>
+        <Link to="/admin/groups" className="rounded-xl border border-gray-200 bg-white dark:bg-gray-900 dark:border-gray-700 px-4 py-3 hover:shadow-md">
+          <p className="text-sm font-medium text-gray-900 dark:text-white">Assignment groups</p>
+        </Link>
+        <Link to="/admin/templates" className="rounded-xl border border-gray-200 bg-white dark:bg-gray-900 dark:border-gray-700 px-4 py-3 hover:shadow-md">
+          <p className="text-sm font-medium text-gray-900 dark:text-white">Templates</p>
+        </Link>
+        <Link to="/admin/field-keys" className="rounded-xl border border-gray-200 bg-white dark:bg-gray-900 dark:border-gray-700 px-4 py-3 hover:shadow-md">
+          <p className="text-sm font-medium text-gray-900 dark:text-white">Field keys</p>
+        </Link>
+        <Link to="/dashboards" className="rounded-xl border border-gray-200 bg-white dark:bg-gray-900 dark:border-gray-700 px-4 py-3 hover:shadow-md">
+          <p className="text-sm font-medium text-gray-900 dark:text-white">Dashboards</p>
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+export default function AdminDashboard() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const payload = await fetchAdminDashboard();
+      setData(payload);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+    const handle = window.setInterval(load, REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(handle);
+  }, [load]);
+
+  return (
+    <main className="grow px-4 sm:px-6 lg:px-8 py-8 w-full max-w-6xl mx-auto" data-testid="admin-dashboard">
+      {loading && !data ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">Loading admin dashboard…</p>
+      ) : error ? (
+        <div data-testid="admin-dashboard-error" className="rounded-xl border border-red-200 bg-red-50 p-4">
+          <p className="text-sm text-red-800">Could not load the dashboard.</p>
+          <button type="button" onClick={load} className="mt-2 text-sm font-medium text-red-700 underline">
+            Retry
+          </button>
+        </div>
+      ) : (
+        <>
+          <OrgHeader org={data?.org} today={data?.today} />
+          <OrgSnapshot snapshot={data?.org_snapshot} />
+          <AttentionRequired cards={data?.attention_required} />
+          <RecentActivity events={data?.recent_activity} />
+          <Navigation />
+        </>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/pages/admin/__tests__/Dashboard.test.jsx
+++ b/frontend/src/pages/admin/__tests__/Dashboard.test.jsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../../../api/admin', () => ({
+  fetchAdminDashboard: vi.fn(),
+}));
+
+import { fetchAdminDashboard } from '../../../api/admin';
+import AdminDashboard from '../Dashboard';
+
+beforeEach(() => {
+  fetchAdminDashboard.mockReset();
+});
+
+const SAMPLE_PAYLOAD = {
+  today: '2026-07-15',
+  org: {
+    id: 1,
+    name: 'Acme Camp',
+    slug: 'acme',
+    active_programs: [
+      { id: 11, name: 'Acme Summer 2026', program_type: 'summer_camp', start_date: '2026-06-15', end_date: '2026-08-20' },
+    ],
+  },
+  org_snapshot: {
+    active_people: 87,
+    memberships_by_role: [
+      { role: 'counselor', count: 32 },
+      { role: 'camper', count: 50 },
+    ],
+    open_camper_care_orders: 4,
+    open_maintenance_tickets: 2,
+    active_flags: 1,
+  },
+  attention_required: [
+    { key: 'stale_maintenance_tickets', label: 'Stale Maintenance tickets', count: 3, threshold_days: 3, deep_link: '/admin/operations/maintenance?filter=stale' },
+    { key: 'stale_camper_care_orders', label: 'Stale Camper Care orders', count: 0, threshold_days: 3, deep_link: '/admin/operations/orders?filter=stale' },
+    { key: 'unresolved_flags', label: 'Unresolved Camper Care flags', count: 2, threshold_days: 7, deep_link: '/admin/operations/flags?filter=stale' },
+    { key: 'pending_template_review', label: 'Pending template review', count: 1, threshold_days: 14, deep_link: '/admin/templates?filter=pending_review' },
+    { key: 'digest_delivery_failures', label: 'Digest delivery failures', count: 0, threshold_days: 3, deep_link: '/admin/settings?tab=notifications' },
+    { key: 'translation_pipeline_failures', label: 'Translation pipeline failures', count: 0, threshold_days: 1, deep_link: '/admin/operations/translations' },
+  ],
+  recent_activity: [
+    {
+      id: 'ev-1', event_type: 'state_changed', content_type: 'order',
+      content_id: 'abc', created_at: '2026-07-15T11:00:00Z',
+      actor: 'Ada Min', is_admin_override: false,
+      deep_link: '/admin/operations/orders/abc',
+      summary: 'Order: new -> in_progress',
+    },
+  ],
+};
+
+function renderDashboard() {
+  return render(
+    <MemoryRouter>
+      <AdminDashboard />
+    </MemoryRouter>,
+  );
+}
+
+describe('Admin Dashboard (Story 54)', () => {
+  it('renders snapshot, attention, and activity sections', async () => {
+    fetchAdminDashboard.mockResolvedValue(SAMPLE_PAYLOAD);
+    renderDashboard();
+    await waitFor(() => expect(fetchAdminDashboard).toHaveBeenCalled());
+    expect(await screen.findByTestId('admin-snapshot')).toBeInTheDocument();
+    expect(screen.getByTestId('admin-attention')).toBeInTheDocument();
+    expect(screen.getByTestId('admin-activity')).toBeInTheDocument();
+    expect(screen.getByText('Acme Camp')).toBeInTheDocument();
+  });
+
+  it('shows all six attention cards', async () => {
+    fetchAdminDashboard.mockResolvedValue(SAMPLE_PAYLOAD);
+    renderDashboard();
+    for (const key of [
+      'stale_maintenance_tickets',
+      'stale_camper_care_orders',
+      'unresolved_flags',
+      'pending_template_review',
+      'digest_delivery_failures',
+      'translation_pipeline_failures',
+    ]) {
+      expect(await screen.findByTestId(`admin-attention-${key}`)).toBeInTheDocument();
+    }
+  });
+
+  it('surfaces a retry button on error', async () => {
+    fetchAdminDashboard.mockRejectedValue(new Error('boom'));
+    renderDashboard();
+    expect(await screen.findByTestId('admin-dashboard-error')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/maintenance/TicketDetail.jsx
+++ b/frontend/src/pages/maintenance/TicketDetail.jsx
@@ -27,6 +27,9 @@ import {
   fetchNoteAudience,
   uploadTicketPhoto,
 } from '../../api/maintenance';
+import AuditTrail from '../../components/AuditTrail';
+import AdminViewingBanner from '../../components/admin/AdminViewingBanner';
+import { useAuth } from '../../auth/AuthContext';
 
 const STATUS_BADGE = {
   new: 'bg-blue-100 text-blue-900 dark:bg-blue-900/40 dark:text-blue-100',
@@ -438,6 +441,7 @@ export default function TicketDetail() {
   const { ticketId } = useParams();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const { user } = useAuth();
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -537,6 +541,7 @@ export default function TicketDetail() {
 
       {ticket && (
         <div className="px-4 py-4 space-y-4">
+          <AdminViewingBanner roleLabel="Maintenance" />
           {/* Ticket header section */}
           <section data-testid="ticket-header">
             <div className="flex items-start justify-between gap-2 flex-wrap">
@@ -627,6 +632,15 @@ export default function TicketDetail() {
                 <PhotoUploadForm ticketId={ticketId} onPhotoAdded={handlePhotoAdded} />
               </div>
             )}
+          </section>
+
+          <section data-testid="ticket-audit">
+            <AuditTrail
+              user={user}
+              contentType="maintenance_ticket"
+              contentId={ticketId}
+              emptyMessage="No audit events yet for this ticket."
+            />
           </section>
         </div>
       )}


### PR DESCRIPTION
## Summary

Step 7_13 PR1/3 — lays the Admin Flow foundation for Stories 54-60.

- New `/api/v1/admin/` namespace under `bunk_logs/api/admin_flow/`, all gated by `IsOrgAdminOrSuperuser`.
- `GET /admin/dashboard/` — org snapshot + six Story 54 attention conditions (stale tickets / stale orders / unresolved flags / pending template review / digest delivery failures / translation pipeline failures) + recent significant audit events.
- `POST /admin/override-edit/` — Story 59 c8 override path for reflections and notes with required reason; writes `OVERRIDE_EDIT` AuditEvent via `core.audit.override_edit`.
- `/admin/audit/*` re-mounts the existing `AuditEventViewSet` so the audit-view meta-event is consistent on the admin path.
- Frontend: new `pages/admin/Dashboard.jsx` is the default at `/admin`; legacy `AdminHub` stays at `/admin/hub`. New `AdminViewingBanner` + `EditAsAdminButton`, plus AuditTrail wired into `MaintenanceTicketDetail` as the representative example.
- Docs skeleton at `docs/role_flows/admin.md`.

## Out of scope (deferred to PR2 / PR3)

- People / Assignments / Programs / Settings CRUD (PR2)
- Global search + Templates wrapper + bulk-import UI (PR3)
- Admin self-reflection card (deferred per plan)

## Test plan

- [x] `make test-backend` — 1065 passed, 1 pre-existing test_translation BeatRegistration failure unchanged
- [x] `npm run test` — 534 frontend tests passing
- [x] `ruff check` on new modules — clean
- [x] Manual: render `/admin/dashboard` as an admin user — six attention cards visible; recent activity shows operational events only.
- [x] Manual: override-edit a reflection with empty reason — 422.
- [x] Manual: override-edit a reflection across orgs — 404.

Made with [Cursor](https://cursor.com)