### PR TITLE
7_22: Seed TemplateAssignments for Crane Lake Summer 2026

### DIFF
--- a/backend/bunk_logs/core/management/commands/seed_summer_2026_assignments.py
+++ b/backend/bunk_logs/core/management/commands/seed_summer_2026_assignments.py
@@ -1,0 +1,301 @@
+"""Seed TemplateAssignment rows for the CLC Summer 2026 program (Step 7_22).
+
+Idempotent: keyed on ``(program, template, target_type='role', target_payload['role'])``.
+Existing scheduled/active rows get title/is_required reconciled in-place; ended or
+cancelled rows are left alone (a fresh scheduled row is added alongside with a
+warning, per acceptance criterion 8 — never resurrect).
+
+Usage
+-----
+    python manage.py seed_summer_2026_assignments \
+        --org-slug clc --program-slug summer-2026 \
+        [--dry-run] [--actor-username <email>]
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+from django.db import transaction
+
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.models import TemplateAssignment
+
+User = get_user_model()
+
+ASSIGNMENT_MANIFEST: list[dict[str, str]] = [
+    {"role": "counselor",          "slug": "clc-2026-counselor-daily",            "title": "Counselor daily bunk log"},
+    {"role": "junior_counselor",   "slug": "clc-2026-junior-counselor-daily",     "title": "Junior counselor daily reflection"},
+    {"role": "general_counselor",  "slug": "clc-2026-general-counselor-daily",    "title": "General counselor daily reflection"},
+    {"role": "specialist",         "slug": "clc-2026-specialist-daily",           "title": "Specialist daily reflection"},
+    {"role": "unit_head",          "slug": "clc-2026-unit-head-daily",            "title": "Unit head daily reflection"},
+    {"role": "leadership_team",    "slug": "clc-2026-leadership-biweekly",        "title": "Leadership team check-in (biweekly)"},
+    {"role": "kitchen_staff",      "slug": "clc-2026-kitchen-daily",              "title": "Kitchen staff daily reflection"},
+    {"role": "maintenance",        "slug": "clc-2026-maintenance-daily",          "title": "Maintenance daily reflection"},
+    {"role": "housekeeping",       "slug": "clc-2026-housekeeping-daily",         "title": "Housekeeping daily reflection"},
+    {"role": "camper_care",        "slug": "clc-2026-camper-care-daily",          "title": "Camper care daily reflection"},
+    {"role": "health_center",      "slug": "clc-2026-health-center-daily",        "title": "Health center daily reflection"},
+    {"role": "special_diets",      "slug": "clc-2026-special-diets-daily",        "title": "Special diets daily reflection"},
+]
+
+ACTOR_ROLES = ("admin", "leadership_team")
+
+
+class Command(BaseCommand):
+    help = "Seed TemplateAssignment rows for the CLC Summer 2026 program (idempotent)."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument("--org-slug", required=True, help="Organization slug (e.g. clc).")
+        parser.add_argument("--program-slug", required=True, help="Program slug (e.g. summer-2026).")
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print what would be created/updated; make no DB writes.",
+        )
+        parser.add_argument(
+            "--actor-username",
+            default=None,
+            help=(
+                "Optional email of an admin or LT user in the target org. Their "
+                "Membership becomes ``created_by`` on each new row."
+            ),
+        )
+
+    def handle(self, *args: Any, **opts: Any) -> None:
+        org = self._get_org(opts["org_slug"])
+        program = self._get_program(org, opts["program_slug"])
+        actor = self._resolve_actor(org, opts.get("actor_username"))
+        plan = self._build_plan(org, program)
+
+        if opts["dry_run"]:
+            self._print_plan(plan)
+            return
+
+        created = updated = unchanged = resurrected_warnings = 0
+        with transaction.atomic():
+            for entry in plan:
+                outcome = self._upsert_assignment(entry, actor=actor)
+                if outcome == "created":
+                    created += 1
+                elif outcome == "updated":
+                    updated += 1
+                elif outcome == "unchanged":
+                    unchanged += 1
+                if outcome == "created-after-ended":
+                    resurrected_warnings += 1
+                    created += 1
+
+        summary = (
+            f"Seeded {len(plan)} assignments — "
+            f"{created} created, {updated} updated, {unchanged} unchanged."
+        )
+        if resurrected_warnings:
+            summary += (
+                f" ({resurrected_warnings} created alongside pre-existing "
+                f"ended/cancelled rows.)"
+            )
+        self.stdout.write(self.style.SUCCESS(summary))
+
+    # ── plan construction ────────────────────────────────────────────────
+
+    def _get_org(self, slug: str) -> Organization:
+        try:
+            return Organization.objects.get(slug=slug)
+        except Organization.DoesNotExist as exc:
+            msg = f"Organization with slug {slug!r} does not exist."
+            raise CommandError(msg) from exc
+
+    def _get_program(self, org: Organization, slug: str) -> Program:
+        try:
+            return Program.all_objects.get(organization=org, slug=slug)
+        except Program.DoesNotExist as exc:
+            msg = (
+                f"Program with slug {slug!r} does not exist in org "
+                f"{org.slug!r}."
+            )
+            raise CommandError(msg) from exc
+
+    def _resolve_actor(
+        self,
+        org: Organization,
+        username: str | None,
+    ) -> Membership | None:
+        if not username:
+            return None
+        try:
+            user = User.objects.get(email=username)
+        except User.DoesNotExist as exc:
+            msg = f"No user with email {username!r}."
+            raise CommandError(msg) from exc
+
+        membership = (
+            Membership.all_objects.filter(
+                person__user=user,
+                program__organization=org,
+                role__in=ACTOR_ROLES,
+                is_active=True,
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        if not membership:
+            roles = ", ".join(ACTOR_ROLES)
+            msg = (
+                f"User {username!r} has no active {roles} membership in org "
+                f"{org.slug!r}."
+            )
+            raise CommandError(msg)
+        return membership
+
+    def _build_plan(self, org: Organization, program: Program) -> list[dict[str, Any]]:
+        plan: list[dict[str, Any]] = []
+        missing: list[str] = []
+        for entry in ASSIGNMENT_MANIFEST:
+            template = (
+                ReflectionTemplate.all_objects.filter(
+                    organization=org,
+                    slug=entry["slug"],
+                )
+                .order_by("-version")
+                .first()
+            )
+            if template is None:
+                missing.append(entry["slug"])
+                continue
+            plan.append({
+                "organization": org,
+                "program": program,
+                "template": template,
+                "role": entry["role"],
+                "title": entry["title"],
+                "start_date": program.start_date,
+                "end_date": program.end_date,
+            })
+        if missing:
+            slugs = ", ".join(sorted(missing))
+            msg = (
+                f"Template(s) not found for org={org.slug}: {slugs}. "
+                f"Run onboard_clc_summer_2026 first."
+            )
+            raise CommandError(msg)
+        return plan
+
+    # ── per-entry write ──────────────────────────────────────────────────
+
+    def _upsert_assignment(
+        self,
+        entry: dict[str, Any],
+        *,
+        actor: Membership | None,
+    ) -> str:
+        existing = TemplateAssignment.all_objects.filter(
+            program=entry["program"],
+            template=entry["template"],
+            target_type=TemplateAssignment.TargetType.ROLE,
+            target_payload__role=entry["role"],
+            status__in=[
+                TemplateAssignment.Status.SCHEDULED,
+                TemplateAssignment.Status.ACTIVE,
+            ],
+        ).first()
+
+        if existing:
+            changes: list[str] = []
+            if existing.title != entry["title"]:
+                existing.title = entry["title"]
+                changes.append("title")
+            if not existing.is_required:
+                existing.is_required = True
+                changes.append("is_required")
+            if changes:
+                existing.save(update_fields=[*changes, "updated_at"])
+                self.stdout.write(
+                    f"updated  role={entry['role']:<18} "
+                    f"({', '.join(changes)})  #{existing.pk}",
+                )
+                return "updated"
+            self.stdout.write(
+                f"unchanged role={entry['role']:<18} "
+                f"#{existing.pk}",
+            )
+            return "unchanged"
+
+        # No active/scheduled row. Warn (don't fail) if a stale ended or
+        # cancelled row exists for the same key — we add a fresh row
+        # alongside rather than resurrecting it.
+        stale_count = TemplateAssignment.all_objects.filter(
+            program=entry["program"],
+            template=entry["template"],
+            target_type=TemplateAssignment.TargetType.ROLE,
+            target_payload__role=entry["role"],
+            status__in=[
+                TemplateAssignment.Status.ENDED,
+                TemplateAssignment.Status.CANCELLED,
+            ],
+        ).count()
+        if stale_count:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"warn     role={entry['role']:<18} "
+                    f"({stale_count} ended/cancelled row(s) exist — "
+                    f"creating a fresh scheduled row alongside)",
+                ),
+            )
+
+        new_assignment = TemplateAssignment.all_objects.create(
+            organization=entry["organization"],
+            program=entry["program"],
+            template=entry["template"],
+            target_type=TemplateAssignment.TargetType.ROLE,
+            target_payload={"role": entry["role"]},
+            start_date=entry["start_date"],
+            end_date=entry["end_date"],
+            cadence_override=None,
+            is_required=True,
+            title=entry["title"],
+            status=TemplateAssignment.Status.SCHEDULED,
+            created_by=actor,
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"created  role={entry['role']:<18} "
+                f"#{new_assignment.pk}",
+            ),
+        )
+        return "created-after-ended" if stale_count else "created"
+
+    # ── dry-run reporting ────────────────────────────────────────────────
+
+    def _print_plan(self, plan: list[dict[str, Any]]) -> None:
+        self.stdout.write(self.style.WARNING("DRY-RUN: no database writes will occur.\n"))
+        for entry in plan:
+            existing = TemplateAssignment.all_objects.filter(
+                program=entry["program"],
+                template=entry["template"],
+                target_type=TemplateAssignment.TargetType.ROLE,
+                target_payload__role=entry["role"],
+                status__in=[
+                    TemplateAssignment.Status.SCHEDULED,
+                    TemplateAssignment.Status.ACTIVE,
+                ],
+            ).first()
+            if existing is None:
+                action = "create"
+            elif (
+                existing.title != entry["title"]
+                or not existing.is_required
+            ):
+                action = "update"
+            else:
+                action = "noop  "
+            self.stdout.write(
+                f"  {action}  role={entry['role']:<18} "
+                f"template={entry['template'].slug:<40} "
+                f"window={entry['start_date']}→{entry['end_date']}",
+            )
+        self.stdout.write(self.style.WARNING(f"\nTotal: {len(plan)} planned actions."))

--- a/backend/bunk_logs/core/tests/test_seed_summer_2026_assignments.py
+++ b/backend/bunk_logs/core/tests/test_seed_summer_2026_assignments.py
@@ -1,0 +1,314 @@
+"""Tests for the ``seed_summer_2026_assignments`` management command (Step 7_22).
+
+Covers the 8 acceptance scenarios in
+``migration_prompts/7_22_seed_summer_2026_assignments.md`` §7.
+"""
+from __future__ import annotations
+
+import io
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from bunk_logs.core.management.commands.seed_summer_2026_assignments import ASSIGNMENT_MANIFEST
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.models import TemplateAssignment
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+SCHEMA = {
+    "fields": [
+        {"key": "note", "type": "textarea", "required": False, "prompts": {"en": "Notes"}},
+    ],
+}
+
+
+def _run(**kwargs) -> tuple[str, str]:
+    out = io.StringIO()
+    err = io.StringIO()
+    call_command("seed_summer_2026_assignments", stdout=out, stderr=err, **kwargs)
+    return out.getvalue(), err.getvalue()
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def org():
+    return Organization.objects.create(name="URJ Crane Lake Camp", slug="clc")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name=f"{org.name} - Summer 2026",
+        slug="summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 28),
+        end_date=date(2026, 8, 16),
+    )
+
+
+def _make_template(org, *, role: str, slug: str, cadence: str = "daily"):
+    return ReflectionTemplate.all_objects.create(
+        organization=org,
+        name=f"{slug} v1",
+        slug=slug,
+        cadence=cadence,
+        role=role,
+        schema=SCHEMA,
+        languages=["en"],
+        subject_mode="self",
+        author_role_filter=[role],
+        status=ReflectionTemplate.Status.PUBLISHED,
+        is_active=True,
+        version=1,
+    )
+
+
+@pytest.fixture
+def all_templates(org):
+    created = {}
+    for entry in ASSIGNMENT_MANIFEST:
+        cadence = "biweekly" if entry["role"] == "leadership_team" else "daily"
+        created[entry["role"]] = _make_template(
+            org, role=entry["role"], slug=entry["slug"], cadence=cadence,
+        )
+    return created
+
+
+# ── 1. happy path ───────────────────────────────────────────────────────
+
+
+def test_happy_path_creates_twelve_assignments(org, program, all_templates):
+    out, _ = _run(org_slug="clc", program_slug="summer-2026")
+    assert TemplateAssignment.all_objects.filter(program=program).count() == 12
+    rows = TemplateAssignment.all_objects.filter(program=program)
+    roles_seen = {row.target_payload["role"] for row in rows}
+    expected_roles = {entry["role"] for entry in ASSIGNMENT_MANIFEST}
+    assert roles_seen == expected_roles
+    for row in rows:
+        assert row.target_type == TemplateAssignment.TargetType.ROLE
+        assert row.is_required is True
+        assert row.status == TemplateAssignment.Status.SCHEDULED
+        assert row.start_date == program.start_date
+        assert row.end_date == program.end_date
+        assert row.cadence_override is None
+        assert row.organization_id == org.pk
+    assert "Seeded 12 assignments" in out
+
+
+# ── 2. idempotency ──────────────────────────────────────────────────────
+
+
+def test_idempotent_when_run_twice(org, program, all_templates):
+    _run(org_slug="clc", program_slug="summer-2026")
+    _run(org_slug="clc", program_slug="summer-2026")
+    assert TemplateAssignment.all_objects.filter(program=program).count() == 12
+
+
+# ── 3. dry run ──────────────────────────────────────────────────────────
+
+
+def test_dry_run_writes_nothing(org, program, all_templates):
+    out, _ = _run(org_slug="clc", program_slug="summer-2026", dry_run=True)
+    assert TemplateAssignment.all_objects.filter(program=program).count() == 0
+    assert "DRY-RUN" in out
+    assert "12 planned actions" in out
+
+
+# ── 4. missing template fails ───────────────────────────────────────────
+
+
+def test_missing_template_raises(org, program, all_templates):
+    missing = all_templates["counselor"]
+    missing.delete()
+    with pytest.raises(CommandError) as excinfo:
+        _run(org_slug="clc", program_slug="summer-2026")
+    assert "clc-2026-counselor-daily" in str(excinfo.value)
+    assert TemplateAssignment.all_objects.filter(program=program).count() == 0
+
+
+# ── 5. title update is reconciled in-place ──────────────────────────────
+
+
+def test_existing_assignment_with_wrong_title_is_corrected(
+    org, program, all_templates,
+):
+    template = all_templates["counselor"]
+    stale = TemplateAssignment.all_objects.create(
+        organization=org,
+        program=program,
+        template=template,
+        target_type=TemplateAssignment.TargetType.ROLE,
+        target_payload={"role": "counselor"},
+        start_date=program.start_date,
+        end_date=program.end_date,
+        is_required=False,
+        title="Old wrong title",
+        status=TemplateAssignment.Status.SCHEDULED,
+    )
+    _run(org_slug="clc", program_slug="summer-2026")
+    stale.refresh_from_db()
+    assert stale.title == "Counselor daily bunk log"
+    assert stale.is_required is True
+    assert TemplateAssignment.all_objects.filter(program=program).count() == 12
+
+
+# ── 6. cross-program isolation ──────────────────────────────────────────
+
+
+def test_other_program_assignments_are_untouched(org, program, all_templates):
+    _run(org_slug="clc", program_slug="summer-2026")
+    pks_2026_before = set(
+        TemplateAssignment.all_objects.filter(program=program).values_list(
+            "pk", flat=True,
+        ),
+    )
+    summer_2027 = Program.all_objects.create(
+        organization=org,
+        name=f"{org.name} - Summer 2027",
+        slug="summer-2027",
+        program_type="summer_camp",
+        start_date=date(2027, 6, 27),
+        end_date=date(2027, 8, 15),
+    )
+    # Templates are org-scoped, so re-running against a different program in
+    # the same org succeeds. The 2026 rows must stay intact.
+    _run(org_slug="clc", program_slug="summer-2027")
+    pks_2026_after = set(
+        TemplateAssignment.all_objects.filter(program=program).values_list(
+            "pk", flat=True,
+        ),
+    )
+    assert pks_2026_after == pks_2026_before
+    assert TemplateAssignment.all_objects.filter(program=program).count() == 12
+    assert TemplateAssignment.all_objects.filter(program=summer_2027).count() == 12
+
+
+# ── 7. cross-org isolation ──────────────────────────────────────────────
+
+
+def test_other_org_run_does_not_affect_clc(org, program, all_templates):
+    _run(org_slug="clc", program_slug="summer-2026")
+    other = Organization.objects.create(name="Other Camp", slug="other")
+    Program.all_objects.create(
+        organization=other,
+        name=f"{other.name} - Summer 2026",
+        slug="summer-2026",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 28),
+        end_date=date(2026, 8, 16),
+    )
+    with pytest.raises(CommandError):
+        _run(org_slug="other", program_slug="summer-2026")
+    assert TemplateAssignment.all_objects.filter(program=program).count() == 12
+
+
+# ── 8. ended/cancelled row → warn + create alongside (no resurrect) ────
+
+
+def test_existing_ended_row_does_not_block_new_creation(
+    org, program, all_templates,
+):
+    template = all_templates["counselor"]
+    ended = TemplateAssignment.all_objects.create(
+        organization=org,
+        program=program,
+        template=template,
+        target_type=TemplateAssignment.TargetType.ROLE,
+        target_payload={"role": "counselor"},
+        start_date=date(2025, 6, 1),
+        end_date=date(2025, 8, 31),
+        is_required=True,
+        title="Last year's counselor log",
+        status=TemplateAssignment.Status.ENDED,
+    )
+    out, _ = _run(org_slug="clc", program_slug="summer-2026")
+    ended.refresh_from_db()
+    assert ended.status == TemplateAssignment.Status.ENDED
+    assert ended.title == "Last year's counselor log"
+    counselor_rows = TemplateAssignment.all_objects.filter(
+        program=program,
+        template=template,
+        target_type=TemplateAssignment.TargetType.ROLE,
+        target_payload__role="counselor",
+    )
+    assert counselor_rows.count() == 2
+    assert counselor_rows.filter(
+        status=TemplateAssignment.Status.SCHEDULED,
+    ).count() == 1
+    assert "warn" in out.lower()
+
+
+# ── actor resolution ────────────────────────────────────────────────────
+
+
+def test_actor_username_attaches_created_by(org, program, all_templates):
+    user = User.objects.create_user(email="alyson@clc.test", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="Aly", last_name="Son", user=user,
+    )
+    lt_membership = Membership.all_objects.create(
+        program=program, person=person, role="leadership_team", is_active=True,
+    )
+    _run(
+        org_slug="clc",
+        program_slug="summer-2026",
+        actor_username="alyson@clc.test",
+    )
+    rows = TemplateAssignment.all_objects.filter(program=program)
+    assert rows.count() == 12
+    for row in rows:
+        assert row.created_by_id == lt_membership.pk
+
+
+def test_actor_username_unknown_user_raises(org, program, all_templates):
+    with pytest.raises(CommandError):
+        _run(
+            org_slug="clc",
+            program_slug="summer-2026",
+            actor_username="nope@clc.test",
+        )
+    assert TemplateAssignment.all_objects.filter(program=program).count() == 0
+
+
+def test_actor_username_without_admin_or_lt_role_raises(
+    org, program, all_templates,
+):
+    user = User.objects.create_user(email="counselor@clc.test", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="C", last_name="Counselor", user=user,
+    )
+    Membership.all_objects.create(
+        program=program, person=person, role="counselor", is_active=True,
+    )
+    with pytest.raises(CommandError):
+        _run(
+            org_slug="clc",
+            program_slug="summer-2026",
+            actor_username="counselor@clc.test",
+        )
+    assert TemplateAssignment.all_objects.filter(program=program).count() == 0
+
+
+# ── pre-flight ──────────────────────────────────────────────────────────
+
+
+def test_missing_org_raises():
+    with pytest.raises(CommandError):
+        _run(org_slug="missing", program_slug="summer-2026")
+
+
+def test_missing_program_raises(org):
+    with pytest.raises(CommandError):
+        _run(org_slug="clc", program_slug="not-here")

--- a/docs/clc-summer-2026-launch.md
+++ b/docs/clc-summer-2026-launch.md
@@ -175,3 +175,110 @@ podman-compose -f backend/docker-compose.local.yml exec django \
 Valid role codes: `counselor`, `junior_counselor`, `specialist`, `general_counselor`,
 `leadership_team`, `kitchen_staff`, `maintenance`, `housekeeping`, `camper_care`,
 `health_center`, `special_diets`, `admin`, `faculty`.
+
+---
+
+## Seeding TemplateAssignments (Step 7_22)
+
+The per-role dashboards refactored in Step 7_21 read from
+`TemplateAssignment` rows. Without those rows, every dashboard returns
+empty. The `seed_summer_2026_assignments` management command writes the
+12 rows Crane Lake needs.
+
+**Prerequisites:** `onboard_clc_summer_2026` must have run first so the
+org, program, and all 12 templates exist.
+
+### Command
+
+```bash
+python manage.py seed_summer_2026_assignments \
+    --org-slug clc \
+    --program-slug summer-2026 \
+    [--actor-username <admin-or-LT-email>] \
+    [--dry-run]
+```
+
+- `--dry-run` reports the plan and writes nothing.
+- `--actor-username` is optional; when supplied, it must be the email of
+  a user with an active `admin` or `leadership_team` Membership in the
+  target org. Their Membership is stamped onto `created_by`.
+
+### What it creates
+
+12 `TemplateAssignment` rows — one per CLC 2026 template, all
+`target_type='role'`, `is_required=True`, `status='scheduled'`,
+`cadence_override=None` (so each template's own cadence applies —
+biweekly for Leadership Team, daily for the rest). Dates flow from the
+Program record.
+
+| Role | Template slug | Title |
+|---|---|---|
+| counselor | `clc-2026-counselor-daily` | Counselor daily bunk log |
+| junior_counselor | `clc-2026-junior-counselor-daily` | Junior counselor daily reflection |
+| general_counselor | `clc-2026-general-counselor-daily` | General counselor daily reflection |
+| specialist | `clc-2026-specialist-daily` | Specialist daily reflection |
+| unit_head | `clc-2026-unit-head-daily` | Unit head daily reflection |
+| leadership_team | `clc-2026-leadership-biweekly` | Leadership team check-in (biweekly) |
+| kitchen_staff | `clc-2026-kitchen-daily` | Kitchen staff daily reflection |
+| maintenance | `clc-2026-maintenance-daily` | Maintenance daily reflection |
+| housekeeping | `clc-2026-housekeeping-daily` | Housekeeping daily reflection |
+| camper_care | `clc-2026-camper-care-daily` | Camper care daily reflection |
+| health_center | `clc-2026-health-center-daily` | Health center daily reflection |
+| special_diets | `clc-2026-special-diets-daily` | Special diets daily reflection |
+
+There is no `admin` row — admin's surface is template oversight, not a
+templated reflection.
+
+### Idempotency contract
+
+Keyed on `(program, template, target_type='role', target_payload['role'])`
+restricted to `status IN ('scheduled', 'active')`.
+
+- Re-running with the same args reconciles `title` / `is_required` on the
+  matched row and never creates duplicates.
+- If only `ended` / `cancelled` rows exist for the key, the command logs
+  a warning and creates a fresh `scheduled` row alongside (does NOT
+  resurrect the old row).
+- The command refuses to run (`CommandError`) if any of the 12 templates
+  is missing — fix that by re-running `onboard_clc_summer_2026` first.
+
+### Verification on staging
+
+1. `python manage.py seed_summer_2026_assignments --org-slug clc --program-slug summer-2026`
+2. Confirm count:
+   ```bash
+   python manage.py shell -c "from bunk_logs.core.models import TemplateAssignment, Program; \
+     p = Program.all_objects.get(slug='summer-2026'); \
+     print(TemplateAssignment.all_objects.filter(program=p).count())"
+   ```
+   Expected: `12`.
+3. Log in as Alyson (or any LT user) and load each per-role dashboard:
+   counselor, junior counselor, general counselor, specialist, unit head,
+   leadership team, kitchen staff, maintenance, housekeeping, camper
+   care, health center, special diets. Each should show its resolved
+   template (no empty-state).
+
+### Final Wave 1 production deploy sequence
+
+Per `docs/wave_1_progress.md`, the cutover is:
+
+1. Deploy `7_20` + `7_21` + `7_22` together in one maintenance window
+   (suggested: evening of June 1 or 2).
+2. After deploy completes, run the seeding command on the production
+   backend (via Render shell):
+   ```bash
+   python manage.py seed_summer_2026_assignments \
+     --org-slug clc --program-slug summer-2026 \
+     --actor-username <alyson@clc.email>
+   ```
+3. Smoke-test as Alyson immediately.
+4. Watch Datadog APM for 24h for unexpected dashboard errors.
+
+### Rollback
+
+Forward fixes are preferred. If the seeded rows are wrong:
+
+- Mark the bad rows `status='cancelled'`, then re-run the seeder (it
+  creates fresh `scheduled` rows alongside).
+- Or revert `7_21` + `7_22` as a pair — the old hard-coded dashboards
+  return as a backstop.


### PR DESCRIPTION
## What

New idempotent management command `seed_summer_2026_assignments` that writes the
12 `TemplateAssignment` rows the CLC Summer 2026 program needs so the per-role
dashboards refactored in Step 7_21 return non-empty results in production.

```bash
python manage.py seed_summer_2026_assignments \
    --org-slug clc \
    --program-slug summer-2026 \
    [--actor-username <admin-or-LT-email>] \
    [--dry-run]
```

One row per CLC 2026 role template, all `target_type='role'`,
`is_required=True`, `status='scheduled'`, `cadence_override=None` (so each
template's own cadence applies — biweekly for Leadership Team, daily for the
other 11). Dates flow from `program.start_date`/`end_date`. No `admin` row
(admin's surface is template oversight, not a templated reflection).

| Role | Template slug | Title |
|---|---|---|
| counselor | `clc-2026-counselor-daily` | Counselor daily bunk log |
| junior_counselor | `clc-2026-junior-counselor-daily` | Junior counselor daily reflection |
| general_counselor | `clc-2026-general-counselor-daily` | General counselor daily reflection |
| specialist | `clc-2026-specialist-daily` | Specialist daily reflection |
| unit_head | `clc-2026-unit-head-daily` | Unit head daily reflection |
| leadership_team | `clc-2026-leadership-biweekly` | Leadership team check-in (biweekly) |
| kitchen_staff | `clc-2026-kitchen-daily` | Kitchen staff daily reflection |
| maintenance | `clc-2026-maintenance-daily` | Maintenance daily reflection |
| housekeeping | `clc-2026-housekeeping-daily` | Housekeeping daily reflection |
| camper_care | `clc-2026-camper-care-daily` | Camper care daily reflection |
| health_center | `clc-2026-health-center-daily` | Health center daily reflection |
| special_diets | `clc-2026-special-diets-daily` | Special diets daily reflection |

### Idempotency contract

Keyed on `(program, template, target_type='role', target_payload['role'])`
restricted to `status IN ('scheduled', 'active')`.

- Re-runs reconcile `title` and `is_required` on the matched row; no duplicates.
- If only `ended`/`cancelled` rows exist for the key, the command logs a warning
  and creates a fresh `scheduled` row alongside (does **not** resurrect).
- Refuses to run (`CommandError`) if the org, program, or any of the 12
  templates is missing.

## Why

Final Wave 1 prompt — without it, the dashboards refactored in 7_21 return
empty in production. This is the cutover that makes decision FA10(a) viable.

- Design spec: `docs/design/form_orchestration_reframe.md` §3.5.
- Decisions: FA1, FA10 (`docs/user_stories/00_cross_cutting/decisions.md`).
- Canonical prompt: `migration_prompts/7_22_seed_summer_2026_assignments.md`.

## Testing

13 tests covering all 8 acceptance scenarios from §7 of the prompt:

1. Happy path — 12 assignments created with the right shape.
2. Idempotency — re-run produces no duplicates.
3. Dry run — no DB writes, plan printed.
4. Missing template — `CommandError` names the missing slug.
5. Title/is_required reconciliation on an existing scheduled row.
6. Cross-program isolation — 2026 rows untouched when seeding 2027.
7. Cross-org isolation — other org's run does not affect CLC.
8. Existing ended row — warning logged, fresh scheduled row created alongside.

Plus: actor-username happy path, unknown user, and user without admin/LT role.

```
13 passed in 0.59s
1148 passed (full backend suite, excluding the pre-existing unrelated
              celery-beat translation test)
ruff check  All checks passed!
```

Smoke test on local dev (per acceptance criterion):

```
$ python manage.py seed_summer_2026_assignments --org-slug clc --program-slug summer-2026
created  role=counselor          #1
...
Seeded 12 assignments — 12 created, 0 updated, 0 unchanged.

$ python manage.py seed_summer_2026_assignments --org-slug clc --program-slug summer-2026
unchanged role=counselor          #1
...
Seeded 12 assignments — 0 created, 0 updated, 12 unchanged.

$ TemplateAssignment.all_objects.filter(program=p).count() == 12  # ✓
```

## Risk

If the template slugs in `ASSIGNMENT_MANIFEST` don't match production templates
exactly, dashboards stay empty after deploy.

Mitigations:

- Dry-run against staging-with-prod-snapshot before deploy.
- The slugs match the 12 entries in `onboard_clc_summer_2026.TEMPLATE_MANIFEST`
  verified at the time of writing this PR (12 templates seeded in
  `backend/templates/reflection_templates/clc_2026/`).
- Pre-flight check raises a clear `CommandError` naming any missing slugs
  rather than silently no-op'ing.

## Rollback

Forward fix preferred. If seeded rows are wrong: mark them `status='cancelled'`
and re-run (creates fresh rows alongside). For a structural rollback, revert
`7_21` + `7_22` as a pair — the old hard-coded dashboards return as a backstop.

## Final Wave 1 sequence

Once merged: deploy `7_20` + `7_21` + `7_22` together (suggested evening of June 1
or 2), run the seeding command on prod, smoke-test as Alyson, watch APM for 24h.


Made with [Cursor](https://cursor.com)