### PR TITLE
3.14 Subject dashboard access control + 3.17 production hardening

### DIFF
--- a/backend/bunk_logs/api/dashboards/subject.py
+++ b/backend/bunk_logs/api/dashboards/subject.py
@@ -26,9 +26,12 @@ from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
 from bunk_logs.core.models import Reflection
+from bunk_logs.core.permissions.super_admin import is_super_admin
+from bunk_logs.core.permissions.visibility import author_group_ids_with_descendants
 
 DEFAULT_WINDOW_DAYS = 30
 MAX_WINDOW_DAYS = 90
+MAX_REFLECTIONS_PER_SUBJECT = 200
 LOW_RATING_LOOKBACK_DAYS = 14
 TREND_LOOKBACK_DAYS = 14
 TREND_DELTA_THRESHOLD = 0.5
@@ -109,6 +112,63 @@ def _is_yes_no_field(field: dict) -> bool:
     return values == {"yes", "no"}
 
 
+def _viewer_capability(person: Person, org) -> str | None:
+    """Highest-privilege capability the person holds in this org (across all programs)."""
+    caps = set(
+        Membership.all_objects.filter(
+            person=person,
+            is_active=True,
+            program__organization=org,
+        ).values_list("capability", flat=True),
+    )
+    for cap in ("admin", "program_lead", "domain_specialist", "supervisor"):
+        if cap in caps:
+            return cap
+    if "participant" in caps:
+        return "participant"
+    return None
+
+
+def _viewer_supervises_subject(viewer: Person, subject: Person) -> bool:
+    """True if viewer authors a group (or any ancestor group) that contains subject."""
+    group_ids = author_group_ids_with_descendants(viewer)
+    if not group_ids:
+        return False
+    return AssignmentGroupMembership.all_objects.filter(
+        person=subject,
+        group_id__in=group_ids,
+        role_in_group="subject",
+        is_active=True,
+    ).exists()
+
+
+def _can_view_subject_dashboard(
+    viewer_person: Person | None,
+    subject: Person,
+    org,
+    user,
+) -> bool:
+    """Explicit capability gate for the subject dashboard.
+
+    Allowed paths:
+    - Super admin (no Person required)
+    - admin / program_lead / domain_specialist membership in org
+    - supervisor capability with a supervises-subject relationship
+    - participant capability with a supervises-subject relationship (covers
+      counselors accessing their campers) or self-view
+    """
+    if is_super_admin(user):
+        return True
+    if viewer_person is None:
+        return False
+    cap = _viewer_capability(viewer_person, org)
+    if cap in ("admin", "program_lead", "domain_specialist"):
+        return True
+    if cap in ("supervisor", "participant"):
+        return viewer_person.id == subject.id or _viewer_supervises_subject(viewer_person, subject)
+    return False
+
+
 def _detect_concerning_patterns(
     series_by_label: dict[str, list[tuple[date, float, int, int | None]]],
     today: date,
@@ -169,6 +229,17 @@ class SubjectDetailView(APIView):
         if subject is None:
             return Response({"detail": "Subject not found."}, status=404)
 
+        # Defense-in-depth: OrgScopedManager already enforces this, but be explicit.
+        if subject.organization_id != org.id:
+            return Response({"detail": "Subject not found."}, status=404)
+
+        viewer_person = Person.all_objects.filter(user=request.user).first()
+        if not _can_view_subject_dashboard(viewer_person, subject, org, request.user):
+            return Response(
+                {"detail": "You do not have permission to view this subject's dashboard."},
+                status=403,
+            )
+
         today = date.today()
         cur_end = _parse_date(request.query_params.get("date_end"), today)
         cur_start = _parse_date(
@@ -180,7 +251,9 @@ class SubjectDetailView(APIView):
         if (cur_end - cur_start).days > MAX_WINDOW_DAYS - 1:
             cur_start = cur_end - timedelta(days=MAX_WINDOW_DAYS - 1)
 
-        # Pull reflections about this subject within window, scoped to viewer
+        # Pull reflections about this subject within window, scoped to viewer.
+        # Cap at MAX_REFLECTIONS_PER_SUBJECT to prevent unbounded queries on
+        # subjects with long histories; the 90-day window already constrains most cases.
         refs = list(
             reflections_visible_for_user(
                 request.user,
@@ -190,7 +263,7 @@ class SubjectDetailView(APIView):
                     period_end__lte=cur_end,
                     is_complete=True,
                 ).select_related("template", "author", "assignment_group"),
-            ).order_by("period_end"),
+            ).order_by("period_end")[:MAX_REFLECTIONS_PER_SUBJECT],
         )
 
         if not refs:

--- a/backend/bunk_logs/api/tests/test_dashboards_subject.py
+++ b/backend/bunk_logs/api/tests/test_dashboards_subject.py
@@ -372,6 +372,97 @@ def test_subject_profile_and_flag_summary(api_client, org, program, setup):
     assert sample["language"] == "en"
 
 
+def test_participant_without_supervisory_relationship_gets_403(api_client, org, program, setup):
+    """A participant with no group relationship to the subject is blocked."""
+    _, camper, _, _ = setup
+    # Different counselor in a completely separate bunk
+    outsider_user = _user("outsider-sd@a.com")
+    outsider = _person(org, "Out", "Sider", outsider_user)
+    other_bunk = AssignmentGroup.all_objects.create(
+        organization=org, program=program, name="Bunk Other",
+        slug="sd-bunk-other", group_type="bunk",
+    )
+    Membership.all_objects.create(program=program, person=outsider, role="counselor", is_active=True)
+    AssignmentGroupMembership.all_objects.create(
+        group=other_bunk, person=outsider, role_in_group="author", is_active=True,
+    )
+    api_client.force_authenticate(user=outsider_user)
+    r = api_client.get(f"/api/v1/dashboards/subject/{camper.id}/", **_hdr(org.slug))
+    assert r.status_code == 403
+
+
+def test_supervisor_capability_blocked_for_non_direct_report(api_client, org, program, setup):
+    """A unit_head (supervisor capability) cannot view a camper outside their groups."""
+    _, camper, _, _ = setup
+    uh_user = _user("uh-sd@a.com")
+    uh = _person(org, "Unit", "Head", uh_user)
+    other_bunk = AssignmentGroup.all_objects.create(
+        organization=org, program=program, name="Bunk UH Other",
+        slug="sd-bunk-uh", group_type="bunk",
+    )
+    Membership.all_objects.create(program=program, person=uh, role="unit_head", is_active=True)
+    AssignmentGroupMembership.all_objects.create(
+        group=other_bunk, person=uh, role_in_group="author", is_active=True,
+    )
+    api_client.force_authenticate(user=uh_user)
+    r = api_client.get(f"/api/v1/dashboards/subject/{camper.id}/", **_hdr(org.slug))
+    assert r.status_code == 403
+
+
+def test_supervisor_allowed_for_direct_report(api_client, org, program, setup):
+    """A unit_head whose bunk IS the camper's group gets through."""
+    bunk, camper, _, _ = setup
+    uh_user = _user("uh-direct-sd@a.com")
+    uh = _person(org, "Direct", "Head", uh_user)
+    Membership.all_objects.create(program=program, person=uh, role="unit_head", is_active=True)
+    # UH is author of a parent group that contains the bunk as a child
+    unit = AssignmentGroup.all_objects.create(
+        organization=org, program=program, name="Unit A",
+        slug="sd-unit-a", group_type="unit", parent=None,
+    )
+    bunk.parent = unit
+    bunk.save()
+    AssignmentGroupMembership.all_objects.create(
+        group=unit, person=uh, role_in_group="author", is_active=True,
+    )
+    api_client.force_authenticate(user=uh_user)
+    r = api_client.get(f"/api/v1/dashboards/subject/{camper.id}/", **_hdr(org.slug))
+    assert r.status_code == 200
+
+
+def test_program_lead_can_view_any_subject(api_client, org, program, setup):
+    """leadership_team (program_lead capability) can view any subject's dashboard."""
+    _, camper, _, _ = setup
+    lt_user = _user("lt-sd@a.com")
+    lt = _person(org, "Lead", "Er", lt_user)
+    Membership.all_objects.create(program=program, person=lt, role="leadership_team", is_active=True)
+    api_client.force_authenticate(user=lt_user)
+    r = api_client.get(f"/api/v1/dashboards/subject/{camper.id}/", **_hdr(org.slug))
+    assert r.status_code == 200
+
+
+def test_domain_specialist_can_view_any_subject(api_client, org, program, setup):
+    """health_center (domain_specialist capability) can view any subject's dashboard."""
+    _, camper, _, _ = setup
+    hc_user = _user("hc-sd@a.com")
+    hc = _person(org, "Health", "Center", hc_user)
+    Membership.all_objects.create(program=program, person=hc, role="health_center", is_active=True)
+    api_client.force_authenticate(user=hc_user)
+    r = api_client.get(f"/api/v1/dashboards/subject/{camper.id}/", **_hdr(org.slug))
+    assert r.status_code == 200
+
+
+def test_subject_from_other_org_returns_404(api_client, org, setup):
+    """Person belonging to a different org resolves to 404 (not 403)."""
+    _, _, counselor_user, _ = setup
+    other_org = Organization.objects.create(name="Other Org", slug="other-org")
+    other_person = _person(other_org, "Cross", "Tenant")
+    api_client.force_authenticate(user=counselor_user)
+    # Must use the first org's header so the lookup is scoped there
+    r = api_client.get(f"/api/v1/dashboards/subject/{other_person.id}/", **_hdr(org.slug))
+    assert r.status_code == 404
+
+
 def test_subject_visible_true_allows_camper_self_view(api_client, org, program, setup):
     _, camper, _, counselor = setup
     visible_tpl = ReflectionTemplate.all_objects.create(


### PR DESCRIPTION
## Summary

- Add explicit capability-based access gate to `GET /api/v1/dashboards/subject/{person_id}/` — returns 403 when the viewer has no legitimate relationship to the subject (Prompt 3.14)
- Bundle Prompt 3.17 production hardening: defense-in-depth org guard + `MAX_REFLECTIONS_PER_SUBJECT = 200` cap on the reflections queryset

## Access rules

| Viewer capability | Subject relationship | Result |
|---|---|---|
| `admin` / `program_lead` / `domain_specialist` | any | 200 |
| `supervisor` or `participant` | authors a group containing the subject | 200 |
| `participant` | viewer == subject (self-view) | 200 |
| anything else | — | 403 |

The participant path covers counselors accessing their campers' dashboards (they are group authors) and blocks cross-bunk / cross-program snooping.

## Test plan

- `test_participant_without_supervisory_relationship_gets_403` — outsider counselor → 403
- `test_supervisor_capability_blocked_for_non_direct_report` — unit_head in a different bunk → 403
- `test_supervisor_allowed_for_direct_report` — unit_head of parent group → 200
- `test_program_lead_can_view_any_subject` — leadership_team → 200
- `test_domain_specialist_can_view_any_subject` — health_center → 200
- `test_subject_from_other_org_returns_404` — cross-tenant person → 404
- All existing subject dashboard tests continue to pass (1183 total, 1 pre-existing unrelated failure)


Made with [Cursor](https://cursor.com)