### PR TITLE
7_14 madrich flow (PR2/2: frontend)

### DIFF
--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -69,6 +69,9 @@ import CamperCareSelfReflectionHistoryPage from './pages/camper-care/SelfReflect
 import KitchenStaffDashboard from './pages/kitchen-staff/Dashboard';
 import KitchenStaffReflectionForm from './pages/kitchen-staff/ReflectionForm';
 import KitchenStaffHistory from './pages/kitchen-staff/History';
+import MadrichDashboard from './pages/madrich/Dashboard';
+import MadrichReflectionForm from './pages/madrich/ReflectionForm';
+import MadrichHistory from './pages/madrich/History';
 import LeadershipTeamDashboard from './pages/leadership-team/Dashboard';
 import LeadershipTeamTeamDashboard from './pages/leadership-team/TeamDashboard';
 import LeadershipTeamMemberReflection from './pages/leadership-team/MemberReflection';
@@ -586,6 +589,40 @@ function Router() {
           element={
             <ProtectedRoute>
               <KitchenStaffReflectionForm />
+            </ProtectedRoute>
+          }
+        />
+
+        {/* Madrich (TBE) (Step 7_14, Stories 61-65)                              */}
+        <Route
+          path="/madrich"
+          element={
+            <ProtectedRoute>
+              <MadrichDashboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/madrich/history"
+          element={
+            <ProtectedRoute>
+              <MadrichHistory />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/madrich/reflection/new"
+          element={
+            <ProtectedRoute>
+              <MadrichReflectionForm />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/madrich/reflection/:reflectionId/edit"
+          element={
+            <ProtectedRoute>
+              <MadrichReflectionForm />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/api/madrich.js
+++ b/frontend/src/api/madrich.js
@@ -1,0 +1,59 @@
+/**
+ * Madrich (TBE) API client — Step 7_14, Stories 61-65.
+ *
+ * Mirrors `kitchenStaff.js` but bound to the weekly Madrich endpoints.
+ * All requests carry the `X-Organization-Slug` header for multi-tenant
+ * routing.
+ */
+import api from '../api';
+
+const BASE = '/api/v1/madrich';
+
+/** GET /api/v1/madrich/dashboard/ */
+export async function fetchDashboard(orgSlug) {
+  const { data } = await api.get(`${BASE}/dashboard/`, {
+    headers: { 'X-Organization-Slug': orgSlug },
+  });
+  return data;
+}
+
+/** POST /api/v1/madrich/reflection/ */
+export async function submitReflection(orgSlug, payload) {
+  const { data } = await api.post(`${BASE}/reflection/`, payload, {
+    headers: { 'X-Organization-Slug': orgSlug },
+  });
+  return data;
+}
+
+/** PATCH /api/v1/madrich/reflection/:id/ */
+export async function updateReflection(orgSlug, reflectionId, payload) {
+  const { data } = await api.patch(`${BASE}/reflection/${reflectionId}/`, payload, {
+    headers: { 'X-Organization-Slug': orgSlug },
+  });
+  return data;
+}
+
+/** GET /api/v1/madrich/reflection/history/ */
+export async function fetchHistory(orgSlug, { page = 1, pageSize = 12 } = {}) {
+  const { data } = await api.get(`${BASE}/reflection/history/`, {
+    params: { page, page_size: pageSize },
+    headers: { 'X-Organization-Slug': orgSlug },
+  });
+  return data;
+}
+
+/**
+ * GET /api/v1/reflections/template-for-me/?role=madrich&language=en
+ *
+ * The shared template-for-me endpoint resolves to the Madrich weekly
+ * template via the viewer's active Membership; we pass `role=madrich`
+ * explicitly for the elevated-actor codepath (admins viewing on behalf
+ * of a Madrich).
+ */
+export async function fetchTemplate(orgSlug, language = 'en') {
+  const { data } = await api.get('/api/v1/reflections/template-for-me/', {
+    params: { role: 'madrich', language },
+    headers: { 'X-Organization-Slug': orgSlug },
+  });
+  return data;
+}

--- a/frontend/src/pages/madrich/Dashboard.jsx
+++ b/frontend/src/pages/madrich/Dashboard.jsx
@@ -1,0 +1,191 @@
+/**
+ * Madrich (TBE) dashboard — Step 7_14, Story 61.
+ *
+ * Three top-level sections (criterion 3) with weekly cadence framing
+ * per criterion 5:
+ *   1. Header — name, role label "Madrich", grade level, active program.
+ *   2. My reflection — current week card (Week of [start]-[end]) with
+ *      "Not yet started" / "Submitted for this week" state.
+ *   3. My reflections — history shortcut.
+ *
+ * No bunk lists, faculty submissions, peer-Madrich data, or camp-side
+ * operational signal per criterion 4. Per TBE Tier 1 scope: English
+ * only, no LanguagePicker.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchDashboard } from '../../api/madrich';
+import { useAuth } from '../../auth/AuthContext';
+
+function formatWeekRange(periodStart, periodEnd) {
+  if (!periodStart || !periodEnd) return '';
+  const start = new Date(`${periodStart}T00:00:00`);
+  const end = new Date(`${periodEnd}T00:00:00`);
+  const sameMonth = start.getMonth() === end.getMonth();
+  const startLabel = start.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+  const endLabel = sameMonth
+    ? end.toLocaleDateString(undefined, { day: 'numeric' })
+    : end.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return `Week of ${startLabel}–${endLabel}`;
+}
+
+function ReflectionStatusCard({ myReflection, weekLabel }) {
+  if (!myReflection) return null;
+  const { state, reflection_id, editable } = myReflection;
+
+  if (state === 'no_template') {
+    return (
+      <section
+        aria-label="My reflection"
+        className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+        data-testid="md-reflection-card"
+      >
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-1">
+          My reflection
+        </h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          No reflections currently assigned. Your Director will set this up shortly.
+        </p>
+      </section>
+    );
+  }
+
+  const isComplete = state === 'complete';
+  const actionPath = editable && reflection_id
+    ? `/madrich/reflection/${reflection_id}/edit`
+    : '/madrich/reflection/new';
+
+  const statusLabel = isComplete ? 'Submitted for this week' : 'Not yet submitted';
+  const statusClass = isComplete
+    ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300'
+    : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300';
+  const ctaLabel = isComplete ? 'Edit reflection' : 'Start reflection';
+
+  return (
+    <section
+      aria-label="My reflection"
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+      data-testid="md-reflection-card"
+    >
+      <div className="flex items-center justify-between mb-1">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+          My reflection
+        </h2>
+        <span
+          className={`text-xs font-medium px-2 py-0.5 rounded-full ${statusClass}`}
+          data-testid="md-reflection-status"
+        >
+          {statusLabel}
+        </span>
+      </div>
+      {weekLabel && (
+        <p
+          className="text-sm text-gray-500 dark:text-gray-400 mb-3"
+          data-testid="md-week-label"
+        >
+          {weekLabel}
+        </p>
+      )}
+      <Link
+        to={actionPath}
+        className="mt-2 inline-block rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium px-4 py-2 transition-colors"
+        data-testid="md-reflection-cta"
+      >
+        {ctaLabel}
+      </Link>
+    </section>
+  );
+}
+
+export default function MadrichDashboard() {
+  const { orgSlug } = useAuth();
+  const [dashboard, setDashboard] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetchDashboard(orgSlug);
+      setDashboard(data);
+      setError(null);
+    } catch {
+      setError('Could not load dashboard.');
+    } finally {
+      setLoading(false);
+    }
+  }, [orgSlug]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-screen" data-testid="md-loading">
+        <p className="text-gray-500 dark:text-gray-400">Loading…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6" data-testid="md-error">
+        <p className="text-red-600 dark:text-red-400">{error}</p>
+        <button
+          onClick={load}
+          className="mt-3 text-sm text-indigo-600 dark:text-indigo-400 underline"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const { header, my_reflection, history_entry, period } = dashboard;
+  const weekLabel = formatWeekRange(period?.start, period?.end);
+  const gradeLevel = header?.grade_level;
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <header className="bg-white dark:bg-gray-800 shadow-sm">
+        <div className="max-w-2xl mx-auto px-4 py-4">
+          <p className="text-sm text-gray-500 dark:text-gray-400">{header.program_name}</p>
+          <h1 className="text-xl font-bold text-gray-900 dark:text-white">
+            {header.name}
+          </h1>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            Madrich{typeof gradeLevel === 'number' ? ` · Grade ${gradeLevel}` : ''}
+          </p>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-4 py-6 space-y-4">
+        <ReflectionStatusCard myReflection={my_reflection} weekLabel={weekLabel} />
+
+        <section
+          aria-label="My reflections"
+          className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+          data-testid="md-history-section"
+        >
+          <div className="flex items-center justify-between">
+            <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+              My reflections
+            </h2>
+            <Link
+              to={history_entry?.url ?? '/madrich/history'}
+              className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+              data-testid="md-history-link"
+            >
+              View history →
+            </Link>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/madrich/History.jsx
+++ b/frontend/src/pages/madrich/History.jsx
@@ -1,0 +1,159 @@
+/**
+ * Madrich (TBE) weekly reflection history — Step 7_14, Story 65.
+ *
+ * Renders one row per week (Monday-Sunday) back through the program
+ * start date. Weeks with no submission appear as "Missed" gap rows
+ * (Story 65 criterion 4). Only the current week is editable; prior
+ * weeks are read-only (Story 62 criterion 6 echoed in c5).
+ *
+ * Preview text is the first non-empty answer per Story 65 c2 (server
+ * preference is the "1 question or concern" line).
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchHistory } from '../../api/madrich';
+import { useAuth } from '../../auth/AuthContext';
+
+function formatWeekRange(periodStart, periodEnd) {
+  if (!periodStart || !periodEnd) return '';
+  const start = new Date(`${periodStart}T00:00:00`);
+  const end = new Date(`${periodEnd}T00:00:00`);
+  const sameMonth = start.getMonth() === end.getMonth();
+  const startLabel = start.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  const endLabel = sameMonth
+    ? end.toLocaleDateString(undefined, { day: 'numeric' })
+    : end.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return `Week of ${startLabel}\u2013${endLabel}`;
+}
+
+function HistoryRow({ row }) {
+  const { period_start, period_end, submitted, reflection_id, preview, editable } = row;
+  const weekLabel = formatWeekRange(period_start, period_end);
+
+  const statusLabel = submitted ? 'Submitted' : 'Missed';
+  const statusClass = submitted
+    ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300'
+    : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400';
+
+  return (
+    <li
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+      data-testid="md-history-row"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-sm font-medium text-gray-900 dark:text-white">{weekLabel}</span>
+            <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${statusClass}`}>
+              {statusLabel}
+            </span>
+          </div>
+          {preview && (
+            <p className="text-sm text-gray-600 dark:text-gray-400 truncate">{preview}</p>
+          )}
+        </div>
+        {editable && reflection_id ? (
+          <Link
+            to={`/madrich/reflection/${reflection_id}/edit`}
+            className="shrink-0 text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:underline"
+            data-testid="md-edit-link"
+          >
+            Edit
+          </Link>
+        ) : submitted && reflection_id ? (
+          <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">Read-only</span>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+export default function MadrichHistory() {
+  const { orgSlug } = useAuth();
+
+  const [history, setHistory] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [page, setPage] = useState(1);
+
+  const load = useCallback(async (p = 1) => {
+    setLoading(true);
+    try {
+      const data = await fetchHistory(orgSlug, { page: p });
+      setHistory(data);
+      setError(null);
+    } catch {
+      setError('Could not load history.');
+    } finally {
+      setLoading(false);
+    }
+  }, [orgSlug]);
+
+  useEffect(() => {
+    load(page);
+  }, [load, page]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white" data-testid="md-history-heading">
+            My reflections
+          </h1>
+          <Link
+            to="/madrich"
+            className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+          >
+            ← Dashboard
+          </Link>
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 rounded-lg bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 text-sm" data-testid="md-history-error">
+            {error}
+          </div>
+        )}
+
+        {loading && !history ? (
+          <p className="text-gray-500 dark:text-gray-400 text-sm" data-testid="md-history-loading">
+            Loading…
+          </p>
+        ) : history?.results?.length === 0 ? (
+          <p className="text-gray-500 dark:text-gray-400 text-sm" data-testid="md-history-empty">
+            No reflections yet.
+          </p>
+        ) : (
+          <>
+            <ul className="space-y-3" data-testid="md-history-list">
+              {(history?.results ?? []).map(row => (
+                <HistoryRow key={row.period_start} row={row} />
+              ))}
+            </ul>
+
+            <div className="mt-6 flex gap-3 justify-center">
+              {history?.previous && (
+                <button
+                  onClick={() => setPage(p => p - 1)}
+                  className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+                  disabled={loading}
+                >
+                  ← Previous
+                </button>
+              )}
+              {history?.next && (
+                <button
+                  onClick={() => setPage(p => p + 1)}
+                  className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+                  disabled={loading}
+                >
+                  Next →
+                </button>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/madrich/ReflectionForm.jsx
+++ b/frontend/src/pages/madrich/ReflectionForm.jsx
@@ -1,0 +1,195 @@
+/**
+ * Madrich (TBE) weekly reflection form — Step 7_14, Stories 62 & 64.
+ *
+ * Story 62 contract:
+ *   * Exactly 3 wins, exactly 2 improvements, 1 question/concern, 5 ratings (1-4).
+ *   * No day-off shortcut (criterion 3) — every week's payload carries all sections.
+ *   * Inline submit error from backend; client-side validation mirrors
+ *     backend schema enforcement via `validateReflectionAnswers`.
+ *
+ * Story 64 visibility disclosure: rendered above the form so the
+ * Madrich sees who can read the submission before they hit Submit.
+ *
+ * TBE Tier 1 scope: English only — no language picker / Hebrew copy.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import ReflectionField from '../../components/templates/ReflectionField';
+import {
+  buildDefaultAnswers,
+  validateReflectionAnswers,
+} from '../../utils/reflection/reflectionFormValidation';
+import { fetchReflection, fetchTemplateById, newClientSubmissionId } from '../../api/counselor';
+import { fetchTemplate, submitReflection, updateReflection } from '../../api/madrich';
+import { useAuth } from '../../auth/AuthContext';
+
+const LANGUAGE = 'en';
+const AUDIENCE_DISCLOSURE =
+  'Your Director(s) and any Temple Beth-El staff assigned to oversee Madrichim can read this reflection. Other Madrichim cannot.';
+
+function flattenError(err, fallback) {
+  const body = err?.response?.data;
+  if (!body) return err?.message || fallback;
+  if (typeof body === 'string') return body;
+  if (typeof body.detail === 'string') return body.detail;
+  if (typeof body === 'object') {
+    try { return JSON.stringify(body); } catch { return fallback; }
+  }
+  return fallback;
+}
+
+export default function MadrichReflectionForm() {
+  const { reflectionId } = useParams();
+  const navigate = useNavigate();
+  const { orgSlug } = useAuth();
+  const isEdit = Boolean(reflectionId);
+
+  const [template, setTemplate] = useState(null);
+  const [answers, setAnswers] = useState({});
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState('');
+  const [fieldErrors, setFieldErrors] = useState({});
+  const clientSubmissionId = useRef(newClientSubmissionId());
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      try {
+        let tpl;
+        let prefillAnswers = null;
+        if (isEdit) {
+          const reflection = await fetchReflection(reflectionId);
+          if (!cancelled) prefillAnswers = reflection.answers || {};
+          tpl = await fetchTemplateById(reflection.template);
+        } else {
+          tpl = await fetchTemplate(orgSlug, LANGUAGE);
+        }
+        if (!cancelled) {
+          setTemplate(tpl);
+          if (prefillAnswers !== null) {
+            setAnswers(prefillAnswers);
+          } else if (tpl?.schema) {
+            setAnswers(buildDefaultAnswers(tpl.schema));
+          }
+        }
+      } catch (err) {
+        if (!cancelled) setSubmitError(flattenError(err, 'Could not load the reflection.'));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [reflectionId, orgSlug, isEdit]);
+
+  const handleFieldChange = useCallback((key, value) => {
+    setAnswers(prev => ({ ...prev, [key]: value }));
+    setFieldErrors(prev => { const n = { ...prev }; delete n[key]; return n; });
+  }, []);
+
+  const handleSubmit = useCallback(async (e) => {
+    e.preventDefault();
+    setSubmitError('');
+    setFieldErrors({});
+
+    if (template?.schema) {
+      const { ok, errors } = validateReflectionAnswers(template.schema, answers);
+      if (!ok) {
+        setFieldErrors(errors);
+        return;
+      }
+    }
+
+    setSubmitting(true);
+    try {
+      if (isEdit) {
+        await updateReflection(orgSlug, reflectionId, {
+          answers,
+          language: LANGUAGE,
+        });
+      } else {
+        await submitReflection(orgSlug, {
+          answers,
+          language: LANGUAGE,
+          client_submission_id: clientSubmissionId.current,
+        });
+      }
+      navigate('/madrich');
+    } catch (err) {
+      setSubmitError(flattenError(err, 'Could not save the reflection.'));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [template, answers, isEdit, orgSlug, reflectionId, navigate]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-screen" data-testid="md-form-loading">
+        <p className="text-gray-500 dark:text-gray-400">Loading…</p>
+      </div>
+    );
+  }
+
+  const fields = template?.schema?.fields ?? [];
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <h1
+          className="text-2xl font-bold text-gray-900 dark:text-white mb-6"
+          data-testid="md-form-heading"
+        >
+          {isEdit ? 'Edit weekly reflection' : 'This week\u2019s reflection'}
+        </h1>
+
+        <div
+          className="mb-6 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 px-4 py-3 text-sm text-blue-800 dark:text-blue-300"
+          data-testid="md-audience-disclosure"
+        >
+          {AUDIENCE_DISCLOSURE}
+        </div>
+
+        <form onSubmit={handleSubmit} noValidate>
+          {fields.map(field => (
+            <div key={field.key} className="mb-6">
+              <ReflectionField
+                field={field}
+                answer={answers[field.key]}
+                onChange={val => handleFieldChange(field.key, val)}
+                error={fieldErrors[field.key]}
+                language={LANGUAGE}
+              />
+            </div>
+          ))}
+
+          {submitError && (
+            <p className="text-red-600 dark:text-red-400 text-sm mb-4" data-testid="md-submit-error">
+              {submitError}
+            </p>
+          )}
+
+          <div className="flex gap-3 mt-6">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="flex-1 rounded-lg bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white font-medium py-2 px-4 transition-colors"
+              data-testid="md-submit-button"
+            >
+              {submitting ? 'Saving…' : isEdit ? 'Save changes' : 'Submit reflection'}
+            </button>
+            <button
+              type="button"
+              onClick={() => navigate(-1)}
+              className="rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 font-medium py-2 px-4 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/madrich/__tests__/Dashboard.test.jsx
+++ b/frontend/src/pages/madrich/__tests__/Dashboard.test.jsx
@@ -1,0 +1,113 @@
+/**
+ * Madrich dashboard tests — Step 7_14, Story 61.
+ *
+ * Covers weekly framing (the "Week of …" label is derived from the
+ * server-provided period_start/period_end, criterion 5), state→CTA
+ * mapping, and the absence of the no-template / camp-side surfaces.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import MadrichDashboard from '../Dashboard';
+
+const getMock = vi.fn();
+vi.mock('../../../api', () => ({
+  default: { get: (...args) => getMock(...args) },
+}));
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ orgSlug: 'tbe', user: { id: 7 } }),
+}));
+
+const samplePayload = {
+  today: '2026-09-09',
+  period: { start: '2026-09-07', end: '2026-09-13', cadence: 'weekly' },
+  header: {
+    name: 'Maya Madrich',
+    role_label: 'Madrich',
+    grade_level: 10,
+    program_name: 'TBE Religious School 2026-27',
+    preferred_language: 'en',
+  },
+  my_reflection: { state: 'missing', reflection_id: null, template_id: 12, editable: false },
+  history_entry: { url: '/madrich/history' },
+};
+
+beforeEach(() => {
+  getMock.mockReset();
+});
+
+describe('MadrichDashboard', () => {
+  it('renders header with name, role, grade, and program', async () => {
+    getMock.mockResolvedValue({ data: samplePayload });
+    render(<MemoryRouter><MadrichDashboard /></MemoryRouter>);
+    await waitFor(() => screen.getByText('Maya Madrich'));
+    expect(screen.getByText('TBE Religious School 2026-27')).toBeInTheDocument();
+    expect(screen.getByText(/Madrich.*Grade 10/)).toBeInTheDocument();
+  });
+
+  it('frames the current week as Monday-Sunday', async () => {
+    getMock.mockResolvedValue({ data: samplePayload });
+    render(<MemoryRouter><MadrichDashboard /></MemoryRouter>);
+    await waitFor(() => screen.getByTestId('md-week-label'));
+    const label = screen.getByTestId('md-week-label').textContent;
+    expect(label).toMatch(/Week of/);
+    expect(label).toMatch(/Sep 7/);
+    expect(label).toMatch(/13/);
+  });
+
+  it('shows "Not yet submitted" + Start CTA when state is missing', async () => {
+    getMock.mockResolvedValue({ data: samplePayload });
+    render(<MemoryRouter><MadrichDashboard /></MemoryRouter>);
+    await waitFor(() => screen.getByTestId('md-reflection-cta'));
+    expect(screen.getByTestId('md-reflection-status')).toHaveTextContent(/Not yet submitted/);
+    expect(screen.getByTestId('md-reflection-cta')).toHaveTextContent('Start reflection');
+    expect(screen.getByTestId('md-reflection-cta')).toHaveAttribute(
+      'href', '/madrich/reflection/new',
+    );
+  });
+
+  it('shows submitted state + Edit CTA when state is complete', async () => {
+    getMock.mockResolvedValue({
+      data: {
+        ...samplePayload,
+        my_reflection: { state: 'complete', reflection_id: 99, template_id: 12, editable: true },
+      },
+    });
+    render(<MemoryRouter><MadrichDashboard /></MemoryRouter>);
+    await waitFor(() => screen.getByTestId('md-reflection-cta'));
+    expect(screen.getByTestId('md-reflection-status')).toHaveTextContent(/Submitted for this week/);
+    expect(screen.getByTestId('md-reflection-cta')).toHaveTextContent('Edit reflection');
+    expect(screen.getByTestId('md-reflection-cta')).toHaveAttribute(
+      'href', '/madrich/reflection/99/edit',
+    );
+  });
+
+  it('shows graceful copy when no template is configured', async () => {
+    getMock.mockResolvedValue({
+      data: {
+        ...samplePayload,
+        my_reflection: { state: 'no_template', reflection_id: null, template_id: null, editable: false },
+      },
+    });
+    render(<MemoryRouter><MadrichDashboard /></MemoryRouter>);
+    await waitFor(() => screen.getByTestId('md-reflection-card'));
+    expect(screen.getByTestId('md-reflection-card')).toHaveTextContent(
+      /No reflections currently assigned/,
+    );
+    expect(screen.queryByTestId('md-reflection-cta')).toBeNull();
+  });
+
+  it('links history section to /madrich/history', async () => {
+    getMock.mockResolvedValue({ data: samplePayload });
+    render(<MemoryRouter><MadrichDashboard /></MemoryRouter>);
+    await waitFor(() => screen.getByTestId('md-history-link'));
+    expect(screen.getByTestId('md-history-link')).toHaveAttribute('href', '/madrich/history');
+  });
+
+  it('shows an error state on load failure', async () => {
+    getMock.mockRejectedValue(new Error('boom'));
+    render(<MemoryRouter><MadrichDashboard /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByTestId('md-error')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/pages/madrich/__tests__/ReflectionForm.test.jsx
+++ b/frontend/src/pages/madrich/__tests__/ReflectionForm.test.jsx
@@ -1,0 +1,203 @@
+/**
+ * Madrich reflection form tests — Step 7_14, Stories 62 & 64.
+ *
+ * Asserts the 3-2-1 contract is enforced client-side (matches the
+ * backend schema validator), that the audience disclosure renders,
+ * and that no day-off shortcut sneaks into the UI per Story 62 c3.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import MadrichReflectionForm from '../ReflectionForm';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+const patchMock = vi.fn();
+vi.mock('../../../api', () => ({
+  default: {
+    get: (...args) => getMock(...args),
+    post: (...args) => postMock(...args),
+    patch: (...args) => patchMock(...args),
+  },
+}));
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ orgSlug: 'tbe', user: { id: 7 } }),
+}));
+
+// Wysiwyg pulls in heavy quill bits; not used by any field in the
+// 3-2-1 template so stub it out.
+vi.mock('../../../components/form/Wysiwyg', () => ({
+  default: ({ value }) => <textarea data-testid="wysiwyg" defaultValue={value || ''} />,
+}));
+
+const TEMPLATE_SCHEMA = {
+  fields: [
+    {
+      key: 'wins',
+      type: 'text_list',
+      required: true,
+      min_items: 3,
+      max_items: 3,
+      prompts: { en: 'Three wins from this week' },
+    },
+    {
+      key: 'improvements',
+      type: 'text_list',
+      required: true,
+      min_items: 2,
+      max_items: 2,
+      prompts: { en: 'Two things to improve next week' },
+    },
+    {
+      key: 'question_or_concern',
+      type: 'text',
+      required: true,
+      prompts: { en: 'One question or concern' },
+    },
+    {
+      key: 'ratings',
+      type: 'rating_group',
+      required: true,
+      scale: [1, 4],
+      categories: [
+        { key: 'reliability_punctuality', labels: { en: 'Reliability' } },
+        { key: 'initiative', labels: { en: 'Initiative' } },
+        { key: 'communication', labels: { en: 'Communication' } },
+        { key: 'problem_solving', labels: { en: 'Problem Solving' } },
+        { key: 'interpersonal', labels: { en: 'Interpersonal' } },
+      ],
+      prompts: { en: 'Rate yourself' },
+    },
+  ],
+};
+
+function renderForm() {
+  return render(
+    <MemoryRouter initialEntries={["/madrich/reflection/new"]}>
+      <Routes>
+        <Route path="/madrich/reflection/new" element={<MadrichReflectionForm />} />
+        <Route path="/madrich" element={<div data-testid="dashboard-stub" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  getMock.mockReset();
+  postMock.mockReset();
+  patchMock.mockReset();
+  getMock.mockResolvedValue({ data: { id: 12, schema: TEMPLATE_SCHEMA, language: 'en' } });
+});
+
+describe('MadrichReflectionForm', () => {
+  it('renders the audience disclosure and no day-off toggle', async () => {
+    renderForm();
+    await waitFor(() => screen.getByTestId('md-audience-disclosure'));
+    expect(screen.getByTestId('md-audience-disclosure')).toHaveTextContent(/Director/);
+    expect(screen.getByTestId('md-audience-disclosure')).toHaveTextContent(/Temple Beth-El/);
+    expect(screen.queryByText(/Day off/i)).toBeNull();
+  });
+
+  it('seeds exactly 3 win inputs and 2 improvement inputs', async () => {
+    renderForm();
+    await waitFor(() => screen.getByText('Three wins from this week'));
+    const winsLabel = screen.getByText('Three wins from this week');
+    const winsContainer = winsLabel.closest('div').parentElement;
+    expect(within(winsContainer).getAllByRole('textbox')).toHaveLength(3);
+
+    const improvementsLabel = screen.getByText('Two things to improve next week');
+    const improvementsContainer = improvementsLabel.closest('div').parentElement;
+    expect(within(improvementsContainer).getAllByRole('textbox')).toHaveLength(2);
+  });
+
+  it('blocks submission when the 3-2-1 contract is unmet', async () => {
+    renderForm();
+    await waitFor(() => screen.getByTestId('md-submit-button'));
+
+    // Leave wins/improvements/question empty, only fill 1 rating.
+    const ratingButtons = screen.getAllByRole('button', { name: /^[1-4]$/ });
+    fireEvent.click(ratingButtons[0]);
+
+    fireEvent.click(screen.getByTestId('md-submit-button'));
+    // No POST should fire — client validation catches the missing pieces.
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it('submits when all 3-2-1 fields and 5 ratings are present', async () => {
+    postMock.mockResolvedValue({ data: { id: 555 } });
+    renderForm();
+    await waitFor(() => screen.getByText('Three wins from this week'));
+
+    const winsContainer = screen.getByText('Three wins from this week').closest('div').parentElement;
+    const winInputs = within(winsContainer).getAllByRole('textbox');
+    winInputs.forEach((input, i) => fireEvent.change(input, { target: { value: `Win #${i + 1}` } }));
+
+    const improvementsContainer = screen.getByText('Two things to improve next week').closest('div').parentElement;
+    const improvementInputs = within(improvementsContainer).getAllByRole('textbox');
+    improvementInputs.forEach((input, i) =>
+      fireEvent.change(input, { target: { value: `Improve #${i + 1}` } }),
+    );
+
+    const questionWrap = screen.getByText('One question or concern').closest('div');
+    const questionInput = within(questionWrap).getByRole('textbox');
+    fireEvent.change(questionInput, { target: { value: 'How do I run an icebreaker?' } });
+
+    // Pick a rating for every one of the 5 categories.
+    ['Reliability', 'Initiative', 'Communication', 'Problem Solving', 'Interpersonal'].forEach(
+      (label) => {
+        const catLabel = screen.getByText(label);
+        const catWrap = catLabel.closest('div');
+        const buttons = within(catWrap).getAllByRole('button', { name: /^[1-4]$/ });
+        fireEvent.click(buttons[2]);
+      },
+    );
+
+    fireEvent.click(screen.getByTestId('md-submit-button'));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+    const [path, body] = postMock.mock.calls[0];
+    expect(path).toBe('/api/v1/madrich/reflection/');
+    expect(body.language).toBe('en');
+    expect(body.client_submission_id).toEqual(expect.any(String));
+    expect(body.answers.wins).toEqual(['Win #1', 'Win #2', 'Win #3']);
+    expect(body.answers.improvements).toEqual(['Improve #1', 'Improve #2']);
+    expect(body.answers.question_or_concern).toMatch(/icebreaker/);
+    expect(Object.keys(body.answers.ratings)).toEqual([
+      'reliability_punctuality',
+      'initiative',
+      'communication',
+      'problem_solving',
+      'interpersonal',
+    ]);
+
+    await waitFor(() => screen.getByTestId('dashboard-stub'));
+  });
+
+  it('surfaces backend validation errors inline', async () => {
+    postMock.mockRejectedValue({ response: { data: { detail: 'You already submitted this week.' } } });
+    renderForm();
+    await waitFor(() => screen.getByText('Three wins from this week'));
+
+    const winsContainer = screen.getByText('Three wins from this week').closest('div').parentElement;
+    const winInputs = within(winsContainer).getAllByRole('textbox');
+    winInputs.forEach((input, i) => fireEvent.change(input, { target: { value: `Win ${i}` } }));
+    const improvementsContainer = screen.getByText('Two things to improve next week').closest('div').parentElement;
+    const improvementInputs = within(improvementsContainer).getAllByRole('textbox');
+    improvementInputs.forEach((input, i) =>
+      fireEvent.change(input, { target: { value: `Improve ${i}` } }),
+    );
+    const questionWrap = screen.getByText('One question or concern').closest('div');
+    fireEvent.change(within(questionWrap).getByRole('textbox'), { target: { value: 'q' } });
+    ['Reliability', 'Initiative', 'Communication', 'Problem Solving', 'Interpersonal'].forEach(
+      (label) => {
+        const catWrap = screen.getByText(label).closest('div');
+        const buttons = within(catWrap).getAllByRole('button', { name: /^[1-4]$/ });
+        fireEvent.click(buttons[0]);
+      },
+    );
+
+    fireEvent.click(screen.getByTestId('md-submit-button'));
+    await waitFor(() => expect(screen.getByTestId('md-submit-error')).toHaveTextContent(/already submitted/));
+  });
+});


### PR DESCRIPTION
## Summary

Frontend half of Step 7_14 (TBE Madrich weekly 3-2-1 flow), built on top of the backend in #114. Implements Stories 61, 62, 64, and 65 with English-only copy per the TBE Tier 1 scope; no Hebrew/Spanish wiring at this stage.

- **Dashboard (`/madrich`, Story 61)**: name + role + grade-level header, weekly "Week of [start]–[end]" framing derived from the server `period`, and a single card that flips between "Not yet submitted / Start reflection" and "Submitted for this week / Edit reflection". No bunk lists, peer Madrich data, or camp-side operational signal.
- **Reflection form (`/madrich/reflection/new` and `/edit`, Stories 62 + 64)**: renders the seeded 3-2-1 template with exact-count validation (3 wins, 2 improvements, 1 question, 5 ratings on a 1–4 scale). No day-off shortcut. Audience disclosure copy above the form names the readers (Director(s) + TBE staff overseeing Madrichim).
- **History (`/madrich/history`, Story 65)**: one row per Monday–Sunday week with "Submitted" / "Missed" badges and a preview line. Edit affordance only on the current week.

Routes mount under `/madrich/*` in `Router.jsx`. New API client `frontend/src/api/madrich.js` proxies the four backend endpoints landed in #114.

## Test plan

- [x] `npm run test` — 559 tests pass (88 files), including 12 new Madrich tests.
- [x] `npm run build` — succeeds.
- [ ] Manual smoke once #114 + this branch are both deployed to a TBE preview: log in as a Madrich seed user, walk dashboard → form → history.

## Related

- Backend: #114 (`feat/7_14_madrich_backend`).
- Prompt: `migration_prompts/7_14_madrich_flow.md` + `docs/user_stories/09_madrich/STORIES.md` 61–65.

Made with [Cursor](https://cursor.com)