### PR TITLE
Wave 1 design: form orchestration reframe + Notes platform + prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ llm_context/
 *backup*.sql
 *dump*.sql
 database_backups/
+
+# Cursor / Claude agent working files
+.claude/

--- a/docs/design/form_orchestration_reframe.md
+++ b/docs/design/form_orchestration_reframe.md
@@ -15,115 +15,177 @@ BunkLogs today has nine fully-tightened role flows, each with its own hard-coded
 
 ## 2. What already exists (gap analysis)
 
-A surprising amount of the form-orchestration substrate is already shipped or specified. The reframe is **less invasive than it looks** because of this.
+**Updated 2026-05-24 after codebase audit.** The original draft of this section underestimated how much form-orchestration substrate is already shipped. The single biggest finding: `TemplateAssignment` already exists as a Django model with a full API surface. What §3 of the original draft called "FormAssignment" is mostly an extension of `TemplateAssignment`, not a new model. This section is updated to reflect that.
 
-### 2.1 Already shipped or specified
+### 2.1 Already shipped
 
 | Capability | Where it lives | Notes |
 |---|---|---|
-| Template versioning & lifecycle | `ReflectionTemplate.version`, draft → published → archived (`docs/template_builder.md`) | Clone, fork-on-edit, language gap checks all working |
-| Template builder UX (LT-scoped) | `frontend/src/pages/leadership-team/...`, prompt `7_12` | The "Save as Form" UX has a real foundation to build on |
-| Author/subject role filtering on templates | `ReflectionTemplate.author_role_filter`, `subject_role_filter` (`docs/data-model.md`) | Already declares who fills it out and who it's about |
-| Group-based subject scoping | `AssignmentGroup` + `AssignmentGroupMembership` | Bunk/unit/caseload/cohort all already modeled |
-| `subject_mode` field | `ReflectionTemplate.subject_mode` (`self`, `single_subject`, `multi_subject`, `group`) | The four shapes of "about whom" are already declared |
-| `assignment_scope` field | `ReflectionTemplate.assignment_scope` | "One per subject in group" vs. "one per group" vs. "no group context" already modeled |
-| `required_per_subject_per_period` | On `ReflectionTemplate` | "Required" is already a numeric field per template |
-| Per-template "team_visibility" axis | `Reflection.team_visibility` + `ReflectionTemplate.supports_privacy` | The privacy toggle exists and is tested |
-| RBAC two-axis design | `Membership.role` × `Membership.capability` (`docs/membership-role-vs-capability.md`) | Permission checks are stable; new role labels do not touch permission code |
-| Per-role visibility paths | `core.permissions.visibility.reflections_visible_to` | The six visibility paths are settled |
-| Task derivation foundation | The `my-tasks` endpoint from prompt `3_19` | Already produces "what does this user owe today" from template + role + group context |
-| Notes platform | Stories 66–70 + prompt `7_19` (in progress) | The communication primitive the landing pages will lean on |
+| `TemplateAssignment` model | `core.models.TemplateAssignment` | Has template FK, target_type (role/individuals/tag_group), target_payload (JSON), start_date, end_date, cadence_override, status (scheduled/active/ended/cancelled), replaces (chain), created_by. OrgScopedManager. |
+| Assignment CRUD API | `api/leadership_team/assignments.py` | POST creates with conflict detection (replace/run_both/cancel); PATCH edits end_date safely; DELETE cancels scheduled. Audit-logged. |
+| `resolve_members(assignment, as_of_date)` helper | same file | Materialises an assignment into a queryset of Memberships per its target_type. |
+| Conflict resolution (FA3's pattern) | same file | End-date prior + create new + chain via `replaces` FK. Already implemented. |
+| Template versioning & lifecycle | `ReflectionTemplate.version` + status enum | Draft → published → archived. Clone, fork-on-edit, language gap checks all working. |
+| Template builder UX (LT-scoped) | `frontend/src/pages/leadership-team/...`, prompt `7_12` | Mature; FA-E will extend this with an "Assign form" dialog. |
+| Author/subject role filtering on templates | `ReflectionTemplate.author_role_filter`, `subject_role_filter` | Already declares who fills it out and who it's about. |
+| Group-based subject scoping | `AssignmentGroup` + `AssignmentGroupMembership` | Bunk/unit/caseload/cohort all already modeled. |
+| `subject_mode` field | `ReflectionTemplate.subject_mode` (`self`, `single_subject`, `multi_subject`, `group`) | The four shapes of "about whom" are already declared. |
+| `assignment_scope` field | `ReflectionTemplate.assignment_scope` | "One per subject in group" vs. "one per group" vs. "no group context" already modeled. |
+| `required_per_subject_per_period` | On `ReflectionTemplate` | Per-template numeric required-ness. |
+| `Reflection.team_visibility` axis | + `ReflectionTemplate.supports_privacy` | Privacy toggle exists and is tested. |
+| RBAC two-axis design | `Membership.role` × `Membership.capability` | Settled; permission checks stable. |
+| Per-role visibility paths | `core.permissions.visibility.reflections_visible_to` | Six visibility paths settled. |
+| Per-role dashboard endpoints | `api/{counselor,unit_head,specialist,camper_care,leadership_team,kitchen_staff,madrich,admin_flow}/dashboard.py` + companion `bunk_dashboard.py`, `camper_dashboard.py`, `team_dashboard.py` | **Each one hard-codes its template lookups via per-role helpers in `common.py`.** This is the main surface area FA-B has to refactor. |
+| Notes module spec | `docs/user_stories/10_notes_platform/` + `migration_prompts/7_19_notes_platform.md` | Designed, not yet implemented. |
 
-### 2.2 What is genuinely new in the reframe
+### 2.2 What is genuinely new for the reframe
 
 | Missing piece | Why it's needed | Rough size |
 |---|---|---|
-| **Explicit `FormAssignment` model** | Today, a template implicitly applies to every Membership matching its `author_role_filter` in every Program where it's seeded. There is no per-Program-and-AssignmentGroup-level *assignment* row that says "this published template is in effect for Bunk Maple starting June 5, daily, required." This makes it impossible to toggle a template on for one group but not another, or to change cadence without versioning the template. | Medium |
-| **Cadence semantics beyond per-period** | `required_per_subject_per_period` knows "daily" implicitly. The reframe wants `daily`, `weekly`, `biweekly`, `monthly`, `quarterly`, `annual`, `one_time`, `custom`. The cadence affects how task-completion windows are derived. | Medium |
-| **"Save as Form" assignment dialog in builder** | The current builder publishes a template; it does not let the LT user say "now assign this to Bunk Maple, weekly, required, starting June 12." That step happens implicitly today. | Small-Medium |
+| **`assignment_group` FK on `TemplateAssignment`** | Today TemplateAssignment targets role, specific individuals, or a tag group — but cannot target "every counselor on Bunk Maple". FA1 requires per-group assignment. Solved by adding a nullable `assignment_group` FK that, when set, narrows the resolved audience to Memberships within that group. | Small |
+| **`is_required` flag on `TemplateAssignment`** | Today every assignment is implicitly required. FA5 separates required (tasks) from optional (form library). Solved by adding a boolean. | Trivial |
+| **`title` field on `TemplateAssignment`** | FA1 specifies a per-assignment display title for dashboard widgets, distinct from `template.name`. Today the dashboard label is derived from the template, which forces a new template version when the LT user just wants a different label. | Small |
+| **Per-role dashboard refactor** | The hard-coded template resolvers in each role's `common.py` (e.g., `camper_reflection_template()`, `counselor_self_template()`) need to consult `TemplateAssignment` rows instead of querying `ReflectionTemplate` directly. This is the main work of Wave 1. | Medium |
+| **`assignment_group` resolution in `resolve_members`** | The existing helper handles role/individuals/tag_group targets. It needs a new branch for the `assignment_group` case (resolve to Memberships whose role matches the template's `author_role_filter` AND who are active in the group). | Small |
+| **Admin capability gate on assignment endpoints** | Today the assignments API restricts mutation to `program_lead` capability. FA7 widens that to `program_lead OR admin`. | Trivial |
+| **Seeding for Summer 2026** | TemplateAssignment rows for Crane Lake Summer 2026 don't exist yet because the per-role dashboards haven't been reading from them. The seeding command creates these as part of FA-S. | Small |
+| **"Assign form" dialog in builder UX** | Today the assignments API exists but the LT template builder UX does not surface an assignment step. FA1's flow (publish template → click "Assign form" → dialog with group, title, cadence, required, dates) needs a new UI surface. | Medium-Large |
 | **Numeric color-coded tabular display** | The platform has individual `TrendCell` and grids for rating-group data, but no general "render any numeric form responses as a color-coded sortable table" component scoped to a subject. | Medium |
-| **Subject landing page (the form-aware profile view)** | Camper profiles exist; counselor/UH/maintenance profile pages exist as concepts. None of them currently aggregate "every form ever filled out about this subject" as their organizing principle. | Medium-Large |
-| **Generalized dashboard widget framework** | Today, role dashboards are hand-coded. The reframe wants role landing pages assembled from configurable widgets driven by which assignments target which roles. | Medium |
-| **Author-side "tasks for me, grouped by assignment" widgets** | The my-tasks endpoint already returns this data; the dashboard widget that renders it with the gauge ("7/12 done") and the per-row completion state ("pale green" / "dark yellow") does not yet exist as a reusable component. | Small-Medium |
+| **Palette library** | FA4 specifies a library of named palettes per scale length. None exists today. | Small-Medium |
+| **Subject landing page (form-aware profile view)** | Camper profiles exist; the form-aware aggregation per FA6 ("every form ever filled out about this subject") is new. | Medium-Large |
+| **Author-side "tasks for me, grouped by assignment" widgets** | Existing dashboard rendering is per-role and ad-hoc. The reframe wants a unified widget framework driven by assignments. | Medium-Large |
 
 ---
 
 ## 3. The proposed data model addition
 
-### 3.1 `FormAssignment` — the new model
+**Updated 2026-05-24.** The original draft proposed a new `FormAssignment` model. The codebase audit revealed `TemplateAssignment` already exists with most of the needed shape. This section now describes the **extension** of `TemplateAssignment` rather than a new model.
 
-The single new concept the reframe needs.
+### 3.1 Three small additions to `TemplateAssignment`
 
 ```python
-class FormAssignment(models.Model):
-    # Identity
-    organization = FK(Organization)
-    program = FK(Program)
-    template = FK(ReflectionTemplate)  # MUST be a published template
-    
-    # Scope: which assignment group(s) this applies to
-    # null = applies program-wide to every eligible Membership
-    assignment_group = FK(AssignmentGroup, null=True)
-    
-    # Cadence
-    cadence = CharField(choices=[
-        'one_time',
-        'daily',
-        'weekly',
-        'biweekly',
-        'monthly',
-        'quarterly',
-        'annual',
-        'custom',  # custom uses cadence_spec JSON
+class TemplateAssignment(models.Model):
+    # === EXISTING (unchanged) ===
+    organization = ForeignKey(Organization)
+    program = ForeignKey(Program)
+    template = ForeignKey(ReflectionTemplate)
+    target_type = CharField(choices=[
+        ('role', 'Role (dynamic)'),
+        ('individuals', 'Individual memberships (static)'),
+        ('tag_group', 'Tag group (dynamic)'),
+        ('assignment_group', 'Assignment group (dynamic)'),  # NEW
     ])
-    cadence_spec = JSONField(default=dict)  # e.g. {"days_of_week": ["sun", "wed"]} for custom
-    
-    # Lifecycle
-    starts_on = DateField()
-    ends_on = DateField(null=True)  # null = open-ended (program lifetime)
-    is_required = BooleanField(default=True)
-    is_active = BooleanField(default=True)
-    
-    # Audit
-    assigned_by = FK(Person)
-    assigned_at = DateTimeField(auto_now_add=True)
-    
-    class Meta:
-        constraints = [
-            # A template can be assigned to the same group with the same cadence only once active at a time
-            UniqueConstraint(
-                fields=['template', 'assignment_group', 'cadence'],
-                condition=Q(is_active=True),
-                name='unique_active_assignment',
-            ),
-        ]
+    target_payload = JSONField()
+    start_date = DateField()
+    end_date = DateField(null=True)
+    cadence_override = CharField(null=True)
+    replaces = ForeignKey('self', null=True)
+    status = CharField(choices=Status.choices)
+    created_by = ForeignKey(Membership)
+    created_at = DateTimeField(auto_now_add=True)
+    updated_at = DateTimeField(auto_now=True)
+
+    # === NEW ===
+    assignment_group = ForeignKey(
+        AssignmentGroup,
+        null=True,
+        blank=True,
+        on_delete=CASCADE,
+        help_text=(
+            "When target_type='assignment_group', the group this assignment "
+            "targets. Memberships are resolved to those whose role matches "
+            "the template's author_role_filter AND who hold an active "
+            "AssignmentGroupMembership in this group with role_in_group='author'."
+        ),
+    )
+    is_required = BooleanField(
+        default=True,
+        help_text=(
+            "When True, the assignment produces tasks in the per-role "
+            "dashboards. When False, it appears in the role's optional "
+            "forms library and does NOT affect the 'all set' state."
+        ),
+    )
+    title = CharField(
+        max_length=255,
+        blank=True,
+        default='',
+        help_text=(
+            "Per-assignment display title for dashboard widgets. "
+            "Falls back to template.name when blank."
+        ),
+    )
 ```
 
-### 3.2 What this *doesn't* change
+### 3.2 What `target_type='assignment_group'` resolves to
 
-Critically, `FormAssignment` is **additive**:
+The existing `resolve_members(assignment, as_of)` helper in `api/leadership_team/assignments.py` gains a new branch:
+
+```python
+if target_type == TemplateAssignment.TargetType.ASSIGNMENT_GROUP:
+    group_id = (assignment.assignment_group_id or
+                (assignment.target_payload or {}).get('assignment_group_id'))
+    if not group_id:
+        return base.none()
+    # Resolve to Memberships whose role matches the template's author_role_filter
+    # AND who are active in the group as authors.
+    author_roles = assignment.template.author_role_filter or []
+    if not author_roles:
+        return base.none()
+    author_person_ids = AssignmentGroupMembership.objects.filter(
+        group_id=group_id,
+        role_in_group='author',
+        is_active=True,
+    ).values_list('person_id', flat=True)
+    return base.filter(person_id__in=author_person_ids, role__in=author_roles)
+```
+
+Note: `assignment_group_id` is stored on the FK column, not in `target_payload`, even though the existing `role` and `tag_group` types use the payload. This is an intentional break from the existing pattern — a foreign key with a database-level constraint is cleaner than a JSON-encoded ID, and the migration path is straightforward.
+
+### 3.3 What this *doesn't* change
+
+Critically, the extension is **additive**:
 
 - `ReflectionTemplate` schema is untouched. All existing template-builder, versioning, and language-gap logic continues to work.
 - `Reflection` is untouched. Submitted reflections continue to reference `template_id` directly.
 - The capability/role model is untouched.
 - The visibility model is untouched.
 - The Notes module (prompt `7_19`) is untouched.
+- The existing `target_type` values (role, individuals, tag_group) continue to work exactly as today. Existing seeded data, if any, remains valid.
 
-### 3.3 How task derivation changes
+### 3.4 How task derivation changes
 
-Today the `my-tasks` endpoint joins `Membership` × `ReflectionTemplate` (via role filters) × `AssignmentGroup` to derive what a user owes. After the reframe it joins `Membership` × `FormAssignment` × `ReflectionTemplate`:
+Today each role's `common.py` has helpers like `camper_reflection_template()` that query `ReflectionTemplate` directly with hard-coded filters. After Wave 1, those helpers consult `TemplateAssignment` rows instead:
 
-- The same Membership × group context defines who the user is and what subjects they have access to.
-- The `FormAssignment` rows define **which templates are in effect** for those groups, **at what cadence**, **with what required-ness**.
-- Cadence drives the completion window for each task ("today" for daily, "this week ending Sunday" for weekly, etc.).
+```python
+# BEFORE: hard-coded template lookup
+def camper_reflection_template(organization, program):
+    return ReflectionTemplate.all_objects.filter(
+        subject_mode='single_subject',
+        cadence='daily',
+        assignment_group_types__contains=['bunk'],
+    ).first()
 
-### 3.4 Backfill story
+# AFTER: assignment-driven lookup
+def camper_reflection_template_for_bunk(viewer, organization, program, bunk):
+    # Find the active TemplateAssignment targeting this bunk + viewer's role
+    # that produces a single_subject template; return its template.
+    assignment = resolve_active_assignment(
+        program=program,
+        target_assignment_group=bunk,
+        viewer_role='counselor',
+        as_of=get_today(organization),
+    )
+    return assignment.template if assignment else None
+```
 
-Every existing implicit "template X is in effect for Bunk Maple" becomes an explicit `FormAssignment` row. The backfill is a one-time data migration:
+The key point: **the dashboard endpoints' API contracts don't change**. They still return the same shape of payload. Only the internal resolution logic changes.
 
-- For each combination of `(Program, ReflectionTemplate, AssignmentGroup)` that the current task-derivation logic produces tasks for, write a `FormAssignment` row with `cadence` inferred from `required_per_subject_per_period` and `starts_on` = the Program's start date.
-- After the migration, the task-derivation logic is rewritten to read from `FormAssignment` directly. The two implementations must agree on every test fixture before the old logic is removed.
-- This means **the reframe is shipped in two phases** (write the new substrate, then cut over). It is never in a state where both paths are computing simultaneously and conflicting.
+### 3.5 No backfill (per FA10(a))
+
+Under the aggressive rollout, there is no live data to migrate. The Summer 2026 launch is the *first* time the new task derivation runs against real users. Seeding (FA-S) creates the TemplateAssignment rows that the new dashboards need, in the same release that ships the dashboards' new resolution logic.
+
+If the existing per-role dashboard logic is producing tasks today (against seeded test data on staging), that test data will produce no tasks after FA-B ships until FA-S seeds the assignments. This is expected and is part of the cutover.
 
 ---
 
@@ -235,8 +297,8 @@ FA10's resolution is the single decision with the largest impact on the rest of 
 1. **The reframe is no longer a "post-Summer-2026" arc.** It's on the June 5 critical path.
 2. **There is no backfill step.** Existing seeded test data on the new architecture is overwritten as part of the cutover. No live production data exists on the new architecture yet (per Steve's reasoning: RBAC still under test with seeded data).
 3. **Existing canonical user stories (Stories 2, 3, 5, 9, UH attention badges, etc.) must be re-verified against the new substrate before June 5.** Most will likely pass without code change; this is a re-verification pass, not a rewrite pass.
-4. **The work that was sequenced as FA-C (backfill data migration) drops out entirely.** FA-A, FA-B, FA-D collapse into a tighter 3-prompt block that must ship before Summer 2026 staff onboarding.
-5. **Zero schedule slack.** See §7 risk section below.
+4. **Wave 1 is FA-A, FA-B, FA-S** — three prompts totaling 9–15 hours (revised after codebase audit revealed `TemplateAssignment` already exists with most of the needed shape).
+5. **The pre-June-5 budget has real slack now.** 9–15 hours fits comfortably in 20–30 hours of available time. See §7 risk section for what could still go wrong.
 
 ## 7. Proposed sequencing — REVISED FOR FA10(a)
 
@@ -244,24 +306,24 @@ Under FA10(a), the FormAssignment substrate must ship before June 5, 2026 staff 
 
 ### Wave 1: Pre-June-5 critical path (MUST ship)
 
-The minimum substrate that lets the new role flows launch on FormAssignment from day one. Three prompts, tight.
+**Resized 2026-05-24 after codebase audit revealed `TemplateAssignment` already exists.** Wave 1 is now substantially smaller than the original estimate — the model exists, the CRUD API exists, the conflict-resolution pattern exists. What remains is extending the model with three fields, refactoring the per-role dashboard helpers, and seeding rows for Summer 2026.
 
 | # | Prompt | Goal | Size |
 |---|---|---|---|
-| FA-A | **`FormAssignment` model and backend** | New model, migration, admin registration, CRUD API endpoints scoped per FA7 permissions, tests. Replaces the old implicit task-derivation logic at the data layer. | 5–7 hrs |
-| FA-B | **Task derivation rewrite (direct cutover, no shadow mode)** | Rewrite `my-tasks` endpoint to compute from FormAssignment rows. Remove the implicit-template-applicability code path in the same release. Updated tests. | 6–9 hrs |
-| FA-S | **Seeding for Summer 2026** | Create the `FormAssignment` rows needed for Crane Lake Summer 2026: the camper bunk log, the counselor self-reflection, the UH reflections, the wellness team reflections, and any other currently-implicit assignments. Idempotent management command. Run on staging, verify with Alyson, then production. | 3–5 hrs |
-| | **Wave 1 total** | | **14–21 hrs** |
+| FA-A | **Extend `TemplateAssignment` and `resolve_members`** | Add `assignment_group` FK, `is_required` flag, `title` field. Add `'assignment_group'` to `target_type` choices. Migration. Extend `resolve_members(assignment, as_of)` with the new branch. Widen the assignments API permission gate from `program_lead` to `program_lead OR admin` (FA7). Tests. | 3–5 hrs |
+| FA-B | **Per-role dashboard refactor** | Replace hard-coded template resolvers in each role's `common.py` with TemplateAssignment-aware lookups. Roles in scope: counselor, unit_head, specialist, camper_care, leadership_team, kitchen_staff, madrich, admin_flow. Each role's dashboard endpoint payload contract stays identical; only internal resolution changes. Updated tests. | 4–6 hrs |
+| FA-S | **Seed TemplateAssignments for Summer 2026** | Idempotent management command that creates the assignment rows Crane Lake Summer 2026 needs: camper bunk log, counselor self-reflection, UH reflections, wellness team reflections, kitchen staff reflections, and any others currently produced by the implicit derivation. Run on staging, verify with Alyson, then production. | 2–4 hrs |
+| | **Wave 1 total** | | **9–15 hrs** |
 
 ### Wave 1 risk surface
 
-Not honest about this would be malpractice. FA10(a) carries real risk:
+Not honest about this would be malpractice. Even with the smaller-than-expected scope, FA10(a) carries real risk:
 
-1. **Zero schedule slack.** 14–21 hours fits in the 20–30 hours of BunkLogs time available between now (May 24) and June 5, but it leaves no buffer for Summer 2026 final QA, Alyson handoff, staff onboarding rehearsal, or runbook execution — all of which are non-negotiable for go-live.
-2. **Existing canonical user stories must be re-verified.** Stories 2, 3, 5, 9, the UH attention-badges story, etc. are written against the implicit-template-applicability model. After Wave 1 lands, each canonical story's acceptance criteria need a pass-through verification: do they still hold on the new substrate? Estimated 3–5 hours of careful reading and test execution. **This time is not in the 14–21 hour estimate above.**
-3. **No live customers yet on the new architecture.** This is what makes FA10(a) viable. But it also means if Wave 1 ships broken, you find out during Crane Lake staff onboarding, not before. There's no "is it working in production?" signal until the very moment it has to work.
-4. **Rollback plan needed.** If Wave 1 ships broken and is detected pre-go-live, the rollback path is: revert the migration, restore the implicit-derivation code, re-seed templates as before. Cost: a day. Plan for it explicitly.
-5. **Helena's buy-in is the single biggest external constraint.** Per the financial model, every other variable can flex but family time cannot. If Wave 1 work creeps past 21 hours, the right move is to descope back to FA10(b) — not push through.
+1. **Eight per-role dashboard files to refactor.** The work is mechanical but the surface area is wide. A subtle bug in one role's resolver could break that role's dashboard silently. Mitigation: each role gets its own commit within FA-B with its own tests passing.
+2. **Existing canonical user stories must be re-verified.** Stories 2, 3, 5, 9, the UH attention-badges story, etc. are written against the implicit-template-applicability model. After Wave 1 lands, each canonical story's acceptance criteria need a pass-through verification: do they still hold on the new substrate? Estimated 3–5 hours of careful reading and test execution. **This time is not in the 9–15 hour estimate above.**
+3. **No live customers yet on the new architecture.** This is what makes FA10(a) viable. But it also means if Wave 1 ships broken, you find out during Crane Lake staff onboarding, not before. There's no "is it working in production?" signal until the very moment it has to work. Mitigation: thorough staging verification with Alyson before deploying to production.
+4. **Rollback plan needed.** If Wave 1 ships broken and is detected pre-go-live, the rollback path is: revert the migration, revert the dashboard refactor commits, leave the implicit-derivation code intact. Cost: a few hours. Plan for it explicitly.
+5. **Helena's buy-in is the single biggest external constraint.** Per the financial model, every other variable can flex but family time cannot. With the smaller Wave 1 scope this is less of an immediate risk, but still applies if the work expands during execution.
 
 ### Wave 1 acceptance criteria
 
@@ -302,13 +364,13 @@ The rest of the reframe — the UX work that makes FormAssignment user-visible. 
 
 | Wave | Hours | When |
 |---|---|---|
-| Wave 1 (FormAssignment substrate) | 14–21 | Before June 5, 2026 |
+| Wave 1 (TemplateAssignment extension + dashboard refactor + seeding) | 9–15 | Before June 5, 2026 |
 | Re-verification of existing stories | 3–5 | Before June 5, 2026 |
 | `7_19` Notes module | 10–14 | Late June 2026 |
 | Wave 2 (reframe UX completion) | 35–54 | July–September 2026 |
-| **Total** | **62–94 hrs** | **May 24 – September 2026** |
+| **Total** | **57–88 hrs** | **May 24 – September 2026** |
 
-At 10–15 hours/week, this is 4–9 months of BunkLogs time. Roughly aligned with the Summer 2026 → TBE September launch arc.
+At 10–15 hours/week, this is 4–9 months of BunkLogs time. Roughly aligned with the Summer 2026 → TBE September launch arc. Wave 1 fits in ~1 week of BunkLogs time with real slack.
 
 ### What this does NOT cover
 

--- a/docs/wave_1_progress.md
+++ b/docs/wave_1_progress.md
@@ -1,0 +1,174 @@
+# Wave 1 Progress — Form Orchestration Reframe (FA10(a))
+
+**Goal:** Ship the TemplateAssignment extension + per-role dashboard refactor + Summer 2026 seeding before June 5, 2026.
+
+**Total estimated work:** 9–15 hours across three prompts, plus 3–5 hours of canonical-story re-verification.
+
+**Hard deadline:** Production deploy by June 3, 2026 (gives 2-day buffer before June 5 staff onboarding).
+
+**Escape hatch:** If any prompt fails or scope creeps past estimate, revert in-progress work and proceed with FA10(b) (post-summer rollout). The existing implicit-template-resolution code remains the production source of truth until 7_21+7_22 are deployed together.
+
+---
+
+## Status legend
+
+- ⬜ Not started
+- 🔄 In progress (branch open, work underway)
+- 👀 In review (PR open, awaiting self-review or test pass)
+- ✅ Merged to main
+- 🚀 Deployed to production
+- ❌ Blocked or reverted
+
+---
+
+## Prompt tracker
+
+### Step 7_20 — Extend TemplateAssignment
+
+**Status:** ⬜ Not started
+**Branch:** _(not yet)_
+**PR:** _(not yet)_
+**Estimated:** 3–5 hours
+**Actual:** _(record when done)_
+
+**Scope reminder:** Add `assignment_group` FK, `is_required` flag, `title` field. Add `'assignment_group'` to TargetType. Extend `resolve_members` with the new branch. Widen permission gate to admin (FA7). Tests.
+
+**Notes / blockers:**
+
+- _Add as you encounter them_
+
+---
+
+### Step 7_21 — Per-role dashboard refactor
+
+**Status:** ⬜ Not started
+**Branch:** _(not yet)_
+**PR:** _(not yet)_
+**Estimated:** 4–6 hours
+**Actual:** _(record when done)_
+**Depends on:** 7_20 merged
+
+**Scope reminder:** Create `core/assignment_resolution.py` shared resolver. Refactor 8 per-role `common.py` files to use it. One commit per role. Update existing tests to create TemplateAssignment rows.
+
+**Per-role progress** (within the prompt):
+
+- ⬜ kitchen_staff
+- ⬜ madrich
+- ⬜ specialist
+- ⬜ counselor
+- ⬜ unit_head
+- ⬜ camper_care
+- ⬜ leadership_team
+- ⬜ admin_flow
+
+**Notes / blockers:**
+
+- _Add as you encounter them_
+
+---
+
+### Step 7_22 — Seed Summer 2026 TemplateAssignments
+
+**Status:** ⬜ Not started
+**Branch:** _(not yet)_
+**PR:** _(not yet)_
+**Estimated:** 2–4 hours
+**Actual:** _(record when done)_
+**Depends on:** 7_21 merged
+
+**Scope reminder:** Idempotent management command `seed_summer_2026_assignments`. Verify the canonical assignment list against actual seeded templates before running.
+
+**Notes / blockers:**
+
+- _Add as you encounter them_
+
+---
+
+### Canonical story re-verification
+
+**Status:** ⬜ Not started
+**Estimated:** 3–5 hours
+**Depends on:** 7_20 + 7_21 + 7_22 merged to staging
+
+For each existing canonical story under `docs/user_stories/01_counselor/` through `09_madrich/`, verify the acceptance criteria still hold against the assignment-driven substrate. Most should pass without code change.
+
+**Per-role re-verification progress:**
+
+- ⬜ 01_counselor (Stories 1–9)
+- ⬜ 02_unit_head (Stories 10–17)
+- ⬜ 03_camper_care (Stories 18–23)
+- ⬜ 04_specialist (Stories 24–29)
+- ⬜ 05_maintenance (Stories 30–34)
+- ⬜ 06_kitchen_staff (Stories 35–40)
+- ⬜ 07_leadership_team (Stories 45–53)
+- ⬜ 08_admin (Stories 54–60)
+- ⬜ 09_madrich (Stories 61–65)
+
+**Findings (record any divergence here):**
+
+- _Add as you find them_
+
+---
+
+## Production deploy plan
+
+When all three prompts are merged and the re-verification passes:
+
+1. **Pre-deploy** (the day before):
+   - Run `seed_summer_2026_assignments --dry-run` against staging-with-prod-snapshot.
+   - Verify the dry-run output matches expectations.
+   - Have Alyson smoke-test the dashboards on staging.
+2. **Deploy window** (target: evening of June 1 or 2, 2026):
+   - Merge 7_20, 7_21, 7_22 to main in order.
+   - Trigger production deploy via the standard Render flow.
+   - Run `python manage.py seed_summer_2026_assignments --org-slug crane-lake-camp --program-slug summer-2026` in production shell.
+   - Verify a sample of dashboards as Alyson.
+3. **Post-deploy monitoring** (next 24–48 hours):
+   - Watch Datadog APM for dashboard endpoint errors.
+   - Watch for support requests from Alyson.
+   - Have rollback plan ready (revert merge commits, in reverse order: 7_22 → 7_21 → 7_20).
+
+---
+
+## Rollback plan
+
+If any of these conditions are true by June 3:
+
+- A Wave 1 prompt has not merged to main.
+- The re-verification surfaced a blocker.
+- Alyson reports problems during staging smoke-test that can't be resolved by June 3.
+
+Then:
+
+1. **Revert 7_22, 7_21, 7_20** in that order (each is independently revertible).
+2. **Re-seed the pre-7_20 state** if any TemplateAssignment rows were created.
+3. **Proceed with the original implicit-template-resolution code** for June 5 launch.
+4. **Update `decisions.md` FA10** to reflect the actual outcome (mark FA10(a) attempted but descoped to FA10(b)).
+5. **Plan Wave 1 for late June / July** as part of post-summer-launch work.
+
+---
+
+## Update cadence
+
+- After each commit: update the status of the active prompt.
+- After each PR merge: flip prompt status to ✅ and update timing actuals.
+- After production deploy: flip 7_20, 7_21, 7_22 to 🚀.
+- If any prompt blocks: flip status to ❌ and record the reason.
+- When Wave 1 is fully ✅+🚀: archive this file at `docs/wave_1_progress_2026_complete.md` and remove from this location.
+
+---
+
+## Wave 1 complete state
+
+Wave 1 is "done" and ready to be archived when:
+
+- ⬜ 7_20 deployed to production
+- ⬜ 7_21 deployed to production
+- ⬜ 7_22 deployed to production
+- ⬜ Seeding command run in production
+- ⬜ Alyson confirms dashboards work for a sample counselor and UH on staging *and* production
+- ⬜ 24 hours of clean Datadog APM signal post-deploy
+- ⬜ Re-verification complete across all 9 role flows
+- ⬜ June 5 staff onboarding runs cleanly on the new substrate
+
+When all checkboxes above are ✅, archive this file and start tracking the next thing (likely the Notes module deploy, 7_19).

--- a/migration_prompts/7_20_extend_template_assignment.md
+++ b/migration_prompts/7_20_extend_template_assignment.md
@@ -1,0 +1,261 @@
+# Step 7_20: Extend TemplateAssignment with assignment_group, is_required, and title
+
+**Goal:** Extend the existing `TemplateAssignment` model (in `core.models`) and its CRUD API (in `api/leadership_team/assignments.py`) to support per-AssignmentGroup targeting, the required/optional flag, and a per-assignment display title. Widen the API permission gate to include `admin` capability alongside `program_lead`.
+
+**Canonical product spec:** `docs/design/form_orchestration_reframe.md` §3, plus decisions FA1, FA4 (no impact this prompt), FA5, FA7 in `docs/user_stories/00_cross_cutting/decisions.md`.
+
+**Depends on:** Step 7_12 (LT template builder + TemplateAssignment shipped).
+
+**Estimated time:** 3–5 hours.
+
+**Strategic context:** This is the first of three Wave 1 prompts (FA-A, FA-B, FA-S) implementing the form-orchestration reframe per FA10(a) decision. Wave 1 MUST ship before June 5, 2026 because the Crane Lake Summer 2026 staff onboarding flows depend on the new assignment-driven task derivation. This prompt is the model-and-API extension; FA-B refactors the per-role dashboards to consume the new shape; FA-S seeds the production assignments.
+
+**Out of scope** (deferred to other prompts):
+
+- Any frontend changes (FA-E in Wave 2 ships the "Assign form" dialog in the builder).
+- Per-role dashboard refactors (FA-B / Step 7_21).
+- Seeding TemplateAssignment rows for Summer 2026 (FA-S / Step 7_22).
+- Cadence semantics expansion beyond what `ReflectionTemplate.CADENCES` already defines.
+
+## Backend tasks
+
+### 1. Migrations and model fields
+
+Add three new fields to `core.models.TemplateAssignment`:
+
+```python
+assignment_group = models.ForeignKey(
+    "core.AssignmentGroup",
+    null=True,
+    blank=True,
+    on_delete=models.CASCADE,
+    related_name="template_assignments",
+    help_text=(
+        "When target_type='assignment_group', the group this assignment "
+        "targets. Memberships resolve to those whose role matches the "
+        "template's author_role_filter AND who hold an active "
+        "AssignmentGroupMembership in this group with role_in_group='author'."
+    ),
+)
+is_required = models.BooleanField(
+    default=True,
+    help_text=(
+        "When True, the assignment produces tasks in the per-role dashboards. "
+        "When False, it appears in the role's optional forms library and does "
+        "NOT affect the 'all set' state (decision FA5)."
+    ),
+)
+title = models.CharField(
+    max_length=255,
+    blank=True,
+    default="",
+    help_text=(
+        "Per-assignment display title for dashboard widgets. "
+        "Falls back to template.name when blank."
+    ),
+)
+```
+
+Add a new value to the `TargetType` enum:
+
+```python
+class TargetType(models.TextChoices):
+    ROLE = "role", "Role (dynamic)"
+    INDIVIDUALS = "individuals", "Individual memberships (static)"
+    TAG_GROUP = "tag_group", "Tag group (dynamic)"
+    ASSIGNMENT_GROUP = "assignment_group", "Assignment group (dynamic)"  # NEW
+```
+
+Migration considerations:
+
+- Standard Django additive migration. All three fields are nullable / have defaults, so existing rows (if any in dev/staging) remain valid.
+- No data migration needed in this prompt; FA-S handles row creation.
+- Update the model docstring to reflect the new target type.
+
+### 2. Extend `resolve_members(assignment, as_of)`
+
+In `api/leadership_team/assignments.py`, add the `assignment_group` branch to `resolve_members`:
+
+```python
+if target_type == TemplateAssignment.TargetType.ASSIGNMENT_GROUP:
+    group_id = assignment.assignment_group_id
+    if not group_id:
+        return base.none()
+    author_roles = assignment.template.author_role_filter or []
+    if not author_roles:
+        return base.none()
+    author_person_ids = AssignmentGroupMembership.objects.filter(
+        group_id=group_id,
+        role_in_group="author",
+        is_active=True,
+    ).values_list("person_id", flat=True)
+    return base.filter(person_id__in=author_person_ids, role__in=author_roles)
+```
+
+Edge cases to test:
+
+- Template has empty `author_role_filter` → return `base.none()` (no resolution possible).
+- AssignmentGroup is inactive → still resolve to its memberships (the assignment's own date window handles activation).
+- AssignmentGroupMembership has `end_date` in the past → excluded by the `is_active=True` filter on AGM (consistent with how other role-scoped queries work in the codebase).
+- Cross-organization safety: the existing `base = Membership.all_objects.filter(program=assignment.program, is_active=True)` already constrains to the assignment's program, which is org-scoped.
+
+### 3. Update API validation in `_validate_target`
+
+In `api/leadership_team/assignments.py`, extend `_validate_target` to handle the new target type:
+
+```python
+VALID_TARGET_TYPES = ("role", "individuals", "tag_group", "assignment_group")
+
+def _validate_target(target_type: str, target_payload: dict) -> None:
+    # ... existing validation ...
+    if target_type == "assignment_group":
+        # assignment_group_id comes via the dedicated FK column on the
+        # request body, not target_payload. This is a deliberate break
+        # from the existing target_payload convention because FK
+        # constraints are cleaner than JSON-encoded IDs.
+        # Validation happens in the POST handler (see task 4).
+        pass
+```
+
+### 4. Update the POST handler
+
+In `LeadershipTeamAssignmentListCreateView.post`, accept and validate the new fields:
+
+```python
+# Existing: template_id, target_type, target_payload, start_date, end_date,
+# cadence_override, conflict_resolution.
+
+# New:
+assignment_group_id = payload.get("assignment_group")
+is_required = payload.get("is_required", True)  # default True per spec
+title = (payload.get("title") or "").strip()
+
+if target_type == "assignment_group":
+    if not assignment_group_id:
+        raise ValidationError(
+            "assignment_group is required when target_type='assignment_group'.",
+        )
+    try:
+        group = AssignmentGroup.objects.get(
+            pk=assignment_group_id, program=ctx.program,
+        )
+    except AssignmentGroup.DoesNotExist as exc:
+        raise NotFound("AssignmentGroup not found.") from exc
+elif assignment_group_id:
+    raise ValidationError(
+        "assignment_group can only be set when target_type='assignment_group'.",
+    )
+else:
+    group = None
+```
+
+When creating the row, pass `assignment_group=group`, `is_required=is_required`, `title=title`.
+
+### 5. Update the PATCH handler
+
+Extend the editable-when-no-responses set to include the new fields:
+
+```python
+# Existing: end_date editable always; cadence_override and target_payload
+# editable only when no responses exist.
+
+# New (when no responses exist):
+# - is_required: editable
+# - title: editable
+# - assignment_group: NOT editable post-creation (would require a new
+#   assignment row; use the conflict_resolution='replace' flow instead)
+```
+
+### 6. Update `_serialize`
+
+Add the new fields to the serialized representation:
+
+```python
+return {
+    # ... existing fields ...
+    "assignment_group": assignment.assignment_group_id,
+    "is_required": assignment.is_required,
+    "title": assignment.title or "",
+    "display_title": assignment.title or (assignment.template.name if assignment.template_id else ""),
+}
+```
+
+The `display_title` convenience field makes downstream consumers (FA-B dashboard refactors) simpler.
+
+### 7. Widen the permission gate (FA7)
+
+The existing endpoints use `viewer_or_403` from `api/leadership_team/common.py`, which restricts to `program_lead` capability. Per decision FA7, widen this to accept `program_lead OR admin` for the assignments endpoints specifically.
+
+Option A (preferred): add a new helper `assignment_viewer_or_403` in `api/leadership_team/common.py` that accepts both capabilities, and use it from `assignments.py`. Leaves the existing helper untouched for the rest of the LT endpoints.
+
+Option B: parameterize `viewer_or_403` with allowed capabilities. More invasive; only do this if the existing helper has a single caller (it doesn't, so option A is safer).
+
+Test: an Admin membership can POST/PATCH/DELETE assignments; a UH membership receives 403.
+
+### 8. Update conflict detection for the new target type
+
+In `_find_conflicts`, add the `assignment_group` branch. Two assignments conflict iff they share template + target_type + assignment_group AND their date windows overlap:
+
+```python
+if target_type == "assignment_group":
+    qs = qs.filter(assignment_group_id=assignment_group_id)
+```
+
+The existing date-overlap logic at the bottom of `_find_conflicts` already handles the date intersection generically.
+
+### 9. Documentation
+
+Update `docs/data-model.md` to mention the new fields on TemplateAssignment. One paragraph; reference back to `docs/design/form_orchestration_reframe.md` §3 for the design rationale.
+
+### 10. Tests
+
+In `backend/bunk_logs/api/tests/test_leadership_team_assignments.py` (or wherever existing TemplateAssignment tests live; if no test file exists, create one):
+
+1. **Model tests**: create a TemplateAssignment with `target_type='assignment_group'`, `assignment_group=<bunk>`, `is_required=False`, `title='Daily Bunk Log'`. Verify all fields persist.
+2. **`resolve_members` tests**:
+   - Resolve an assignment_group assignment to its expected counselors.
+   - Resolve when template has empty `author_role_filter` → returns empty queryset.
+   - Resolve when AssignmentGroup has no active author AGMs → returns empty.
+   - Resolve a `role` assignment (existing behavior) → still works, regression check.
+3. **API tests** (using DRF APIClient):
+   - POST a new assignment_group assignment as an LT user → 201.
+   - POST as an Admin user → 201 (FA7 widening verified).
+   - POST as a UH user → 403.
+   - POST without assignment_group when target_type='assignment_group' → 400.
+   - POST with assignment_group when target_type='role' → 400.
+   - PATCH the title and is_required of a created assignment → 200.
+   - PATCH the assignment_group → 400 (immutable post-creation; use replace flow).
+   - GET list shows new fields in payload.
+   - Conflict detection: create two overlapping assignments on the same bunk → 409 requiring conflict_resolution.
+
+### 11. Acceptance criteria for this prompt
+
+- All three new fields land on `TemplateAssignment` and migrate cleanly.
+- `resolve_members` correctly handles all four target types.
+- API endpoints accept, validate, and serialize the new fields.
+- Admin capability can use the assignment endpoints (FA7 satisfied).
+- All existing tests still pass.
+- New tests cover the cases enumerated in task 10.
+- `pytest`, `ruff check` clean.
+- Frontend tests unaffected (no frontend changes).
+
+### 12. Commit / PR conventions
+
+Per the existing migration prompts pattern:
+
+- Branch: `step/7_20_extend_template_assignment`
+- Commit messages use the step ID scope: `feat(7_20_extend_template_assignment): add assignment_group FK and is_required/title fields`
+- Open a PR with `gh pr create`; title `7_20: Extend TemplateAssignment with assignment_group, is_required, title`. Don't merge yourself.
+- PR description includes:
+  - **What**: summary of changes.
+  - **Why**: link to `docs/design/form_orchestration_reframe.md` and decisions FA1/FA5/FA7.
+  - **Testing**: list of new tests; result of running `pytest` and `ruff check`.
+  - **Risk assessment**: this is an additive migration; rollback is a revert of the model migration plus the API changes.
+  - **Rollback plan**: revert the merge commit; the migration is backward-compatible because all new fields are nullable / have defaults.
+
+## What this prompt does NOT do
+
+- Does NOT modify any per-role dashboard endpoint (that's FA-B / Step 7_21).
+- Does NOT create any TemplateAssignment rows (that's FA-S / Step 7_22).
+- Does NOT add frontend UX (that's FA-E in Wave 2).
+- Does NOT change `ReflectionTemplate`, `Reflection`, `Membership`, or any visibility logic.

--- a/migration_prompts/7_21_dashboard_template_resolution.md
+++ b/migration_prompts/7_21_dashboard_template_resolution.md
@@ -1,0 +1,237 @@
+# Step 7_21: Per-role dashboard refactor — TemplateAssignment-driven template resolution
+
+**Goal:** Replace the hard-coded template resolvers in each per-role `common.py` with TemplateAssignment-aware lookups. Each role's dashboard endpoint payload contract stays IDENTICAL; only the internal template resolution changes.
+
+**Canonical product spec:** `docs/design/form_orchestration_reframe.md` §3.4, plus decisions FA1, FA5, FA10 in `docs/user_stories/00_cross_cutting/decisions.md`.
+
+**Depends on:** Step 7_20 (TemplateAssignment extended with `assignment_group`, `is_required`, `title`).
+
+**Estimated time:** 4–6 hours.
+
+**Strategic context:** This is the second of three Wave 1 prompts (FA-A=7_20, FA-B=7_21, FA-S=7_22). FA10(a) says Wave 1 ships before June 5, 2026. This is the largest of the three prompts because the refactor touches eight per-role `common.py` files. Each role gets its own commit within this prompt so a regression in one role is independently revertible.
+
+The core insight: **the dashboard endpoint API contracts don't change**. The same JSON shape is returned. Only the internal query logic changes from `ReflectionTemplate.all_objects.filter(hard_coded_filters)` to `TemplateAssignment.all_objects.filter(viewer_context).first().template`.
+
+**Out of scope** (deferred):
+
+- The TemplateAssignment model extension (Step 7_20).
+- Seeding TemplateAssignment rows for Summer 2026 (Step 7_22). Until FA-S ships, the refactored dashboards will return empty results because no assignments exist. That's expected; FA-B and FA-S must ship as a coordinated pair before production deploy.
+- Any frontend changes.
+- Changes to `ReflectionTemplate`, `Reflection`, visibility logic, or the capability/role model.
+
+## Backend tasks
+
+### 1. New shared helper module: `core/assignment_resolution.py`
+
+Create a new module that all per-role dashboards consume. This keeps the resolution logic DRY across the eight role directories.
+
+Key function signatures:
+
+```python
+def active_assignments_for(
+    *,
+    viewer: Person,
+    organization: Organization,
+    program: Program,
+    as_of: date,
+    target_role: str | None = None,
+    target_assignment_group: AssignmentGroup | None = None,
+    require_required: bool = True,
+) -> list[TemplateAssignment]:
+    """Return active TemplateAssignment rows for a viewer-in-context.
+
+    Filters:
+    - status='active' (or 'scheduled' that has reached start_date by as_of)
+    - start_date <= as_of <= end_date (or end_date is null)
+    - organization, program match
+    - When target_role is set, includes assignments where target_type='role' and
+      target_payload['role'] matches, OR target_type='individuals' and the
+      viewer's Membership is in target_payload['membership_ids'], OR
+      target_type='assignment_group' and the viewer is an author on the group
+      with a matching role, OR target_type='tag_group' and viewer's
+      Membership tags include the tag.
+    - When require_required=True, excludes is_required=False assignments
+      (used by task derivation; optional-form library passes False).
+    """
+
+
+def resolve_template_for(
+    *,
+    viewer: Person,
+    organization: Organization,
+    program: Program,
+    as_of: date,
+    role: str,
+    subject_mode: str,
+    cadence: str | None = None,
+    assignment_group: AssignmentGroup | None = None,
+) -> ReflectionTemplate | None:
+    """Return the active ReflectionTemplate for a (viewer, role, subject_mode) tuple.
+
+    This replaces the per-role hard-coded helpers. The caller provides the
+    static template-shape requirements (subject_mode, optionally cadence)
+    and the resolver finds the TemplateAssignment whose template matches.
+
+    Returns None when no assignment is active. Callers MUST handle the
+    None case (the existing hard-coded helpers also could return None).
+
+    Org-shadows-global resolution preserved: if multiple assignments
+    match, prefer the one whose template's organization is the caller's
+    org over a global template.
+    """
+```
+
+The module also exposes:
+
+```python
+def list_required_assignments_for(viewer, organization, program, as_of) -> list[TemplateAssignment]:
+    """All required, active assignments where the viewer is in the resolved audience."""
+
+def list_optional_assignments_for(viewer, organization, program, as_of) -> list[TemplateAssignment]:
+    """All optional (is_required=False), active assignments where the viewer is in the resolved audience. Used by the Wave 2 'forms I can also fill out' library; not consumed by Wave 1 dashboards but the helper is here for symmetry."""
+```
+
+Place the module at `backend/bunk_logs/core/assignment_resolution.py`. It depends on `core.models` and on `api.leadership_team.assignments.resolve_members` (or factor `resolve_members` down into core to avoid the api→core import cycle if any).
+
+**Note on `resolve_members`**: it currently lives in `api/leadership_team/assignments.py`. For this prompt, move it to `core/assignment_resolution.py` and import it from the LT module. Both surfaces should use the same resolver.
+
+### 2. Refactor each role's `common.py`
+
+Eight role directories to update. Each gets its own commit. Order them by ascending risk (simplest first) so regressions surface early:
+
+1. **`api/kitchen_staff/common.py`** — single self-reflection template; smallest surface
+2. **`api/madrich/common.py`** — single weekly reflection template; small surface
+3. **`api/specialist/common.py`** — self-reflection + camper notes
+4. **`api/counselor/common.py`** — camper reflections + self-reflection (largest surface; has `camper_reflection_template` and `counselor_self_template` helpers)
+5. **`api/unit_head/common.py`** — UH self-reflection + bunk dashboards
+6. **`api/camper_care/common.py`** — CC self-reflection + caseload + flags
+7. **`api/leadership_team/common.py`** — LT self-reflection + team dashboards
+8. **`api/admin_flow/common.py`** — admin self-reflection + oversight
+
+For each role:
+
+- Identify every function in `common.py` that does `ReflectionTemplate.all_objects.filter(...)` or similar direct template lookups.
+- Replace its body with a call to `resolve_template_for(...)` from the new shared helper.
+- Pass the static template-shape requirements (subject_mode, cadence if applicable) and the viewer-context.
+- Preserve the function signature so callers in `dashboard.py`, `bunk_dashboard.py`, `camper_dashboard.py`, `team_dashboard.py`, etc., don't need to change.
+- Run the role's tests (`pytest backend/bunk_logs/api/tests/test_{role}_*.py`) after each role's refactor.
+
+Example: `api/counselor/common.py::camper_reflection_template` becomes:
+
+```python
+def camper_reflection_template(
+    organization: Organization,
+    program: Program,
+    *,
+    viewer: Person | None = None,
+    bunk: AssignmentGroup | None = None,
+    as_of: date | None = None,
+) -> ReflectionTemplate | None:
+    """Active daily camper-reflection template for a bunk roster.
+
+    Now resolves via TemplateAssignment. The bunk parameter is preferred;
+    if omitted, the resolver falls back to a program-wide assignment.
+    """
+    from bunk_logs.core.assignment_resolution import resolve_template_for
+    from bunk_logs.core.time_utils import get_today
+
+    if viewer is None or as_of is None:
+        # Backward-compat: callers that didn't pass viewer/as_of get the
+        # program-wide template via a synthetic resolution. This branch
+        # exists because some test fixtures and management commands call
+        # this helper without a viewer context. New code should pass them.
+        as_of = as_of or get_today(organization)
+
+    return resolve_template_for(
+        viewer=viewer,
+        organization=organization,
+        program=program,
+        as_of=as_of,
+        role="counselor",
+        subject_mode="single_subject",
+        cadence="daily",
+        assignment_group=bunk,
+    )
+```
+
+Callers in `counselor/dashboard.py` and elsewhere need to pass the new keyword args. The viewer context is already available there via `viewer_or_403`.
+
+### 3. Backward-compatibility consideration
+
+The legacy `ReflectionTemplate` direct queries also appear in:
+
+- Management commands (`seed_role_template`, `onboard_clc_summer_2026`).
+- Test fixtures.
+
+These should continue to work because:
+
+- The refactor only changes how dashboards *resolve* templates; templates themselves are still queryable directly via the ORM.
+- Management commands that seed templates do not need refactoring in this prompt.
+
+If any management command currently does "find the daily camper template" to inject test data, it should be updated to either (a) call the refactored helper with a mock viewer, or (b) use direct ORM queries since management commands run outside the dashboard request context.
+
+### 4. Tests
+
+For each role, update existing dashboard tests so they:
+
+- Create a TemplateAssignment row pointing at the test template (this is the new requirement; before the refactor, just creating the template was enough).
+- Assert the dashboard payload includes the expected template-derived data (same assertions as before).
+- Add a new test: when no TemplateAssignment exists for a role, the dashboard returns the empty-state shape (no tasks, but no 500 either).
+
+The existing tests will FAIL after the refactor until they're updated to create assignment rows. This is expected and is the signal that the refactor is doing its job.
+
+### 5. Documentation
+
+Add a new section to `docs/data-model.md` titled "Template resolution after Step 7_21" explaining:
+
+- Dashboards no longer hard-code template lookups.
+- Template resolution flows through `core.assignment_resolution.resolve_template_for`.
+- Adding a new role's dashboard means writing a new `common.py` that calls the same resolver.
+
+### 6. Acceptance criteria for this prompt
+
+- `core/assignment_resolution.py` exists with the documented signatures.
+- All eight per-role `common.py` files use the resolver instead of direct template queries.
+- Every dashboard endpoint's payload contract is unchanged (verified by existing dashboard contract tests).
+- New tests verify the empty-state behavior when no assignment exists.
+- `pytest` passes (after test fixtures are updated to create assignment rows).
+- `ruff check` clean.
+- Frontend tests still pass (no frontend changes; this is a backend-only refactor).
+
+### 7. Commit / PR conventions
+
+Per the existing migration prompts pattern:
+
+- Branch: `step/7_21_dashboard_template_resolution`
+- One commit per role refactored, in the order specified in task 2: `refactor(7_21_kitchen_staff): consume TemplateAssignment for kitchen self-reflection`, `refactor(7_21_madrich): ...`, etc.
+- Plus a leading commit `feat(7_21_assignment_resolution): add core.assignment_resolution shared resolver` for the new module.
+- Plus a trailing commit `test(7_21): update fixtures to create TemplateAssignment rows` if test updates span roles.
+- Open a single PR with `gh pr create`; title `7_21: Per-role dashboard refactor — TemplateAssignment-driven template resolution`. Don't merge yourself.
+- PR description includes:
+  - **What**: summary of changes, including the list of 8 roles refactored.
+  - **Why**: link to `docs/design/form_orchestration_reframe.md` §3.4 and decision FA10.
+  - **Testing**: dashboard contract tests still pass; new empty-state tests added.
+  - **Risk assessment**: this is the riskiest of the Wave 1 prompts. A bug in resolution silently empties a dashboard. Mitigation: per-role commits so we can revert individually.
+  - **Rollback plan**: if a single role's resolver breaks, revert that role's commit and re-deploy. The shared resolver module can stay; it has no consumers if no role is refactored.
+
+## What this prompt does NOT do
+
+- Does NOT modify TemplateAssignment itself (that's 7_20).
+- Does NOT create any TemplateAssignment rows for production data (that's 7_22).
+- Does NOT change `ReflectionTemplate`, `Reflection`, or any other model.
+- Does NOT add frontend UX.
+- Does NOT change visibility / permission logic.
+
+## Critical warning
+
+Until Step 7_22 (seeding) ships in the same release window, the refactored dashboards will return empty results in production. **FA-B (7_21) and FA-S (7_22) must be deployed to production within the same release cycle**, or staging-only until both are ready. Do NOT merge 7_21 to production without 7_22 ready to follow immediately.
+
+Suggested production deploy sequence (in the same maintenance window):
+
+1. Merge 7_20.
+2. Merge 7_21.
+3. Merge 7_22.
+4. Run the FA-S seeding command.
+5. Smoke test as Alyson.
+
+If 7_22 is not ready when 7_21 lands, 7_21 stays on staging only.

--- a/migration_prompts/7_22_seed_summer_2026_assignments.md
+++ b/migration_prompts/7_22_seed_summer_2026_assignments.md
@@ -1,0 +1,196 @@
+# Step 7_22: Seed TemplateAssignments for Crane Lake Summer 2026
+
+**Goal:** Create the TemplateAssignment rows that Crane Lake Summer 2026 needs so the refactored dashboards (Step 7_21) produce the same tasks as the pre-refactor implicit logic. Ship via an idempotent management command.
+
+**Canonical product spec:** `docs/design/form_orchestration_reframe.md` §3.5, plus decisions FA1, FA10 in `docs/user_stories/00_cross_cutting/decisions.md`.
+
+**Depends on:** Step 7_20 (TemplateAssignment extended), Step 7_21 (per-role dashboards refactored).
+
+**Estimated time:** 2–4 hours.
+
+**Strategic context:** This is the third and final Wave 1 prompt (FA-A=7_20, FA-B=7_21, FA-S=7_22). Without this prompt, the refactored dashboards from 7_21 will return empty results — there are no TemplateAssignment rows for them to consume. This prompt makes the post-refactor dashboards produce the same task list as pre-refactor, with no functional change visible to end users. It's the cutover that makes FA10(a) viable.
+
+**Out of scope** (deferred):
+
+- Any model changes (those land in 7_20).
+- Any dashboard refactor (that's 7_21).
+- Any frontend changes.
+- TemplateAssignment rows for TBE Religious School (covered separately when TBE onboarding runs in late August).
+- Optional (`is_required=False`) assignments — Wave 1 ships required tasks only; the optional-form library is Wave 2 (FA-G).
+
+## Backend tasks
+
+### 1. New management command: `seed_summer_2026_assignments`
+
+Place at `backend/bunk_logs/core/management/commands/seed_summer_2026_assignments.py`.
+
+Command signature:
+
+```bash
+python manage.py seed_summer_2026_assignments \
+    --org-slug crane-lake-camp \
+    --program-slug summer-2026 \
+    [--dry-run] \
+    [--actor-username <admin-user>]
+```
+
+Behavior:
+
+- Idempotent: re-running with the same args produces the same set of assignments (no duplicates, no orphans).
+- `--dry-run`: prints what would be created/updated, makes no DB changes.
+- `--actor-username`: optional; resolves to a User whose Membership becomes the `created_by` on each row. Defaults to a synthetic platform actor when not provided.
+- Wraps all writes in a single transaction so a partial failure leaves no partial seed.
+
+### 2. The canonical assignment list for Summer 2026
+
+Per the existing implicit logic that the per-role dashboards used to derive tasks. Enumerate every template-and-context combination here and create one TemplateAssignment row per entry.
+
+| Role | Template (by slug, org-shadow-aware) | target_type | assignment_group / payload | cadence | is_required | title |
+|---|---|---|---|---|---|---|
+| counselor | `counselor-camper-log-{daily}` (single_subject) | assignment_group | each active Bunk in the program | daily | true | "Daily Camper Bunk Log" |
+| counselor | `counselor-self-reflection-{daily}` (self) | role | `{role: 'counselor'}` | daily | true | "Counselor Daily Self-Reflection" |
+| junior_counselor | `junior-counselor-self-reflection-{daily}` (self) | role | `{role: 'junior_counselor'}` | daily | true | "JC Daily Self-Reflection" |
+| general_counselor | `general-counselor-self-reflection-{daily}` (self) | role | `{role: 'general_counselor'}` | daily | true | "GC Daily Self-Reflection" |
+| specialist | `specialist-self-reflection-{daily}` (self) | role | `{role: 'specialist'}` | daily | true | "Specialist Daily Self-Reflection" |
+| unit_head | `unit-head-self-reflection-{daily}` (self) | role | `{role: 'unit_head'}` | daily | true | "Unit Head Daily Self-Reflection" |
+| kitchen_staff | `kitchen-staff-self-reflection-{daily}` (self) | role | `{role: 'kitchen_staff'}` | daily | true | "Kitchen Daily Self-Reflection" |
+| maintenance | `maintenance-self-reflection-{daily}` (self) | role | `{role: 'maintenance'}` | daily | true | "Maintenance Daily Self-Reflection" |
+| housekeeping | `housekeeping-self-reflection-{daily}` (self) | role | `{role: 'housekeeping'}` | daily | true | "Housekeeping Daily Self-Reflection" |
+| camper_care | `camper-care-self-reflection-{daily}` (self) | role | `{role: 'camper_care'}` | daily | true | "Camper Care Daily Self-Reflection" |
+| health_center | `health-center-self-reflection-{daily}` (self) | role | `{role: 'health_center'}` | daily | true | "Health Center Daily Self-Reflection" |
+| special_diets | `special-diets-self-reflection-{daily}` (self) | role | `{role: 'special_diets'}` | daily | true | "Special Diets Daily Self-Reflection" |
+| leadership_team | `leadership-team-self-reflection-{daily}` (self) | role | `{role: 'leadership_team'}` | daily | true | "LT Daily Self-Reflection" |
+| admin | `admin-self-reflection-{daily}` (self) | role | `{role: 'admin'}` | daily | true | "Admin Daily Self-Reflection" |
+
+**This table is a starting point.** During implementation:
+
+1. Read each per-role `common.py` (post-7_21 refactor) and confirm which templates each role's dashboard expects to resolve.
+2. Check `docs/clc-2026-templates.md` and the existing seeded templates via `python manage.py shell` → `ReflectionTemplate.all_objects.filter(...)` to confirm the actual template slugs.
+3. Adjust the table above to match reality. The structure (one assignment per role-and-template combination) is correct; only the slugs and titles need verification.
+
+For the counselor camper-log entry specifically: the command should enumerate all `AssignmentGroup` rows in the Summer 2026 program where `group_type='bunk'` and `is_active=True`, then create one TemplateAssignment per bunk. This is the only entry that produces multiple assignment rows; the rest produce one row each.
+
+### 3. Implementation outline
+
+```python
+class Command(BaseCommand):
+    help = "Seed TemplateAssignment rows for a Summer 2026 program."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--org-slug", required=True)
+        parser.add_argument("--program-slug", required=True)
+        parser.add_argument("--dry-run", action="store_true")
+        parser.add_argument("--actor-username")
+
+    def handle(self, *args, **opts):
+        org = Organization.objects.get(slug=opts["org_slug"])
+        program = Program.objects.get(organization=org, slug=opts["program_slug"])
+        actor = self._resolve_actor(org, opts.get("actor_username"))
+        plan = self._build_plan(org, program)
+
+        if opts["dry_run"]:
+            self._print_plan(plan)
+            return
+
+        with transaction.atomic():
+            for entry in plan:
+                self._upsert_assignment(entry, actor=actor)
+        self.stdout.write(self.style.SUCCESS(f"Seeded {len(plan)} assignments."))
+
+    def _build_plan(self, org, program) -> list[dict]:
+        # ... assemble the table above into a list of dicts ...
+        # Each dict has: template, target_type, target_payload,
+        # assignment_group, cadence, is_required, title, start_date.
+
+    def _upsert_assignment(self, entry, *, actor):
+        # Find an active TemplateAssignment matching (program, template,
+        # target_type, target identifiers). Update title/is_required/etc. if
+        # found; create if not.
+```
+
+The idempotency key is `(program, template, target_type, target_identifiers)` where `target_identifiers` is the role string, the assignment_group id, the membership_ids list, or the tag string depending on target_type.
+
+### 4. Date window
+
+- `start_date`: program's `start_date` (Crane Lake Summer 2026 starts June 5, 2026).
+- `end_date`: program's `end_date` (or null for open-ended).
+
+### 5. Pre-flight checks before writes
+
+The command should refuse to run if:
+
+- The organization or program doesn't exist (raise CommandError).
+- Any expected template is missing in the program's templates (warn, list missing, exit non-zero unless `--force` is passed).
+- An assignment with the same key already exists in a status that isn't `active` or `scheduled` (e.g. `ended` or `cancelled`) — log a warning and skip rather than reactivate. The intent is "seed fresh assignments," not "resurrect old ones."
+
+### 6. Cross-program safety
+
+Re-running the command against a different `--program-slug` must not affect Summer 2026 assignments. The idempotency key includes `program`, so this is automatic, but include an explicit test.
+
+### 7. Tests
+
+Create `backend/bunk_logs/core/management/tests/test_seed_summer_2026_assignments.py`:
+
+1. **Happy path**: seed against a fixture with all expected templates → expected number of assignments created.
+2. **Idempotency**: run twice → same row count, no duplicates.
+3. **Dry run**: produces no DB writes.
+4. **Missing template**: run against a fixture missing one template → exit with helpful error.
+5. **Bunk enumeration**: fixture with 3 bunks → 3 counselor-camper-log assignments created (one per bunk).
+6. **Cross-program isolation**: seed Summer 2026, then create a Summer 2027 program in the same org, run for Summer 2027 → Summer 2026 assignments untouched.
+7. **Cross-org isolation**: seed Crane Lake, then run for a different org → Crane Lake assignments untouched.
+
+### 8. Documentation
+
+Add a new section to `docs/clc-summer-2026-launch.md` titled "Seeding TemplateAssignments (Step 7_22)" with:
+
+- The command invocation.
+- The list of assignments it creates.
+- The expected verification step (run the command against staging, log into staging as Alyson, confirm dashboards populate correctly).
+- The production deploy sequence (per Step 7_21's critical warning: 7_20 → 7_21 → 7_22 → run seeding command, all in one maintenance window).
+
+### 9. Acceptance criteria for this prompt
+
+- Command exists and is idempotent.
+- All assignments listed in task 2 are created when run against the Crane Lake Summer 2026 fixtures.
+- Per-role dashboards (post-7_21 refactor) return non-empty results after seeding.
+- All tests in task 7 pass.
+- `pytest`, `ruff check` clean.
+- Frontend tests unaffected.
+- Smoke test on staging: a seeded counselor sees their daily camper bunk log task and their daily self-reflection task; a seeded UH sees their daily UH self-reflection task; etc.
+
+### 10. Commit / PR conventions
+
+Per the existing migration prompts pattern:
+
+- Branch: `step/7_22_seed_summer_2026_assignments`
+- Commit: `feat(7_22_seed_summer_2026_assignments): seed TemplateAssignment rows for Crane Lake Summer 2026`
+- Open a PR with `gh pr create`; title `7_22: Seed TemplateAssignments for Crane Lake Summer 2026`. Don't merge yourself.
+- PR description includes:
+  - **What**: summary of the command and the assignment list it produces.
+  - **Why**: link to `docs/design/form_orchestration_reframe.md` and decision FA10.
+  - **Testing**: list of tests; dry-run output from staging.
+  - **Risk assessment**: this is the cutover. If template slugs in the seed table don't match production templates, dashboards will be empty after deploy. Mitigation: dry-run against staging-with-prod-data-snapshot before deploy.
+  - **Rollback plan**: TemplateAssignment rows can be marked `status='cancelled'` and the pre-7_21 dashboards code can be restored to fall back to direct template queries. But the cleaner rollback is "revert 7_21 and 7_22 together" — the same maintenance window strategy applies in reverse.
+
+## What this prompt does NOT do
+
+- Does NOT modify any model or dashboard code.
+- Does NOT add frontend UX.
+- Does NOT seed TBE assignments (covered in TBE onboarding, post-summer).
+- Does NOT seed any `is_required=False` (optional) assignments.
+
+## Final Wave 1 sequence
+
+Once 7_22 is merged:
+
+1. Deploy 7_20 + 7_21 + 7_22 to production in a single maintenance window (suggested: a weekend evening late May / very early June).
+2. Run the seeding command in production: `python manage.py seed_summer_2026_assignments --org-slug crane-lake-camp --program-slug summer-2026`.
+3. Smoke test as Alyson immediately after.
+4. Monitor Datadog APM for unexpected dashboard errors over the next 24 hours.
+5. By June 3 at the latest, declare Wave 1 done or trigger the FA10(b) escape-hatch rollback.
+
+After Wave 1 ships and stabilizes:
+
+- Re-verify the existing canonical user stories against the new substrate (per the design doc §7 acceptance criteria).
+- Plan Notes module deploy (7_19) for late June.
+- Begin Wave 2 work in July (FA-E, FA-P, FA-F, FA-G, FA-H, FA-I).


### PR DESCRIPTION
Adds the form-orchestration design doc, Notes platform stories, FA1–FA10 decisions, and Wave 1 implementation prompts (7_20, 7_21, 7_22). Wave 1 prompts must ship before June 5, 2026 per FA10(a).