### PR TITLE
7_21: Per-role dashboard refactor — TemplateAssignment-driven template resolution

### DIFF
--- a/backend/bunk_logs/api/camper_care/common.py
+++ b/backend/bunk_logs/api/camper_care/common.py
@@ -17,13 +17,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from django.db.models import Q
 from rest_framework.exceptions import PermissionDenied
 
-from bunk_logs.api.counselor.common import _resolve_template
 from bunk_logs.api.counselor.common import enforce_edit_window  # noqa: F401 (re-export)
 from bunk_logs.api.counselor.common import is_day_off_answer  # noqa: F401 (re-export)
 from bunk_logs.api.counselor.common import is_editable_today  # noqa: F401 (re-export)
+from bunk_logs.core.assignment_resolution import resolve_template_for
 from bunk_logs.core.models import AssignmentGroup
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
@@ -200,21 +199,25 @@ def caseload_bunk_ids(
 
 
 def camper_care_self_template(
-    organization: Organization, program: Program,
+    organization: Organization,
+    program: Program,
+    *,
+    viewer: Person | None = None,
+    as_of: date | None = None,
 ) -> ReflectionTemplate | None:
-    """Daily Camper Care self-reflection template, org-shadowing-global.
+    """Daily Camper Care self-reflection template.
 
-    Uses the same fallback resolver the counselor / UH flows use so a
-    customer can ship a single template targeting multiple supervisor
-    roles via ``author_role_filter``. Returns ``None`` when no template
-    is configured for the program type — callers must handle that case
-    (the dashboard renders a "no template configured" placeholder).
+    Resolves via :func:`resolve_template_for` (Step 7_21): returns the
+    template bound by an active ``TemplateAssignment`` for the
+    (org, program, ``camper_care``, ``self``, ``daily``) tuple, or
+    ``None`` when no assignment is active (dashboard placeholder).
     """
-    qs = ReflectionTemplate.all_objects.filter(
-        Q(role="camper_care") | Q(author_role_filter__contains=["camper_care"]),
+    return resolve_template_for(
+        organization=organization,
+        program=program,
+        as_of=as_of or get_today(organization),
+        role="camper_care",
         subject_mode="self",
         cadence="daily",
-    )
-    return _resolve_template(
-        qs, organization=organization, program_type=program.program_type,
+        viewer=viewer,
     )

--- a/backend/bunk_logs/api/counselor/common.py
+++ b/backend/bunk_logs/api/counselor/common.py
@@ -21,6 +21,7 @@ from django.db.models import Q
 from django.db.models import When
 from rest_framework.exceptions import PermissionDenied
 
+from bunk_logs.core.assignment_resolution import resolve_template_for
 from bunk_logs.core.models import AssignmentGroup
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import CamperDayState
@@ -158,8 +159,9 @@ def _resolve_template(
 ) -> ReflectionTemplate | None:
     """Apply the org-shadows-global ordering used throughout Step 7_6.
 
-    Both org-scoped and global templates may be ``is_active=True``; the
-    org-scoped row wins, falling back to the global if none exists.
+    Retained as a public helper for legacy call sites (a few tests and
+    management commands import it directly). Per-role dashboards now go
+    through :func:`resolve_template_for` instead.
     """
     qs = qs.filter(
         Q(organization=organization) | Q(organization__isnull=True),
@@ -183,52 +185,70 @@ def _resolve_template(
 def camper_reflection_template(
     organization: Organization,
     program: Program,
+    *,
+    viewer: Person | None = None,
+    bunk: AssignmentGroup | None = None,
+    as_of: date | None = None,
 ) -> ReflectionTemplate | None:
     """Active daily camper-reflection template for a bunk roster (Story 3).
 
-    Picks the ``subject_mode='single_subject'`` template with ``'bunk'`` in
-    its ``assignment_group_types``. There is conventionally one per program;
-    if multiple exist the org-shadow ordering picks the org-scoped one.
+    Resolves via :func:`resolve_template_for` (Step 7_21): returns the
+    template bound by an active ``TemplateAssignment`` for the
+    (org, program, ``counselor``, ``single_subject``, ``daily``)
+    tuple. When ``bunk`` is supplied, a group-specific assignment is
+    preferred; otherwise a program-wide role assignment is used.
+
+    Returns ``None`` when no assignment is active — the dashboard
+    surfaces that as the ``no_template`` empty state.
     """
-    qs = ReflectionTemplate.all_objects.filter(
+    return resolve_template_for(
+        organization=organization,
+        program=program,
+        as_of=as_of or get_today(organization),
+        role="counselor",
         subject_mode="single_subject",
         cadence="daily",
-        assignment_group_types__contains=["bunk"],
+        viewer=viewer,
+        assignment_group=bunk,
     )
-    return _resolve_template(qs, organization=organization, program_type=program.program_type)
 
 
 def counselor_self_template(
     viewer: Person,
     organization: Organization,
     program: Program,
+    *,
+    as_of: date | None = None,
 ) -> ReflectionTemplate | None:
     """Active daily self-reflection template that applies to the viewer's role.
 
-    A template applies when EITHER its ``role`` field matches one of the
-    viewer's active memberships, OR its ``author_role_filter`` contains one
-    of those roles. The single ``role`` field is the canonical binding;
-    ``author_role_filter`` exists for finer-grained gating (e.g. a global
-    template targeting both ``counselor`` and ``junior_counselor``).
+    Resolves via :func:`resolve_template_for` (Step 7_21): the viewer's
+    active Memberships are inspected and the first assignment whose
+    template targets one of those roles (``role`` field or
+    ``author_role_filter``) wins. Junior counselors share the counselor
+    template by virtue of ``author_role_filter`` matching either role.
     """
-    viewer_roles = set(
+    viewer_roles = list(
         Membership.objects.filter(
             person=viewer, program=program, is_active=True,
         ).values_list("role", flat=True),
     )
     if not viewer_roles:
         return None
-
-    role_q = Q(role__in=viewer_roles)
+    anchor = as_of or get_today(organization)
     for role in viewer_roles:
-        role_q |= Q(author_role_filter__contains=[role])
-
-    qs = ReflectionTemplate.all_objects.filter(
-        role_q,
-        subject_mode="self",
-        cadence="daily",
-    )
-    return _resolve_template(qs, organization=organization, program_type=program.program_type)
+        template = resolve_template_for(
+            organization=organization,
+            program=program,
+            as_of=anchor,
+            role=role,
+            subject_mode="self",
+            cadence="daily",
+            viewer=viewer,
+        )
+        if template is not None:
+            return template
+    return None
 
 
 def is_editable_today(

--- a/backend/bunk_logs/api/kitchen_staff/common.py
+++ b/backend/bunk_logs/api/kitchen_staff/common.py
@@ -3,7 +3,11 @@
 Key invariants
 --------------
 * A Kitchen Staff viewer must have an active ``kitchen_staff`` Membership.
-* Template resolution uses the ``kitchen_staff`` role filter with daily cadence.
+* Template resolution flows through
+  :func:`bunk_logs.core.assignment_resolution.resolve_template_for`
+  (Step 7_21) instead of inline ``ReflectionTemplate`` queries, so the
+  active template is whichever one the Leadership Team has assigned
+  to the program for the day.
 * Edit window: until rollover boundary (same as specialist/counselor).
 * Preferred language is read from ``Person.preferred_language`` and forwarded
   to the template localizer so prompts arrive in the user's preferred language.
@@ -14,16 +18,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from django.db.models import Q
 from rest_framework.exceptions import PermissionDenied
 
-from bunk_logs.api.counselor.common import _resolve_template
 from bunk_logs.api.counselor.common import enforce_edit_window  # noqa: F401 (re-export)
 from bunk_logs.api.counselor.common import is_day_off_answer  # noqa: F401 (re-export)
 from bunk_logs.api.counselor.common import is_editable_today  # noqa: F401 (re-export)
+from bunk_logs.core.assignment_resolution import resolve_template_for
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
-from bunk_logs.core.models import ReflectionTemplate
 from bunk_logs.core.time_utils import get_today
 
 if TYPE_CHECKING:
@@ -31,6 +33,7 @@ if TYPE_CHECKING:
 
     from bunk_logs.core.models import Organization
     from bunk_logs.core.models import Program
+    from bunk_logs.core.models import ReflectionTemplate
 
 
 __all__ = [
@@ -87,13 +90,24 @@ def viewer_or_403(request) -> ViewerContext:
 def kitchen_staff_template(
     organization: Organization,
     program: Program,
+    *,
+    viewer: Person | None = None,
+    as_of: date | None = None,
 ) -> ReflectionTemplate | None:
-    """Active daily kitchen_staff self-reflection template for the program."""
-    qs = ReflectionTemplate.all_objects.filter(
-        Q(role="kitchen_staff") | Q(author_role_filter__contains=["kitchen_staff"]),
+    """Active daily kitchen_staff self-reflection template for the program.
+
+    Resolves via :func:`resolve_template_for` (Step 7_21): the template
+    is the one bound by an active ``TemplateAssignment`` for this
+    (org, program) targeting the ``kitchen_staff`` role. Returns
+    ``None`` when no assignment is active — the dashboard surfaces that
+    as the ``no_template`` empty state.
+    """
+    return resolve_template_for(
+        organization=organization,
+        program=program,
+        as_of=as_of or get_today(organization),
+        role="kitchen_staff",
         subject_mode="self",
         cadence="daily",
-    )
-    return _resolve_template(
-        qs, organization=organization, program_type=program.program_type,
+        viewer=viewer,
     )

--- a/backend/bunk_logs/api/leadership_team/assignments.py
+++ b/backend/bunk_logs/api/leadership_team/assignments.py
@@ -37,9 +37,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from bunk_logs.core import audit
+from bunk_logs.core.assignment_resolution import resolve_members
 from bunk_logs.core.models import AssignmentGroup
-from bunk_logs.core.models import AssignmentGroupMembership
-from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Reflection
 from bunk_logs.core.models import ReflectionTemplate
 from bunk_logs.core.models import TemplateAssignment
@@ -49,56 +48,11 @@ from .common import assignment_viewer_or_403
 CONFLICT_CHOICES = ("replace", "run_both", "cancel")
 VALID_TARGET_TYPES = ("role", "individuals", "tag_group", "assignment_group")
 
-
-# ---------------------------------------------------------------------------
-# Membership resolution
-# ---------------------------------------------------------------------------
-
-
-def resolve_members(assignment: TemplateAssignment, as_of: date):
-    """Return the Memberships that an assignment applies to on ``as_of``.
-
-    * ``role``: dynamic — current active Memberships in the program with
-      that role.
-    * ``individuals``: static snapshot from ``target_payload['membership_ids']``.
-      Filtered to currently active so a deactivated member silently drops.
-    * ``tag_group``: dynamic — Memberships whose ``tags`` JSON contains
-      the given tag.
-    * ``assignment_group``: dynamic — Memberships whose role is in
-      template.author_role_filter AND who are active authors in the group.
-    """
-    payload = assignment.target_payload or {}
-    base = Membership.all_objects.filter(
-        program=assignment.program, is_active=True,
-    )
-    target_type = assignment.target_type
-    if target_type == TemplateAssignment.TargetType.ROLE:
-        role = payload.get("role")
-        return base.filter(role=role) if role else base.none()
-    if target_type == TemplateAssignment.TargetType.INDIVIDUALS:
-        ids = payload.get("membership_ids") or []
-        if not isinstance(ids, list):
-            return base.none()
-        return base.filter(pk__in=ids)
-    if target_type == TemplateAssignment.TargetType.TAG_GROUP:
-        tag = payload.get("tag")
-        if not tag:
-            return base.none()
-        return base.filter(tags__contains=[tag])
-    if target_type == TemplateAssignment.TargetType.ASSIGNMENT_GROUP:
-        group_id = assignment.assignment_group_id
-        if not group_id:
-            return base.none()
-        author_roles = assignment.template.author_role_filter or []
-        if not author_roles:
-            return base.none()
-        author_person_ids = AssignmentGroupMembership.all_objects.filter(
-            group_id=group_id,
-            role_in_group="author",
-            is_active=True,
-        ).values_list("person_id", flat=True)
-        return base.filter(person_id__in=author_person_ids, role__in=author_roles)
-    return base.none()
+# ``resolve_members`` was moved to ``core.assignment_resolution`` in Step 7_21 so
+# the per-role dashboards share one implementation. Existing imports from
+# ``bunk_logs.api.leadership_team.assignments`` keep working through this
+# re-export.
+__all__ = ["resolve_members"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/bunk_logs/api/leadership_team/common.py
+++ b/backend/bunk_logs/api/leadership_team/common.py
@@ -24,13 +24,12 @@ from datetime import date
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
-from django.db.models import Q
 from rest_framework.exceptions import PermissionDenied
 
-from bunk_logs.api.counselor.common import _resolve_template
 from bunk_logs.api.counselor.common import enforce_edit_window  # noqa: F401 (re-export)
 from bunk_logs.api.counselor.common import is_day_off_answer  # noqa: F401 (re-export)
 from bunk_logs.api.counselor.common import is_editable_today  # noqa: F401 (re-export)
+from bunk_logs.core.assignment_resolution import resolve_template_for
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
 from bunk_logs.core.models import ReflectionTemplate
@@ -208,22 +207,29 @@ def team_membership_ids(
 
 
 def leadership_team_self_template(
-    organization: Organization, program: Program,
+    organization: Organization,
+    program: Program,
+    *,
+    viewer: Person | None = None,
+    as_of: date | None = None,
 ) -> ReflectionTemplate | None:
-    """Active LT self-reflection template, org-shadowing-global.
+    """Active LT self-reflection template.
 
-    Picks the template targeting role=``leadership_team`` with
-    ``subject_mode='self'``. The cadence is whatever the org/program has
-    configured — default biweekly (see seed migration 0034) but
-    overridable per program (Story 50 c2). The org-shadow resolver
-    inherits the highest-version active row.
+    Resolves via :func:`resolve_template_for` (Step 7_21): returns the
+    template bound by an active ``TemplateAssignment`` for the
+    (org, program, ``leadership_team``, ``self``) tuple. Cadence is
+    deliberately NOT constrained here — LT cadence is per-program
+    (Story 50 c2), default biweekly, but the assignment's
+    ``cadence_override`` may surface a weekly/monthly variant without
+    requiring a different template.
     """
-    qs = ReflectionTemplate.all_objects.filter(
-        Q(role="leadership_team") | Q(author_role_filter__contains=["leadership_team"]),
+    return resolve_template_for(
+        organization=organization,
+        program=program,
+        as_of=as_of or get_today(organization),
+        role="leadership_team",
         subject_mode="self",
-    )
-    return _resolve_template(
-        qs, organization=organization, program_type=program.program_type,
+        viewer=viewer,
     )
 
 

--- a/backend/bunk_logs/api/madrich/common.py
+++ b/backend/bunk_logs/api/madrich/common.py
@@ -20,13 +20,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from django.db.models import Q
 from rest_framework.exceptions import PermissionDenied
 
-from bunk_logs.api.counselor.common import _resolve_template
+from bunk_logs.core.assignment_resolution import resolve_template_for
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
-from bunk_logs.core.models import ReflectionTemplate
 from bunk_logs.core.time_utils import get_current_period
 from bunk_logs.core.time_utils import get_today
 
@@ -36,6 +34,7 @@ if TYPE_CHECKING:
     from bunk_logs.core.models import Organization
     from bunk_logs.core.models import Program
     from bunk_logs.core.models import Reflection
+    from bunk_logs.core.models import ReflectionTemplate
 
 
 __all__ = [
@@ -95,15 +94,25 @@ def viewer_or_403(request) -> ViewerContext:
 def madrich_template(
     organization: Organization,
     program: Program,
+    *,
+    viewer: Person | None = None,
+    as_of: date | None = None,
 ) -> ReflectionTemplate | None:
-    """Active weekly madrich self-reflection template for the program."""
-    qs = ReflectionTemplate.all_objects.filter(
-        Q(role="madrich") | Q(author_role_filter__contains=["madrich"]),
+    """Active weekly madrich self-reflection template for the program.
+
+    Resolves via :func:`resolve_template_for` (Step 7_21): returns the
+    template bound by an active ``TemplateAssignment`` for the
+    (org, program, ``madrich``, ``self``, ``weekly``) tuple, or
+    ``None`` when no assignment is active.
+    """
+    return resolve_template_for(
+        organization=organization,
+        program=program,
+        as_of=as_of or get_today(organization),
+        role="madrich",
         subject_mode="self",
         cadence="weekly",
-    )
-    return _resolve_template(
-        qs, organization=organization, program_type=program.program_type,
+        viewer=viewer,
     )
 
 

--- a/backend/bunk_logs/api/specialist/common.py
+++ b/backend/bunk_logs/api/specialist/common.py
@@ -16,16 +16,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from django.db.models import Q
 from rest_framework.exceptions import PermissionDenied
 
-from bunk_logs.api.counselor.common import _resolve_template
 from bunk_logs.api.counselor.common import enforce_edit_window  # noqa: F401 (re-export)
 from bunk_logs.api.counselor.common import is_day_off_answer  # noqa: F401 (re-export)
 from bunk_logs.api.counselor.common import is_editable_today  # noqa: F401 (re-export)
+from bunk_logs.core.assignment_resolution import resolve_template_for
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
-from bunk_logs.core.models import ReflectionTemplate
 from bunk_logs.core.time_utils import get_today
 
 if TYPE_CHECKING:
@@ -33,6 +31,7 @@ if TYPE_CHECKING:
 
     from bunk_logs.core.models import Organization
     from bunk_logs.core.models import Program
+    from bunk_logs.core.models import ReflectionTemplate
 
 
 __all__ = [
@@ -119,17 +118,23 @@ def specialist_program_ids(person: Person) -> list[int]:
 def specialist_self_template(
     organization: Organization,
     program: Program,
+    *,
+    viewer: Person | None = None,
+    as_of: date | None = None,
 ) -> ReflectionTemplate | None:
     """Active daily specialist self-reflection template for the program.
 
-    Uses the shared org-shadow resolver. Returns ``None`` when no template
-    is configured (dashboard shows a placeholder).
+    Resolves via :func:`resolve_template_for` (Step 7_21): returns the
+    template bound by an active ``TemplateAssignment`` for the
+    (org, program, ``specialist``, ``self``, ``daily``) tuple, or
+    ``None`` when no assignment is active (dashboard shows a placeholder).
     """
-    qs = ReflectionTemplate.all_objects.filter(
-        Q(role="specialist") | Q(author_role_filter__contains=["specialist"]),
+    return resolve_template_for(
+        organization=organization,
+        program=program,
+        as_of=as_of or get_today(organization),
+        role="specialist",
         subject_mode="self",
         cadence="daily",
-    )
-    return _resolve_template(
-        qs, organization=organization, program_type=program.program_type,
+        viewer=viewer,
     )

--- a/backend/bunk_logs/api/tests/conftest.py
+++ b/backend/bunk_logs/api/tests/conftest.py
@@ -27,12 +27,33 @@ Re-seeding the template at the start of every test fixes both:
 
 Keeping the fixture as ``autouse=True`` here (rather than in each test
 file) means new test modules pick up the protection automatically.
+
+Step 7_21: TemplateAssignment auto-seeding
+------------------------------------------
+
+After Step 7_21 the per-role dashboards resolve templates by looking
+for an active ``TemplateAssignment``. Existing tests built up a
+``Program`` and expected the seeded role template to "just work";
+under the new resolver they would all hit ``no_template`` instead.
+
+The :func:`_autobind_role_assignments_to_new_programs` autouse fixture
+connects a ``post_save`` handler on ``Program`` that creates a
+role-targeted assignment for every seeded role template the moment a
+test creates its program. Tests that want to verify the no-template
+empty-state should either skip that fixture explicitly or delete the
+auto-created rows.
 """
 from __future__ import annotations
 
-import pytest
+from datetime import date
+from datetime import timedelta
 
+import pytest
+from django.db.models.signals import post_save
+
+from bunk_logs.core.models import Program
 from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.models import TemplateAssignment
 
 _COUNSELOR_SELF_REFLECTION_SCHEMA = {
     "fields": [
@@ -365,4 +386,131 @@ def _ensure_leadership_team_self_reflection_template(db):
             "role": "leadership_team",
             "program_type": None,
         },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 7_21 — TemplateAssignment auto-seeding for the seeded role templates
+# ---------------------------------------------------------------------------
+
+
+_AUTOSEED_ROLE_SLUGS: tuple[tuple[str, str], ...] = (
+    ("counselor", "counselor-self-reflection"),
+    ("junior_counselor", "counselor-self-reflection"),
+    ("unit_head", "unit-head-self-reflection"),
+    ("camper_care", "camper-care-self-reflection"),
+    ("kitchen_staff", "kitchen-staff-self-reflection"),
+    ("leadership_team", "leadership-team-self-reflection"),
+    ("madrich", "tbe-madrich-3-2-1-weekly"),
+)
+
+
+def _seed_role_assignments_for_program(program: Program) -> None:
+    """Create one role-targeted assignment per seeded role template.
+
+    Idempotent: ``get_or_create`` keyed on (program, template, role) so
+    repeat invocations (e.g. fixtures that ``save()`` the same Program
+    twice) don't blow up. Start_date is anchored far enough in the past
+    to be safe for any test — programs in the future, in the past, or
+    aligned with "today" should all see the assignment as active.
+    """
+    if program.organization_id is None:
+        return
+    anchor = program.start_date or date.today()
+    start = min(anchor, date.today()) - timedelta(days=365)
+    for role, slug in _AUTOSEED_ROLE_SLUGS:
+        template = ReflectionTemplate.all_objects.filter(
+            slug=slug, organization__isnull=True,
+        ).first()
+        if template is None:
+            continue
+        TemplateAssignment.all_objects.get_or_create(
+            organization=program.organization,
+            program=program,
+            template=template,
+            target_type=TemplateAssignment.TargetType.ROLE,
+            target_payload={"role": role},
+            defaults={
+                "start_date": start,
+                "status": TemplateAssignment.Status.ACTIVE,
+                "is_required": True,
+            },
+        )
+
+
+def _on_program_saved(sender, instance, created, **kwargs):
+    del sender, kwargs
+    if not created:
+        return
+    _seed_role_assignments_for_program(instance)
+
+
+@pytest.fixture(autouse=True)
+def _autobind_role_assignments_to_new_programs(db):
+    """Auto-bind seeded role templates to any ``Program`` created in a test.
+
+    Step 7_21 made the per-role helpers route through
+    ``TemplateAssignment``; tests that previously relied on the seeded
+    template alone now need an active assignment binding it to the
+    program. Hooking ``post_save`` keeps existing fixtures unchanged.
+    Tests that need the "no assignment" empty-state should delete the
+    auto-created rows.
+    """
+    post_save.connect(_on_program_saved, sender=Program)
+    yield
+    post_save.disconnect(_on_program_saved, sender=Program)
+
+
+# ---------------------------------------------------------------------------
+# Helper for tests that build their own (non-seeded) ReflectionTemplate
+# ---------------------------------------------------------------------------
+
+
+def make_active_assignment(
+    *,
+    template,
+    program,
+    target_role: str | None = None,
+    assignment_group=None,
+    is_required: bool = True,
+):
+    """Create a Step 7_21-style TemplateAssignment row for a test template.
+
+    Tests that mint their own ``ReflectionTemplate`` (typically the
+    counselor camper-reflection template, which is org-scoped and not
+    seeded by the autouse fixtures above) call this to make the
+    template visible to the per-role dashboards' resolvers.
+
+    The window is anchored a year before "today" / the program's
+    start_date so the assignment is always live regardless of the
+    program's date span.
+    """
+    anchor = program.start_date or date.today()
+    start = min(anchor, date.today()) - timedelta(days=365)
+    if assignment_group is not None:
+        return TemplateAssignment.all_objects.create(
+            organization=program.organization,
+            program=program,
+            template=template,
+            target_type=TemplateAssignment.TargetType.ASSIGNMENT_GROUP,
+            target_payload={},
+            assignment_group=assignment_group,
+            start_date=start,
+            status=TemplateAssignment.Status.ACTIVE,
+            is_required=is_required,
+        )
+    role = target_role or (
+        (template.author_role_filter or [None])[0]
+        or template.role
+        or "counselor"
+    )
+    return TemplateAssignment.all_objects.create(
+        organization=program.organization,
+        program=program,
+        template=template,
+        target_type=TemplateAssignment.TargetType.ROLE,
+        target_payload={"role": role},
+        start_date=start,
+        status=TemplateAssignment.Status.ACTIVE,
+        is_required=is_required,
     )

--- a/backend/bunk_logs/api/tests/test_counselor_camper_reflection_writes.py
+++ b/backend/bunk_logs/api/tests/test_counselor_camper_reflection_writes.py
@@ -108,8 +108,10 @@ def campers(org, bunk):
 
 
 @pytest.fixture
-def camper_template(org):
-    return ReflectionTemplate.all_objects.create(
+def camper_template(org, program):
+    from bunk_logs.api.tests.conftest import make_active_assignment
+
+    template = ReflectionTemplate.all_objects.create(
         organization=org, name="Bunk Log", slug="bunk-log-cw",
         cadence="daily", subject_mode="single_subject",
         assignment_scope="per_subject_in_group",
@@ -117,6 +119,8 @@ def camper_template(org):
         languages=["en"], is_active=True, program_type="summer_camp",
         author_role_filter=["counselor"], supports_privacy=True,
     )
+    make_active_assignment(template=template, program=program, target_role="counselor")
+    return template
 
 
 def _client(user, org):

--- a/backend/bunk_logs/api/tests/test_counselor_camper_reflections.py
+++ b/backend/bunk_logs/api/tests/test_counselor_camper_reflections.py
@@ -135,8 +135,10 @@ def campers(org, bunk):
 
 
 @pytest.fixture
-def template(org):
-    return ReflectionTemplate.all_objects.create(
+def template(org, program):
+    from bunk_logs.api.tests.conftest import make_active_assignment
+
+    t = ReflectionTemplate.all_objects.create(
         organization=org,
         name="Bunk Log",
         slug="bunk-log-cr",
@@ -149,6 +151,8 @@ def template(org):
         program_type="summer_camp",
         author_role_filter=["counselor"],
     )
+    make_active_assignment(template=t, program=program, target_role="counselor")
+    return t
 
 
 def _client(user, org):

--- a/backend/bunk_logs/api/tests/test_counselor_dashboard.py
+++ b/backend/bunk_logs/api/tests/test_counselor_dashboard.py
@@ -153,8 +153,10 @@ def campers(org, bunk):
 
 
 @pytest.fixture
-def camper_template(org):
-    return ReflectionTemplate.all_objects.create(
+def camper_template(org, program):
+    from bunk_logs.api.tests.conftest import make_active_assignment
+
+    t = ReflectionTemplate.all_objects.create(
         organization=org,
         name="Bunk Log",
         slug="bunk-log-cd",
@@ -167,11 +169,15 @@ def camper_template(org):
         program_type="summer_camp",
         author_role_filter=["counselor"],
     )
+    make_active_assignment(template=t, program=program, target_role="counselor")
+    return t
 
 
 @pytest.fixture
-def self_template(org):
-    return ReflectionTemplate.all_objects.create(
+def self_template(org, program):
+    from bunk_logs.api.tests.conftest import make_active_assignment
+
+    t = ReflectionTemplate.all_objects.create(
         organization=org,
         name="Counselor Self",
         slug="counselor-self-cd",
@@ -183,6 +189,8 @@ def self_template(org):
         is_active=True,
         program_type="summer_camp",
     )
+    make_active_assignment(template=t, program=program, target_role="counselor")
+    return t
 
 
 def _client(user, org):

--- a/backend/bunk_logs/api/tests/test_counselor_self_reflection_history.py
+++ b/backend/bunk_logs/api/tests/test_counselor_self_reflection_history.py
@@ -71,8 +71,10 @@ def counselor_membership(program, counselor_person):
 
 
 @pytest.fixture
-def self_template(org):
-    return ReflectionTemplate.all_objects.create(
+def self_template(org, program):
+    from bunk_logs.api.tests.conftest import make_active_assignment
+
+    t = ReflectionTemplate.all_objects.create(
         organization=org,
         name="Counselor Self",
         slug="counselor-self-sh",
@@ -84,6 +86,8 @@ def self_template(org):
         is_active=True,
         program_type="summer_camp",
     )
+    make_active_assignment(template=t, program=program, target_role="counselor")
+    return t
 
 
 def _client(user, org):

--- a/backend/bunk_logs/api/tests/test_kitchen_staff_endpoints.py
+++ b/backend/bunk_logs/api/tests/test_kitchen_staff_endpoints.py
@@ -166,6 +166,27 @@ class TestKitchenStaffDashboard:
             r = api.get("/api/v1/kitchen-staff/dashboard/", **_hdr(org.slug))
         assert r.status_code in (401, 403)
 
+    def test_dashboard_empty_state_without_template_assignment(
+        self, ks_api, org, program, ks_user_person,
+    ):
+        """Step 7_21: without an active TemplateAssignment the dashboard
+        returns ``state='no_template'`` instead of 500ing.
+
+        The autouse fixture in api/tests/conftest.py creates a
+        role-targeted assignment per program; this test deletes those
+        rows to exercise the empty path the LT will see on day zero of
+        a new program rollout (before FA-S / Step 7_22 seeds anything).
+        """
+        from bunk_logs.core.models import TemplateAssignment
+
+        TemplateAssignment.all_objects.filter(program=program).delete()
+        with organization_context(org):
+            r = ks_api.get("/api/v1/kitchen-staff/dashboard/", **_hdr(org.slug))
+        assert r.status_code == 200
+        body = r.json()
+        assert body["my_reflection"]["state"] == "no_template"
+        assert body["my_reflection"]["template_id"] is None
+
 
 # ---------------------------------------------------------------------------
 # Reflection create (Story 40)

--- a/backend/bunk_logs/api/tests/test_unit_head_endpoints.py
+++ b/backend/bunk_logs/api/tests/test_unit_head_endpoints.py
@@ -207,8 +207,10 @@ def campers(org, bunk):
 
 
 @pytest.fixture
-def camper_template(org):
-    return ReflectionTemplate.all_objects.create(
+def camper_template(org, program):
+    from bunk_logs.api.tests.conftest import make_active_assignment
+
+    t = ReflectionTemplate.all_objects.create(
         organization=org,
         name="Bunk Log",
         slug="bunk-log-uh",
@@ -221,6 +223,8 @@ def camper_template(org):
         program_type="summer_camp",
         author_role_filter=["counselor"],
     )
+    make_active_assignment(template=t, program=program, target_role="counselor")
+    return t
 
 
 def _client(user, org):

--- a/backend/bunk_logs/api/unit_head/common.py
+++ b/backend/bunk_logs/api/unit_head/common.py
@@ -19,14 +19,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from django.db.models import Q
 from rest_framework.exceptions import PermissionDenied
 
-from bunk_logs.api.counselor.common import _resolve_template
 from bunk_logs.api.counselor.common import enforce_edit_window
 from bunk_logs.api.counselor.common import is_day_off_answer
 from bunk_logs.api.counselor.common import is_editable_today
 from bunk_logs.api.counselor.common import off_camp_camper_ids
+from bunk_logs.core.assignment_resolution import resolve_template_for
 from bunk_logs.core.models import AssignmentGroup
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
@@ -179,23 +178,27 @@ def bunk_camper_ids(bunk: AssignmentGroup) -> list[int]:
 
 
 def unit_head_self_template(
-    organization: Organization, program: Program,
+    organization: Organization,
+    program: Program,
+    *,
+    viewer: Person | None = None,
+    as_of: date | None = None,
 ) -> ReflectionTemplate | None:
     """Daily self-reflection template for the UH role.
 
-    Same org-shadows-global resolver used by the counselor self
-    template. We look up by ``role='unit_head'`` OR
-    ``author_role_filter`` containing ``'unit_head'`` so a customer can
-    ship a single template targeting multiple supervisor roles by
-    listing them in ``author_role_filter``.
+    Resolves via :func:`resolve_template_for` (Step 7_21): returns the
+    template bound by an active ``TemplateAssignment`` for the
+    (org, program, ``unit_head``, ``self``, ``daily``) tuple, or
+    ``None`` when no assignment is active.
     """
-    qs = ReflectionTemplate.all_objects.filter(
-        Q(role="unit_head") | Q(author_role_filter__contains=["unit_head"]),
+    return resolve_template_for(
+        organization=organization,
+        program=program,
+        as_of=as_of or get_today(organization),
+        role="unit_head",
         subject_mode="self",
         cadence="daily",
-    )
-    return _resolve_template(
-        qs, organization=organization, program_type=program.program_type,
+        viewer=viewer,
     )
 
 

--- a/backend/bunk_logs/core/assignment_resolution.py
+++ b/backend/bunk_logs/core/assignment_resolution.py
@@ -1,0 +1,402 @@
+"""Shared TemplateAssignment-aware resolution for per-role dashboards (Step 7_21).
+
+What this module does
+---------------------
+Per-role ``common.py`` files used to query ``ReflectionTemplate`` directly
+with hard-coded filters. After Step 7_21 those helpers delegate to
+``resolve_template_for`` here, which finds the active
+``TemplateAssignment`` whose template matches the requested
+(subject_mode, cadence, role) shape. That makes "which template applies
+to this dashboard" a configuration choice the Leadership Team can drive
+instead of a code-baked default.
+
+Why a separate module
+---------------------
+- Every role's dashboard now needs the same resolver; keeping it in one
+  place prevents drift between roles.
+- ``resolve_members`` (the LT API's audience materializer) lives here
+  too so the assignments API and the dashboards share one source of
+  truth.
+
+Key invariant
+-------------
+The resolver returns ``None`` when no matching assignment is active —
+callers must handle that (the legacy hard-coded helpers also could
+return ``None``).
+"""
+
+from __future__ import annotations
+
+from datetime import date  # noqa: TC003 — used in keyword-only annotations
+from typing import TYPE_CHECKING
+
+from django.db.models import Case
+from django.db.models import IntegerField
+from django.db.models import Q
+from django.db.models import When
+
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import TemplateAssignment
+
+if TYPE_CHECKING:
+    from bunk_logs.core.models import Organization
+    from bunk_logs.core.models import Person
+    from bunk_logs.core.models import Program
+    from bunk_logs.core.models import ReflectionTemplate
+
+
+__all__ = [
+    "active_assignments_for",
+    "list_optional_assignments_for",
+    "list_required_assignments_for",
+    "resolve_members",
+    "resolve_template_for",
+]
+
+
+_ACTIVE_STATUSES = (
+    TemplateAssignment.Status.ACTIVE,
+    TemplateAssignment.Status.SCHEDULED,
+)
+
+
+# ---------------------------------------------------------------------------
+# Membership resolution (moved from api/leadership_team/assignments.py)
+# ---------------------------------------------------------------------------
+
+
+def resolve_members(assignment: TemplateAssignment, as_of: date):
+    """Return the Memberships that an assignment applies to on ``as_of``.
+
+    * ``role``: dynamic — current active Memberships in the program with
+      that role.
+    * ``individuals``: static snapshot from
+      ``target_payload['membership_ids']``, filtered to currently active
+      so a deactivated member silently drops.
+    * ``tag_group``: dynamic — Memberships whose ``tags`` JSON contains
+      the given tag.
+    * ``assignment_group``: dynamic — Memberships whose role is in
+      ``template.author_role_filter`` AND who are active authors in the
+      group.
+    """
+    payload = assignment.target_payload or {}
+    base = Membership.all_objects.filter(
+        program=assignment.program, is_active=True,
+    )
+    target_type = assignment.target_type
+    if target_type == TemplateAssignment.TargetType.ROLE:
+        role = payload.get("role")
+        return base.filter(role=role) if role else base.none()
+    if target_type == TemplateAssignment.TargetType.INDIVIDUALS:
+        ids = payload.get("membership_ids") or []
+        if not isinstance(ids, list):
+            return base.none()
+        return base.filter(pk__in=ids)
+    if target_type == TemplateAssignment.TargetType.TAG_GROUP:
+        tag = payload.get("tag")
+        if not tag:
+            return base.none()
+        return base.filter(tags__contains=[tag])
+    if target_type == TemplateAssignment.TargetType.ASSIGNMENT_GROUP:
+        group_id = assignment.assignment_group_id
+        if not group_id:
+            return base.none()
+        author_roles = assignment.template.author_role_filter or []
+        if not author_roles:
+            return base.none()
+        author_person_ids = AssignmentGroupMembership.all_objects.filter(
+            group_id=group_id,
+            role_in_group="author",
+            is_active=True,
+        ).values_list("person_id", flat=True)
+        return base.filter(
+            person_id__in=author_person_ids, role__in=author_roles,
+        )
+    return base.none()
+
+
+# ---------------------------------------------------------------------------
+# Active assignment filter (no template matching yet)
+# ---------------------------------------------------------------------------
+
+
+def _active_assignments_base_qs(
+    *, organization: Organization, program: Program, as_of: date,
+):
+    """Active+in-window TemplateAssignment rows for (org, program) on ``as_of``.
+
+    "Active" means ``status='active'`` OR a ``'scheduled'`` row whose
+    ``start_date`` has been reached — both are treated as live so the
+    LT can pre-stage an assignment that flips on automatically.
+    """
+    return TemplateAssignment.all_objects.filter(
+        organization=organization,
+        program=program,
+        status__in=_ACTIVE_STATUSES,
+        start_date__lte=as_of,
+    ).filter(Q(end_date__isnull=True) | Q(end_date__gte=as_of))
+
+
+def _viewer_membership_ids(
+    viewer: Person, program: Program, *, role: str | None = None,
+) -> set[int]:
+    qs = Membership.all_objects.filter(
+        person=viewer, program=program, is_active=True,
+    )
+    if role:
+        qs = qs.filter(role=role)
+    return set(qs.values_list("id", flat=True))
+
+
+def _viewer_in_audience(
+    assignment: TemplateAssignment,
+    viewer: Person,
+    *,
+    program: Program,
+    target_role: str | None,
+) -> bool:
+    """Whether ``viewer`` falls inside an assignment's resolved audience.
+
+    Mirrors the cases in ``resolve_members`` but answers a yes/no
+    question for one Person without materializing the full queryset.
+    When ``target_role`` is given, also requires the viewer to have an
+    active Membership with that role in the program.
+    """
+    if target_role is not None:
+        viewer_role_ids = _viewer_membership_ids(
+            viewer, program, role=target_role,
+        )
+        if not viewer_role_ids:
+            return False
+    payload = assignment.target_payload or {}
+    target_type = assignment.target_type
+    if target_type == TemplateAssignment.TargetType.ROLE:
+        role = payload.get("role")
+        if not role:
+            return False
+        viewer_roles = set(
+            Membership.all_objects.filter(
+                person=viewer, program=program, is_active=True,
+            ).values_list("role", flat=True),
+        )
+        return role in viewer_roles
+    if target_type == TemplateAssignment.TargetType.INDIVIDUALS:
+        ids = payload.get("membership_ids") or []
+        if not isinstance(ids, list):
+            return False
+        viewer_membership_ids = _viewer_membership_ids(viewer, program)
+        return any(int(i) in viewer_membership_ids for i in ids if i is not None)
+    if target_type == TemplateAssignment.TargetType.TAG_GROUP:
+        tag = payload.get("tag")
+        if not tag:
+            return False
+        return Membership.all_objects.filter(
+            person=viewer,
+            program=program,
+            is_active=True,
+            tags__contains=[tag],
+        ).exists()
+    if target_type == TemplateAssignment.TargetType.ASSIGNMENT_GROUP:
+        group_id = assignment.assignment_group_id
+        if not group_id:
+            return False
+        author_roles = assignment.template.author_role_filter or []
+        if not author_roles:
+            return False
+        return AssignmentGroupMembership.all_objects.filter(
+            group_id=group_id,
+            person=viewer,
+            role_in_group="author",
+            is_active=True,
+        ).filter(
+            Q(person__memberships__role__in=author_roles)
+            & Q(person__memberships__program=program)
+            & Q(person__memberships__is_active=True),
+        ).exists()
+    return False
+
+
+def active_assignments_for(
+    *,
+    viewer: Person,
+    organization: Organization,
+    program: Program,
+    as_of: date,
+    target_role: str | None = None,
+    target_assignment_group: AssignmentGroup | None = None,
+    require_required: bool = True,
+) -> list[TemplateAssignment]:
+    """Return active TemplateAssignment rows for a viewer-in-context.
+
+    Filters
+    -------
+    - status='active' OR ('scheduled' with start_date <= as_of)
+    - start_date <= as_of <= end_date (end_date null is open-ended)
+    - organization and program match
+    - When ``target_role`` is set, restricts to assignments where:
+        * target_type='role' and target_payload['role'] matches, OR
+        * target_type='individuals' and the viewer's Membership is in
+          target_payload['membership_ids'], OR
+        * target_type='assignment_group' and the viewer is an author in
+          that group whose role is in template.author_role_filter, OR
+        * target_type='tag_group' and the viewer's Membership tags
+          include the tag.
+    - When ``require_required`` is True (default), drops is_required=False
+      rows (those land in the Wave 2 optional-form library instead).
+    """
+    qs = _active_assignments_base_qs(
+        organization=organization, program=program, as_of=as_of,
+    ).select_related("template")
+    if require_required:
+        qs = qs.filter(is_required=True)
+    if target_assignment_group is not None:
+        qs = qs.filter(assignment_group=target_assignment_group)
+    out: list[TemplateAssignment] = []
+    for assignment in qs:
+        if _viewer_in_audience(
+            assignment, viewer, program=program, target_role=target_role,
+        ):
+            out.append(assignment)
+    return out
+
+
+def list_required_assignments_for(
+    viewer: Person, organization: Organization, program: Program, as_of: date,
+) -> list[TemplateAssignment]:
+    """All required, active assignments where the viewer is in the audience."""
+    return active_assignments_for(
+        viewer=viewer,
+        organization=organization,
+        program=program,
+        as_of=as_of,
+        require_required=True,
+    )
+
+
+def list_optional_assignments_for(
+    viewer: Person, organization: Organization, program: Program, as_of: date,
+) -> list[TemplateAssignment]:
+    """Optional (is_required=False), active assignments for the viewer.
+
+    Wave 1 dashboards do not consume this list — it's exposed here for
+    symmetry with the required side and is the seed for the Wave 2
+    "forms I can also fill out" library.
+    """
+    qs = _active_assignments_base_qs(
+        organization=organization, program=program, as_of=as_of,
+    ).filter(is_required=False).select_related("template")
+    out: list[TemplateAssignment] = []
+    for assignment in qs:
+        if _viewer_in_audience(
+            assignment, viewer, program=program, target_role=None,
+        ):
+            out.append(assignment)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Template resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_template_for(
+    *,
+    organization: Organization,
+    program: Program,
+    as_of: date,
+    role: str,
+    subject_mode: str,
+    viewer: Person | None = None,
+    cadence: str | None = None,
+    assignment_group: AssignmentGroup | None = None,
+) -> ReflectionTemplate | None:
+    """Return the active ReflectionTemplate for a (role, subject_mode) tuple.
+
+    Replaces the per-role hard-coded ``ReflectionTemplate.all_objects.filter(...)``
+    helpers. The caller supplies the static template-shape requirements
+    (``subject_mode``, optionally ``cadence``) and the resolver finds the
+    ``TemplateAssignment`` whose template matches and whose date window
+    contains ``as_of``.
+
+    Parameters
+    ----------
+    organization, program, as_of
+        Tenant context. Only assignments for this (org, program) on
+        ``as_of`` are considered.
+    role
+        The AUTHOR role the template targets. An assignment qualifies
+        when either ``template.role == role`` OR
+        ``role in template.author_role_filter``. This is the canonical
+        match used by every per-role helper.
+    subject_mode
+        Required match on ``template.subject_mode`` ("self",
+        "single_subject", ...). Distinguishes a counselor's self
+        template from the camper-reflection template they author.
+    viewer
+        Currently advisory only — kept in the signature for symmetry
+        with ``active_assignments_for`` and so future call sites can
+        narrow the resolution to "templates the viewer is in audience
+        for" without breaking callers.
+    cadence
+        Optional cadence match. Compared against ``cadence_override``
+        when set on the assignment, falling back to
+        ``template.cadence``.
+    assignment_group
+        When provided, prefers assignments whose ``assignment_group``
+        FK matches; falls back to program-wide (target_type='role')
+        assignments when no group-specific row exists.
+
+    Returns
+    -------
+    The matching ``ReflectionTemplate``, or ``None`` when no assignment
+    is active. Callers MUST handle the ``None`` case — the legacy
+    hard-coded helpers had the same contract.
+
+    Notes
+    -----
+    Org-shadows-global resolution is preserved: when multiple
+    assignments match, the one whose template's ``organization == organization``
+    wins over a global (``organization IS NULL``) template, then the
+    highest ``template.version`` breaks remaining ties.
+    """
+    del viewer  # reserved for forward-compat
+    qs = _active_assignments_base_qs(
+        organization=organization, program=program, as_of=as_of,
+    ).filter(
+        Q(template__role=role) | Q(template__author_role_filter__contains=[role]),
+        template__subject_mode=subject_mode,
+    ).select_related("template")
+    if cadence is not None:
+        qs = qs.filter(
+            Q(cadence_override=cadence)
+            | Q(cadence_override__isnull=True, template__cadence=cadence)
+            | Q(cadence_override="", template__cadence=cadence),
+        )
+    if assignment_group is not None:
+        # Prefer a group-specific assignment, but accept a program-wide
+        # (target_type='role') fallback so an LT can ship a single role
+        # assignment without per-bunk rows.
+        qs = qs.filter(
+            Q(assignment_group=assignment_group)
+            | Q(
+                assignment_group__isnull=True,
+                target_type=TemplateAssignment.TargetType.ROLE,
+            ),
+        )
+    qs = qs.annotate(
+        _org_priority=Case(
+            When(template__organization=organization, then=0),
+            When(template__organization__isnull=True, then=1),
+            default=2,
+            output_field=IntegerField(),
+        ),
+        _group_priority=Case(
+            When(assignment_group__isnull=False, then=0),
+            default=1,
+            output_field=IntegerField(),
+        ),
+    ).order_by("_org_priority", "_group_priority", "-template__version")
+    assignment = qs.first()
+    return assignment.template if assignment else None

--- a/backend/bunk_logs/core/test_assignment_resolution.py
+++ b/backend/bunk_logs/core/test_assignment_resolution.py
@@ -1,0 +1,382 @@
+"""Tests for ``bunk_logs.core.assignment_resolution`` (Step 7_21).
+
+Covers
+------
+* ``resolve_template_for`` matches an active TemplateAssignment by
+  (subject_mode, cadence, role).
+* Returns ``None`` when no assignment is active.
+* Org-shadow ordering: org-scoped template wins over global.
+* ``cadence_override`` on the assignment overrides ``template.cadence``.
+* ``assignment_group``-targeted assignment is preferred when supplied.
+* ``active_assignments_for`` filters by audience membership.
+* ``require_required=True`` excludes optional assignments; the optional
+  list returns them.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from bunk_logs.core.assignment_resolution import active_assignments_for
+from bunk_logs.core.assignment_resolution import list_optional_assignments_for
+from bunk_logs.core.assignment_resolution import list_required_assignments_for
+from bunk_logs.core.assignment_resolution import resolve_template_for
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.models import TemplateAssignment
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+TODAY = date(2026, 6, 15)
+SCHEMA = {"fields": [{"key": "note", "type": "textarea", "required": False, "prompts": {"en": "Notes"}}]}
+
+
+@pytest.fixture
+def org():
+    return Organization.objects.create(name="Resolver Camp", slug="resolver-camp")
+
+
+@pytest.fixture
+def other_org():
+    return Organization.objects.create(name="Other Camp", slug="other-camp")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org, name=f"{org.name} Summer 2026", slug="summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1), end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def viewer(org, program):
+    user = User.objects.create_user(email="v@resolver.test", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="View", last_name="Er", user=user,
+    )
+    Membership.all_objects.create(
+        program=program, person=person, role="counselor", is_active=True,
+    )
+    return person
+
+
+@pytest.fixture
+def lt_membership(program, org):
+    user = User.objects.create_user(email="lt@resolver.test", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="LT", last_name="Lead", user=user,
+    )
+    return Membership.all_objects.create(
+        program=program, person=person, role="leadership_team", is_active=True,
+    )
+
+
+@pytest.fixture
+def org_template(org):
+    return ReflectionTemplate.all_objects.create(
+        organization=org, name="Counselor Self", slug="counselor-self-org",
+        cadence="daily", subject_mode="self", schema=SCHEMA, languages=["en"],
+        is_active=True, role="counselor", author_role_filter=["counselor"],
+    )
+
+
+@pytest.fixture
+def global_template():
+    return ReflectionTemplate.all_objects.create(
+        organization=None, name="Counselor Self Global", slug="counselor-self-global",
+        cadence="daily", subject_mode="self", schema=SCHEMA, languages=["en"],
+        is_active=True, role="counselor", author_role_filter=["counselor"],
+    )
+
+
+def _active_role_assignment(
+    *, organization, program, template, role, lt_membership,
+    start=None, end=None, is_required=True,
+):
+    return TemplateAssignment.all_objects.create(
+        organization=organization, program=program, template=template,
+        target_type=TemplateAssignment.TargetType.ROLE,
+        target_payload={"role": role},
+        start_date=start or (TODAY - timedelta(days=1)),
+        end_date=end,
+        status=TemplateAssignment.Status.ACTIVE,
+        created_by=lt_membership,
+        is_required=is_required,
+    )
+
+
+class TestResolveTemplateFor:
+    def test_returns_none_when_no_assignment(self, org, program, org_template):
+        result = resolve_template_for(
+            organization=org, program=program, as_of=TODAY,
+            role="counselor", subject_mode="self", cadence="daily",
+        )
+        assert result is None
+
+    def test_matches_active_role_assignment(
+        self, org, program, org_template, lt_membership,
+    ):
+        _active_role_assignment(
+            organization=org, program=program, template=org_template,
+            role="counselor", lt_membership=lt_membership,
+        )
+        result = resolve_template_for(
+            organization=org, program=program, as_of=TODAY,
+            role="counselor", subject_mode="self", cadence="daily",
+        )
+        assert result == org_template
+
+    def test_org_shadows_global(
+        self, org, program, org_template, global_template, lt_membership,
+    ):
+        _active_role_assignment(
+            organization=org, program=program, template=global_template,
+            role="counselor", lt_membership=lt_membership,
+        )
+        _active_role_assignment(
+            organization=org, program=program, template=org_template,
+            role="counselor", lt_membership=lt_membership,
+        )
+        result = resolve_template_for(
+            organization=org, program=program, as_of=TODAY,
+            role="counselor", subject_mode="self", cadence="daily",
+        )
+        assert result == org_template
+
+    def test_excludes_assignment_outside_window(
+        self, org, program, org_template, lt_membership,
+    ):
+        _active_role_assignment(
+            organization=org, program=program, template=org_template,
+            role="counselor", lt_membership=lt_membership,
+            start=TODAY - timedelta(days=30),
+            end=TODAY - timedelta(days=1),
+        )
+        result = resolve_template_for(
+            organization=org, program=program, as_of=TODAY,
+            role="counselor", subject_mode="self", cadence="daily",
+        )
+        assert result is None
+
+    def test_excludes_other_org(
+        self, org, other_org, program, org_template, lt_membership,
+    ):
+        _active_role_assignment(
+            organization=org, program=program, template=org_template,
+            role="counselor", lt_membership=lt_membership,
+        )
+        result = resolve_template_for(
+            organization=other_org, program=program, as_of=TODAY,
+            role="counselor", subject_mode="self", cadence="daily",
+        )
+        assert result is None
+
+    def test_cadence_override_wins(
+        self, org, program, org_template, lt_membership,
+    ):
+        assignment = _active_role_assignment(
+            organization=org, program=program, template=org_template,
+            role="counselor", lt_membership=lt_membership,
+        )
+        assignment.cadence_override = "weekly"
+        assignment.save(update_fields=["cadence_override"])
+        # daily resolution should now miss; weekly should hit.
+        assert resolve_template_for(
+            organization=org, program=program, as_of=TODAY,
+            role="counselor", subject_mode="self", cadence="daily",
+        ) is None
+        assert resolve_template_for(
+            organization=org, program=program, as_of=TODAY,
+            role="counselor", subject_mode="self", cadence="weekly",
+        ) == org_template
+
+    def test_subject_mode_must_match(
+        self, org, program, org_template, lt_membership,
+    ):
+        _active_role_assignment(
+            organization=org, program=program, template=org_template,
+            role="counselor", lt_membership=lt_membership,
+        )
+        result = resolve_template_for(
+            organization=org, program=program, as_of=TODAY,
+            role="counselor", subject_mode="single_subject", cadence="daily",
+        )
+        assert result is None
+
+    def test_role_matches_author_role_filter(
+        self, org, program, lt_membership,
+    ):
+        template = ReflectionTemplate.all_objects.create(
+            organization=org, name="Camper Reflection", slug="camper-reflection",
+            cadence="daily", subject_mode="single_subject",
+            assignment_group_types=["bunk"],
+            schema=SCHEMA, languages=["en"], is_active=True,
+            author_role_filter=["counselor", "junior_counselor"],
+        )
+        _active_role_assignment(
+            organization=org, program=program, template=template,
+            role="counselor", lt_membership=lt_membership,
+        )
+        assert resolve_template_for(
+            organization=org, program=program, as_of=TODAY,
+            role="junior_counselor", subject_mode="single_subject", cadence="daily",
+        ) == template
+
+    def test_assignment_group_specific_preferred(
+        self, org, program, lt_membership,
+    ):
+        template = ReflectionTemplate.all_objects.create(
+            organization=org, name="Camper Reflection", slug="camper-reflection",
+            cadence="daily", subject_mode="single_subject",
+            assignment_group_types=["bunk"],
+            schema=SCHEMA, languages=["en"], is_active=True,
+            author_role_filter=["counselor"],
+        )
+        bunk = AssignmentGroup.objects.create(
+            organization=org, program=program, name="Bunk Pine", slug="bunk-pine",
+            group_type="bunk", is_active=True,
+        )
+        other_bunk = AssignmentGroup.objects.create(
+            organization=org, program=program, name="Bunk Oak", slug="bunk-oak",
+            group_type="bunk", is_active=True,
+        )
+        # Program-wide role assignment.
+        _active_role_assignment(
+            organization=org, program=program, template=template,
+            role="counselor", lt_membership=lt_membership,
+        )
+        # Group-specific assignment for the OTHER bunk.
+        TemplateAssignment.all_objects.create(
+            organization=org, program=program, template=template,
+            target_type=TemplateAssignment.TargetType.ASSIGNMENT_GROUP,
+            target_payload={}, assignment_group=other_bunk,
+            start_date=TODAY - timedelta(days=1),
+            status=TemplateAssignment.Status.ACTIVE,
+            created_by=lt_membership,
+        )
+        # Resolving for ``bunk`` (no group-specific row) falls back to
+        # the program-wide role assignment.
+        result_bunk = resolve_template_for(
+            organization=org, program=program, as_of=TODAY,
+            role="counselor", subject_mode="single_subject", cadence="daily",
+            assignment_group=bunk,
+        )
+        assert result_bunk == template
+        # Resolving for ``other_bunk`` is also fine — both rows match,
+        # the group-specific one wins by ``_group_priority`` ordering.
+        result_other = resolve_template_for(
+            organization=org, program=program, as_of=TODAY,
+            role="counselor", subject_mode="single_subject", cadence="daily",
+            assignment_group=other_bunk,
+        )
+        assert result_other == template
+
+
+class TestActiveAssignmentsFor:
+    def test_role_targeted_audience(
+        self, org, program, viewer, org_template, lt_membership,
+    ):
+        _active_role_assignment(
+            organization=org, program=program, template=org_template,
+            role="counselor", lt_membership=lt_membership,
+        )
+        out = active_assignments_for(
+            viewer=viewer, organization=org, program=program,
+            as_of=TODAY, target_role="counselor",
+        )
+        assert len(out) == 1
+
+    def test_role_targeted_excludes_other_role(
+        self, org, program, viewer, org_template, lt_membership,
+    ):
+        # Viewer is a counselor; assignment targets kitchen_staff.
+        ks_template = ReflectionTemplate.all_objects.create(
+            organization=org, name="Kitchen", slug="ks-self",
+            cadence="daily", subject_mode="self", schema=SCHEMA,
+            languages=["en"], is_active=True, role="kitchen_staff",
+            author_role_filter=["kitchen_staff"],
+        )
+        _active_role_assignment(
+            organization=org, program=program, template=ks_template,
+            role="kitchen_staff", lt_membership=lt_membership,
+        )
+        out = active_assignments_for(
+            viewer=viewer, organization=org, program=program,
+            as_of=TODAY, target_role="kitchen_staff",
+        )
+        assert out == []
+
+    def test_required_vs_optional(
+        self, org, program, viewer, org_template, lt_membership,
+    ):
+        _active_role_assignment(
+            organization=org, program=program, template=org_template,
+            role="counselor", lt_membership=lt_membership, is_required=False,
+        )
+        required = list_required_assignments_for(
+            viewer, organization=org, program=program, as_of=TODAY,
+        )
+        optional = list_optional_assignments_for(
+            viewer, organization=org, program=program, as_of=TODAY,
+        )
+        assert required == []
+        assert len(optional) == 1
+
+    def test_individuals_audience(
+        self, org, program, viewer, org_template, lt_membership,
+    ):
+        my_membership = Membership.all_objects.get(person=viewer)
+        TemplateAssignment.all_objects.create(
+            organization=org, program=program, template=org_template,
+            target_type=TemplateAssignment.TargetType.INDIVIDUALS,
+            target_payload={"membership_ids": [my_membership.id]},
+            start_date=TODAY - timedelta(days=1),
+            status=TemplateAssignment.Status.ACTIVE,
+            created_by=lt_membership,
+        )
+        out = active_assignments_for(
+            viewer=viewer, organization=org, program=program, as_of=TODAY,
+        )
+        assert len(out) == 1
+
+    def test_assignment_group_audience(
+        self, org, program, viewer, lt_membership,
+    ):
+        template = ReflectionTemplate.all_objects.create(
+            organization=org, name="Bunk Reflection", slug="bunk-reflection",
+            cadence="daily", subject_mode="single_subject",
+            assignment_group_types=["bunk"],
+            schema=SCHEMA, languages=["en"], is_active=True,
+            author_role_filter=["counselor"],
+        )
+        bunk = AssignmentGroup.objects.create(
+            organization=org, program=program, name="Bunk Maple", slug="bunk-maple",
+            group_type="bunk", is_active=True,
+        )
+        AssignmentGroupMembership.objects.create(
+            group=bunk, person=viewer, role_in_group="author", is_active=True,
+        )
+        TemplateAssignment.all_objects.create(
+            organization=org, program=program, template=template,
+            target_type=TemplateAssignment.TargetType.ASSIGNMENT_GROUP,
+            target_payload={}, assignment_group=bunk,
+            start_date=TODAY - timedelta(days=1),
+            status=TemplateAssignment.Status.ACTIVE,
+            created_by=lt_membership,
+        )
+        out = active_assignments_for(
+            viewer=viewer, organization=org, program=program, as_of=TODAY,
+        )
+        assert len(out) == 1

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -214,3 +214,25 @@ Two new control fields were added:
 - `title` (str, blank): per-assignment display label; falls back to `template.name` via the read-only `display_title` field on the API response.
 
 The assignments endpoints (`/api/v1/leadership-team/assignments/`) now accept both `program_lead` and `admin` capabilities (decision FA7). See `docs/design/form_orchestration_reframe.md` §3 for design rationale.
+
+---
+
+## Template resolution after Step 7_21
+
+Per-role dashboards used to query `ReflectionTemplate` directly with hard-coded filters (one per role flow). After Step 7_21 they all delegate to a single resolver in `bunk_logs.core.assignment_resolution`:
+
+- `resolve_template_for(*, organization, program, as_of, role, subject_mode, cadence=None, assignment_group=None, viewer=None)` returns the active `ReflectionTemplate` for a `(role, subject_mode)` tuple, or `None` when no `TemplateAssignment` is active.
+
+Key implications:
+
+- **The Leadership Team controls which template each role sees.** Without an active `TemplateAssignment`, the dashboard renders the `no_template` empty state — no template, no tasks. This is the explicit contract the LT-driven form orchestration relies on (decision FA10).
+- **Org-shadows-global ordering is preserved.** When multiple assignments match, the one whose template's `organization` equals the caller's org wins over a global (`organization IS NULL`) template, then a higher `template.version` breaks remaining ties.
+- **`assignment_group` is preferred when supplied.** For per-bunk templates (e.g. counselor camper-reflection) the resolver prefers a group-specific assignment over a program-wide role assignment, so an LT can override one bunk's template without touching the rest of the program.
+- **`cadence_override` wins over `template.cadence`.** When the LT pins a template to a different cadence on a per-assignment basis, the resolver matches against the override first.
+
+Per-role `common.py` files (`api/<role>/common.py`) now contain thin wrappers that call `resolve_template_for` with the appropriate role/subject_mode/cadence shape. Adding a new role flow means writing one such wrapper and calling the same resolver — no per-role template query logic should ever land in dashboards again.
+
+Companion helpers:
+- `active_assignments_for(...)` — viewer-aware audience filter; the basis for "what tasks do I owe?" task derivation.
+- `list_required_assignments_for(...)` / `list_optional_assignments_for(...)` — symmetry pair; the optional list seeds the Wave 2 "forms I can also fill out" library.
+- `resolve_members(...)` — moved here from `api/leadership_team/assignments.py` so the LT assignments API and the per-role dashboards share one audience-resolution implementation. The legacy import path still works through a re-export.

--- a/docs/wave_1_progress.md
+++ b/docs/wave_1_progress.md
@@ -25,45 +25,53 @@
 
 ### Step 7_20 — Extend TemplateAssignment
 
-**Status:** ⬜ Not started
-**Branch:** _(not yet)_
-**PR:** _(not yet)_
+**Status:** ✅ Merged to main
+**Branch:** `step/7_20_extend_template_assignment` (merged)
+**PR:** https://github.com/pantheonsteve/BunkLogs/pull/118
 **Estimated:** 3–5 hours
-**Actual:** _(record when done)_
+**Actual:** 0.25 hours
 
 **Scope reminder:** Add `assignment_group` FK, `is_required` flag, `title` field. Add `'assignment_group'` to TargetType. Extend `resolve_members` with the new branch. Widen permission gate to admin (FA7). Tests.
 
+**Verified post-merge (2026-05-24):**
+- `TemplateAssignment` model has `assignment_group`, `is_required`, `title`, `ASSIGNMENT_GROUP` in TargetType ✅
+- `resolve_members` handles the new branch with `author_role_filter` check ✅
+- `_serialize` exposes `assignment_group`, `is_required`, `title`, `display_title` ✅
+- `assignment_viewer_or_403` helper exists in `api/leadership_team/common.py` (FA7 widening) ✅
+- Migration index `core_templa_assignm_8ec6ca_idx` on `(assignment_group, status)` ✅
+
 **Notes / blockers:**
 
-- _Add as you encounter them_
+- None.
 
 ---
 
 ### Step 7_21 — Per-role dashboard refactor
 
-**Status:** ⬜ Not started
-**Branch:** _(not yet)_
-**PR:** _(not yet)_
+**Status:** 👀 In review
+**Branch:** `step/7_21_dashboard_template_resolution`
+**PR:** _(open after push)_
 **Estimated:** 4–6 hours
-**Actual:** _(record when done)_
+**Actual:** ~3 hours
 **Depends on:** 7_20 merged
 
 **Scope reminder:** Create `core/assignment_resolution.py` shared resolver. Refactor 8 per-role `common.py` files to use it. One commit per role. Update existing tests to create TemplateAssignment rows.
 
 **Per-role progress** (within the prompt):
 
-- ⬜ kitchen_staff
-- ⬜ madrich
-- ⬜ specialist
-- ⬜ counselor
-- ⬜ unit_head
-- ⬜ camper_care
-- ⬜ leadership_team
-- ⬜ admin_flow
+- ✅ kitchen_staff
+- ✅ madrich
+- ✅ specialist
+- ✅ counselor (camper-reflection + self templates)
+- ✅ unit_head
+- ✅ camper_care
+- ✅ leadership_team
+- ➖ admin_flow — no template helper to refactor; admin's template surface is oversight (`templates.py`, `dashboard.py::_pending_template_review_count`), not resolution
 
 **Notes / blockers:**
 
-- _Add as you encounter them_
+- Backend test suite passes 1135 tests after refactor + fixture updates. One pre-existing failure in `core/test_translation::TestBeatRegistration::test_migration_installs_the_periodic_task_row` is unrelated (PeriodicTask seed missing in test DB).
+- Production note: dashboards will return `no_template` empty state in prod until 7_22 seeds TemplateAssignment rows. Do NOT deploy 7_21 standalone — coordinate with 7_22.
 
 ---
 


### PR DESCRIPTION
## What

Replaces the hard-coded `ReflectionTemplate.all_objects.filter(...)` resolvers in each per-role `common.py` with a shared TemplateAssignment-aware lookup. The dashboard endpoint payload contracts are unchanged; only the internal template resolution path changes.

### Commits (one per role, in ascending risk order)

1. `feat(7_21_assignment_resolution)` — new `core.assignment_resolution` module:
   - `resolve_template_for(...)` — finds the active `ReflectionTemplate` for a `(role, subject_mode, cadence, [assignment_group])` tuple from active `TemplateAssignment` rows.
   - `active_assignments_for(...)` — viewer-aware audience filter.
   - `list_required_assignments_for(...)` / `list_optional_assignments_for(...)` — Wave 2 symmetry helpers.
   - `resolve_members(...)` — moved here from `api/leadership_team/assignments.py`; the LT module now re-exports it so the legacy import path keeps working.
2. `refactor(7_21_kitchen_staff)` — kitchen_staff_template → resolve_template_for
3. `refactor(7_21_madrich)` — madrich_template → resolve_template_for
4. `refactor(7_21_specialist)` — specialist_self_template → resolve_template_for
5. `refactor(7_21_counselor)` — both camper_reflection_template AND counselor_self_template
6. `refactor(7_21_unit_head)` — unit_head_self_template → resolve_template_for
7. `refactor(7_21_camper_care)` — camper_care_self_template → resolve_template_for
8. `refactor(7_21_leadership_team)` — leadership_team_self_template → resolve_template_for
9. `test(7_21)` — auto-seed TemplateAssignment in conftest + per-file template fixture updates + empty-state test
10. `docs(7_21)` — data-model.md "Template resolution after Step 7_21" section + wave_1_progress.md status update

**Note on admin_flow:** the prompt listed 8 roles including `admin_flow/common.py`. The admin namespace has no template-resolution helper today — its template surface is *oversight* (`templates.py`, `dashboard.py::_pending_template_review_count`), not resolution. Nothing to refactor there, so no admin-only commit was needed.

## Why

- Decision FA10(a) ships Wave 1 before June 5, 2026. This is the second of three Wave 1 prompts (7_20 = FA-A, 7_21 = FA-B, 7_22 = FA-S).
- See `docs/design/form_orchestration_reframe.md` §3.4 and decision FA10 in `docs/user_stories/00_cross_cutting/decisions.md`.
- The Leadership Team needs to control which template each role sees without code changes. After 7_21 the per-role dashboards source their templates from `TemplateAssignment`, not from hard-coded role/cadence filters.

## Testing

- Backend: `make test-backend` → 1135 passed (one pre-existing failure in `core/test_translation::TestBeatRegistration::test_migration_installs_the_periodic_task_row` is unrelated to 7_21 — `PeriodicTask` seeding gap in the test DB).
- Frontend: `npm test` → 559 passed.
- Lint: `ruff check` clean on all changed files.
- New tests:
  - `core/test_assignment_resolution.py` — 14 unit tests covering org-shadow ordering, cadence_override, assignment_group preference, audience filters, required-vs-optional split.
  - `test_kitchen_staff_endpoints::test_dashboard_empty_state_without_template_assignment` — explicit empty-state assertion (`state='no_template'`, `template_id=None`) when no `TemplateAssignment` is active.
- Test fixture changes:
  - `api/tests/conftest.py` — autouse `post_save` hook on `Program` auto-creates a role-targeted `TemplateAssignment` per seeded role template, plus exposes `make_active_assignment(template, program, target_role)` for tests that mint their own templates.
  - Five test files updated to call `make_active_assignment` alongside test-owned templates.

## Risk assessment

This is the riskiest of the Wave 1 prompts: a bug in resolution silently empties a dashboard rather than 500ing, so it can ship undetected if the test surface is thin.

Mitigations:
- One commit per role refactored so a regression in one role can be reverted with a single revert.
- `resolve_template_for` returns `None` when no assignment is active, and every dashboard already handles that path (renders the `no_template` empty state).
- All existing dashboard contract tests still pass after the refactor, with the same payload shapes.
- The shared resolver module is unit-tested in isolation (`test_assignment_resolution.py`).

## Rollback plan

- Single-role regression: `git revert <role's refactor commit>` and re-deploy. The shared resolver stays in place (no consumers left for the reverted role) until the next attempt.
- Full revert: revert in reverse commit order (docs → test → leadership_team → ... → kitchen_staff → assignment_resolution). The legacy `_resolve_template` helper is still present in `api/counselor/common.py` so reverted roles can use it directly.

## Production coordination

⚠ **Do NOT merge to production without 7_22 (FA-S seeding) ready to follow.** Until 7_22 seeds `TemplateAssignment` rows in production, every refactored dashboard returns the `no_template` empty state. Acceptable on staging; not acceptable in production.

Suggested production deploy sequence (same maintenance window):
1. Merge 7_20 (done — PR #118).
2. Merge 7_21 (this PR).
3. Merge 7_22.
4. Run the FA-S seeding command in production shell.
5. Smoke test as Alyson.

Made with [Cursor](https://cursor.com)