### PR TITLE
7_20: Extend TemplateAssignment with assignment_group, is_required, title

### DIFF
--- a/backend/bunk_logs/api/leadership_team/assignments.py
+++ b/backend/bunk_logs/api/leadership_team/assignments.py
@@ -1,4 +1,4 @@
-"""LT Template Assignment API (Step 7_12 PR B — Story 52).
+"""LT Template Assignment API (Step 7_12 PR B — Story 52; extended Step 7_20).
 
 Endpoints under ``/api/v1/leadership-team/assignments/``:
 
@@ -9,6 +9,9 @@ Endpoints under ``/api/v1/leadership-team/assignments/``:
                         ``"run_both"`` / ``"cancel"``).
 * ``PATCH /<id>/``    — only ``end_date`` may be edited once any
                         Reflection responses exist (Story 52 c4/c9).
+                        ``is_required`` and ``title`` are also editable
+                        when no responses exist. ``assignment_group`` is
+                        immutable post-creation (use the replace flow).
 * ``DELETE /<id>/``   — cancel a *scheduled* assignment (never started).
 
 Also exposes a helper ``resolve_members(assignment, as_of_date)`` used
@@ -34,15 +37,17 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from bunk_logs.core import audit
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Reflection
 from bunk_logs.core.models import ReflectionTemplate
 from bunk_logs.core.models import TemplateAssignment
 
-from .common import viewer_or_403
+from .common import assignment_viewer_or_403
 
 CONFLICT_CHOICES = ("replace", "run_both", "cancel")
-VALID_TARGET_TYPES = ("role", "individuals", "tag_group")
+VALID_TARGET_TYPES = ("role", "individuals", "tag_group", "assignment_group")
 
 
 # ---------------------------------------------------------------------------
@@ -59,6 +64,8 @@ def resolve_members(assignment: TemplateAssignment, as_of: date):
       Filtered to currently active so a deactivated member silently drops.
     * ``tag_group``: dynamic — Memberships whose ``tags`` JSON contains
       the given tag.
+    * ``assignment_group``: dynamic — Memberships whose role is in
+      template.author_role_filter AND who are active authors in the group.
     """
     payload = assignment.target_payload or {}
     base = Membership.all_objects.filter(
@@ -78,6 +85,19 @@ def resolve_members(assignment: TemplateAssignment, as_of: date):
         if not tag:
             return base.none()
         return base.filter(tags__contains=[tag])
+    if target_type == TemplateAssignment.TargetType.ASSIGNMENT_GROUP:
+        group_id = assignment.assignment_group_id
+        if not group_id:
+            return base.none()
+        author_roles = assignment.template.author_role_filter or []
+        if not author_roles:
+            return base.none()
+        author_person_ids = AssignmentGroupMembership.all_objects.filter(
+            group_id=group_id,
+            role_in_group="author",
+            is_active=True,
+        ).values_list("person_id", flat=True)
+        return base.filter(person_id__in=author_person_ids, role__in=author_roles)
     return base.none()
 
 
@@ -93,6 +113,12 @@ def _serialize(assignment: TemplateAssignment) -> dict[str, Any]:
         "template_slug": assignment.template.slug if assignment.template_id else None,
         "target_type": assignment.target_type,
         "target_payload": assignment.target_payload or {},
+        "assignment_group": assignment.assignment_group_id,
+        "is_required": assignment.is_required,
+        "title": assignment.title or "",
+        "display_title": assignment.title or (
+            assignment.template.name if assignment.template_id else ""
+        ),
         "start_date": assignment.start_date.isoformat(),
         "end_date": assignment.end_date.isoformat() if assignment.end_date else None,
         "cadence_override": assignment.cadence_override,
@@ -122,6 +148,11 @@ def _validate_target(target_type: str, target_payload: dict) -> None:
     if target_type == "tag_group" and not target_payload.get("tag"):
         msg = "target_payload.tag is required for target_type='tag_group'."
         raise ValidationError(msg)
+    if target_type == "assignment_group":
+        # assignment_group_id comes via the dedicated FK column on the
+        # request body, not target_payload. Validation happens in the
+        # POST handler where we can check DB existence.
+        pass
 
 
 def _targets_equal(a: dict, b: dict) -> bool:
@@ -132,12 +163,13 @@ def _targets_equal(a: dict, b: dict) -> bool:
 def _find_conflicts(
     *, organization, template: ReflectionTemplate, target_type: str,
     target_payload: dict, start: date, end: date | None,
+    assignment_group_id: int | None = None,
 ):
     """Return queryset of overlapping assignments on (template, target).
 
     Two assignments conflict iff they share template + target_type +
-    target identifiers (role or tag) AND their date windows overlap.
-    Individuals targets are treated as never-overlapping conflicts
+    target identifiers (role, tag, or assignment_group) AND their date
+    windows overlap. Individuals targets are treated as never-overlapping
     (they're explicit per-membership picks).
     """
     if target_type == "individuals":
@@ -155,6 +187,8 @@ def _find_conflicts(
         qs = qs.filter(target_payload__role=target_payload.get("role"))
     elif target_type == "tag_group":
         qs = qs.filter(target_payload__tag=target_payload.get("tag"))
+    elif target_type == "assignment_group":
+        qs = qs.filter(assignment_group_id=assignment_group_id)
     end_filter = end or date.max
     return qs.filter(start_date__lte=end_filter).filter(
         Q(end_date__gte=start) | Q(end_date__isnull=True),
@@ -172,7 +206,7 @@ class LeadershipTeamAssignmentListCreateView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request, *args, **kwargs):
-        ctx = viewer_or_403(request)
+        ctx = assignment_viewer_or_403(request)
         qs = (
             TemplateAssignment.objects
             .filter(organization=ctx.organization)
@@ -185,7 +219,7 @@ class LeadershipTeamAssignmentListCreateView(APIView):
         return Response({"assignments": [_serialize(a) for a in qs[:200]]})
 
     def post(self, request, *args, **kwargs):
-        ctx = viewer_or_403(request)
+        ctx = assignment_viewer_or_403(request)
         payload = dict(request.data) if isinstance(request.data, dict) else {}
 
         template_id = payload.get("template")
@@ -214,6 +248,27 @@ class LeadershipTeamAssignmentListCreateView(APIView):
             raise ValidationError(msg)
         _validate_target(target_type, target_payload)
 
+        # New fields (Step 7_20).
+        assignment_group_id = payload.get("assignment_group")
+        is_required = payload.get("is_required", True)
+        title = (payload.get("title") or "").strip()
+
+        group: AssignmentGroup | None = None
+        if target_type == "assignment_group":
+            if not assignment_group_id:
+                msg = "assignment_group is required when target_type='assignment_group'."
+                raise ValidationError(msg)
+            try:
+                group = AssignmentGroup.objects.get(
+                    pk=assignment_group_id, program=ctx.program,
+                )
+            except AssignmentGroup.DoesNotExist as exc:
+                msg = "AssignmentGroup not found."
+                raise NotFound(msg) from exc
+        elif assignment_group_id:
+            msg = "assignment_group can only be set when target_type='assignment_group'."
+            raise ValidationError(msg)
+
         start = parse_date(payload.get("start_date") or "")
         if start is None:
             msg = "start_date is required (YYYY-MM-DD)."
@@ -231,6 +286,7 @@ class LeadershipTeamAssignmentListCreateView(APIView):
             target_payload=target_payload,
             start=start,
             end=end,
+            assignment_group_id=assignment_group_id,
         ))
         conflict_resolution = (payload.get("conflict_resolution") or "").lower()
         if conflicts and conflict_resolution not in CONFLICT_CHOICES:
@@ -255,6 +311,9 @@ class LeadershipTeamAssignmentListCreateView(APIView):
                 template=template,
                 target_type=target_type,
                 target_payload=target_payload,
+                assignment_group=group,
+                is_required=is_required,
+                title=title,
                 start_date=start,
                 end_date=end,
                 cadence_override=payload.get("cadence_override") or None,
@@ -262,7 +321,6 @@ class LeadershipTeamAssignmentListCreateView(APIView):
                 created_by=ctx.membership,
             )
             if conflict_resolution == "replace" and conflicts:
-                # End the prior assignment(s) the day before start.
                 stop = start - timedelta(days=1)
                 for prior in conflicts:
                     prior.end_date = stop
@@ -287,15 +345,18 @@ class LeadershipTeamAssignmentListCreateView(APIView):
 
 
 class LeadershipTeamAssignmentDetailView(APIView):
-    """``PATCH /<id>/`` — edit end_date (only field editable once responses exist).
+    """``PATCH /<id>/`` — edit allowed fields; ``DELETE /<id>/`` cancels scheduled.
 
-    ``DELETE /<id>/`` cancels a scheduled assignment.
+    Always editable: ``end_date``.
+    Editable only when no responses exist: ``cadence_override``,
+    ``target_payload``, ``is_required``, ``title``.
+    Immutable post-creation: ``assignment_group`` (use the replace flow).
     """
 
     permission_classes = [IsAuthenticated]
 
     def _get(self, request, pk: int) -> TemplateAssignment:
-        ctx = viewer_or_403(request)
+        ctx = assignment_viewer_or_403(request)
         try:
             return TemplateAssignment.objects.select_related("template").get(
                 organization=ctx.organization, pk=pk,
@@ -312,8 +373,14 @@ class LeadershipTeamAssignmentDetailView(APIView):
             period_start__gte=assignment.start_date,
         ).exists()
 
+        if "assignment_group" in payload:
+            msg = (
+                "assignment_group is immutable post-creation. "
+                "Use conflict_resolution='replace' to create a new assignment."
+            )
+            raise ValidationError(msg)
+
         if has_responses:
-            # Only end_date may be edited once responses exist.
             editable = {"end_date"}
             disallowed = set(payload.keys()) - editable
             if disallowed:
@@ -337,6 +404,10 @@ class LeadershipTeamAssignmentDetailView(APIView):
             for k in ("cadence_override", "target_payload"):
                 if k in payload:
                     setattr(assignment, k, payload[k])
+            if "is_required" in payload:
+                assignment.is_required = bool(payload["is_required"])
+            if "title" in payload:
+                assignment.title = (payload["title"] or "").strip()
         assignment.save()
 
         audit.edited(

--- a/backend/bunk_logs/api/leadership_team/common.py
+++ b/backend/bunk_logs/api/leadership_team/common.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
 __all__ = [
     "LT_SELF_TEMPLATE_SLUG",
     "ViewerContext",
+    "assignment_viewer_or_403",
     "leadership_team_self_template",
     "resolve_period",
     "supervised_role_supervisions",
@@ -67,6 +68,45 @@ class ViewerContext:
     membership: Membership
     program: Program
     today: date
+
+
+def assignment_viewer_or_403(request) -> ViewerContext:
+    """Like ``viewer_or_403`` but also accepts ``admin`` capability (decision FA7).
+
+    Used exclusively by the assignments endpoints so the wider gate doesn't
+    silently apply to other LT surfaces.
+    """
+    org = getattr(request, "organization", None)
+    if org is None:
+        msg = "Organization context required."
+        raise PermissionDenied(msg)
+    if not request.user.is_authenticated:
+        msg = "Authentication required."
+        raise PermissionDenied(msg)
+    person = Person.objects.filter(user=request.user).first()
+    if person is None:
+        msg = "Person profile required."
+        raise PermissionDenied(msg)
+    membership = (
+        Membership.objects.filter(
+            person=person,
+            capability__in=["program_lead", "admin"],
+            is_active=True,
+        )
+        .select_related("program", "program__organization")
+        .order_by("-created_at")
+        .first()
+    )
+    if membership is None:
+        msg = "Leadership Team or Admin role required."
+        raise PermissionDenied(msg)
+    return ViewerContext(
+        person=person,
+        organization=org,
+        membership=membership,
+        program=membership.program,
+        today=get_today(org),
+    )
 
 
 def viewer_or_403(request) -> ViewerContext:

--- a/backend/bunk_logs/api/tests/test_leadership_team_assignments.py
+++ b/backend/bunk_logs/api/tests/test_leadership_team_assignments.py
@@ -1,0 +1,518 @@
+"""Tests for Step 7_20: TemplateAssignment extension.
+
+Covers:
+- Model persistence for new fields
+- resolve_members for all target types (including regression on existing ones)
+- API: POST/PATCH/GET with new fields, permission checks (LT, Admin, UH → 403)
+- Conflict detection for assignment_group target type
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+from bunk_logs.api.leadership_team.assignments import resolve_members
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.models import TemplateAssignment
+
+User = get_user_model()
+
+TODAY = date(2026, 6, 15)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Base fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(
+        name="Assignments Camp", slug="assignments-camp",
+        settings={"rollover_hour": 0, "timezone": "UTC"},
+    )
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org, name="Assignments Camp Summer 2026",
+        slug="summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1), end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def lt_user():
+    return User.objects.create_user(email="lt@assign.test", password="pw")
+
+
+@pytest.fixture
+def lt_membership(program, org, lt_user):
+    person = Person.all_objects.create(
+        organization=org, first_name="LT", last_name="Lead", user=lt_user,
+    )
+    return Membership.all_objects.create(
+        program=program, person=person, role="leadership_team", is_active=True,
+    )
+
+
+@pytest.fixture
+def admin_user():
+    return User.objects.create_user(email="admin@assign.test", password="pw")
+
+
+@pytest.fixture
+def admin_membership(program, org, admin_user):
+    person = Person.all_objects.create(
+        organization=org, first_name="Org", last_name="Admin", user=admin_user,
+    )
+    return Membership.all_objects.create(
+        program=program, person=person, role="admin", is_active=True,
+    )
+
+
+@pytest.fixture
+def uh_user():
+    return User.objects.create_user(email="uh@assign.test", password="pw")
+
+
+@pytest.fixture
+def uh_membership(program, org, uh_user):
+    person = Person.all_objects.create(
+        organization=org, first_name="Unit", last_name="Head", user=uh_user,
+    )
+    return Membership.all_objects.create(
+        program=program, person=person, role="unit_head", is_active=True,
+    )
+
+
+@pytest.fixture
+def published_template(org):
+    return ReflectionTemplate.all_objects.create(
+        organization=org,
+        name="Counselor Daily",
+        slug="counselor-daily-assign",
+        cadence="daily",
+        role="counselor",
+        schema={"fields": [{"key": "x", "type": "textarea", "prompts": {"en": "x?"}}]},
+        languages=["en"],
+        subject_mode="self",
+        author_role_filter=["counselor"],
+        status=ReflectionTemplate.Status.PUBLISHED,
+        is_active=True,
+        version=1,
+    )
+
+
+@pytest.fixture
+def bunk(org, program):
+    return AssignmentGroup.all_objects.create(
+        organization=org, program=program,
+        name="Bunk A", slug="bunk-a", group_type="bunk",
+    )
+
+
+def _client(user, org):
+    c = APIClient()
+    c.force_authenticate(user=user)
+    c.credentials(HTTP_X_ORGANIZATION_SLUG=org.slug)
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_new_fields_persist(org, program, lt_membership, bunk, published_template):
+    """assignment_group FK, is_required=False, and title round-trip through the ORM."""
+    assignment = TemplateAssignment.all_objects.create(
+        organization=org,
+        program=program,
+        template=published_template,
+        target_type=TemplateAssignment.TargetType.ASSIGNMENT_GROUP,
+        assignment_group=bunk,
+        is_required=False,
+        title="Daily Bunk Log",
+        start_date=date(2026, 6, 1),
+        created_by=lt_membership,
+    )
+    assignment.refresh_from_db()
+    assert assignment.assignment_group_id == bunk.pk
+    assert assignment.is_required is False
+    assert assignment.title == "Daily Bunk Log"
+    assert assignment.target_type == "assignment_group"
+
+
+# ---------------------------------------------------------------------------
+# resolve_members tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_resolve_members_assignment_group(
+    org, program, lt_membership, bunk, published_template,
+):
+    """assignment_group target resolves to Memberships with matching role + AGM author."""
+    counselor_person = Person.all_objects.create(
+        organization=org, first_name="C1", last_name="Smith",
+    )
+    counselor_mb = Membership.all_objects.create(
+        program=program, person=counselor_person, role="counselor", is_active=True,
+    )
+    AssignmentGroupMembership.all_objects.create(
+        group=bunk, person=counselor_person, role_in_group="author", is_active=True,
+    )
+    # Non-author in the same bunk — should NOT appear.
+    camper_person = Person.all_objects.create(
+        organization=org, first_name="Camper", last_name="Jones",
+    )
+    Membership.all_objects.create(
+        program=program, person=camper_person, role="camper", is_active=True,
+    )
+    AssignmentGroupMembership.all_objects.create(
+        group=bunk, person=camper_person, role_in_group="subject", is_active=True,
+    )
+
+    assignment = TemplateAssignment.all_objects.create(
+        organization=org, program=program, template=published_template,
+        target_type=TemplateAssignment.TargetType.ASSIGNMENT_GROUP,
+        assignment_group=bunk,
+        start_date=date(2026, 6, 1), created_by=lt_membership,
+    )
+    result = list(resolve_members(assignment, as_of=TODAY))
+    assert len(result) == 1
+    assert result[0].pk == counselor_mb.pk
+
+
+@pytest.mark.django_db
+def test_resolve_members_assignment_group_empty_author_role_filter(
+    org, program, lt_membership, bunk,
+):
+    """Empty author_role_filter → base.none() (cannot resolve without role constraint)."""
+    template_no_filter = ReflectionTemplate.all_objects.create(
+        organization=org, name="No Filter", slug="no-filter",
+        cadence="daily",
+        schema={"fields": [{"key": "x", "type": "textarea", "prompts": {"en": "x?"}}]},
+        languages=["en"], subject_mode="self",
+        author_role_filter=[],
+        status=ReflectionTemplate.Status.PUBLISHED, is_active=True, version=1,
+    )
+    assignment = TemplateAssignment.all_objects.create(
+        organization=org, program=program, template=template_no_filter,
+        target_type=TemplateAssignment.TargetType.ASSIGNMENT_GROUP,
+        assignment_group=bunk,
+        start_date=date(2026, 6, 1), created_by=lt_membership,
+    )
+    assert resolve_members(assignment, as_of=TODAY).count() == 0
+
+
+@pytest.mark.django_db
+def test_resolve_members_assignment_group_no_active_authors(
+    org, program, lt_membership, bunk, published_template,
+):
+    """No active AGM authors in the group → empty queryset."""
+    person = Person.all_objects.create(
+        organization=org, first_name="C", last_name="Gone",
+    )
+    Membership.all_objects.create(
+        program=program, person=person, role="counselor", is_active=True,
+    )
+    AssignmentGroupMembership.all_objects.create(
+        group=bunk, person=person, role_in_group="author", is_active=False,
+    )
+    assignment = TemplateAssignment.all_objects.create(
+        organization=org, program=program, template=published_template,
+        target_type=TemplateAssignment.TargetType.ASSIGNMENT_GROUP,
+        assignment_group=bunk,
+        start_date=date(2026, 6, 1), created_by=lt_membership,
+    )
+    assert resolve_members(assignment, as_of=TODAY).count() == 0
+
+
+@pytest.mark.django_db
+def test_resolve_members_role_regression(
+    org, program, lt_membership, published_template,
+):
+    """role target type still resolves correctly (regression check)."""
+    person = Person.all_objects.create(
+        organization=org, first_name="R", last_name="Role",
+    )
+    mb = Membership.all_objects.create(
+        program=program, person=person, role="counselor", is_active=True,
+    )
+    assignment = TemplateAssignment.all_objects.create(
+        organization=org, program=program, template=published_template,
+        target_type=TemplateAssignment.TargetType.ROLE,
+        target_payload={"role": "counselor"},
+        start_date=date(2026, 6, 1), created_by=lt_membership,
+    )
+    result = list(resolve_members(assignment, as_of=TODAY))
+    assert any(r.pk == mb.pk for r in result)
+
+
+# ---------------------------------------------------------------------------
+# API tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_post_assignment_group_as_lt(
+    org, program, lt_membership, lt_user, bunk, published_template,
+):
+    """LT user can POST an assignment_group assignment → 201."""
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/leadership-team/assignments/",
+            data={
+                "template": published_template.id,
+                "target_type": "assignment_group",
+                "assignment_group": bunk.id,
+                "target_payload": {},
+                "start_date": "2026-06-01",
+                "end_date": "2026-08-31",
+                "is_required": False,
+                "title": "Daily Bunk Log",
+            },
+            format="json",
+        )
+    assert resp.status_code == 201, resp.data
+    body = resp.json()
+    assert body["target_type"] == "assignment_group"
+    assert body["assignment_group"] == bunk.id
+    assert body["is_required"] is False
+    assert body["title"] == "Daily Bunk Log"
+    assert body["display_title"] == "Daily Bunk Log"
+
+
+@pytest.mark.django_db
+def test_post_assignment_group_as_admin(
+    org, program, admin_membership, admin_user, bunk, published_template,
+):
+    """Admin capability can POST assignments (FA7 widening) → 201."""
+    c = _client(admin_user, org)
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/leadership-team/assignments/",
+            data={
+                "template": published_template.id,
+                "target_type": "assignment_group",
+                "assignment_group": bunk.id,
+                "target_payload": {},
+                "start_date": "2026-06-01",
+            },
+            format="json",
+        )
+    assert resp.status_code == 201, resp.data
+
+
+@pytest.mark.django_db
+def test_post_assignment_group_as_uh_is_403(
+    org, program, uh_membership, uh_user, bunk, published_template,
+):
+    """UH (supervisor capability) cannot POST assignments → 403."""
+    c = _client(uh_user, org)
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/leadership-team/assignments/",
+            data={
+                "template": published_template.id,
+                "target_type": "assignment_group",
+                "assignment_group": bunk.id,
+                "target_payload": {},
+                "start_date": "2026-06-01",
+            },
+            format="json",
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_post_assignment_group_without_group_id_is_400(
+    org, program, lt_membership, lt_user, published_template,
+):
+    """target_type='assignment_group' without assignment_group → 400."""
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/leadership-team/assignments/",
+            data={
+                "template": published_template.id,
+                "target_type": "assignment_group",
+                "target_payload": {},
+                "start_date": "2026-06-01",
+            },
+            format="json",
+        )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_post_assignment_group_with_role_target_type_is_400(
+    org, program, lt_membership, lt_user, bunk, published_template,
+):
+    """Supplying assignment_group when target_type='role' → 400."""
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/leadership-team/assignments/",
+            data={
+                "template": published_template.id,
+                "target_type": "role",
+                "target_payload": {"role": "counselor"},
+                "assignment_group": bunk.id,
+                "start_date": "2026-06-01",
+            },
+            format="json",
+        )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_patch_title_and_is_required(
+    org, program, lt_membership, lt_user, bunk, published_template,
+):
+    """PATCH title and is_required on an assignment with no responses → 200."""
+    assignment = TemplateAssignment.all_objects.create(
+        organization=org, program=program, template=published_template,
+        target_type=TemplateAssignment.TargetType.ASSIGNMENT_GROUP,
+        assignment_group=bunk,
+        is_required=True,
+        title="",
+        start_date=date(2026, 6, 1), created_by=lt_membership,
+    )
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.patch(
+            f"/api/v1/leadership-team/assignments/{assignment.id}/",
+            data={"title": "Renamed", "is_required": False},
+            format="json",
+        )
+    assert resp.status_code == 200, resp.data
+    body = resp.json()
+    assert body["title"] == "Renamed"
+    assert body["is_required"] is False
+
+
+@pytest.mark.django_db
+def test_patch_assignment_group_is_400(
+    org, program, lt_membership, lt_user, bunk, published_template,
+):
+    """PATCH assignment_group is immutable post-creation → 400."""
+    assignment = TemplateAssignment.all_objects.create(
+        organization=org, program=program, template=published_template,
+        target_type=TemplateAssignment.TargetType.ASSIGNMENT_GROUP,
+        assignment_group=bunk,
+        start_date=date(2026, 6, 1), created_by=lt_membership,
+    )
+    other_bunk = AssignmentGroup.all_objects.create(
+        organization=org, program=program,
+        name="Bunk B", slug="bunk-b", group_type="bunk",
+    )
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.patch(
+            f"/api/v1/leadership-team/assignments/{assignment.id}/",
+            data={"assignment_group": other_bunk.id},
+            format="json",
+        )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_get_list_includes_new_fields(
+    org, program, lt_membership, lt_user, bunk, published_template,
+):
+    """GET list response includes assignment_group, is_required, title, display_title."""
+    TemplateAssignment.all_objects.create(
+        organization=org, program=program, template=published_template,
+        target_type=TemplateAssignment.TargetType.ASSIGNMENT_GROUP,
+        assignment_group=bunk, is_required=False, title="My Title",
+        start_date=date(2026, 6, 1), created_by=lt_membership,
+    )
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/leadership-team/assignments/")
+    assert resp.status_code == 200
+    assignments = resp.json()["assignments"]
+    assert assignments
+    a = assignments[0]
+    assert "assignment_group" in a
+    assert "is_required" in a
+    assert "title" in a
+    assert "display_title" in a
+    assert a["display_title"] == "My Title"
+
+
+@pytest.mark.django_db
+def test_display_title_falls_back_to_template_name(
+    org, program, lt_membership, lt_user, bunk, published_template,
+):
+    """display_title falls back to template.name when title is blank."""
+    TemplateAssignment.all_objects.create(
+        organization=org, program=program, template=published_template,
+        target_type=TemplateAssignment.TargetType.ASSIGNMENT_GROUP,
+        assignment_group=bunk, is_required=True, title="",
+        start_date=date(2026, 6, 1), created_by=lt_membership,
+    )
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/leadership-team/assignments/")
+    a = resp.json()["assignments"][0]
+    assert a["display_title"] == published_template.name
+
+
+@pytest.mark.django_db
+def test_conflict_detection_assignment_group(
+    org, program, lt_membership, lt_user, bunk, published_template,
+):
+    """Two overlapping assignment_group assignments on the same bunk → 409."""
+    TemplateAssignment.all_objects.create(
+        organization=org, program=program, template=published_template,
+        target_type=TemplateAssignment.TargetType.ASSIGNMENT_GROUP,
+        assignment_group=bunk,
+        start_date=date(2026, 6, 1), end_date=date(2026, 8, 31),
+        status=TemplateAssignment.Status.SCHEDULED,
+        created_by=lt_membership,
+    )
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.post(
+            "/api/v1/leadership-team/assignments/",
+            data={
+                "template": published_template.id,
+                "target_type": "assignment_group",
+                "assignment_group": bunk.id,
+                "target_payload": {},
+                "start_date": "2026-07-01",
+                "end_date": "2026-08-31",
+            },
+            format="json",
+        )
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["conflicts"]
+    assert body["choices"]

--- a/backend/bunk_logs/core/migrations/0040_templateassignment_assignment_group_is_required_title.py
+++ b/backend/bunk_logs/core/migrations/0040_templateassignment_assignment_group_is_required_title.py
@@ -1,0 +1,80 @@
+"""Step 7_20: Extend TemplateAssignment with assignment_group FK, is_required, and title.
+
+All three fields are additive and nullable/defaulted, so existing rows remain valid.
+No data migration is needed; FA-S (Step 7_22) handles seeding rows.
+"""
+import django.db.models.deletion
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0039_refresh_tbe_madrich_template_category_labels"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="templateassignment",
+            name="assignment_group",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="template_assignments",
+                to="core.assignmentgroup",
+                help_text=(
+                    "When target_type='assignment_group', the group this assignment "
+                    "targets. Memberships resolve to those whose role matches the "
+                    "template's author_role_filter AND who hold an active "
+                    "AssignmentGroupMembership in this group with role_in_group='author'."
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="templateassignment",
+            name="is_required",
+            field=models.BooleanField(
+                default=True,
+                help_text=(
+                    "When True, the assignment produces tasks in the per-role dashboards. "
+                    "When False, it appears in the role's optional forms library and does "
+                    "NOT affect the 'all set' state (decision FA5)."
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="templateassignment",
+            name="title",
+            field=models.CharField(
+                blank=True,
+                default="",
+                max_length=255,
+                help_text=(
+                    "Per-assignment display title for dashboard widgets. "
+                    "Falls back to template.name when blank."
+                ),
+            ),
+        ),
+        migrations.AlterField(
+            model_name="templateassignment",
+            name="target_type",
+            field=models.CharField(
+                max_length=16,
+                choices=[
+                    ("role", "Role (dynamic)"),
+                    ("individuals", "Individual memberships (static)"),
+                    ("tag_group", "Tag group (dynamic)"),
+                    ("assignment_group", "Assignment group (dynamic)"),
+                ],
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="templateassignment",
+            index=models.Index(
+                fields=["assignment_group", "status"],
+                name="core_templa_assignm_8ec6ca_idx",
+            ),
+        ),
+    ]

--- a/backend/bunk_logs/core/models.py
+++ b/backend/bunk_logs/core/models.py
@@ -730,21 +730,24 @@ class TemplateAssignment(models.Model):
 
     LT users assign a published template to either a role (dynamic — new
     members joining mid-window get the template), a static list of
-    individual Memberships (snapshotted at creation), or a tag-based
-    group. Each assignment has its own date window and may override the
-    template's cadence.
+    individual Memberships (snapshotted at creation), a tag-based group,
+    or an AssignmentGroup (dynamic — resolves to AssignmentGroupMembership
+    rows with role_in_group='author' whose Membership.role matches
+    template.author_role_filter). Each assignment has its own date window
+    and may override the template's cadence.
 
-    Conflict resolution: when a new assignment overlaps an existing one
-    on the same (template, target), the LT may ``"replace"`` (sets
-    ``replaces`` FK and ends the prior assignment day-before),
-    ``"run_both"`` (no coupling), or ``"cancel"`` (no record created;
-    handled at API layer).
+    The ``is_required`` flag controls whether the assignment produces
+    tasks in per-role dashboards (True) or lands in the optional forms
+    library without affecting the 'all set' state (False; decision FA5).
+
+    See ``docs/design/form_orchestration_reframe.md`` §3 for design rationale.
     """
 
     class TargetType(models.TextChoices):
         ROLE = "role", "Role (dynamic)"
         INDIVIDUALS = "individuals", "Individual memberships (static)"
         TAG_GROUP = "tag_group", "Tag group (dynamic)"
+        ASSIGNMENT_GROUP = "assignment_group", "Assignment group (dynamic)"
 
     class Status(models.TextChoices):
         SCHEDULED = "scheduled", "Scheduled"
@@ -791,6 +794,36 @@ class TemplateAssignment(models.Model):
     status = models.CharField(
         max_length=16, choices=Status.choices, default=Status.SCHEDULED,
     )
+    assignment_group = models.ForeignKey(
+        "core.AssignmentGroup",
+        null=True,
+        blank=True,
+        on_delete=models.CASCADE,
+        related_name="template_assignments",
+        help_text=(
+            "When target_type='assignment_group', the group this assignment "
+            "targets. Memberships resolve to those whose role matches the "
+            "template's author_role_filter AND who hold an active "
+            "AssignmentGroupMembership in this group with role_in_group='author'."
+        ),
+    )
+    is_required = models.BooleanField(
+        default=True,
+        help_text=(
+            "When True, the assignment produces tasks in the per-role dashboards. "
+            "When False, it appears in the role's optional forms library and does "
+            "NOT affect the 'all set' state (decision FA5)."
+        ),
+    )
+    title = models.CharField(
+        max_length=255,
+        blank=True,
+        default="",
+        help_text=(
+            "Per-assignment display title for dashboard widgets. "
+            "Falls back to template.name when blank."
+        ),
+    )
     created_by = models.ForeignKey(
         Membership,
         on_delete=models.SET_NULL,
@@ -809,6 +842,7 @@ class TemplateAssignment(models.Model):
         indexes = [
             models.Index(fields=["organization", "template", "status"]),
             models.Index(fields=["program", "start_date", "end_date"]),
+            models.Index(fields=["assignment_group", "status"], name="core_templa_assignm_8ec6ca_idx"),
         ]
 
     def __str__(self) -> str:

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -202,3 +202,15 @@ This allows the API and UI to group submissions and detect partial batches.
 | `GET /api/v1/assignment-groups/{id}/subjects/` | Persons in subject role |
 | `GET /api/v1/assignment-groups/{id}/authors/` | Persons in author role |
 | `GET /api/v1/reflections/` | List reflections (now includes `?subject=`, `?author=`, `?assignment_group=`) |
+
+---
+
+## TemplateAssignment (as of Step 7_20)
+
+`TemplateAssignment` binds a published `ReflectionTemplate` to a target audience for a date window. As of Step 7_20 it supports four `target_type` values: `role`, `individuals`, `tag_group`, and `assignment_group`. The last type resolves dynamically to `Membership` rows whose role is in `template.author_role_filter` AND who hold an active `AssignmentGroupMembership` with `role_in_group='author'` in the specified group.
+
+Two new control fields were added:
+- `is_required` (bool, default `True`): when `False` the assignment lands in the role's optional forms library and does not affect the dashboard "all set" state (decision FA5).
+- `title` (str, blank): per-assignment display label; falls back to `template.name` via the read-only `display_title` field on the API response.
+
+The assignments endpoints (`/api/v1/leadership-team/assignments/`) now accept both `program_lead` and `admin` capabilities (decision FA7). See `docs/design/form_orchestration_reframe.md` §3 for design rationale.


### PR DESCRIPTION
## What

Extends `TemplateAssignment` (Step 7_20 — FA-A) with three new fields and a new target type, as specified in `docs/design/form_orchestration_reframe.md` §3:

- **`assignment_group` FK** (`AssignmentGroup`, nullable) — targets a dynamic group when `target_type='assignment_group'`. Resolves to Memberships whose role is in `template.author_role_filter` AND who hold an active `AssignmentGroupMembership` with `role_in_group='author'`.
- **`is_required` bool** (default `True`) — when `False`, the assignment lands in the optional forms library and does not affect the dashboard "all set" state (decision FA5).
- **`title` CharField** (blank) — per-assignment display label; read-only `display_title` on the API response falls back to `template.name`.
- **`ASSIGNMENT_GROUP` TargetType** value added to the enum.

Permission gate on `/api/v1/leadership-team/assignments/` widened to accept `program_lead` OR `admin` capability via new `assignment_viewer_or_403` helper (decision FA7). Existing `viewer_or_403` is unchanged.

## Why

- Decisions FA1 / FA5 / FA7 from `docs/user_stories/00_cross_cutting/decisions.md`
- Design: `docs/design/form_orchestration_reframe.md` §3
- Wave 1 prerequisite: FA-B (Step 7_21) and FA-S (Step 7_22) both depend on these fields landing first.

## Testing

15 new tests in `backend/bunk_logs/api/tests/test_leadership_team_assignments.py`:
- Model persistence round-trip for all three new fields
- `resolve_members` for `assignment_group`, empty `author_role_filter`, no active AGM authors, and regression on `role` target type
- POST as LT user → 201; as Admin user → 201 (FA7); as UH → 403
- POST without `assignment_group` when `target_type='assignment_group'` → 400
- POST with `assignment_group` when `target_type='role'` → 400
- PATCH `title` + `is_required` → 200; PATCH `assignment_group` → 400 (immutable)
- GET list includes new fields + `display_title` fallback
- Conflict detection for `assignment_group` target → 409

`pytest`: 1139 passed, 1 pre-existing failure (`test_migration_installs_the_periodic_task_row` — unrelated to this step, present on `main`). `ruff check`: clean on all changed files.

## Risk assessment

Additive migration only — all new fields are `null=True` / `blank=True` / `default=True`. No existing rows are modified. Frontend tests unaffected (no frontend changes).

## Rollback plan

Revert the merge commit. Migration 0040 is backward-compatible; a simple `migrate` back to 0039 drops the three columns and the new index cleanly.

Made with [Cursor](https://cursor.com)