### PR TITLE
7_13b: Admin People + Assignments + Programs/Settings (PR2/3)

### DIFF
--- a/backend/bunk_logs/api/admin_flow/assignments.py
+++ b/backend/bunk_logs/api/admin_flow/assignments.py
@@ -1,0 +1,497 @@
+"""Admin Assignments unified API (Step 7_13 PR2, Story 56).
+
+Single ``/api/v1/admin/assignments/`` surface that fans out across five
+relationship types via a ``sub_tab`` query / body parameter:
+
+* ``uh_counselor``    -- :class:`Supervision` with
+                         ``target_type=MEMBERSHIP``
+* ``cc_caseload``     -- :class:`Supervision` with
+                         ``target_type=BUNK``
+* ``lt_team``         -- :class:`Supervision` with
+                         ``target_type=ROLE_IN_PROGRAM``
+* ``counselor_bunk``  -- :class:`AssignmentGroupMembership` (Counselor
+                         membership added to a Bunk as ``role_in_group='author'``)
+* ``camper_bunk``     -- :class:`AssignmentGroupMembership` (Camper /
+                         Student membership added as ``role_in_group='subject'``)
+
+Behavioural invariants enforced server-side:
+
+* Story 56 c4 + A4 -- backdated assignments do NOT retroactively
+  reattribute historical content. The endpoint silently records the
+  earliest *effective* start date (clamped to today) on the underlying
+  row, so historical reflections / supervisions stay anchored to whoever
+  authored them. The original ``start_date`` is preserved in
+  ``metadata.requested_start_date`` for auditability.
+* Story 56 c9 -- overlapping supervisions surface as a ``warnings``
+  array on the create response (they don't block).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from django.db import transaction
+from django.utils.dateparse import parse_date
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Supervision
+from bunk_logs.core.permissions import IsOrgAdminOrSuperuser
+
+from .common import viewer_or_403
+
+SUPERVISION_SUB_TABS = {
+    "uh_counselor": Supervision.TargetType.MEMBERSHIP,
+    "cc_caseload": Supervision.TargetType.BUNK,
+    "lt_team": Supervision.TargetType.ROLE_IN_PROGRAM,
+}
+GROUP_SUB_TABS = {"counselor_bunk", "camper_bunk"}
+VALID_SUB_TABS = set(SUPERVISION_SUB_TABS) | GROUP_SUB_TABS
+
+
+def _coerce_date(raw, fallback: date | None = None) -> date | None:
+    if not raw:
+        return fallback
+    if isinstance(raw, date):
+        return raw
+    return parse_date(str(raw)) or fallback
+
+
+def _serialize_supervision(s: Supervision) -> dict:
+    return {
+        "id": s.id,
+        "kind": "supervision",
+        "sub_tab": _sub_tab_for_supervision(s),
+        "supervisor_membership_id": s.supervisor_membership_id,
+        "supervisor_name": _person_name(s.supervisor_membership),
+        "target_type": s.target_type,
+        "target_membership_id": s.target_membership_id,
+        "target_role": s.target_role or None,
+        "target_program_id": s.target_program_id,
+        "target_bunk_id": s.target_bunk_id,
+        "start_date": s.start_date.isoformat() if s.start_date else None,
+        "end_date": s.end_date.isoformat() if s.end_date else None,
+        "is_active": s.is_active(),
+    }
+
+
+def _sub_tab_for_supervision(s: Supervision) -> str:
+    for tab, ttype in SUPERVISION_SUB_TABS.items():
+        if s.target_type == ttype:
+            return tab
+    return "unknown"
+
+
+def _serialize_group_membership(g: AssignmentGroupMembership) -> dict:
+    return {
+        "id": g.id,
+        "kind": "group_membership",
+        "sub_tab": "camper_bunk" if g.role_in_group == "subject" else "counselor_bunk",
+        "group_id": g.group_id,
+        "group_name": g.group.name if g.group_id else None,
+        "person_id": g.person_id,
+        "person_name": g.person.full_name if g.person_id else None,
+        "role_in_group": g.role_in_group,
+        "start_date": g.start_date.isoformat() if g.start_date else None,
+        "end_date": g.end_date.isoformat() if g.end_date else None,
+        "is_active": g.is_active,
+        "metadata": g.metadata or {},
+    }
+
+
+def _person_name(membership: Membership | None) -> str | None:
+    if membership is None or membership.person_id is None:
+        return None
+    return membership.person.full_name
+
+
+class AdminAssignmentsListCreateView(APIView):
+    """GET (list) + POST (create) across all five sub-tabs."""
+
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def get(self, request, *args, **kwargs):
+        viewer_or_403(request)
+        sub_tab = (request.query_params.get("sub_tab") or "").strip()
+        if sub_tab and sub_tab not in VALID_SUB_TABS:
+            return Response(
+                {"detail": f"Unknown sub_tab {sub_tab!r}."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        results: list[dict] = []
+        if not sub_tab or sub_tab in SUPERVISION_SUB_TABS:
+            qs = Supervision.objects.select_related(
+                "supervisor_membership__person", "target_membership__person",
+                "target_program", "target_bunk",
+            )
+            if sub_tab:
+                qs = qs.filter(target_type=SUPERVISION_SUB_TABS[sub_tab])
+            results.extend(_serialize_supervision(s) for s in qs.order_by("-created_at")[:500])
+        if not sub_tab or sub_tab in GROUP_SUB_TABS:
+            qs = AssignmentGroupMembership.objects.select_related("group", "person")
+            if sub_tab == "counselor_bunk":
+                qs = qs.filter(role_in_group="author", group__group_type="bunk")
+            elif sub_tab == "camper_bunk":
+                qs = qs.filter(role_in_group="subject", group__group_type__in=("bunk", "classroom"))
+            results.extend(
+                _serialize_group_membership(g)
+                for g in qs.order_by("-created_at")[:500]
+            )
+        return Response({"results": results})
+
+    def post(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        sub_tab = (request.data.get("sub_tab") or "").strip()
+        if sub_tab not in VALID_SUB_TABS:
+            return Response(
+                {"detail": "sub_tab is required (one of: " + ", ".join(sorted(VALID_SUB_TABS)) + ")."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if sub_tab in SUPERVISION_SUB_TABS:
+            return _create_supervision(ctx, request, sub_tab)
+        return _create_group_membership(ctx, request, sub_tab)
+
+
+# ---------------------------------------------------------------------------
+# Supervision create / patch
+# ---------------------------------------------------------------------------
+
+
+def _create_supervision(ctx, request, sub_tab: str) -> Response:
+    target_type = SUPERVISION_SUB_TABS[sub_tab]
+    sup_id = request.data.get("supervisor_membership_id")
+    sup = _resolve_membership(ctx, sup_id)
+    if sup is None:
+        return Response(
+            {"detail": "Valid supervisor_membership_id is required."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    requested_start = _coerce_date(request.data.get("start_date"), ctx.today)
+    effective_start = requested_start
+    backdated = requested_start < ctx.today
+    if backdated:
+        effective_start = ctx.today
+    end_date = _coerce_date(request.data.get("end_date"), None)
+
+    target_membership = None
+    target_role = ""
+    target_program = None
+    target_bunk = None
+    if target_type == Supervision.TargetType.MEMBERSHIP:
+        target_membership = _resolve_membership(ctx, request.data.get("target_membership_id"))
+        if target_membership is None:
+            return Response(
+                {"detail": "target_membership_id is required for uh_counselor."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+    elif target_type == Supervision.TargetType.BUNK:
+        target_bunk = _resolve_assignment_group(ctx, request.data.get("target_bunk_id"))
+        if target_bunk is None:
+            return Response(
+                {"detail": "target_bunk_id is required for cc_caseload."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+    elif target_type == Supervision.TargetType.ROLE_IN_PROGRAM:
+        target_role = (request.data.get("target_role") or "").strip()
+        target_program = _resolve_program(ctx, request.data.get("target_program_id"))
+        if not target_role or target_program is None:
+            return Response(
+                {"detail": "target_role and target_program_id are required for lt_team."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+    with transaction.atomic():
+        supervision = Supervision(
+            supervisor_membership=sup,
+            target_type=target_type,
+            target_membership=target_membership,
+            target_role=target_role,
+            target_program=target_program,
+            target_bunk=target_bunk,
+            start_date=effective_start,
+            end_date=end_date,
+        )
+        try:
+            supervision.save()
+        except Exception as exc:
+            return Response(
+                {"detail": str(exc)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        actor = ctx.membership or request.user
+        meta = {}
+        if backdated:
+            meta["requested_start_date"] = requested_start.isoformat()
+            meta["backdated_clamp"] = "Historical content remains anchored to original assignments."
+        audit_module.created(
+            actor, supervision, content_type="supervision",
+            after_state={
+                "supervisor_membership_id": supervision.supervisor_membership_id,
+                "target_type": supervision.target_type,
+                "start_date": supervision.start_date.isoformat(),
+                "end_date": supervision.end_date.isoformat() if supervision.end_date else None,
+            },
+            metadata=meta or None,
+        )
+
+    warnings = _conflict_warnings_for_supervision(supervision)
+    return Response(
+        {
+            "supervision": _serialize_supervision(supervision),
+            "warnings": warnings,
+            "backdated_clamped": backdated,
+            "requested_start_date": requested_start.isoformat() if backdated else None,
+        },
+        status=status.HTTP_201_CREATED,
+    )
+
+
+def _conflict_warnings_for_supervision(supervision: Supervision) -> list[dict]:
+    """Surface overlapping supervisions on the same target (not blocking).
+
+    Story 56 c9 -- the conflict warning is a soft heuristic the UI
+    renders next to the new row so a co-supervisor situation is
+    obvious.
+    """
+    overlap = Supervision.all_objects.filter(
+        target_type=supervision.target_type,
+    ).exclude(pk=supervision.pk).filter(
+        target_membership_id=supervision.target_membership_id,
+        target_role=supervision.target_role,
+        target_program_id=supervision.target_program_id,
+        target_bunk_id=supervision.target_bunk_id,
+    )
+    return [
+        {
+            "supervision_id": s.id,
+            "supervisor_membership_id": s.supervisor_membership_id,
+            "supervisor_name": _person_name(s.supervisor_membership),
+            "kind": "co_supervisor",
+        }
+        for s in overlap.select_related("supervisor_membership__person")[:10]
+    ]
+
+
+# ---------------------------------------------------------------------------
+# AssignmentGroupMembership create / patch
+# ---------------------------------------------------------------------------
+
+
+def _create_group_membership(ctx, request, sub_tab: str) -> Response:
+    group = _resolve_assignment_group(ctx, request.data.get("group_id"))
+    if group is None:
+        return Response(
+            {"detail": "Valid group_id is required."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    person = _resolve_person(ctx, request.data.get("person_id"))
+    if person is None:
+        return Response(
+            {"detail": "Valid person_id is required."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    role_in_group = "author" if sub_tab == "counselor_bunk" else "subject"
+
+    requested_start = _coerce_date(request.data.get("start_date"), ctx.today)
+    effective_start = requested_start
+    backdated = requested_start < ctx.today
+    if backdated:
+        effective_start = ctx.today
+
+    if AssignmentGroupMembership.all_objects.filter(
+        group=group, person=person, role_in_group=role_in_group,
+    ).exists():
+        return Response(
+            {"detail": "Person already assigned to this group with this role."},
+            status=status.HTTP_409_CONFLICT,
+        )
+    meta = dict(request.data.get("metadata") or {})
+    if backdated:
+        meta.update({
+            "requested_start_date": requested_start.isoformat(),
+            "backdated_clamp": "Historical content remains anchored to original assignments.",
+        })
+    with transaction.atomic():
+        membership = AssignmentGroupMembership.all_objects.create(
+            group=group,
+            person=person,
+            role_in_group=role_in_group,
+            start_date=effective_start,
+            end_date=_coerce_date(request.data.get("end_date")),
+            is_active=request.data.get("is_active", True),
+            metadata=meta,
+        )
+        actor = ctx.membership or request.user
+        audit_module.created(
+            actor, membership, content_type="assignment_group_membership",
+            after_state={
+                "group_id": membership.group_id,
+                "person_id": membership.person_id,
+                "role_in_group": membership.role_in_group,
+                "start_date": membership.start_date.isoformat() if membership.start_date else None,
+            },
+        )
+    return Response(
+        {
+            "assignment_group_membership": _serialize_group_membership(membership),
+            "backdated_clamped": backdated,
+            "requested_start_date": requested_start.isoformat() if backdated else None,
+        },
+        status=status.HTTP_201_CREATED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Detail (PATCH) -- soft-end only
+# ---------------------------------------------------------------------------
+
+
+class AdminAssignmentDetailView(APIView):
+    """PATCH `/admin/assignments/<id>/?kind=supervision|group_membership`."""
+
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def patch(self, request, assignment_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        kind = (request.query_params.get("kind") or request.data.get("kind") or "").strip()
+        if kind == "supervision":
+            return self._patch_supervision(ctx, request, assignment_id)
+        if kind == "group_membership":
+            return self._patch_group_membership(ctx, request, assignment_id)
+        return Response(
+            {"detail": "kind must be 'supervision' or 'group_membership'."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    def _patch_supervision(self, ctx, request, pk) -> Response:
+        try:
+            s = Supervision.all_objects.select_related(
+                "supervisor_membership__person", "supervisor_membership__program",
+            ).get(pk=pk)
+        except (Supervision.DoesNotExist, ValueError):
+            return Response({"detail": "Supervision not found."}, status=status.HTTP_404_NOT_FOUND)
+        if s.supervisor_membership.program.organization_id != ctx.organization.id:
+            return Response({"detail": "Supervision not found."}, status=status.HTTP_404_NOT_FOUND)
+        if "end_date" not in request.data:
+            return Response(
+                {"detail": "Only end_date may be patched on a Supervision."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        before = {
+            "end_date": s.end_date.isoformat() if s.end_date else None,
+        }
+        s.end_date = _coerce_date(request.data.get("end_date"))
+        s.save(update_fields=["end_date"])
+        after = {"end_date": s.end_date.isoformat() if s.end_date else None}
+        actor = ctx.membership or request.user
+        if s.end_date is not None:
+            audit_module.deactivated(
+                actor, s,
+                before_state=before, after_state=after,
+                content_type="supervision",
+                reason=(request.data.get("reason") or "").strip(),
+            )
+        else:
+            audit_module.edited(actor, s, before, after, content_type="supervision")
+        return Response(_serialize_supervision(s))
+
+    def _patch_group_membership(self, ctx, request, pk) -> Response:
+        try:
+            g = AssignmentGroupMembership.all_objects.select_related(
+                "group", "person",
+            ).get(pk=pk)
+        except (AssignmentGroupMembership.DoesNotExist, ValueError):
+            return Response(
+                {"detail": "AssignmentGroupMembership not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        if g.group.organization_id != ctx.organization.id:
+            return Response(
+                {"detail": "AssignmentGroupMembership not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        before = {
+            "end_date": g.end_date.isoformat() if g.end_date else None,
+            "is_active": g.is_active,
+        }
+        changed: list[str] = []
+        if "end_date" in request.data:
+            g.end_date = _coerce_date(request.data.get("end_date"))
+            changed.append("end_date")
+        if "is_active" in request.data:
+            g.is_active = bool(request.data.get("is_active"))
+            changed.append("is_active")
+        if changed:
+            g.save(update_fields=changed)
+        after = {
+            "end_date": g.end_date.isoformat() if g.end_date else None,
+            "is_active": g.is_active,
+        }
+        actor = ctx.membership or request.user
+        if g.is_active is False:
+            audit_module.deactivated(
+                actor, g,
+                before_state=before, after_state=after,
+                content_type="assignment_group_membership",
+                reason=(request.data.get("reason") or "").strip(),
+            )
+        else:
+            audit_module.edited(
+                actor, g, before, after,
+                content_type="assignment_group_membership",
+            )
+        return Response(_serialize_group_membership(g))
+
+
+# ---------------------------------------------------------------------------
+# Resolvers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_membership(ctx, raw) -> Membership | None:
+    if raw in (None, ""):
+        return None
+    try:
+        return Membership.all_objects.select_related("program", "person").get(
+            pk=raw, program__organization=ctx.organization,
+        )
+    except (Membership.DoesNotExist, ValueError):
+        return None
+
+
+def _resolve_assignment_group(ctx, raw) -> AssignmentGroup | None:
+    if raw in (None, ""):
+        return None
+    try:
+        return AssignmentGroup.all_objects.get(
+            pk=raw, organization=ctx.organization,
+        )
+    except (AssignmentGroup.DoesNotExist, ValueError):
+        return None
+
+
+def _resolve_program(ctx, raw) -> Program | None:
+    if raw in (None, ""):
+        return None
+    try:
+        return Program.all_objects.get(pk=raw, organization=ctx.organization)
+    except (Program.DoesNotExist, ValueError):
+        return None
+
+
+def _resolve_person(ctx, raw) -> Person | None:
+    if raw in (None, ""):
+        return None
+    try:
+        return Person.all_objects.get(pk=raw, organization=ctx.organization)
+    except (Person.DoesNotExist, ValueError):
+        return None

--- a/backend/bunk_logs/api/admin_flow/dashboard.py
+++ b/backend/bunk_logs/api/admin_flow/dashboard.py
@@ -320,7 +320,7 @@ def _digest_delivery_failure_count(organization) -> int:
     failures in the last 7 days surfaces as one card-worthy event.
     """
     try:
-        from bunk_logs.messaging.models import EmailLog  # noqa: PLC0415
+        from bunk_logs.messaging.models import EmailLog
     except ImportError:  # pragma: no cover - messaging app should always be installed
         return 0
     since = timezone.now() - timedelta(days=7)
@@ -345,7 +345,7 @@ def _digest_delivery_failure_count(organization) -> int:
 def _translation_failure_count(organization) -> int:
     """Terminal translation failures in the last 24h for this org."""
     try:
-        from bunk_logs.core.models import TranslationRecord  # noqa: PLC0415
+        from bunk_logs.core.models import TranslationRecord
     except ImportError:  # pragma: no cover
         return 0
     since = timezone.now() - timedelta(hours=TRANSLATION_FAILURE_LOOKBACK_HOURS)

--- a/backend/bunk_logs/api/admin_flow/dashboard.py
+++ b/backend/bunk_logs/api/admin_flow/dashboard.py
@@ -320,7 +320,7 @@ def _digest_delivery_failure_count(organization) -> int:
     failures in the last 7 days surfaces as one card-worthy event.
     """
     try:
-        from bunk_logs.messaging.models import EmailLog
+        from bunk_logs.messaging.models import EmailLog  # noqa: PLC0415
     except ImportError:  # pragma: no cover - messaging app should always be installed
         return 0
     since = timezone.now() - timedelta(days=7)
@@ -345,7 +345,7 @@ def _digest_delivery_failure_count(organization) -> int:
 def _translation_failure_count(organization) -> int:
     """Terminal translation failures in the last 24h for this org."""
     try:
-        from bunk_logs.core.models import TranslationRecord
+        from bunk_logs.core.models import TranslationRecord  # noqa: PLC0415
     except ImportError:  # pragma: no cover
         return 0
     since = timezone.now() - timedelta(hours=TRANSLATION_FAILURE_LOOKBACK_HOURS)

--- a/backend/bunk_logs/api/admin_flow/people.py
+++ b/backend/bunk_logs/api/admin_flow/people.py
@@ -1,0 +1,588 @@
+"""Admin People + Membership management (Step 7_13 PR2, Story 55).
+
+Endpoints under ``/api/v1/admin/``:
+
+* ``GET    /people/``                          list + filter
+* ``POST   /people/``                          create Person (with first Membership)
+* ``GET    /people/<id>/``                     profile (identity + memberships + recent activity)
+* ``PATCH  /people/<id>/``                     edit identity (audit'd)
+* ``POST   /people/<id>/memberships/``         add Membership
+* ``PATCH  /memberships/<id>/``                edit Membership role/dates/tags/grade
+* ``POST   /memberships/<id>/deactivate/``     soft-deactivate
+* ``POST   /people/<id>/invite/``              trigger invitation email (audited)
+
+Design notes:
+
+* All writes funnel through :mod:`bunk_logs.core.audit` so the action
+  appears in the cross-cutting audit trail (Step 7_4). ``Membership``
+  inherits audit content-type ``membership`` from its model name.
+* Person email conflicts (Story 55 c9) return 409 with the existing
+  Person + Memberships payload so the UI can offer "Add membership to
+  the existing record" instead of forcing a duplicate.
+* `Membership.role` is immutable post-create (capability derives from
+  it; mutations would corrupt the RBAC layer). PATCH /memberships/<id>/
+  silently ignores `role` and `capability`.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from django.db import transaction
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.models import AuditEvent
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.permissions import IsOrgAdminOrSuperuser
+
+from .common import viewer_or_403
+
+VALID_ROLES = frozenset(role for role, _ in Membership.ROLES)
+RECENT_ACTIVITY_DAYS = 30
+
+
+# ---------------------------------------------------------------------------
+# Serialisation helpers (lean, hand-rolled — no DRF serializer overhead)
+# ---------------------------------------------------------------------------
+
+
+def _serialize_membership(m: Membership) -> dict:
+    return {
+        "id": m.id,
+        "program_id": m.program_id,
+        "program_name": m.program.name if m.program_id else None,
+        "role": m.role,
+        "capability": m.capability,
+        "grade_level": m.grade_level,
+        "tags": m.tags or [],
+        "start_date": m.start_date.isoformat() if m.start_date else None,
+        "end_date": m.end_date.isoformat() if m.end_date else None,
+        "is_active": m.is_active,
+        "metadata": m.metadata or {},
+        "created_at": m.created_at.isoformat() if m.created_at else None,
+    }
+
+
+def _serialize_person(person: Person, *, include_memberships: bool = False) -> dict:
+    payload: dict[str, Any] = {
+        "id": person.id,
+        "organization_id": person.organization_id,
+        "first_name": person.first_name,
+        "last_name": person.last_name,
+        "preferred_name": person.preferred_name,
+        "full_name": person.full_name,
+        "email": person.email,
+        "date_of_birth": person.date_of_birth.isoformat() if person.date_of_birth else None,
+        "preferred_language": person.preferred_language,
+        "translation_preference": person.translation_preference,
+        "external_ids": person.external_ids or {},
+        "has_user": person.user_id is not None,
+        "created_at": person.created_at.isoformat() if person.created_at else None,
+    }
+    if include_memberships:
+        payload["memberships"] = [
+            _serialize_membership(m)
+            for m in Membership.all_objects.filter(person=person)
+            .select_related("program")
+            .order_by("-is_active", "-created_at")
+        ]
+    return payload
+
+
+def _person_snapshot(person: Person) -> dict:
+    return {
+        "first_name": person.first_name,
+        "last_name": person.last_name,
+        "preferred_name": person.preferred_name,
+        "email": person.email,
+        "preferred_language": person.preferred_language,
+        "translation_preference": person.translation_preference,
+        "external_ids": person.external_ids or {},
+        "date_of_birth": person.date_of_birth.isoformat() if person.date_of_birth else None,
+    }
+
+
+def _membership_snapshot(m: Membership) -> dict:
+    return {
+        "role": m.role,
+        "capability": m.capability,
+        "grade_level": m.grade_level,
+        "tags": list(m.tags or []),
+        "start_date": m.start_date.isoformat() if m.start_date else None,
+        "end_date": m.end_date.isoformat() if m.end_date else None,
+        "is_active": m.is_active,
+        "metadata": dict(m.metadata or {}),
+    }
+
+
+def _resolve_program(ctx, program_id) -> Program | None:
+    if program_id in (None, ""):
+        return None
+    try:
+        return Program.all_objects.get(pk=program_id, organization=ctx.organization)
+    except Program.DoesNotExist:
+        return None
+
+
+def _normalize_tags(values) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for v in values or []:
+        if v is None:
+            continue
+        t = str(v).strip().lower()
+        if not t or t in seen:
+            continue
+        seen.add(t)
+        out.append(t)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# People list + create
+# ---------------------------------------------------------------------------
+
+
+class AdminPeopleListCreateView(APIView):
+    """``GET`` list + ``POST`` create."""
+
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        qs = Person.all_objects.filter(organization=ctx.organization)
+
+        search = (request.query_params.get("search") or "").strip()
+        if search:
+            qs = (
+                qs.filter(last_name__icontains=search)
+                | qs.filter(first_name__icontains=search)
+                | qs.filter(preferred_name__icontains=search)
+                | qs.filter(email__icontains=search)
+            ).distinct()
+
+        role = (request.query_params.get("role") or "").strip()
+        if role:
+            qs = qs.filter(memberships__role=role, memberships__is_active=True).distinct()
+
+        program_id = (request.query_params.get("program") or "").strip()
+        if program_id:
+            qs = qs.filter(memberships__program_id=program_id).distinct()
+
+        tag = (request.query_params.get("tag") or "").strip().lower()
+        if tag:
+            qs = qs.filter(memberships__tags__contains=[tag]).distinct()
+
+        status_filter = (request.query_params.get("status") or "").strip().lower()
+        if status_filter == "active":
+            qs = qs.filter(memberships__is_active=True).distinct()
+        elif status_filter == "inactive":
+            # Anyone whose every membership is deactivated.
+            qs = qs.exclude(memberships__is_active=True).distinct()
+
+        qs = qs.order_by("last_name", "first_name")
+        try:
+            page_size = max(1, min(int(request.query_params.get("page_size", "100")), 500))
+        except (TypeError, ValueError):
+            page_size = 100
+        try:
+            offset = max(0, int(request.query_params.get("offset", "0")))
+        except (TypeError, ValueError):
+            offset = 0
+        total = qs.count()
+        items = list(qs[offset : offset + page_size])
+        return Response({
+            "count": total,
+            "offset": offset,
+            "page_size": page_size,
+            "results": [_serialize_person(p) for p in items],
+        })
+
+    def post(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        data = request.data or {}
+        first_name = (data.get("first_name") or "").strip()
+        last_name = (data.get("last_name") or "").strip()
+        if not first_name or not last_name:
+            return Response(
+                {"detail": "first_name and last_name are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        email = (data.get("email") or "").strip()
+        membership_payload = data.get("membership") or None
+        if not isinstance(membership_payload, dict):
+            return Response(
+                {"detail": "A `membership` object is required to create a Person."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Email conflict (Story 55 c9).
+        if email:
+            existing = Person.all_objects.filter(
+                organization=ctx.organization, email__iexact=email,
+            ).first()
+            if existing is not None:
+                return Response(
+                    {
+                        "detail": "A Person with this email already exists in this org.",
+                        "existing_person": _serialize_person(existing, include_memberships=True),
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+        # Resolve / validate program for the initial Membership.
+        program = _resolve_program(ctx, membership_payload.get("program_id"))
+        if program is None:
+            return Response(
+                {"detail": "Valid membership.program_id is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        role = (membership_payload.get("role") or "").strip()
+        if role not in VALID_ROLES:
+            return Response(
+                {"detail": f"Unknown role {role!r}."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        actor = ctx.membership or request.user
+        with transaction.atomic():
+            person = Person.all_objects.create(
+                organization=ctx.organization,
+                first_name=first_name,
+                last_name=last_name,
+                preferred_name=(data.get("preferred_name") or "").strip(),
+                email=email,
+                preferred_language=(data.get("preferred_language") or "en"),
+                external_ids=data.get("external_ids") or {},
+            )
+            membership = Membership.all_objects.create(
+                program=program,
+                person=person,
+                role=role,
+                grade_level=membership_payload.get("grade_level"),
+                tags=_normalize_tags(membership_payload.get("tags") or []),
+                start_date=membership_payload.get("start_date") or None,
+                end_date=membership_payload.get("end_date") or None,
+                is_active=membership_payload.get("is_active", True),
+                metadata=membership_payload.get("metadata") or {},
+            )
+            audit_module.created(
+                actor, membership, after_state=_membership_snapshot(membership),
+            )
+        return Response(
+            _serialize_person(person, include_memberships=True),
+            status=status.HTTP_201_CREATED,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Person detail / patch
+# ---------------------------------------------------------------------------
+
+
+PERSON_PATCH_FIELDS = (
+    "first_name",
+    "last_name",
+    "preferred_name",
+    "email",
+    "date_of_birth",
+    "preferred_language",
+    "translation_preference",
+    "external_ids",
+)
+
+
+class AdminPeopleDetailView(APIView):
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def get(self, request, person_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        person = _get_person_or_404(ctx, person_id)
+        if person is None:
+            return _not_found("Person")
+        payload = _serialize_person(person, include_memberships=True)
+        payload["recent_activity"] = _recent_activity_for_person(ctx, person)
+        return Response(payload)
+
+    def patch(self, request, person_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        person = _get_person_or_404(ctx, person_id)
+        if person is None:
+            return _not_found("Person")
+        before = _person_snapshot(person)
+        changed: list[str] = []
+        for field in PERSON_PATCH_FIELDS:
+            if field not in request.data:
+                continue
+            value = request.data[field]
+            if field == "email" and value:
+                value = str(value).strip()
+                # Conflict guard on email change.
+                if value.lower() != (person.email or "").lower():
+                    other = Person.all_objects.filter(
+                        organization=ctx.organization, email__iexact=value,
+                    ).exclude(pk=person.pk).first()
+                    if other is not None:
+                        return Response(
+                            {"detail": "Another Person already has this email."},
+                            status=status.HTTP_409_CONFLICT,
+                        )
+            current = getattr(person, field, None)
+            if current == value:
+                continue
+            setattr(person, field, value)
+            changed.append(field)
+        if changed:
+            person.save(update_fields=changed)
+            actor = ctx.membership or request.user
+            audit_module.edited(
+                actor, person, before, _person_snapshot(person),
+                content_type="person",
+            )
+        return Response(_serialize_person(person, include_memberships=True))
+
+
+def _get_person_or_404(ctx, person_id) -> Person | None:
+    try:
+        return Person.all_objects.get(pk=person_id, organization=ctx.organization)
+    except (Person.DoesNotExist, ValueError):
+        return None
+
+
+def _not_found(label: str) -> Response:
+    return Response(
+        {"detail": f"{label} not found in this org."},
+        status=status.HTTP_404_NOT_FOUND,
+    )
+
+
+def _recent_activity_for_person(ctx, person: Person) -> list[dict]:
+    """Last 30 days of AuditEvent rows tied to this Person's content."""
+    since = timezone.now() - timedelta(days=RECENT_ACTIVITY_DAYS)
+    membership_ids = list(
+        Membership.all_objects.filter(person=person).values_list("id", flat=True),
+    )
+    qs = AuditEvent.all_objects.filter(
+        organization=ctx.organization, created_at__gte=since,
+    ).filter(
+        # Either the audit row's actor is this Person's Membership, or
+        # the content row's PK matches this person/their membership.
+        # The cross-cutting filter is intentionally loose; the goal is
+        # the "Recent activity" tab feels useful, not exhaustive.
+    )
+    rows = list(
+        qs.filter(
+            actor_membership_id__in=membership_ids,
+        ).order_by("-created_at")[:50],
+    )
+    # Plus events about Person's Memberships directly.
+    membership_rows = list(
+        AuditEvent.all_objects.filter(
+            organization=ctx.organization,
+            content_type="membership",
+            content_id__in=[str(mid) for mid in membership_ids],
+            created_at__gte=since,
+        ).order_by("-created_at")[:50],
+    )
+    seen: set = set()
+    combined: list[AuditEvent] = []
+    for ev in [*rows, *membership_rows]:
+        if ev.id in seen:
+            continue
+        seen.add(ev.id)
+        combined.append(ev)
+    combined.sort(key=lambda e: e.created_at, reverse=True)
+    return [
+        {
+            "id": str(ev.id),
+            "event_type": ev.event_type,
+            "content_type": ev.content_type,
+            "content_id": ev.content_id,
+            "created_at": ev.created_at.isoformat(),
+            "is_admin_override": ev.is_admin_override,
+            "reason_note": ev.reason_note or "",
+        }
+        for ev in combined[:RECENT_ACTIVITY_DAYS]
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Person -> add Membership
+# ---------------------------------------------------------------------------
+
+
+class AdminPersonMembershipsView(APIView):
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def post(self, request, person_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        person = _get_person_or_404(ctx, person_id)
+        if person is None:
+            return _not_found("Person")
+        program = _resolve_program(ctx, request.data.get("program_id"))
+        if program is None:
+            return Response(
+                {"detail": "Valid program_id is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        role = (request.data.get("role") or "").strip()
+        if role not in VALID_ROLES:
+            return Response(
+                {"detail": f"Unknown role {role!r}."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if Membership.all_objects.filter(
+            program=program, person=person, role=role,
+        ).exists():
+            return Response(
+                {"detail": "Person already has this (program, role) Membership."},
+                status=status.HTTP_409_CONFLICT,
+            )
+        actor = ctx.membership or request.user
+        with transaction.atomic():
+            membership = Membership.all_objects.create(
+                program=program,
+                person=person,
+                role=role,
+                grade_level=request.data.get("grade_level"),
+                tags=_normalize_tags(request.data.get("tags") or []),
+                start_date=request.data.get("start_date") or None,
+                end_date=request.data.get("end_date") or None,
+                is_active=request.data.get("is_active", True),
+                metadata=request.data.get("metadata") or {},
+            )
+            audit_module.created(
+                actor, membership, after_state=_membership_snapshot(membership),
+            )
+        return Response(_serialize_membership(membership), status=status.HTTP_201_CREATED)
+
+
+# ---------------------------------------------------------------------------
+# Membership patch + deactivate
+# ---------------------------------------------------------------------------
+
+
+MEMBERSHIP_PATCH_FIELDS = (
+    "grade_level",
+    "tags",
+    "start_date",
+    "end_date",
+    "is_active",
+    "metadata",
+)
+
+
+class AdminMembershipDetailView(APIView):
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def patch(self, request, membership_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        membership = _get_membership_or_404(ctx, membership_id)
+        if membership is None:
+            return _not_found("Membership")
+        before = _membership_snapshot(membership)
+        changed: list[str] = []
+        for field in MEMBERSHIP_PATCH_FIELDS:
+            if field not in request.data:
+                continue
+            value = request.data[field]
+            if field == "tags":
+                value = _normalize_tags(value or [])
+            current = getattr(membership, field, None)
+            if current == value:
+                continue
+            setattr(membership, field, value)
+            changed.append(field)
+        if changed:
+            membership.save(update_fields=changed)
+            actor = ctx.membership or request.user
+            audit_module.edited(
+                actor, membership, before, _membership_snapshot(membership),
+            )
+        return Response(_serialize_membership(membership))
+
+
+class AdminMembershipDeactivateView(APIView):
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def post(self, request, membership_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        membership = _get_membership_or_404(ctx, membership_id)
+        if membership is None:
+            return _not_found("Membership")
+        reason = (request.data.get("reason") or "").strip()
+        if membership.is_active is False:
+            return Response(_serialize_membership(membership))
+        before = _membership_snapshot(membership)
+        membership.is_active = False
+        if not membership.end_date:
+            membership.end_date = ctx.today
+        membership.save(update_fields=["is_active", "end_date"])
+        actor = ctx.membership or request.user
+        audit_module.deactivated(
+            actor, membership,
+            before_state=before, after_state=_membership_snapshot(membership),
+            reason=reason,
+        )
+        return Response(_serialize_membership(membership))
+
+
+def _get_membership_or_404(ctx, membership_id) -> Membership | None:
+    try:
+        return Membership.all_objects.select_related("program", "person").get(
+            pk=membership_id, program__organization=ctx.organization,
+        )
+    except (Membership.DoesNotExist, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Invite
+# ---------------------------------------------------------------------------
+
+
+class AdminPersonInviteView(APIView):
+    """Trigger an invitation email for a Person (Story 55).
+
+    PR2 ships the audited affordance + payload contract; actual email
+    delivery is wired up in a follow-up by reusing the messaging app.
+    The audit row is enough to satisfy "we know who invited who when"
+    and lets the UI surface a "Sent" confirmation immediately.
+    """
+
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def post(self, request, person_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        person = _get_person_or_404(ctx, person_id)
+        if person is None:
+            return _not_found("Person")
+        if not person.email:
+            return Response(
+                {"detail": "Person has no email -- cannot send invitation."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        actor = ctx.membership or request.user
+        audit_module.created(
+            actor, person,
+            after_state={
+                "invitation_sent": True,
+                "recipient_email": person.email,
+            },
+            content_type="person_invitation",
+            metadata={
+                "channel": "email",
+                "scheduled": bool(request.data.get("scheduled")),
+            },
+        )
+        return Response({
+            "status": "queued",
+            "recipient_email": person.email,
+        })

--- a/backend/bunk_logs/api/admin_flow/programs.py
+++ b/backend/bunk_logs/api/admin_flow/programs.py
@@ -1,0 +1,382 @@
+"""Admin Programs + Settings management (Step 7_13 PR2, Stories 58 + 56).
+
+Endpoints under ``/api/v1/admin/``:
+
+* ``GET    /programs/``                 list active + archived programs
+* ``POST   /programs/``                 create
+* ``GET    /programs/<id>/``            detail
+* ``PATCH  /programs/<id>/``            edit identity, dates, settings
+* ``POST   /programs/<id>/end/``        End Program transaction (Story 58 c5)
+* ``GET    /settings/``                 org-level settings JSON
+* ``PATCH  /settings/``                 partial update
+
+Key invariants:
+
+* ``POST /programs/<id>/end/`` runs inside a single ``transaction.atomic``
+  block so partial failures roll back. Memberships are soft-deactivated
+  (``is_active=False`` + ``end_date=today``), open orders and tickets
+  are closed via the state machine (``unable_to_fulfill``) with an
+  ``override_close`` audit row, and an end-of-program AuditEvent is
+  written per affected row.
+* End Program refuses (400) when there are still open Camper Care
+  flags -- those need to be resolved or migrated by the Admin
+  intentionally rather than swept up automatically.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from django.db import transaction
+from django.utils.dateparse import parse_date
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.models import AuditEvent
+from bunk_logs.core.models import Flag
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Order
+from bunk_logs.core.models import Program
+from bunk_logs.core.permissions import IsOrgAdminOrSuperuser
+from bunk_logs.core.state_machine import OrderStateMachine
+
+from .common import viewer_or_403
+
+PROGRAM_PATCH_FIELDS = (
+    "name",
+    "slug",
+    "program_type",
+    "start_date",
+    "end_date",
+    "settings",
+    "is_active",
+)
+SETTINGS_PATCH_FIELDS = (
+    "settings",
+    "supported_languages",
+    "rollover_hour",
+    "tag_vocabulary",
+)
+
+
+def _serialize_program(p: Program) -> dict:
+    return {
+        "id": p.id,
+        "name": p.name,
+        "slug": p.slug,
+        "program_type": p.program_type,
+        "start_date": p.start_date.isoformat() if p.start_date else None,
+        "end_date": p.end_date.isoformat() if p.end_date else None,
+        "is_active": p.is_active,
+        "settings": p.settings or {},
+        "created_at": p.created_at.isoformat() if p.created_at else None,
+    }
+
+
+def _program_snapshot(p: Program) -> dict:
+    return {
+        "name": p.name,
+        "slug": p.slug,
+        "program_type": p.program_type,
+        "start_date": p.start_date.isoformat() if p.start_date else None,
+        "end_date": p.end_date.isoformat() if p.end_date else None,
+        "is_active": p.is_active,
+        "settings": dict(p.settings or {}),
+    }
+
+
+def _coerce_date(raw, fallback: date | None = None) -> date | None:
+    if not raw:
+        return fallback
+    if isinstance(raw, date):
+        return raw
+    return parse_date(str(raw)) or fallback
+
+
+# ---------------------------------------------------------------------------
+# Programs list / create
+# ---------------------------------------------------------------------------
+
+
+class AdminProgramsListCreateView(APIView):
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        qs = Program.all_objects.filter(organization=ctx.organization)
+        status_filter = (request.query_params.get("status") or "").strip().lower()
+        if status_filter == "active":
+            qs = qs.filter(is_active=True)
+        elif status_filter == "archived":
+            qs = qs.filter(is_active=False)
+        return Response({
+            "results": [_serialize_program(p) for p in qs.order_by("-start_date")],
+        })
+
+    def post(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        data = request.data or {}
+        actor = ctx.membership or request.user
+        try:
+            program = Program(
+                organization=ctx.organization,
+                name=data.get("name") or "",
+                slug=data.get("slug") or "",
+                program_type=data.get("program_type") or "",
+                start_date=_coerce_date(data.get("start_date")),
+                end_date=_coerce_date(data.get("end_date")),
+                settings=data.get("settings") or {},
+                is_active=bool(data.get("is_active", True)),
+            )
+            with transaction.atomic():
+                program.save()
+                audit_module.created(
+                    actor, program, content_type="program",
+                    after_state=_program_snapshot(program),
+                )
+        except Exception as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(_serialize_program(program), status=status.HTTP_201_CREATED)
+
+
+# ---------------------------------------------------------------------------
+# Program detail / patch / end
+# ---------------------------------------------------------------------------
+
+
+class AdminProgramDetailView(APIView):
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def get(self, request, program_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        program = _get_program(ctx, program_id)
+        if program is None:
+            return _not_found()
+        return Response(_serialize_program(program))
+
+    def patch(self, request, program_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        program = _get_program(ctx, program_id)
+        if program is None:
+            return _not_found()
+        before = _program_snapshot(program)
+        changed: list[str] = []
+        for field in PROGRAM_PATCH_FIELDS:
+            if field not in request.data:
+                continue
+            value = request.data[field]
+            if field in ("start_date", "end_date"):
+                value = _coerce_date(value, getattr(program, field, None))
+            current = getattr(program, field, None)
+            if current == value:
+                continue
+            setattr(program, field, value)
+            changed.append(field)
+        if changed:
+            try:
+                with transaction.atomic():
+                    program.save(update_fields=changed)
+                    actor = ctx.membership or request.user
+                    audit_module.edited(
+                        actor, program, before, _program_snapshot(program),
+                        content_type="program",
+                    )
+            except Exception as exc:
+                return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(_serialize_program(program))
+
+
+class AdminProgramEndView(APIView):
+    """``POST /admin/programs/<id>/end/`` -- Story 58 c5 + Story 56 cleanup.
+
+    All side effects run in a single transaction. The response body
+    summarises the rows touched so the UI can render the typed
+    confirmation summary.
+    """
+
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def post(self, request, program_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        program = _get_program(ctx, program_id)
+        if program is None:
+            return _not_found()
+        reason = (request.data.get("reason") or "").strip()
+        if not reason:
+            return Response(
+                {"detail": "reason is required to end a program."},
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
+        if program.is_active is False:
+            return Response(
+                {"detail": "Program is already ended/inactive."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        open_flags = Flag.all_objects.filter(
+            organization=ctx.organization, program=program,
+            status=Flag.Status.ACTIVE,
+        ).count()
+        if open_flags:
+            return Response(
+                {"detail": (
+                    f"Refusing to end program with {open_flags} active Camper Care "
+                    "flags. Resolve or reassign first."
+                )},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        actor = ctx.membership or request.user
+        end_date = ctx.today
+
+        with transaction.atomic():
+            # Deactivate active Memberships.
+            ms_qs = Membership.all_objects.filter(program=program, is_active=True)
+            deactivated_count = 0
+            for m in list(ms_qs):
+                before = {"is_active": m.is_active, "end_date": m.end_date.isoformat() if m.end_date else None}
+                m.is_active = False
+                if not m.end_date:
+                    m.end_date = end_date
+                m.save(update_fields=["is_active", "end_date"])
+                audit_module.deactivated(
+                    actor, m,
+                    before_state=before,
+                    after_state={"is_active": False, "end_date": end_date.isoformat()},
+                    reason=f"Program ended: {reason}",
+                )
+                deactivated_count += 1
+
+            # Close open orders.
+            open_orders = list(
+                Order.all_objects.filter(
+                    organization=ctx.organization, program=program,
+                    status__in=(OrderStateMachine.NEW, OrderStateMachine.IN_PROGRESS),
+                ),
+            )
+            for o in open_orders:
+                before = {"status": o.status}
+                o.status = OrderStateMachine.UNABLE_TO_FULFILL
+                o.save(update_fields=["status"])
+                audit_module.override_close(
+                    actor, o,
+                    before_state=before, after_state={"status": o.status},
+                    reason=f"Program ended: {reason}",
+                )
+
+            # Close open maintenance tickets.
+            open_tickets = list(
+                MaintenanceTicket.all_objects.filter(
+                    organization=ctx.organization, program=program,
+                    status__in=(OrderStateMachine.NEW, OrderStateMachine.IN_PROGRESS),
+                ),
+            )
+            for t in open_tickets:
+                before = {"status": t.status}
+                t.status = OrderStateMachine.UNABLE_TO_FULFILL
+                t.save(update_fields=["status"])
+                audit_module.override_close(
+                    actor, t,
+                    before_state=before, after_state={"status": t.status},
+                    reason=f"Program ended: {reason}",
+                )
+
+            before_prog = _program_snapshot(program)
+            program.is_active = False
+            # If End Program runs before the originally scheduled start
+            # date (rare but legitimate — e.g. cancellation during setup
+            # for TBE Fall 2026), respect the model's check constraint
+            # ``end_date >= start_date`` by leaving ``end_date`` alone.
+            # ``is_active=False`` is the canonical "ended" signal; the
+            # ``ended_at`` is captured on the response summary and in the
+            # audit row.
+            if program.start_date and end_date >= program.start_date:
+                program.end_date = end_date
+                program.save(update_fields=["is_active", "end_date"])
+            else:
+                program.save(update_fields=["is_active"])
+            audit_module.deactivated(
+                actor, program, content_type="program",
+                before_state=before_prog,
+                after_state=_program_snapshot(program),
+                reason=reason,
+            )
+
+        return Response({
+            "program": _serialize_program(program),
+            "summary": {
+                "memberships_deactivated": deactivated_count,
+                "orders_closed": len(open_orders),
+                "maintenance_tickets_closed": len(open_tickets),
+                "ended_at": end_date.isoformat(),
+            },
+        })
+
+
+def _get_program(ctx, program_id) -> Program | None:
+    try:
+        return Program.all_objects.get(pk=program_id, organization=ctx.organization)
+    except (Program.DoesNotExist, ValueError):
+        return None
+
+
+def _not_found() -> Response:
+    return Response({"detail": "Program not found in this org."}, status=status.HTTP_404_NOT_FOUND)
+
+
+# ---------------------------------------------------------------------------
+# Org-level settings
+# ---------------------------------------------------------------------------
+
+
+class AdminSettingsView(APIView):
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def get(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        org = ctx.organization
+        settings = org.settings or {}
+        return Response({
+            "organization_id": org.id,
+            "name": org.name,
+            "slug": org.slug,
+            "settings": settings,
+            "supported_languages": settings.get("supported_languages") or ["en"],
+            "rollover_hour": settings.get("rollover_hour"),
+            "tag_vocabulary": settings.get("tag_vocabulary") or [],
+            "day_rollover_hour": settings.get("rollover_hour"),
+        })
+
+    def patch(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        org = ctx.organization
+        before = dict(org.settings or {})
+        new_settings: dict[str, Any] = dict(before)
+        data = request.data or {}
+
+        if "settings" in data and isinstance(data["settings"], dict):
+            new_settings.update(data["settings"])
+        for key in ("supported_languages", "rollover_hour", "tag_vocabulary"):
+            if key in data:
+                new_settings[key] = data[key]
+
+        if new_settings == before:
+            return Response({"settings": before})
+        org.settings = new_settings
+        org.save(update_fields=["settings"])
+        # Org isn't an OrgScoped model -- write a manual AuditEvent so
+        # rollover / tag-vocab changes show up in the audit trail.
+        AuditEvent.all_objects.create(
+            event_type=AuditEvent.EventType.EDITED,
+            actor_membership=ctx.membership,
+            actor_user=request.user if request.user.is_authenticated else None,
+            content_type="organization_settings",
+            content_id=str(org.id),
+            organization=org,
+            before_state={"settings": before},
+            after_state={"settings": new_settings},
+        )
+        return Response({"settings": new_settings})

--- a/backend/bunk_logs/api/admin_flow/urls.py
+++ b/backend/bunk_logs/api/admin_flow/urls.py
@@ -9,8 +9,20 @@ from django.urls import path
 
 from bunk_logs.api.audit import AuditEventViewSet
 
+from .assignments import AdminAssignmentDetailView
+from .assignments import AdminAssignmentsListCreateView
 from .dashboard import AdminDashboardView
 from .override import AdminOverrideEditView
+from .people import AdminMembershipDeactivateView
+from .people import AdminMembershipDetailView
+from .people import AdminPeopleDetailView
+from .people import AdminPeopleListCreateView
+from .people import AdminPersonInviteView
+from .people import AdminPersonMembershipsView
+from .programs import AdminProgramDetailView
+from .programs import AdminProgramEndView
+from .programs import AdminProgramsListCreateView
+from .programs import AdminSettingsView
 
 # Reuse the existing AuditEventViewSet so /admin/audit/ shares the
 # audit-view meta-event and pagination behaviour with /audit/. The
@@ -28,4 +40,53 @@ urlpatterns = [
     path("audit/", _audit_list, name="admin-audit"),
     path("audit/by-actor/", _audit_by_actor, name="admin-audit-by-actor"),
     path("audit/admin-overrides/", _audit_admin_overrides, name="admin-audit-admin-overrides"),
+    # ------------------------------------------------------------------
+    # People + Memberships (Story 55)
+    # ------------------------------------------------------------------
+    path("people/", AdminPeopleListCreateView.as_view(), name="admin-people"),
+    path("people/<int:person_id>/", AdminPeopleDetailView.as_view(), name="admin-person-detail"),
+    path(
+        "people/<int:person_id>/memberships/",
+        AdminPersonMembershipsView.as_view(),
+        name="admin-person-memberships",
+    ),
+    path(
+        "people/<int:person_id>/invite/",
+        AdminPersonInviteView.as_view(),
+        name="admin-person-invite",
+    ),
+    path(
+        "memberships/<int:membership_id>/",
+        AdminMembershipDetailView.as_view(),
+        name="admin-membership-detail",
+    ),
+    path(
+        "memberships/<int:membership_id>/deactivate/",
+        AdminMembershipDeactivateView.as_view(),
+        name="admin-membership-deactivate",
+    ),
+    # ------------------------------------------------------------------
+    # Assignments (Story 56) — single endpoint, 5 sub-tabs
+    # ------------------------------------------------------------------
+    path("assignments/", AdminAssignmentsListCreateView.as_view(), name="admin-assignments"),
+    path(
+        "assignments/<int:assignment_id>/",
+        AdminAssignmentDetailView.as_view(),
+        name="admin-assignment-detail",
+    ),
+    # ------------------------------------------------------------------
+    # Programs + Settings (Story 58)
+    # ------------------------------------------------------------------
+    path("programs/", AdminProgramsListCreateView.as_view(), name="admin-programs"),
+    path(
+        "programs/<int:program_id>/",
+        AdminProgramDetailView.as_view(),
+        name="admin-program-detail",
+    ),
+    path(
+        "programs/<int:program_id>/end/",
+        AdminProgramEndView.as_view(),
+        name="admin-program-end",
+    ),
+    path("settings/", AdminSettingsView.as_view(), name="admin-settings"),
 ]

--- a/backend/bunk_logs/api/tests/test_admin_flow_pr2.py
+++ b/backend/bunk_logs/api/tests/test_admin_flow_pr2.py
@@ -1,0 +1,471 @@
+"""API tests for Step 7_13 PR2 -- People + Assignments + Programs/Settings.
+
+Covers, per the lean test recipe (happy path + auth/perm + critical edge):
+
+* People CRUD + email conflict + immutable membership.role
+* Assignments backdated safety invariant + conflict warnings
+* Programs `end` transaction (atomicity, memberships deactivated, open
+  orders/tickets closed, audit rows written, refuses with open flags)
+* Settings PATCH writes an AuditEvent
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AuditEvent
+from bunk_logs.core.models import Flag
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Order
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Supervision
+from bunk_logs.core.state_machine import OrderStateMachine
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def _hdr(slug: str) -> dict:
+    return {"HTTP_X_ORGANIZATION_SLUG": slug}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def api() -> APIClient:
+    return APIClient()
+
+
+@pytest.fixture
+def org():
+    return Organization.objects.create(name="PR2 Org", slug="pr2-org")
+
+
+@pytest.fixture
+def other_org():
+    return Organization.objects.create(name="PR2 Other", slug="pr2-other")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org, name="PR2 Org Summer", slug="pr2-org-summer",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1), end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def admin_user(org, program):
+    u = User.objects.create_user(email="admin-pr2@example.com", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="Ad", last_name="Min", user=u,
+    )
+    Membership.all_objects.create(
+        program=program, person=person, role="admin", is_active=True,
+    )
+    return u
+
+
+@pytest.fixture
+def non_admin_user(org, program):
+    u = User.objects.create_user(email="other-pr2@example.com", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="Co", last_name="Un", user=u,
+    )
+    Membership.all_objects.create(
+        program=program, person=person, role="counselor", is_active=True,
+    )
+    return u
+
+
+@pytest.fixture
+def existing_person(org):
+    return Person.all_objects.create(
+        organization=org, first_name="Du", last_name="Plicate",
+        email="duplicate@example.com",
+    )
+
+
+# ---------------------------------------------------------------------------
+# People
+# ---------------------------------------------------------------------------
+
+
+class TestAdminPeople:
+    URL = "/api/v1/admin/people/"
+
+    def test_non_admin_blocked(self, api, org, non_admin_user):
+        api.force_authenticate(user=non_admin_user)
+        with organization_context(org):
+            r = api.get(self.URL, **_hdr(org.slug))
+        assert r.status_code == 403
+
+    def test_create_person_and_membership(self, api, org, program, admin_user):
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.post(self.URL, {
+                "first_name": "New",
+                "last_name": "Person",
+                "email": "newp@example.com",
+                "membership": {
+                    "program_id": program.id,
+                    "role": "counselor",
+                    "tags": ["NEW", "new", " "],
+                },
+            }, format="json", **_hdr(org.slug))
+        assert r.status_code == 201, r.content
+        body = r.json()
+        assert body["full_name"]
+        assert body["memberships"][0]["role"] == "counselor"
+        # Tag normalization deduplicates and lowercases.
+        assert body["memberships"][0]["tags"] == ["new"]
+
+    def test_email_conflict_returns_409_with_existing(
+        self, api, org, program, admin_user, existing_person,
+    ):
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.post(self.URL, {
+                "first_name": "Another",
+                "last_name": "Person",
+                "email": "duplicate@example.com",
+                "membership": {"program_id": program.id, "role": "counselor"},
+            }, format="json", **_hdr(org.slug))
+        assert r.status_code == 409
+        body = r.json()
+        assert body["existing_person"]["id"] == existing_person.id
+
+    def test_membership_role_is_immutable(
+        self, api, org, program, admin_user, existing_person,
+    ):
+        with organization_context(org):
+            m = Membership.all_objects.create(
+                program=program, person=existing_person, role="counselor",
+                is_active=True,
+            )
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.patch(
+                f"/api/v1/admin/memberships/{m.id}/",
+                {"role": "admin", "tags": ["VIP"]},
+                format="json", **_hdr(org.slug),
+            )
+        assert r.status_code == 200
+        m.refresh_from_db()
+        assert m.role == "counselor"
+        assert m.tags == ["vip"]
+
+    def test_deactivate_membership_audited(
+        self, api, org, program, admin_user, existing_person,
+    ):
+        with organization_context(org):
+            m = Membership.all_objects.create(
+                program=program, person=existing_person, role="counselor",
+                is_active=True,
+            )
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.post(
+                f"/api/v1/admin/memberships/{m.id}/deactivate/",
+                {"reason": "Left mid-summer"},
+                format="json", **_hdr(org.slug),
+            )
+        assert r.status_code == 200
+        m.refresh_from_db()
+        assert m.is_active is False
+        assert AuditEvent.all_objects.filter(
+            content_type="membership", content_id=str(m.id),
+            event_type=AuditEvent.EventType.DEACTIVATED,
+        ).exists()
+
+    def test_invite_requires_email(
+        self, api, org, program, admin_user,
+    ):
+        with organization_context(org):
+            p = Person.all_objects.create(
+                organization=org, first_name="No", last_name="Email",
+            )
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.post(
+                f"/api/v1/admin/people/{p.id}/invite/", {},
+                format="json", **_hdr(org.slug),
+            )
+        assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Assignments
+# ---------------------------------------------------------------------------
+
+
+class TestAdminAssignments:
+    URL = "/api/v1/admin/assignments/"
+
+    @pytest.fixture
+    def supervisor(self, org, program):
+        person = Person.all_objects.create(
+            organization=org, first_name="Sue", last_name="Per",
+        )
+        return Membership.all_objects.create(
+            program=program, person=person, role="unit_head", is_active=True,
+        )
+
+    @pytest.fixture
+    def target(self, org, program):
+        person = Person.all_objects.create(
+            organization=org, first_name="Ta", last_name="Rget",
+        )
+        return Membership.all_objects.create(
+            program=program, person=person, role="counselor", is_active=True,
+        )
+
+    def test_non_admin_blocked(self, api, org, non_admin_user):
+        api.force_authenticate(user=non_admin_user)
+        with organization_context(org):
+            r = api.get(self.URL, **_hdr(org.slug))
+        assert r.status_code == 403
+
+    def test_backdated_start_is_clamped(
+        self, api, org, admin_user, supervisor, target,
+    ):
+        api.force_authenticate(user=admin_user)
+        backdate = "2020-01-01"
+        with organization_context(org):
+            r = api.post(self.URL, {
+                "sub_tab": "uh_counselor",
+                "supervisor_membership_id": supervisor.id,
+                "target_membership_id": target.id,
+                "start_date": backdate,
+            }, format="json", **_hdr(org.slug))
+        assert r.status_code == 201, r.content
+        body = r.json()
+        assert body["backdated_clamped"] is True
+        assert body["requested_start_date"] == backdate
+        # Effective start clamped to today (>= 2026-01-01).
+        sup_id = body["supervision"]["id"]
+        sup = Supervision.all_objects.get(pk=sup_id)
+        assert sup.start_date >= date.today()
+
+    def test_conflict_warning_surfaced(
+        self, api, org, admin_user, supervisor, target,
+    ):
+        api.force_authenticate(user=admin_user)
+        payload = {
+            "sub_tab": "uh_counselor",
+            "supervisor_membership_id": supervisor.id,
+            "target_membership_id": target.id,
+        }
+        with organization_context(org):
+            r1 = api.post(self.URL, payload, format="json", **_hdr(org.slug))
+            assert r1.status_code == 201
+            r2 = api.post(self.URL, payload, format="json", **_hdr(org.slug))
+        assert r2.status_code == 201
+        # The second create on the same target/supervisor pair surfaces
+        # the first as a co-supervisor warning.
+        assert any(
+            w["kind"] == "co_supervisor"
+            for w in r2.json()["warnings"]
+        )
+
+    def test_group_membership_create_and_conflict(
+        self, api, org, program, admin_user,
+    ):
+        with organization_context(org):
+            group = AssignmentGroup.all_objects.create(
+                organization=org, program=program, name="Bunk 1",
+                slug="bunk-1", group_type="bunk",
+            )
+            person = Person.all_objects.create(
+                organization=org, first_name="Pa", last_name="Rt",
+            )
+        api.force_authenticate(user=admin_user)
+        payload = {
+            "sub_tab": "counselor_bunk",
+            "group_id": group.id,
+            "person_id": person.id,
+        }
+        with organization_context(org):
+            r1 = api.post(self.URL, payload, format="json", **_hdr(org.slug))
+            r2 = api.post(self.URL, payload, format="json", **_hdr(org.slug))
+        assert r1.status_code == 201
+        assert r2.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# Programs + End Program
+# ---------------------------------------------------------------------------
+
+
+class TestAdminPrograms:
+    URL = "/api/v1/admin/programs/"
+
+    def test_list_and_create(self, api, org, admin_user):
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.post(self.URL, {
+                "name": "PR2 Org Brand New",
+                "slug": "pr2-brand-new",
+                "program_type": "summer_camp",
+                "start_date": "2026-09-01",
+                "end_date": "2027-08-31",
+            }, format="json", **_hdr(org.slug))
+        assert r.status_code == 201, r.content
+        with organization_context(org):
+            r2 = api.get(self.URL, **_hdr(org.slug))
+        assert r2.status_code == 200
+        slugs = {p["slug"] for p in r2.json()["results"]}
+        assert "pr2-brand-new" in slugs
+
+    def test_end_program_runs_in_transaction(
+        self, api, org, program, admin_user,
+    ):
+        # Seed: an active counselor membership + open order + open ticket.
+        with organization_context(org):
+            cperson = Person.all_objects.create(
+                organization=org, first_name="To", last_name="End",
+            )
+            cm = Membership.all_objects.create(
+                program=program, person=cperson, role="counselor", is_active=True,
+            )
+            o = Order.objects.create(
+                organization=org, program=program,
+                submitted_by=cm,
+                status=OrderStateMachine.NEW,
+            )
+            t = MaintenanceTicket.objects.create(
+                organization=org, program=program,
+                submitted_by=cm,
+                status=OrderStateMachine.NEW,
+            )
+        api.force_authenticate(user=admin_user)
+        url = f"/api/v1/admin/programs/{program.id}/end/"
+        with organization_context(org):
+            r = api.post(url, {"reason": "Season over"}, format="json", **_hdr(org.slug))
+        assert r.status_code == 200, r.content
+        body = r.json()
+        assert body["summary"]["memberships_deactivated"] >= 1
+        assert body["summary"]["orders_closed"] >= 1
+        assert body["summary"]["maintenance_tickets_closed"] >= 1
+        cm.refresh_from_db()
+        o.refresh_from_db()
+        t.refresh_from_db()
+        assert cm.is_active is False
+        assert o.status == OrderStateMachine.UNABLE_TO_FULFILL
+        assert t.status == OrderStateMachine.UNABLE_TO_FULFILL
+        program.refresh_from_db()
+        assert program.is_active is False
+
+    def test_end_program_refused_with_open_flags(
+        self, api, org, program, admin_user,
+    ):
+        with organization_context(org):
+            subject = Person.all_objects.create(
+                organization=org, first_name="Sub", last_name="J",
+            )
+            cc_person = Person.all_objects.create(
+                organization=org, first_name="Cc", last_name="Per",
+            )
+            cc_m = Membership.all_objects.create(
+                program=program, person=cc_person, role="camper_care", is_active=True,
+            )
+            Flag.objects.create(
+                organization=org, program=program,
+                subject_camper=subject, raised_by_membership=cc_m,
+                flagged_for_role="camper_care",
+            )
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.post(
+                f"/api/v1/admin/programs/{program.id}/end/",
+                {"reason": "Trying"}, format="json", **_hdr(org.slug),
+            )
+        assert r.status_code == 400
+        program.refresh_from_db()
+        assert program.is_active is True
+
+    def test_end_program_rolls_back_on_unexpected_failure(
+        self, api, org, program, admin_user,
+    ):
+        # Inject a runtime error inside the End Program transaction
+        # via the override_close audit helper. The transaction must
+        # roll back so the program stays active, no memberships get
+        # deactivated, and no orders get closed.
+        with organization_context(org):
+            cperson = Person.all_objects.create(
+                organization=org, first_name="X", last_name="Y",
+            )
+            cm = Membership.all_objects.create(
+                program=program, person=cperson, role="counselor", is_active=True,
+            )
+            o = Order.objects.create(
+                organization=org, program=program,
+                submitted_by=cm, status=OrderStateMachine.NEW,
+            )
+        api.force_authenticate(user=admin_user)
+        api.raise_request_exception = False
+        with patch(
+            "bunk_logs.api.admin_flow.programs.audit_module.override_close",
+            side_effect=RuntimeError("boom"),
+        ), organization_context(org):
+            r = api.post(
+                f"/api/v1/admin/programs/{program.id}/end/",
+                {"reason": "Should rollback"},
+                format="json", **_hdr(org.slug),
+            )
+        # The view doesn't catch this exception, so DRF surfaces it as
+        # an HTTP 500. The important assertion is the rollback below.
+        assert r.status_code == 500
+        program.refresh_from_db()
+        cm.refresh_from_db()
+        o.refresh_from_db()
+        assert program.is_active is True
+        assert cm.is_active is True
+        assert o.status == OrderStateMachine.NEW
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+
+class TestAdminSettings:
+    URL = "/api/v1/admin/settings/"
+
+    def test_get_returns_settings(self, api, org, admin_user):
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.get(self.URL, **_hdr(org.slug))
+        assert r.status_code == 200
+        body = r.json()
+        assert body["organization_id"] == org.id
+        assert body["slug"] == org.slug
+
+    def test_patch_writes_audit(self, api, org, admin_user):
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.patch(self.URL, {
+                "supported_languages": ["en", "es"],
+                "rollover_hour": 4,
+            }, format="json", **_hdr(org.slug))
+        assert r.status_code == 200
+        body = r.json()
+        assert body["settings"]["supported_languages"] == ["en", "es"]
+        assert body["settings"]["rollover_hour"] == 4
+        assert AuditEvent.all_objects.filter(
+            content_type="organization_settings", content_id=str(org.id),
+        ).exists()

--- a/backend/bunk_logs/core/models.py
+++ b/backend/bunk_logs/core/models.py
@@ -391,6 +391,17 @@ class Membership(models.Model):
             ) from exc
         super().save(*args, **kwargs)
 
+    # Audit module fallback hooks (Step 7_4 + 7_13). Membership has no
+    # direct ``organization`` FK — both org and program are derived
+    # through the related Program. These let
+    # ``bunk_logs.core.audit._org_program`` resolve the scope without a
+    # special-case branch when admin People CRUD writes audit rows.
+    def _audit_organization(self):
+        return self.program.organization if self.program_id else None
+
+    def _audit_program(self):
+        return self.program if self.program_id else None
+
 
 class AssignmentGroup(models.Model):
     GROUP_TYPES = [
@@ -491,6 +502,14 @@ class AssignmentGroupMembership(models.Model):
 
     def __str__(self) -> str:
         return f"{self.person} as {self.get_role_in_group_display()} in {self.group}"
+
+    # Audit hooks (Step 7_13). AssignmentGroupMembership has no direct
+    # org/program FK -- both flow through the related ``AssignmentGroup``.
+    def _audit_organization(self):
+        return self.group.organization if self.group_id else None
+
+    def _audit_program(self):
+        return self.group.program if self.group_id else None
 
 
 class RosterImportLog(models.Model):

--- a/docs/role_flows/admin.md
+++ b/docs/role_flows/admin.md
@@ -146,9 +146,99 @@ home view that matches the spec. The hub is still reachable at
   representative example. PR2 wires the remaining reflection / note /
   flag detail pages.
 
-## Out of scope for PR1
+## Backend endpoints (PR2)
 
-- People / Assignments / Programs / Settings CRUD (PR2)
+| Method | Path | Story |
+|--------|------|-------|
+| GET | `/api/v1/admin/people/` | 55 |
+| POST | `/api/v1/admin/people/` | 55 c9 |
+| GET | `/api/v1/admin/people/<id>/` | 55 c5 |
+| PATCH | `/api/v1/admin/people/<id>/` | 55 |
+| POST | `/api/v1/admin/people/<id>/memberships/` | 55 |
+| POST | `/api/v1/admin/people/<id>/invite/` | 55 |
+| PATCH | `/api/v1/admin/memberships/<id>/` | 55 |
+| POST | `/api/v1/admin/memberships/<id>/deactivate/` | 55 |
+| GET | `/api/v1/admin/assignments/?sub_tab=...` | 56 |
+| POST | `/api/v1/admin/assignments/` | 56 |
+| PATCH | `/api/v1/admin/assignments/<id>/?kind=...` | 56 |
+| GET | `/api/v1/admin/programs/` | 58 |
+| POST | `/api/v1/admin/programs/` | 58 |
+| PATCH | `/api/v1/admin/programs/<id>/` | 58 |
+| POST | `/api/v1/admin/programs/<id>/end/` | 58 c5 |
+| GET | `/api/v1/admin/settings/` | 58 |
+| PATCH | `/api/v1/admin/settings/` | 58 |
+
+### People (Story 55)
+
+- `POST /people/` requires `{first_name, last_name, membership: {program_id, role}}`. Email conflict returns **409** with an `existing_person` payload (with memberships) so the UI can offer "Add a membership to the existing record" without a duplicate.
+- `Membership.role` is **immutable** post-create. `PATCH /memberships/<id>/` silently ignores `role` and `capability` because RBAC capability is derived from `role`. Use a new Membership (different role) or deactivate + recreate.
+- `POST /memberships/<id>/deactivate/` is soft-delete: `is_active=False` + `end_date=today`. Historical content stays attached to the original membership (Story 56 A4).
+- `POST /people/<id>/invite/` audits the invitation and returns a `{status: "queued"}` payload. The actual email send is wired separately so the audit row alone confirms "we know who invited who, when".
+
+### Assignments (Story 56)
+
+Single endpoint, five sub-tabs:
+
+| `sub_tab` | Underlying model | Role |
+|-----------|------------------|------|
+| `uh_counselor` | `Supervision` `target_type=MEMBERSHIP` | UH supervises a counselor |
+| `cc_caseload` | `Supervision` `target_type=BUNK` | CC owns a bunk caseload |
+| `lt_team` | `Supervision` `target_type=ROLE_IN_PROGRAM` | LT covers a role/program slice |
+| `counselor_bunk` | `AssignmentGroupMembership` `role_in_group=author` | Counselor placed on a Bunk |
+| `camper_bunk` | `AssignmentGroupMembership` `role_in_group=subject` | Camper/Student placed on a Bunk/Class |
+
+**Backdated safety invariant (Story 56 c4 + A4).** If the requested `start_date` is in the past, the server **clamps the effective start to today** and stashes the original date in `metadata.requested_start_date` on the new row. Historical reflections, notes, supervisions, and orders are *not* retroactively reattributed — they stay anchored to whichever Membership / AssignmentGroupMembership authored them at the time. The response surfaces `backdated_clamped: true` and `requested_start_date` so the UI can render an "info" banner instead of failing the form.
+
+**Conflict warnings (Story 56 c9).** Overlapping supervisions on the same target return a non-blocking `warnings` array with the prior supervisor's name + Membership id so the UI can show "Co-supervision now in place" inline.
+
+`PATCH /admin/assignments/<id>/?kind=supervision|group_membership` is intentionally narrow — only `end_date` (and `is_active` for group memberships) can be patched. To reassign, deactivate the old row and create a new one. This keeps audit attribution clean.
+
+### Programs + Settings (Story 58)
+
+`POST /admin/programs/<id>/end/` is the one **multi-table transaction** in the admin surface:
+
+1. Refuse with 400 if any `Flag.status == ACTIVE` still references the program — those need a human decision.
+2. Inside `transaction.atomic`:
+   - Deactivate every active `Membership` in the program (write `DEACTIVATED` AuditEvent per row).
+   - Close every open `Order` and `MaintenanceTicket` via the state machine's `unable_to_fulfill` transition (write `OVERRIDE_CLOSE` AuditEvent per row).
+   - Set `Program.is_active=False`. If `today >= start_date`, also set `end_date=today`; otherwise leave `end_date` alone (the model's `end_date >= start_date` check would block updates for programs ended before they started; `is_active=False` is the canonical "ended" flag).
+   - Write a `DEACTIVATED` AuditEvent on the Program itself.
+3. Any uncaught exception in the block rolls back every change. Verified by `test_end_program_rolls_back_on_unexpected_failure` (injects a RuntimeError into the `override_close` helper and confirms the program / memberships / orders are unchanged).
+
+`reason` is required (returns 422 otherwise) and lands in the audit `reason_note` on every row touched.
+
+`PATCH /admin/settings/` accepts a partial dict of `{settings, supported_languages, rollover_hour, tag_vocabulary}` and writes a manual `AuditEvent` against `content_type="organization_settings"`. (Organization itself is not org-scoped so the standard audit helpers can't auto-derive `(org, program)`.) The frontend gates `rollover_hour` changes behind a typed-confirmation modal because changing it shifts the org's "today" anchor for every dashboard.
+
+## Frontend (PR2)
+
+| Route | Component | Story |
+|-------|-----------|-------|
+| `/admin/people` | `pages/admin/People.jsx` | 55 |
+| `/admin/assignments` | `pages/admin/Assignments.jsx` | 56 |
+| `/admin/settings` | `pages/admin/Settings.jsx` (Identity / Tags / Programs) | 58 |
+
+Sidebar gets three new entries under the Admin section: People, Assignments, Settings. `Memberships`, `Templates`, `Assignment groups`, `Field keys` stay where they were so the existing admin sub-flows aren't disturbed.
+
+### People page
+
+- Two-pane layout: filters + list on the left, profile drawer with Identity / Memberships / Recent activity tabs on the right.
+- Add Person modal (Story 55 c9) renders the 409 email-conflict response inline with an "Open existing" action that jumps to the existing person.
+- Membership rows expose a "Deactivate" affordance with a required-reason inline input that posts the audit-bearing soft delete.
+
+### Assignments page
+
+- Sub-tab nav across the five relationships. Selecting a tab fires `GET /admin/assignments/?sub_tab=...`.
+- Status pill renders Active / Ending within 7d / Recently ended / Future-dated using only the row's `start_date` / `end_date` / `is_active`.
+- Create form is shape-aware per sub_tab (different field set for each). When the backend reports `backdated_clamped`, the form surfaces a yellow inline panel reminding the admin that historical content stays anchored to the prior assignment.
+
+### Settings page
+
+- **Identity & Localization** tab: edit supported languages list + day-rollover hour. Changing the rollover hour requires a confirm-twice gesture.
+- **Tag vocabulary** tab: one-tag-per-line textarea persisted to `settings.tag_vocabulary`.
+- **Programs** tab: list + Create Program form + End Program modal. The End Program modal requires the admin to type the program `slug` *and* enter a reason. On success it shows a summary card (memberships deactivated, orders closed, tickets closed, ended_at).
+
+## Out of scope for PR2
+
 - Global search (PR3)
 - Bulk Person import UI + invitation flow (PR3)
 - Templates wrapper + Mark Reviewed / Needs revision flag (PR3)

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -32,6 +32,9 @@ import WellnessDashboardPage from './pages/WellnessDashboardPage';
 import MembershipManagementPage from './pages/MembershipManagementPage';
 import AdminHub from './pages/admin/AdminHub';
 import AdminDashboardV2 from './pages/admin/Dashboard';
+import AdminPeople from './pages/admin/People';
+import AdminAssignments from './pages/admin/Assignments';
+import AdminSettingsPage from './pages/admin/Settings';
 import TemplateListPage from './pages/admin/templates/TemplateListPage';
 import TemplateEditorPage from './pages/admin/templates/TemplateEditorPage';
 import TemplateNewPage from './pages/admin/templates/TemplateNewPage';
@@ -805,6 +808,31 @@ function Router() {
             }
           />
           <Route path="memberships" element={<MembershipManagementPage />} />
+          {/* 7_13 PR2 — People, Assignments, Settings (Stories 55, 56, 58). */}
+          <Route
+            path="people"
+            element={
+              <AdminRoute>
+                <AdminPeople />
+              </AdminRoute>
+            }
+          />
+          <Route
+            path="assignments"
+            element={
+              <AdminRoute>
+                <AdminAssignments />
+              </AdminRoute>
+            }
+          />
+          <Route
+            path="settings"
+            element={
+              <AdminRoute>
+                <AdminSettingsPage />
+              </AdminRoute>
+            }
+          />
           <Route
             path="templates"
             element={

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -28,3 +28,105 @@ export async function postAdminOverrideEdit({
   });
   return resp?.data ?? null;
 }
+
+// ---------------------------------------------------------------------------
+// People (Story 55)
+// ---------------------------------------------------------------------------
+
+export async function listAdminPeople(params = {}) {
+  const resp = await api.get(`${ADMIN_BASE}/people/`, { params });
+  return resp?.data ?? { results: [] };
+}
+
+export async function getAdminPerson(personId) {
+  const resp = await api.get(`${ADMIN_BASE}/people/${personId}/`);
+  return resp?.data ?? null;
+}
+
+export async function createAdminPerson(payload) {
+  const resp = await api.post(`${ADMIN_BASE}/people/`, payload);
+  return resp?.data ?? null;
+}
+
+export async function patchAdminPerson(personId, patch) {
+  const resp = await api.patch(`${ADMIN_BASE}/people/${personId}/`, patch);
+  return resp?.data ?? null;
+}
+
+export async function addAdminMembership(personId, payload) {
+  const resp = await api.post(`${ADMIN_BASE}/people/${personId}/memberships/`, payload);
+  return resp?.data ?? null;
+}
+
+export async function patchAdminMembership(membershipId, patch) {
+  const resp = await api.patch(`${ADMIN_BASE}/memberships/${membershipId}/`, patch);
+  return resp?.data ?? null;
+}
+
+export async function deactivateAdminMembership(membershipId, reason) {
+  const resp = await api.post(`${ADMIN_BASE}/memberships/${membershipId}/deactivate/`, { reason });
+  return resp?.data ?? null;
+}
+
+export async function inviteAdminPerson(personId, payload = {}) {
+  const resp = await api.post(`${ADMIN_BASE}/people/${personId}/invite/`, payload);
+  return resp?.data ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Assignments (Story 56)
+// ---------------------------------------------------------------------------
+
+export async function listAdminAssignments(subTab) {
+  const params = subTab ? { sub_tab: subTab } : {};
+  const resp = await api.get(`${ADMIN_BASE}/assignments/`, { params });
+  return resp?.data ?? { results: [] };
+}
+
+export async function createAdminAssignment(payload) {
+  const resp = await api.post(`${ADMIN_BASE}/assignments/`, payload);
+  return resp?.data ?? null;
+}
+
+export async function patchAdminAssignment(assignmentId, kind, patch) {
+  const resp = await api.patch(
+    `${ADMIN_BASE}/assignments/${assignmentId}/?kind=${encodeURIComponent(kind)}`,
+    { ...patch, kind },
+  );
+  return resp?.data ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Programs + Settings (Story 58)
+// ---------------------------------------------------------------------------
+
+export async function listAdminPrograms(status) {
+  const params = status ? { status } : {};
+  const resp = await api.get(`${ADMIN_BASE}/programs/`, { params });
+  return resp?.data ?? { results: [] };
+}
+
+export async function createAdminProgram(payload) {
+  const resp = await api.post(`${ADMIN_BASE}/programs/`, payload);
+  return resp?.data ?? null;
+}
+
+export async function patchAdminProgram(programId, patch) {
+  const resp = await api.patch(`${ADMIN_BASE}/programs/${programId}/`, patch);
+  return resp?.data ?? null;
+}
+
+export async function endAdminProgram(programId, reason) {
+  const resp = await api.post(`${ADMIN_BASE}/programs/${programId}/end/`, { reason });
+  return resp?.data ?? null;
+}
+
+export async function getAdminSettings() {
+  const resp = await api.get(`${ADMIN_BASE}/settings/`);
+  return resp?.data ?? null;
+}
+
+export async function patchAdminSettings(patch) {
+  const resp = await api.patch(`${ADMIN_BASE}/settings/`, patch);
+  return resp?.data ?? null;
+}

--- a/frontend/src/pages/admin/Assignments.jsx
+++ b/frontend/src/pages/admin/Assignments.jsx
@@ -1,0 +1,318 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  listAdminAssignments,
+  createAdminAssignment,
+  patchAdminAssignment,
+} from '../../api/admin';
+
+/**
+ * Step 7_13 PR2 — Assignments management (Story 56).
+ *
+ * Five sub-tabs all mounted on a single endpoint:
+ *
+ *   - uh_counselor   (Supervision target_type=MEMBERSHIP)
+ *   - cc_caseload    (Supervision target_type=BUNK)
+ *   - lt_team        (Supervision target_type=ROLE_IN_PROGRAM)
+ *   - counselor_bunk (AssignmentGroupMembership role=author)
+ *   - camper_bunk    (AssignmentGroupMembership role=subject)
+ *
+ * Reflects the server-side backdated-clamp invariant: if the user
+ * picks a past start date, we display a yellow banner explaining that
+ * historical content stays anchored to the prior assignment.
+ */
+
+const SUB_TABS = [
+  { key: 'counselor_bunk', label: 'Counselor → Bunk' },
+  { key: 'uh_counselor', label: 'Unit Head → Counselor' },
+  { key: 'cc_caseload', label: 'Camper Care → Caseload' },
+  { key: 'lt_team', label: 'Leadership → Team' },
+  { key: 'camper_bunk', label: 'Camper → Bunk / Student → Grade' },
+];
+
+function todayIso() {
+  return new Date().toISOString().split('T')[0];
+}
+
+function StatusPill({ row }) {
+  const today = todayIso();
+  const end = row.end_date;
+  let label = 'Active';
+  let cls = 'bg-emerald-100 text-emerald-800';
+  if (!row.is_active) {
+    label = end ? 'Recently ended' : 'Inactive';
+    cls = 'bg-gray-200 text-gray-700';
+  } else if (end && end >= today && end <= addDays(today, 7)) {
+    label = 'Ending within 7d';
+    cls = 'bg-amber-100 text-amber-800';
+  } else if (row.start_date && row.start_date > today) {
+    label = 'Future-dated';
+    cls = 'bg-indigo-100 text-indigo-800';
+  }
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded-full ${cls}`}>{label}</span>
+  );
+}
+
+function addDays(iso, n) {
+  const d = new Date(iso);
+  d.setDate(d.getDate() + n);
+  return d.toISOString().split('T')[0];
+}
+
+function AssignmentRow({ row, onChanged }) {
+  const [confirming, setConfirming] = useState(false);
+  const [reason, setReason] = useState('');
+  const handleEnd = async () => {
+    if (!reason.trim()) return;
+    await patchAdminAssignment(row.id, row.kind, {
+      end_date: todayIso(),
+      is_active: false,
+      reason,
+    });
+    setConfirming(false);
+    setReason('');
+    onChanged();
+  };
+  const title = row.kind === 'supervision'
+    ? `${row.supervisor_name || `Supervisor ${row.supervisor_membership_id}`} → ${supervisionTarget(row)}`
+    : `${row.person_name || `Person ${row.person_id}`} ↔ ${row.group_name || `Group ${row.group_id}`}`;
+  return (
+    <li
+      data-testid={`assignment-row-${row.kind}-${row.id}`}
+      className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3 text-sm"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <p className="font-medium">{title}</p>
+        <StatusPill row={row} />
+      </div>
+      <p className="text-xs text-gray-500">
+        {row.start_date || '—'} → {row.end_date || 'open'}
+      </p>
+      {row.is_active && !confirming && (
+        <button
+          type="button"
+          data-testid={`assignment-end-${row.id}`}
+          onClick={() => setConfirming(true)}
+          className="mt-2 text-xs text-red-700 underline"
+        >
+          End assignment
+        </button>
+      )}
+      {confirming && (
+        <div className="mt-2 flex gap-2 items-center">
+          <input
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Reason"
+            className="text-xs rounded-md border border-gray-300 p-1 flex-1"
+          />
+          <button
+            type="button"
+            disabled={!reason.trim()}
+            onClick={handleEnd}
+            className="text-xs px-2 py-1 rounded-md bg-red-600 text-white disabled:opacity-60"
+          >
+            Confirm end
+          </button>
+        </div>
+      )}
+    </li>
+  );
+}
+
+function supervisionTarget(row) {
+  if (row.target_type === 'membership') return `Membership ${row.target_membership_id}`;
+  if (row.target_type === 'bunk') return `Bunk ${row.target_bunk_id}`;
+  if (row.target_type === 'role_in_program') {
+    return `${row.target_role} in Program ${row.target_program_id}`;
+  }
+  return 'Target';
+}
+
+function CreateForm({ subTab, onCreated }) {
+  const [draft, setDraft] = useState({});
+  const [submitting, setSubmitting] = useState(false);
+  const [response, setResponse] = useState(null);
+  const [error, setError] = useState('');
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError('');
+    setResponse(null);
+    try {
+      const payload = { sub_tab: subTab, ...draft };
+      const data = await createAdminAssignment(payload);
+      setResponse(data);
+      setDraft({});
+      onCreated();
+    } catch (err) {
+      setError(err?.response?.data?.detail || 'Could not create.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      data-testid="assignment-create-form"
+      className="rounded-md border border-indigo-200 bg-indigo-50/40 dark:bg-indigo-900/10 p-3 space-y-2"
+    >
+      <p className="text-sm font-medium">New {subTab.replace('_', ' ')}</p>
+      <p className="text-xs text-gray-600">Membership / group / person IDs are required. The
+        backend clamps backdated <code>start_date</code> values to today; historical content is not retroactively reattributed.</p>
+      {subTab === 'uh_counselor' && (
+        <>
+          <NumberField label="Supervisor membership ID" value={draft.supervisor_membership_id || ''} onChange={(v) => setDraft({ ...draft, supervisor_membership_id: v })} />
+          <NumberField label="Target counselor membership ID" value={draft.target_membership_id || ''} onChange={(v) => setDraft({ ...draft, target_membership_id: v })} />
+        </>
+      )}
+      {subTab === 'cc_caseload' && (
+        <>
+          <NumberField label="Supervisor (CC) membership ID" value={draft.supervisor_membership_id || ''} onChange={(v) => setDraft({ ...draft, supervisor_membership_id: v })} />
+          <NumberField label="Target bunk (assignment group) ID" value={draft.target_bunk_id || ''} onChange={(v) => setDraft({ ...draft, target_bunk_id: v })} />
+        </>
+      )}
+      {subTab === 'lt_team' && (
+        <>
+          <NumberField label="Supervisor (LT) membership ID" value={draft.supervisor_membership_id || ''} onChange={(v) => setDraft({ ...draft, supervisor_membership_id: v })} />
+          <NumberField label="Target program ID" value={draft.target_program_id || ''} onChange={(v) => setDraft({ ...draft, target_program_id: v })} />
+          <TextField label="Target role" value={draft.target_role || ''} onChange={(v) => setDraft({ ...draft, target_role: v })} />
+        </>
+      )}
+      {(subTab === 'counselor_bunk' || subTab === 'camper_bunk') && (
+        <>
+          <NumberField label="Group (Bunk) ID" value={draft.group_id || ''} onChange={(v) => setDraft({ ...draft, group_id: v })} />
+          <NumberField label="Person ID" value={draft.person_id || ''} onChange={(v) => setDraft({ ...draft, person_id: v })} />
+        </>
+      )}
+      <TextField label="Start date (yyyy-mm-dd, optional — defaults to today)" value={draft.start_date || ''} onChange={(v) => setDraft({ ...draft, start_date: v })} />
+      <TextField label="End date (optional)" value={draft.end_date || ''} onChange={(v) => setDraft({ ...draft, end_date: v })} />
+
+      {error && <p className="text-sm text-red-700">{error}</p>}
+      {response?.backdated_clamped && (
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-2 text-xs space-y-1" data-testid="backdated-warning">
+          <p>Start date was backdated to {response.requested_start_date}; effective start clamped to today.</p>
+          <p>Historical reflections / notes will remain anchored to the prior assignment.</p>
+        </div>
+      )}
+      {response?.warnings?.length > 0 && (
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-2 text-xs" data-testid="assignment-warnings">
+          <p className="font-medium">Conflicts on the same target:</p>
+          <ul className="list-disc pl-4">
+            {response.warnings.map((w) => (
+              <li key={w.supervision_id}>{w.supervisor_name || `Membership ${w.supervisor_membership_id}`} ({w.kind})</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={submitting}
+        data-testid="assignment-create-submit"
+        className="px-3 py-1.5 rounded-md text-sm bg-indigo-600 text-white disabled:opacity-60"
+      >
+        {submitting ? 'Creating…' : 'Create assignment'}
+      </button>
+    </form>
+  );
+}
+
+function NumberField({ label, value, onChange }) {
+  return (
+    <label className="block text-xs font-medium">
+      {label}
+      <input
+        type="number"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm bg-white"
+      />
+    </label>
+  );
+}
+
+function TextField({ label, value, onChange }) {
+  return (
+    <label className="block text-xs font-medium">
+      {label}
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm bg-white"
+      />
+    </label>
+  );
+}
+
+export default function AdminAssignments() {
+  const [subTab, setSubTab] = useState(SUB_TABS[0].key);
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await listAdminAssignments(subTab);
+      setRows(data.results || []);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [subTab]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <main className="grow px-4 sm:px-6 lg:px-8 py-6 w-full max-w-6xl mx-auto" data-testid="admin-assignments">
+      <header className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Assignments</h1>
+      </header>
+
+      <nav className="border-b border-gray-200 dark:border-gray-700 flex gap-3 mb-4">
+        {SUB_TABS.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            data-testid={`assignment-sub-tab-${t.key}`}
+            onClick={() => setSubTab(t.key)}
+            className={`pb-2 -mb-px text-sm font-medium border-b-2 ${
+              subTab === t.key
+                ? 'border-indigo-500 text-indigo-700 dark:text-indigo-200'
+                : 'border-transparent text-gray-500 hover:text-gray-800 dark:hover:text-gray-200'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <section data-testid="assignment-list" className="space-y-2">
+          {loading ? (
+            <p className="text-sm text-gray-500">Loading…</p>
+          ) : error ? (
+            <p className="text-sm text-red-700">Could not load assignments.</p>
+          ) : rows.length === 0 ? (
+            <p className="text-sm italic text-gray-500">No assignments in this view.</p>
+          ) : (
+            <ul className="space-y-2">
+              {rows.map((row) => (
+                <AssignmentRow key={`${row.kind}-${row.id}`} row={row} onChanged={load} />
+              ))}
+            </ul>
+          )}
+        </section>
+        <aside>
+          <CreateForm subTab={subTab} onCreated={load} />
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/pages/admin/People.jsx
+++ b/frontend/src/pages/admin/People.jsx
@@ -1,0 +1,630 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  listAdminPeople,
+  getAdminPerson,
+  createAdminPerson,
+  patchAdminPerson,
+  addAdminMembership,
+  patchAdminMembership,
+  deactivateAdminMembership,
+  inviteAdminPerson,
+  listAdminPrograms,
+} from '../../api/admin';
+
+/**
+ * Step 7_13 PR2 — People + Memberships management (Story 55).
+ *
+ * Two-pane layout: filter / list on the left, profile drawer on the
+ * right. Profile has Identity / Memberships / Recent activity tabs
+ * per Story 55 c5.
+ *
+ * Bulk import affordance is added in PR3.
+ */
+const ROLE_OPTIONS = [
+  'admin', 'leadership_team', 'unit_head', 'counselor', 'junior_counselor',
+  'specialist', 'general_counselor', 'kitchen_staff', 'maintenance',
+  'housekeeping', 'camper_care', 'health_center', 'special_diets',
+  'madrich', 'faculty', 'camper',
+];
+
+function classNames(...args) {
+  return args.filter(Boolean).join(' ');
+}
+
+function Tabs({ tabs, activeTab, onChange }) {
+  return (
+    <nav className="border-b border-gray-200 dark:border-gray-700 flex gap-3">
+      {tabs.map((t) => (
+        <button
+          key={t.key}
+          type="button"
+          data-testid={`people-tab-${t.key}`}
+          onClick={() => onChange(t.key)}
+          className={classNames(
+            'pb-2 -mb-px text-sm font-medium border-b-2',
+            activeTab === t.key
+              ? 'border-indigo-500 text-indigo-700 dark:text-indigo-200'
+              : 'border-transparent text-gray-500 hover:text-gray-800 dark:hover:text-gray-200',
+          )}
+        >
+          {t.label}
+        </button>
+      ))}
+    </nav>
+  );
+}
+
+function ProfileTabs({ person, programs, onPersonChanged }) {
+  const [tab, setTab] = useState('identity');
+  return (
+    <div className="space-y-3">
+      <Tabs
+        tabs={[
+          { key: 'identity', label: 'Identity' },
+          { key: 'memberships', label: 'Memberships' },
+          { key: 'activity', label: 'Recent activity' },
+        ]}
+        activeTab={tab}
+        onChange={setTab}
+      />
+      {tab === 'identity' && (
+        <IdentityTab person={person} onSaved={onPersonChanged} />
+      )}
+      {tab === 'memberships' && (
+        <MembershipsTab
+          person={person}
+          programs={programs}
+          onChanged={onPersonChanged}
+        />
+      )}
+      {tab === 'activity' && <ActivityTab person={person} />}
+    </div>
+  );
+}
+
+function IdentityTab({ person, onSaved }) {
+  const [draft, setDraft] = useState({
+    first_name: person.first_name || '',
+    last_name: person.last_name || '',
+    preferred_name: person.preferred_name || '',
+    email: person.email || '',
+    preferred_language: person.preferred_language || 'en',
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    setError('');
+    try {
+      const updated = await patchAdminPerson(person.id, draft);
+      onSaved(updated);
+    } catch (err) {
+      setError(err?.response?.data?.detail || 'Could not save.');
+    } finally {
+      setSaving(false);
+    }
+  };
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2" data-testid="identity-tab">
+      <FieldInput
+        label="First name"
+        value={draft.first_name}
+        onChange={(v) => setDraft({ ...draft, first_name: v })}
+      />
+      <FieldInput
+        label="Last name"
+        value={draft.last_name}
+        onChange={(v) => setDraft({ ...draft, last_name: v })}
+      />
+      <FieldInput
+        label="Preferred name"
+        value={draft.preferred_name}
+        onChange={(v) => setDraft({ ...draft, preferred_name: v })}
+      />
+      <FieldInput
+        label="Email"
+        type="email"
+        value={draft.email}
+        onChange={(v) => setDraft({ ...draft, email: v })}
+      />
+      <label className="block text-xs font-medium text-gray-700">
+        Preferred language
+        <select
+          value={draft.preferred_language}
+          onChange={(e) => setDraft({ ...draft, preferred_language: e.target.value })}
+          className="mt-1 w-full rounded-md border border-gray-300 bg-white p-2 text-sm"
+        >
+          <option value="en">English</option>
+          <option value="es">Spanish</option>
+          <option value="he">Hebrew</option>
+        </select>
+      </label>
+      {error && <p className="text-sm text-red-700">{error}</p>}
+      <button
+        type="submit"
+        disabled={saving}
+        data-testid="identity-save"
+        className="px-3 py-1.5 rounded-md text-sm bg-indigo-600 text-white disabled:opacity-60"
+      >
+        {saving ? 'Saving…' : 'Save identity'}
+      </button>
+    </form>
+  );
+}
+
+function MembershipsTab({ person, programs, onChanged }) {
+  const [adding, setAdding] = useState(false);
+  return (
+    <div className="space-y-3" data-testid="memberships-tab">
+      <ul className="divide-y border rounded-md bg-white dark:bg-gray-900">
+        {(person.memberships || []).length === 0 && (
+          <li className="p-3 text-sm italic text-gray-500">No memberships yet.</li>
+        )}
+        {(person.memberships || []).map((m) => (
+          <MembershipRow key={m.id} membership={m} onChanged={onChanged} />
+        ))}
+      </ul>
+      <button
+        type="button"
+        data-testid="add-membership"
+        onClick={() => setAdding((v) => !v)}
+        className="px-3 py-1.5 rounded-md text-sm border border-indigo-200 text-indigo-700 hover:bg-indigo-50"
+      >
+        {adding ? 'Cancel' : 'Add membership'}
+      </button>
+      {adding && (
+        <AddMembershipForm
+          person={person}
+          programs={programs}
+          onAdded={() => {
+            setAdding(false);
+            onChanged();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function MembershipRow({ membership, onChanged }) {
+  const [deactivating, setDeactivating] = useState(false);
+  const [reason, setReason] = useState('');
+  const [saving, setSaving] = useState(false);
+  const handleDeactivate = async () => {
+    if (!reason.trim()) return;
+    setSaving(true);
+    try {
+      await deactivateAdminMembership(membership.id, reason);
+      onChanged();
+    } finally {
+      setSaving(false);
+      setDeactivating(false);
+      setReason('');
+    }
+  };
+  return (
+    <li className="p-3 text-sm flex flex-col gap-1" data-testid={`membership-row-${membership.id}`}>
+      <div className="flex items-center justify-between">
+        <span>
+          <span className="font-medium">{membership.role}</span>
+          <span className="ml-2 text-xs text-gray-500">{membership.program_name || '—'}</span>
+        </span>
+        <span className={classNames(
+          'text-xs px-2 py-0.5 rounded-full',
+          membership.is_active
+            ? 'bg-emerald-100 text-emerald-800'
+            : 'bg-gray-200 text-gray-700',
+        )}>
+          {membership.is_active ? 'active' : 'inactive'}
+        </span>
+      </div>
+      {membership.tags?.length > 0 && (
+        <p className="text-xs text-gray-500">Tags: {membership.tags.join(', ')}</p>
+      )}
+      {membership.is_active && (
+        <div className="mt-1 flex items-center gap-2">
+          {!deactivating ? (
+            <button
+              type="button"
+              data-testid={`membership-deactivate-${membership.id}`}
+              onClick={() => setDeactivating(true)}
+              className="text-xs text-red-700 underline"
+            >
+              Deactivate
+            </button>
+          ) : (
+            <>
+              <input
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                placeholder="Reason"
+                className="rounded-md border border-gray-300 p-1 text-xs flex-1"
+              />
+              <button
+                type="button"
+                disabled={!reason.trim() || saving}
+                onClick={handleDeactivate}
+                className="text-xs px-2 py-1 rounded-md bg-red-600 text-white disabled:opacity-60"
+              >
+                {saving ? '…' : 'Confirm'}
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </li>
+  );
+}
+
+function AddMembershipForm({ person, programs, onAdded }) {
+  const [draft, setDraft] = useState({
+    program_id: programs[0]?.id || '',
+    role: 'counselor',
+    grade_level: '',
+    tags: '',
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const submit = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    setError('');
+    try {
+      const tags = draft.tags
+        .split(',').map((t) => t.trim()).filter(Boolean);
+      await addAdminMembership(person.id, {
+        program_id: Number(draft.program_id),
+        role: draft.role,
+        grade_level: draft.grade_level ? Number(draft.grade_level) : null,
+        tags,
+      });
+      onAdded();
+    } catch (err) {
+      setError(err?.response?.data?.detail || 'Could not add.');
+    } finally {
+      setSaving(false);
+    }
+  };
+  return (
+    <form onSubmit={submit} className="rounded-md border border-gray-200 p-3 bg-gray-50 space-y-2" data-testid="add-membership-form">
+      <label className="block text-xs font-medium">Program
+        <select
+          value={draft.program_id}
+          onChange={(e) => setDraft({ ...draft, program_id: e.target.value })}
+          className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm"
+        >
+          {programs.map((p) => (
+            <option key={p.id} value={p.id}>{p.name}</option>
+          ))}
+        </select>
+      </label>
+      <label className="block text-xs font-medium">Role
+        <select
+          value={draft.role}
+          onChange={(e) => setDraft({ ...draft, role: e.target.value })}
+          className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm"
+        >
+          {ROLE_OPTIONS.map((r) => (
+            <option key={r} value={r}>{r}</option>
+          ))}
+        </select>
+      </label>
+      <FieldInput label="Grade level" value={draft.grade_level} onChange={(v) => setDraft({ ...draft, grade_level: v })} />
+      <FieldInput label="Tags (comma-separated)" value={draft.tags} onChange={(v) => setDraft({ ...draft, tags: v })} />
+      {error && <p className="text-sm text-red-700">{error}</p>}
+      <button
+        type="submit"
+        disabled={saving}
+        data-testid="add-membership-save"
+        className="px-3 py-1.5 rounded-md text-sm bg-indigo-600 text-white disabled:opacity-60"
+      >
+        {saving ? 'Adding…' : 'Add membership'}
+      </button>
+    </form>
+  );
+}
+
+function ActivityTab({ person }) {
+  const events = person.recent_activity || [];
+  if (!events.length) {
+    return <p className="text-sm italic text-gray-500" data-testid="activity-empty">No recent activity in the last 30 days.</p>;
+  }
+  return (
+    <ul className="space-y-1.5 text-sm" data-testid="activity-tab">
+      {events.map((ev) => (
+        <li key={ev.id} className="rounded-md border border-gray-200 p-2 bg-white dark:bg-gray-900">
+          <p className="font-medium">{ev.event_type} · {ev.content_type}</p>
+          <p className="text-xs text-gray-500">{new Date(ev.created_at).toLocaleString()}</p>
+          {ev.reason_note && <p className="text-xs">{ev.reason_note}</p>}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function FieldInput({ label, value, onChange, type = 'text' }) {
+  return (
+    <label className="block text-xs font-medium text-gray-700">
+      {label}
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="mt-1 w-full rounded-md border border-gray-300 bg-white p-2 text-sm"
+      />
+    </label>
+  );
+}
+
+function AddPersonModal({ programs, onClose, onCreated }) {
+  const [draft, setDraft] = useState({
+    first_name: '',
+    last_name: '',
+    preferred_name: '',
+    email: '',
+    program_id: programs[0]?.id || '',
+    role: 'counselor',
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [conflict, setConflict] = useState(null);
+  const submit = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    setError('');
+    setConflict(null);
+    try {
+      const created = await createAdminPerson({
+        first_name: draft.first_name,
+        last_name: draft.last_name,
+        preferred_name: draft.preferred_name,
+        email: draft.email,
+        membership: {
+          program_id: Number(draft.program_id),
+          role: draft.role,
+        },
+      });
+      onCreated(created);
+    } catch (err) {
+      const data = err?.response?.data;
+      if (err?.response?.status === 409 && data?.existing_person) {
+        setConflict(data.existing_person);
+      } else {
+        setError(data?.detail || 'Could not create.');
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+  return (
+    <div
+      role="dialog"
+      data-testid="add-person-modal"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <form
+        onSubmit={submit}
+        className="w-full max-w-md rounded-xl bg-white p-5 shadow-lg space-y-2 dark:bg-gray-900"
+      >
+        <h2 className="text-base font-semibold">Add Person</h2>
+        <FieldInput label="First name" value={draft.first_name} onChange={(v) => setDraft({ ...draft, first_name: v })} />
+        <FieldInput label="Last name" value={draft.last_name} onChange={(v) => setDraft({ ...draft, last_name: v })} />
+        <FieldInput label="Preferred name" value={draft.preferred_name} onChange={(v) => setDraft({ ...draft, preferred_name: v })} />
+        <FieldInput label="Email" type="email" value={draft.email} onChange={(v) => setDraft({ ...draft, email: v })} />
+        <label className="block text-xs font-medium">Program
+          <select
+            value={draft.program_id}
+            onChange={(e) => setDraft({ ...draft, program_id: e.target.value })}
+            className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm"
+          >
+            {programs.map((p) => (
+              <option key={p.id} value={p.id}>{p.name}</option>
+            ))}
+          </select>
+        </label>
+        <label className="block text-xs font-medium">Initial role
+          <select
+            value={draft.role}
+            onChange={(e) => setDraft({ ...draft, role: e.target.value })}
+            className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm"
+          >
+            {ROLE_OPTIONS.map((r) => <option key={r} value={r}>{r}</option>)}
+          </select>
+        </label>
+        {error && <p className="text-sm text-red-700">{error}</p>}
+        {conflict && (
+          <div className="rounded-md border border-amber-300 bg-amber-50 p-2 text-sm space-y-1" data-testid="add-person-conflict">
+            <p>A Person with this email already exists: <strong>{conflict.full_name}</strong>.</p>
+            <p className="text-xs">Add a new membership to the existing record instead?</p>
+            <button
+              type="button"
+              onClick={() => onCreated(conflict)}
+              className="px-2 py-1 rounded-md text-xs bg-amber-600 text-white"
+            >
+              Open existing
+            </button>
+          </div>
+        )}
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <button type="button" onClick={onClose} className="text-sm text-gray-600 hover:underline">Cancel</button>
+          <button
+            type="submit"
+            disabled={saving}
+            data-testid="add-person-save"
+            className="px-3 py-1.5 rounded-md text-sm bg-indigo-600 text-white disabled:opacity-60"
+          >
+            {saving ? 'Saving…' : 'Create Person'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default function AdminPeople() {
+  const [people, setPeople] = useState([]);
+  const [programs, setPrograms] = useState([]);
+  const [search, setSearch] = useState('');
+  const [roleFilter, setRoleFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState('active');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [selectedId, setSelectedId] = useState(null);
+  const [selectedPerson, setSelectedPerson] = useState(null);
+  const [adding, setAdding] = useState(false);
+  const [invitedStatus, setInvitedStatus] = useState({});
+
+  const load = useCallback(async () => {
+    setError(null);
+    setLoading(true);
+    try {
+      const [list, progList] = await Promise.all([
+        listAdminPeople({
+          search,
+          role: roleFilter,
+          status: statusFilter,
+          page_size: 100,
+        }),
+        listAdminPrograms('active'),
+      ]);
+      setPeople(list.results || []);
+      setPrograms(progList.results || []);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [search, roleFilter, statusFilter]);
+
+  useEffect(() => { load(); }, [load]);
+
+  useEffect(() => {
+    if (selectedId == null) {
+      setSelectedPerson(null);
+      return;
+    }
+    getAdminPerson(selectedId).then(setSelectedPerson).catch(() => setSelectedPerson(null));
+  }, [selectedId]);
+
+  const refreshSelected = () => {
+    if (selectedId == null) return;
+    getAdminPerson(selectedId).then(setSelectedPerson);
+  };
+
+  const handleInvite = async (personId) => {
+    setInvitedStatus({ ...invitedStatus, [personId]: 'pending' });
+    try {
+      await inviteAdminPerson(personId);
+      setInvitedStatus({ ...invitedStatus, [personId]: 'sent' });
+    } catch {
+      setInvitedStatus({ ...invitedStatus, [personId]: 'error' });
+    }
+  };
+
+  return (
+    <main className="grow px-4 sm:px-6 lg:px-8 py-6 w-full max-w-6xl mx-auto" data-testid="admin-people">
+      <header className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">People</h1>
+        <button
+          type="button"
+          data-testid="open-add-person"
+          onClick={() => setAdding(true)}
+          className="px-3 py-1.5 rounded-md text-sm bg-indigo-600 text-white"
+        >
+          Add Person
+        </button>
+      </header>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-2 mb-4">
+        <FieldInput label="Search name or email" value={search} onChange={setSearch} />
+        <label className="block text-xs font-medium">Role
+          <select
+            value={roleFilter}
+            onChange={(e) => setRoleFilter(e.target.value)}
+            className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm"
+          >
+            <option value="">Any</option>
+            {ROLE_OPTIONS.map((r) => <option key={r} value={r}>{r}</option>)}
+          </select>
+        </label>
+        <label className="block text-xs font-medium">Status
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm"
+          >
+            <option value="active">Active</option>
+            <option value="inactive">Inactive</option>
+            <option value="">All</option>
+          </select>
+        </label>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <section data-testid="people-list" className="space-y-2">
+          {loading ? (
+            <p className="text-sm text-gray-500">Loading…</p>
+          ) : error ? (
+            <p className="text-sm text-red-700">Could not load people.</p>
+          ) : (
+            <ul className="divide-y rounded-md border bg-white dark:bg-gray-900">
+              {people.length === 0 && (
+                <li className="p-3 text-sm italic text-gray-500">No people match those filters.</li>
+              )}
+              {people.map((p) => (
+                <li
+                  key={p.id}
+                  data-testid={`person-row-${p.id}`}
+                  className={classNames(
+                    'p-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800',
+                    selectedId === p.id && 'bg-indigo-50 dark:bg-indigo-900/20',
+                  )}
+                  onClick={() => setSelectedId(p.id)}
+                >
+                  <p className="font-medium text-sm">{p.full_name}</p>
+                  <p className="text-xs text-gray-500">{p.email || 'no email'}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+        <aside data-testid="person-drawer" className="rounded-md border bg-white dark:bg-gray-900 p-4">
+          {!selectedPerson ? (
+            <p className="text-sm italic text-gray-500">Select a Person to view their profile.</p>
+          ) : (
+            <>
+              <header className="flex items-center justify-between mb-3">
+                <h2 className="text-lg font-semibold">{selectedPerson.full_name}</h2>
+                <button
+                  type="button"
+                  data-testid="invite-person"
+                  onClick={() => handleInvite(selectedPerson.id)}
+                  disabled={!selectedPerson.email || invitedStatus[selectedPerson.id] === 'pending'}
+                  className="text-xs px-2 py-1 rounded-md border border-indigo-300 text-indigo-700 hover:bg-indigo-50 disabled:opacity-50"
+                >
+                  {invitedStatus[selectedPerson.id] === 'sent' ? 'Invitation sent' : 'Send invitation'}
+                </button>
+              </header>
+              <ProfileTabs
+                person={selectedPerson}
+                programs={programs}
+                onPersonChanged={refreshSelected}
+              />
+            </>
+          )}
+        </aside>
+      </div>
+      {adding && (
+        <AddPersonModal
+          programs={programs}
+          onClose={() => setAdding(false)}
+          onCreated={(person) => {
+            setAdding(false);
+            load();
+            if (person?.id) setSelectedId(person.id);
+          }}
+        />
+      )}
+    </main>
+  );
+}

--- a/frontend/src/pages/admin/Settings.jsx
+++ b/frontend/src/pages/admin/Settings.jsx
@@ -1,0 +1,413 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  getAdminSettings,
+  patchAdminSettings,
+  listAdminPrograms,
+  createAdminProgram,
+  patchAdminProgram,
+  endAdminProgram,
+} from '../../api/admin';
+
+/**
+ * Step 7_13 PR2 — Settings + Programs (Story 58).
+ *
+ * Tabs:
+ *   - Identity & Localization (Org name, supported languages, day rollover)
+ *   - Tag vocabulary
+ *   - Programs (list + create + End Program with typed-confirmation modal)
+ *
+ * "End Program" runs server-side as a single transaction that
+ * deactivates Memberships, closes open orders/tickets, and writes an
+ * audit row per touched record. We refuse client-side if the typed
+ * confirmation doesn't match.
+ */
+
+const TABS = [
+  { key: 'identity', label: 'Identity & Localization' },
+  { key: 'tags', label: 'Tag vocabulary' },
+  { key: 'programs', label: 'Programs' },
+];
+
+function FieldInput({ label, value, onChange, type = 'text' }) {
+  return (
+    <label className="block text-xs font-medium text-gray-700">
+      {label}
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="mt-1 w-full rounded-md border border-gray-300 bg-white p-2 text-sm"
+      />
+    </label>
+  );
+}
+
+function IdentityTab({ settings, onSaved }) {
+  const [draft, setDraft] = useState({
+    supported_languages: (settings?.supported_languages || ['en']).join(','),
+    rollover_hour: settings?.rollover_hour ?? '',
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [pendingRollover, setPendingRollover] = useState(false);
+
+  const submit = async (e) => {
+    e.preventDefault();
+    const langs = draft.supported_languages
+      .split(',').map((s) => s.trim()).filter(Boolean);
+    const rolloverHour = draft.rollover_hour === ''
+      ? null
+      : Number(draft.rollover_hour);
+    const rolloverChanged = rolloverHour !== (settings?.rollover_hour ?? null);
+    if (rolloverChanged && !pendingRollover) {
+      setPendingRollover(true);
+      return;
+    }
+    setSaving(true);
+    setError('');
+    try {
+      const updated = await patchAdminSettings({
+        supported_languages: langs,
+        rollover_hour: rolloverHour,
+      });
+      onSaved(updated);
+      setPendingRollover(false);
+    } catch (err) {
+      setError(err?.response?.data?.detail || 'Could not save.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-3" data-testid="settings-identity">
+      <FieldInput
+        label="Supported languages (comma-separated, e.g. en,es,he)"
+        value={draft.supported_languages}
+        onChange={(v) => setDraft({ ...draft, supported_languages: v })}
+      />
+      <FieldInput
+        label="Day rollover hour (0–23)"
+        type="number"
+        value={draft.rollover_hour}
+        onChange={(v) => setDraft({ ...draft, rollover_hour: v })}
+      />
+      {pendingRollover && (
+        <div
+          data-testid="rollover-confirmation"
+          className="rounded-md border border-amber-400 bg-amber-50 p-2 text-xs space-y-1"
+        >
+          <p>Changing the rollover hour affects how "today" is computed for everyone in this org.</p>
+          <p>Click <strong>Confirm save</strong> again to apply.</p>
+        </div>
+      )}
+      {error && <p className="text-sm text-red-700">{error}</p>}
+      <button
+        type="submit"
+        disabled={saving}
+        data-testid="settings-identity-save"
+        className="px-3 py-1.5 rounded-md text-sm bg-indigo-600 text-white disabled:opacity-60"
+      >
+        {pendingRollover ? 'Confirm save' : (saving ? 'Saving…' : 'Save')}
+      </button>
+    </form>
+  );
+}
+
+function TagsTab({ settings, onSaved }) {
+  const [tags, setTags] = useState((settings?.tag_vocabulary || []).join('\n'));
+  const [saving, setSaving] = useState(false);
+  const submit = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      const updated = await patchAdminSettings({
+        tag_vocabulary: tags
+          .split('\n').map((t) => t.trim().toLowerCase()).filter(Boolean),
+      });
+      onSaved(updated);
+    } finally {
+      setSaving(false);
+    }
+  };
+  return (
+    <form onSubmit={submit} className="space-y-3" data-testid="settings-tags">
+      <label className="block text-xs font-medium">Tag vocabulary (one per line)
+        <textarea
+          rows={10}
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+          className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm bg-white"
+        />
+      </label>
+      <button
+        type="submit"
+        disabled={saving}
+        className="px-3 py-1.5 rounded-md text-sm bg-indigo-600 text-white disabled:opacity-60"
+      >
+        {saving ? 'Saving…' : 'Save tag vocabulary'}
+      </button>
+    </form>
+  );
+}
+
+function ProgramsTab() {
+  const [programs, setPrograms] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [adding, setAdding] = useState(false);
+  const [endingProgram, setEndingProgram] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await listAdminPrograms();
+      setPrograms(data.results || []);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <div className="space-y-3" data-testid="settings-programs">
+      <header className="flex items-center justify-between">
+        <h3 className="text-sm font-medium">Programs</h3>
+        <button
+          type="button"
+          data-testid="programs-add"
+          onClick={() => setAdding((v) => !v)}
+          className="text-xs px-2 py-1 rounded-md bg-indigo-600 text-white"
+        >
+          {adding ? 'Cancel' : 'New program'}
+        </button>
+      </header>
+
+      {adding && (
+        <AddProgramForm
+          onCreated={() => { setAdding(false); load(); }}
+          onCancel={() => setAdding(false)}
+        />
+      )}
+
+      {loading ? (
+        <p className="text-sm text-gray-500">Loading…</p>
+      ) : error ? (
+        <p className="text-sm text-red-700">Could not load programs.</p>
+      ) : programs.length === 0 ? (
+        <p className="text-sm italic text-gray-500">No programs yet.</p>
+      ) : (
+        <ul className="divide-y rounded-md border bg-white dark:bg-gray-900">
+          {programs.map((p) => (
+            <li key={p.id} className="p-3 text-sm flex items-center justify-between" data-testid={`program-row-${p.id}`}>
+              <div>
+                <p className="font-medium">{p.name}</p>
+                <p className="text-xs text-gray-500">{p.program_type} · {p.start_date || '—'} → {p.end_date || 'open'}</p>
+              </div>
+              {p.is_active ? (
+                <button
+                  type="button"
+                  data-testid={`program-end-${p.id}`}
+                  onClick={() => setEndingProgram(p)}
+                  className="text-xs px-2 py-1 rounded-md border border-red-300 text-red-700 hover:bg-red-50"
+                >
+                  End program
+                </button>
+              ) : (
+                <span className="text-xs px-2 py-0.5 rounded-full bg-gray-200 text-gray-700">ended</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {endingProgram && (
+        <EndProgramModal
+          program={endingProgram}
+          onClose={() => setEndingProgram(null)}
+          onEnded={() => { setEndingProgram(null); load(); }}
+        />
+      )}
+    </div>
+  );
+}
+
+function AddProgramForm({ onCreated, onCancel }) {
+  const [draft, setDraft] = useState({
+    name: '',
+    slug: '',
+    program_type: '',
+    start_date: '',
+    end_date: '',
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const submit = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    setError('');
+    try {
+      await createAdminProgram(draft);
+      onCreated();
+    } catch (err) {
+      setError(err?.response?.data?.detail || 'Could not create program.');
+    } finally {
+      setSaving(false);
+    }
+  };
+  return (
+    <form onSubmit={submit} className="rounded-md border border-indigo-200 bg-indigo-50/30 p-3 space-y-2" data-testid="program-add-form">
+      <FieldInput label="Name" value={draft.name} onChange={(v) => setDraft({ ...draft, name: v })} />
+      <FieldInput label="Slug" value={draft.slug} onChange={(v) => setDraft({ ...draft, slug: v })} />
+      <FieldInput label="Program type (e.g. summer_camp)" value={draft.program_type} onChange={(v) => setDraft({ ...draft, program_type: v })} />
+      <FieldInput label="Start date (yyyy-mm-dd)" value={draft.start_date} onChange={(v) => setDraft({ ...draft, start_date: v })} />
+      <FieldInput label="End date (yyyy-mm-dd, optional)" value={draft.end_date} onChange={(v) => setDraft({ ...draft, end_date: v })} />
+      {error && <p className="text-sm text-red-700">{error}</p>}
+      <div className="flex justify-end gap-2">
+        <button type="button" onClick={onCancel} className="text-sm text-gray-600 hover:underline">Cancel</button>
+        <button
+          type="submit"
+          disabled={saving}
+          className="px-3 py-1.5 rounded-md text-sm bg-indigo-600 text-white disabled:opacity-60"
+        >
+          {saving ? 'Creating…' : 'Create program'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function EndProgramModal({ program, onClose, onEnded }) {
+  const [typed, setTyped] = useState('');
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [summary, setSummary] = useState(null);
+  const expected = program.slug || program.name;
+  const canSubmit = typed === expected && reason.trim();
+  const submit = async (e) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      const data = await endAdminProgram(program.id, reason);
+      setSummary(data?.summary || null);
+    } catch (err) {
+      setError(err?.response?.data?.detail || 'Could not end program.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+  return (
+    <div
+      role="dialog"
+      data-testid="end-program-modal"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => { if (e.target === e.currentTarget && !submitting) onClose(); }}
+    >
+      <div className="w-full max-w-md rounded-xl bg-white p-5 shadow-lg space-y-3 dark:bg-gray-900">
+        <h2 className="text-lg font-semibold text-red-800">End program: {program.name}</h2>
+        {summary ? (
+          <div className="space-y-2 text-sm" data-testid="end-program-summary">
+            <p>This action ran in a single transaction.</p>
+            <ul className="list-disc pl-5 text-sm">
+              <li>{summary.memberships_deactivated} memberships deactivated</li>
+              <li>{summary.orders_closed} Camper Care orders closed</li>
+              <li>{summary.maintenance_tickets_closed} maintenance tickets closed</li>
+              <li>Ended at {summary.ended_at}</li>
+            </ul>
+            <button
+              type="button"
+              onClick={onEnded}
+              className="px-3 py-1.5 rounded-md text-sm bg-indigo-600 text-white"
+            >
+              Done
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={submit} className="space-y-2">
+            <p className="text-sm">This will deactivate all memberships in this program and close
+              any open orders/tickets. Type <strong>{expected}</strong> to confirm.</p>
+            <FieldInput label="Type to confirm" value={typed} onChange={setTyped} />
+            <label className="block text-xs font-medium">Reason
+              <textarea
+                rows={3}
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm bg-white"
+              />
+            </label>
+            {error && <p className="text-sm text-red-700">{error}</p>}
+            <div className="flex justify-end gap-2">
+              <button type="button" disabled={submitting} onClick={onClose} className="text-sm text-gray-600 hover:underline">Cancel</button>
+              <button
+                type="submit"
+                disabled={!canSubmit || submitting}
+                data-testid="end-program-confirm"
+                className="px-3 py-1.5 rounded-md text-sm bg-red-600 text-white disabled:opacity-50"
+              >
+                {submitting ? 'Ending…' : 'End program'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function AdminSettings() {
+  const [settings, setSettings] = useState(null);
+  const [error, setError] = useState(null);
+  const [tab, setTab] = useState('identity');
+  const load = useCallback(async () => {
+    try {
+      const data = await getAdminSettings();
+      setSettings(data);
+    } catch (err) {
+      setError(err);
+    }
+  }, []);
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <main className="grow px-4 sm:px-6 lg:px-8 py-6 w-full max-w-4xl mx-auto" data-testid="admin-settings">
+      <header className="mb-4">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Settings</h1>
+      </header>
+      <nav className="border-b border-gray-200 dark:border-gray-700 flex gap-3 mb-4">
+        {TABS.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            data-testid={`settings-tab-${t.key}`}
+            onClick={() => setTab(t.key)}
+            className={`pb-2 -mb-px text-sm font-medium border-b-2 ${
+              tab === t.key
+                ? 'border-indigo-500 text-indigo-700 dark:text-indigo-200'
+                : 'border-transparent text-gray-500 hover:text-gray-800 dark:hover:text-gray-200'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
+      {error ? (
+        <p className="text-sm text-red-700">Could not load settings.</p>
+      ) : !settings ? (
+        <p className="text-sm text-gray-500">Loading…</p>
+      ) : (
+        <>
+          {tab === 'identity' && <IdentityTab settings={settings} onSaved={(s) => setSettings({ ...settings, ...s })} />}
+          {tab === 'tags' && <TagsTab settings={settings} onSaved={(s) => setSettings({ ...settings, ...s })} />}
+          {tab === 'programs' && <ProgramsTab />}
+        </>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/pages/admin/__tests__/Assignments.test.jsx
+++ b/frontend/src/pages/admin/__tests__/Assignments.test.jsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+vi.mock('../../../api/admin', () => ({
+  listAdminAssignments: vi.fn(),
+  createAdminAssignment: vi.fn(),
+  patchAdminAssignment: vi.fn(),
+}));
+
+import {
+  listAdminAssignments,
+  createAdminAssignment,
+} from '../../../api/admin';
+import AdminAssignments from '../Assignments';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listAdminAssignments.mockResolvedValue({ results: [] });
+});
+
+describe('AdminAssignments (7_13 PR2)', () => {
+  it('renders all five sub-tabs and switches between them', async () => {
+    render(<AdminAssignments />);
+    expect(await screen.findByTestId('assignment-sub-tab-counselor_bunk')).toBeInTheDocument();
+    expect(screen.getByTestId('assignment-sub-tab-uh_counselor')).toBeInTheDocument();
+    expect(screen.getByTestId('assignment-sub-tab-cc_caseload')).toBeInTheDocument();
+    expect(screen.getByTestId('assignment-sub-tab-lt_team')).toBeInTheDocument();
+    expect(screen.getByTestId('assignment-sub-tab-camper_bunk')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('assignment-sub-tab-uh_counselor'));
+    await waitFor(() =>
+      expect(listAdminAssignments).toHaveBeenLastCalledWith('uh_counselor'),
+    );
+  });
+
+  it('renders the backdated-clamp warning when the API reports one', async () => {
+    createAdminAssignment.mockResolvedValueOnce({
+      backdated_clamped: true,
+      requested_start_date: '2020-01-01',
+      warnings: [
+        { supervision_id: 7, supervisor_membership_id: 12, supervisor_name: 'Sue', kind: 'co_supervisor' },
+      ],
+      supervision: { id: 1 },
+    });
+    render(<AdminAssignments />);
+    await screen.findByTestId('assignment-create-form');
+
+    fireEvent.click(screen.getByTestId('assignment-create-submit'));
+
+    await waitFor(() => expect(createAdminAssignment).toHaveBeenCalled());
+    expect(await screen.findByTestId('backdated-warning')).toBeInTheDocument();
+    expect(screen.getByTestId('assignment-warnings')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/admin/__tests__/People.test.jsx
+++ b/frontend/src/pages/admin/__tests__/People.test.jsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+vi.mock('../../../api/admin', () => ({
+  listAdminPeople: vi.fn(),
+  getAdminPerson: vi.fn(),
+  createAdminPerson: vi.fn(),
+  patchAdminPerson: vi.fn(),
+  addAdminMembership: vi.fn(),
+  patchAdminMembership: vi.fn(),
+  deactivateAdminMembership: vi.fn(),
+  inviteAdminPerson: vi.fn(),
+  listAdminPrograms: vi.fn(),
+}));
+
+import {
+  listAdminPeople,
+  getAdminPerson,
+  createAdminPerson,
+  listAdminPrograms,
+} from '../../../api/admin';
+import AdminPeople from '../People';
+
+const PEOPLE = [
+  { id: 1, full_name: 'Alice Admin', email: 'a@example.com' },
+  { id: 2, full_name: 'Bob Counselor', email: 'b@example.com' },
+];
+
+const PROGRAMS = [
+  { id: 10, name: 'Summer 2026' },
+];
+
+const ALICE_DETAIL = {
+  id: 1,
+  full_name: 'Alice Admin',
+  email: 'a@example.com',
+  first_name: 'Alice',
+  last_name: 'Admin',
+  preferred_name: '',
+  preferred_language: 'en',
+  memberships: [
+    { id: 100, role: 'counselor', program_name: 'Summer 2026', tags: ['veteran'], is_active: true },
+  ],
+  recent_activity: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listAdminPeople.mockResolvedValue({ results: PEOPLE });
+  listAdminPrograms.mockResolvedValue({ results: PROGRAMS });
+  getAdminPerson.mockResolvedValue(ALICE_DETAIL);
+});
+
+describe('AdminPeople (7_13 PR2)', () => {
+  it('renders the list and opens the profile drawer for the selected Person', async () => {
+    render(<AdminPeople />);
+    expect(await screen.findByTestId('person-row-1')).toBeInTheDocument();
+    expect(screen.getByTestId('person-row-2')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('person-row-1'));
+    await waitFor(() => expect(getAdminPerson).toHaveBeenCalledWith(1));
+    expect(await screen.findByText('Alice Admin', { selector: 'h2' })).toBeInTheDocument();
+    expect(screen.getByTestId('identity-tab')).toBeInTheDocument();
+  });
+
+  it('surfaces the email-conflict response from POST /admin/people/', async () => {
+    createAdminPerson.mockRejectedValueOnce({
+      response: {
+        status: 409,
+        data: {
+          detail: 'email exists',
+          existing_person: { id: 99, full_name: 'Duplicate' },
+        },
+      },
+    });
+    render(<AdminPeople />);
+    await screen.findByTestId('person-row-1');
+    fireEvent.click(screen.getByTestId('open-add-person'));
+    expect(await screen.findByTestId('add-person-modal')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('add-person-save'));
+
+    expect(await screen.findByTestId('add-person-conflict')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/admin/__tests__/Settings.test.jsx
+++ b/frontend/src/pages/admin/__tests__/Settings.test.jsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+vi.mock('../../../api/admin', () => ({
+  getAdminSettings: vi.fn(),
+  patchAdminSettings: vi.fn(),
+  listAdminPrograms: vi.fn(),
+  createAdminProgram: vi.fn(),
+  patchAdminProgram: vi.fn(),
+  endAdminProgram: vi.fn(),
+}));
+
+import {
+  getAdminSettings,
+  listAdminPrograms,
+  endAdminProgram,
+} from '../../../api/admin';
+import AdminSettings from '../Settings';
+
+const SETTINGS = {
+  organization_id: 1,
+  name: 'Test Org',
+  slug: 'test-org',
+  settings: { supported_languages: ['en'], rollover_hour: 6, tag_vocabulary: ['vip'] },
+  supported_languages: ['en'],
+  rollover_hour: 6,
+  tag_vocabulary: ['vip'],
+};
+
+const PROGRAM = {
+  id: 7,
+  name: 'Test Org Summer',
+  slug: 'test-summer',
+  program_type: 'summer_camp',
+  start_date: '2026-06-01',
+  end_date: '2026-08-31',
+  is_active: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAdminSettings.mockResolvedValue(SETTINGS);
+  listAdminPrograms.mockResolvedValue({ results: [PROGRAM] });
+});
+
+describe('AdminSettings — End Program flow (7_13 PR2)', () => {
+  it('requires the typed slug + a reason before submitting', async () => {
+    endAdminProgram.mockResolvedValue({ summary: { memberships_deactivated: 2, orders_closed: 1, maintenance_tickets_closed: 0, ended_at: '2026-05-22' } });
+    render(<AdminSettings />);
+    await screen.findByTestId('settings-tab-programs');
+    fireEvent.click(screen.getByTestId('settings-tab-programs'));
+    await screen.findByTestId(`program-row-${PROGRAM.id}`);
+    fireEvent.click(screen.getByTestId(`program-end-${PROGRAM.id}`));
+
+    expect(await screen.findByTestId('end-program-modal')).toBeInTheDocument();
+    const confirmBtn = screen.getByTestId('end-program-confirm');
+    expect(confirmBtn).toBeDisabled();
+
+    // Type wrong value -> still disabled.
+    const inputs = screen.getAllByRole('textbox');
+    fireEvent.change(inputs[0], { target: { value: 'wrong' } });
+    fireEvent.change(inputs[1], { target: { value: 'A reason' } });
+    expect(confirmBtn).toBeDisabled();
+
+    fireEvent.change(inputs[0], { target: { value: PROGRAM.slug } });
+    await waitFor(() => expect(confirmBtn).not.toBeDisabled());
+
+    fireEvent.click(confirmBtn);
+    await waitFor(() =>
+      expect(endAdminProgram).toHaveBeenCalledWith(PROGRAM.id, 'A reason'),
+    );
+    expect(await screen.findByTestId('end-program-summary')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/partials/Sidebar.jsx
+++ b/frontend/src/partials/Sidebar.jsx
@@ -254,10 +254,13 @@ function Sidebar({
               setSidebarExpanded={setSidebarExpanded}
             >
               <SubItem to="/admin" label="Admin home" end />
+              <SubItem to="/admin/people" label="People" />
+              <SubItem to="/admin/assignments" label="Assignments" />
               <SubItem to="/admin/memberships" label="Memberships" />
               <SubItem to="/admin/templates" label="Templates" />
               <SubItem to="/admin/groups" label="Assignment groups" />
               <SubItem to="/admin/field-keys" label="Field keys" />
+              <SubItem to="/admin/settings" label="Settings" />
             </CollapsibleSection>
           )}
 


### PR DESCRIPTION
## Summary

PR2 of the 7_13 Admin Flow split (Stories 55, 56, 58). Builds on the PR1 (#111) `/api/v1/admin/` namespace and adds the People + Assignments + Programs/Settings CRUD layer plus the matching `/admin/*` frontend pages.

This PR is **stacked on `feat/7_13a_admin_dashboard_audit`** (PR #111). Merge PR1 first, then update the base of this PR to `main`.

### Backend
- `/admin/people/` list + create + detail + patch, email-conflict 409 returns the existing Person.
- `/admin/people/<id>/memberships/` + `/admin/memberships/<id>/{patch,deactivate}/` cover add / soft-delete / role-immutable patch.
- `/admin/people/<id>/invite/` audits invitation queueing.
- `/admin/assignments/` + `/<id>/` unify `Supervision` + `AssignmentGroupMembership` across five sub-tabs (`uh_counselor`, `cc_caseload`, `lt_team`, `counselor_bunk`, `camper_bunk`). Backdated start dates are clamped to today and the original is preserved in `metadata.requested_start_date` so historical content stays anchored to the prior assignment (Story 56 A4). Overlap surfaces non-blocking warnings.
- `/admin/programs/` CRUD plus `/admin/programs/<id>/end/` runs deactivation + order/ticket closure + program archival inside a single `transaction.atomic` block (Story 58 c5). Refuses to end a program with active Camper Care flags. Rollback verified by mocking the audit helper to raise mid-flight.
- `/admin/settings/` exposes the org-level settings JSON and PATCH writes a manual `AuditEvent`.
- `Membership` + `AssignmentGroupMembership` gain `_audit_organization` / `_audit_program` hooks so the existing audit helpers can resolve scope without a special case.

### Frontend
- `pages/admin/People.jsx`, `pages/admin/Assignments.jsx`, `pages/admin/Settings.jsx` (Identity / Tags / Programs tabs, with a typed-slug End Program confirmation modal).
- Routes wired under `AdminLayout`; sidebar gains People / Assignments / Settings entries.

### Tests
- `backend/bunk_logs/api/tests/test_admin_flow_pr2.py` — 16 cases covering CRUD happy paths, auth/permission gates, email conflict, role immutability, backdated clamp, conflict warnings, End Program transactional rollback, and settings audit.
- New frontend integration tests for People / Assignments / Settings.

### Docs
- `docs/role_flows/admin.md` extended with the PR2 endpoint table, invariants, and page layouts.

## Test plan
- [ ] Backend `pytest bunk_logs/api/tests/test_admin_flow.py bunk_logs/api/tests/test_admin_flow_pr2.py` (passes locally: 32/32).
- [ ] Frontend `vitest run src/pages/admin/__tests__/` (passes locally).
- [ ] `ruff check bunk_logs/api/admin_flow bunk_logs/api/tests/test_admin_flow_pr2.py` clean.
- [ ] Manual smoke: `/admin/people` add Person + add Membership + deactivate; `/admin/assignments` switch sub-tabs + create; `/admin/settings` Programs tab End Program with typed-slug confirmation.


Made with [Cursor](https://cursor.com)