### PR TITLE
3.16 Subject dashboard: Notes panel + authoring form

### DIFF
--- a/frontend/src/api/subjects.js
+++ b/frontend/src/api/subjects.js
@@ -1,0 +1,41 @@
+/**
+ * Subject notes API client (Prompt 3.15/3.16).
+ *
+ * Thin wrappers around `/api/v1/subjects/{person_id}/notes/*`.
+ */
+
+import api from '../api';
+
+export const VISIBILITY_OPTIONS = Object.freeze([
+  { value: 'supervisors_only', label: 'Supervisors only (default)' },
+  { value: 'team', label: 'Team — all with dashboard access' },
+  { value: 'domain_only', label: 'Domain specialists and above' },
+  { value: 'admin_only', label: 'Admin only' },
+]);
+
+/** Create a new SubjectNote. Returns `{ data, status }`. */
+export async function createSubjectNote(personId, {
+  body,
+  context = '',
+  visibility = 'supervisors_only',
+  isSensitive = false,
+  subjectVisible = false,
+}) {
+  const res = await api.post(`/api/v1/subjects/${personId}/notes/`, {
+    body,
+    context,
+    visibility,
+    is_sensitive: isSensitive,
+    subject_visible: subjectVisible,
+  });
+  return { data: res.data, status: res.status };
+}
+
+/** Append an amendment to an existing immutable note. */
+export async function amendSubjectNote(personId, noteId, { body }) {
+  const res = await api.post(
+    `/api/v1/subjects/${personId}/notes/${noteId}/amend/`,
+    { body },
+  );
+  return { data: res.data, status: res.status };
+}

--- a/frontend/src/dashboards/subject/SubjectDetail.jsx
+++ b/frontend/src/dashboards/subject/SubjectDetail.jsx
@@ -14,7 +14,8 @@
 
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { AlertTriangle, FileText, Users } from 'lucide-react';
+import { AlertTriangle, FileText, MessageSquarePlus, Users } from 'lucide-react';
+import { VISIBILITY_OPTIONS, createSubjectNote } from '../../api/subjects';
 import PrivacyChip from '../../components/reflection/PrivacyChip';
 import { ratingColor } from '../colors';
 import {
@@ -473,6 +474,243 @@ function FormResponsesCard({ block, language = 'en' }) {
 }
 
 // ---------------------------------------------------------------------------
+// Notes panel
+// ---------------------------------------------------------------------------
+
+const VISIBILITY_BADGE = {
+  team: { label: 'Team', cls: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200' },
+  supervisors_only: { label: 'Supervisors', cls: 'bg-sky-100 text-sky-800 dark:bg-sky-900/30 dark:text-sky-200' },
+  domain_only: { label: 'Domain specialists', cls: 'bg-violet-100 text-violet-800 dark:bg-violet-900/30 dark:text-violet-200' },
+  admin_only: { label: 'Admin only', cls: 'bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-200' },
+};
+
+function NoteCard({ note }) {
+  const badge = VISIBILITY_BADGE[note.visibility] ?? { label: note.visibility, cls: 'bg-gray-100 text-gray-700' };
+  const dateStr = note.created_at ? new Date(note.created_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' }) : '';
+  return (
+    <li
+      className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-3"
+      data-testid={`subject-note-${note.id}`}
+    >
+      <div className="flex flex-wrap items-center gap-2 mb-2">
+        <span className="text-xs text-gray-500 dark:text-gray-400">
+          {note.author?.name ?? 'Unknown'} · {dateStr}
+        </span>
+        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${badge.cls}`}>
+          {badge.label}
+        </span>
+        {note.context && (
+          <span className="text-xs font-mono px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-700">
+            {note.context}
+          </span>
+        )}
+        {note.subject_visible && (
+          <span className="text-xs px-2 py-0.5 rounded bg-yellow-50 text-yellow-700 border border-yellow-200 dark:bg-yellow-900/20 dark:text-yellow-200 dark:border-yellow-800">
+            visible to subject
+          </span>
+        )}
+        {note.amendment_of && (
+          <span className="text-xs italic text-gray-400">amendment</span>
+        )}
+      </div>
+      <p className="text-sm text-gray-800 dark:text-gray-200 whitespace-pre-wrap">{note.body}</p>
+    </li>
+  );
+}
+
+function NoteForm({ personId, onSuccess, onCancel }) {
+  const [body, setBody] = useState('');
+  const [context, setContext] = useState('');
+  const [visibility, setVisibility] = useState('supervisors_only');
+  const [subjectVisible, setSubjectVisible] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!body.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await createSubjectNote(personId, { body: body.trim(), context: context.trim(), visibility, subjectVisible });
+      setBody('');
+      setContext('');
+      setVisibility('supervisors_only');
+      setSubjectVisible(false);
+      onSuccess();
+    } catch (err) {
+      setError(err.response?.data?.detail ?? err.message ?? 'Failed to save note.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mt-4 rounded-lg border border-indigo-200 dark:border-indigo-800 bg-indigo-50 dark:bg-indigo-900/20 p-4 space-y-3"
+      data-testid="subject-note-form"
+    >
+      <div>
+        <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1" htmlFor="note-body">
+          Note <span className="text-rose-500">*</span>
+        </label>
+        <textarea
+          id="note-body"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={4}
+          required
+          placeholder="Write your observation…"
+          className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400 resize-y"
+          data-testid="subject-note-body"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1" htmlFor="note-context">
+            Context tag <span className="text-gray-400">(optional)</span>
+          </label>
+          <input
+            id="note-context"
+            type="text"
+            value={context}
+            onChange={(e) => setContext(e.target.value)}
+            placeholder="e.g. swim_instruction"
+            maxLength={64}
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            data-testid="subject-note-context"
+          />
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1" htmlFor="note-visibility">
+            Visibility
+          </label>
+          <select
+            id="note-visibility"
+            value={visibility}
+            onChange={(e) => setVisibility(e.target.value)}
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            data-testid="subject-note-visibility"
+          >
+            {VISIBILITY_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <label className="flex items-center gap-2 text-xs text-gray-700 dark:text-gray-300 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={subjectVisible}
+          onChange={(e) => setSubjectVisible(e.target.checked)}
+          className="rounded border-gray-300 dark:border-gray-600 text-indigo-600"
+          data-testid="subject-note-subject-visible"
+        />
+        Make visible to the subject on their dashboard
+      </label>
+
+      {error && (
+        <p className="text-sm text-rose-600 dark:text-rose-400">{error}</p>
+      )}
+
+      <div className="flex items-center gap-2 pt-1">
+        <button
+          type="submit"
+          disabled={submitting || !body.trim()}
+          className="px-4 py-1.5 text-sm font-medium rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          data-testid="subject-note-submit"
+        >
+          {submitting ? 'Saving…' : 'Save note'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700"
+          data-testid="subject-note-cancel"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function NotesPanel({ notes = [], personId, onNoteCreated }) {
+  const [open, setOpen] = useState(true);
+  const [formOpen, setFormOpen] = useState(false);
+
+  const handleSuccess = () => {
+    setFormOpen(false);
+    if (onNoteCreated) onNoteCreated();
+  };
+
+  return (
+    <section
+      className="mb-6 bg-white dark:bg-gray-800 shadow-sm rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden"
+      data-testid="subject-notes-panel"
+    >
+      <header className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex items-center gap-2">
+          <MessageSquarePlus className="w-5 h-5 text-indigo-500" />
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Notes</h2>
+          {notes.length > 0 && (
+            <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+              {notes.length}
+            </span>
+          )}
+        </div>
+        <div className="flex gap-2 items-center">
+          {personId && !formOpen && (
+            <button
+              type="button"
+              onClick={() => { setOpen(true); setFormOpen(true); }}
+              className="text-xs font-medium px-3 py-1.5 rounded-md bg-indigo-50 dark:bg-indigo-900/30 border border-indigo-200 dark:border-indigo-800 text-indigo-700 dark:text-indigo-200 hover:bg-indigo-100 dark:hover:bg-indigo-900/50"
+              data-testid="subject-note-add-btn"
+            >
+              + Add note
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            className="text-xs font-medium px-3 py-1.5 rounded-md border border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+          >
+            {open ? 'Collapse' : 'Expand'}
+          </button>
+        </div>
+      </header>
+
+      {open && (
+        <div className="p-4">
+          {formOpen && (
+            <NoteForm
+              personId={personId}
+              onSuccess={handleSuccess}
+              onCancel={() => setFormOpen(false)}
+            />
+          )}
+          {notes.length === 0 && !formOpen ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400 italic" data-testid="subject-notes-empty">
+              No notes yet.
+            </p>
+          ) : (
+            <ul className="mt-4 space-y-3">
+              {notes.map((n) => (
+                <NoteCard key={n.id} note={n} />
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Recent text responses
 // ---------------------------------------------------------------------------
 
@@ -512,7 +750,7 @@ function RecentTexts({ texts }) {
 // Root
 // ---------------------------------------------------------------------------
 
-export default function SubjectDetail({ payload, onRangeChange }) {
+export default function SubjectDetail({ payload, onRangeChange, personId, onNoteCreated }) {
   if (!payload) return null;
   const {
     subject,
@@ -521,6 +759,7 @@ export default function SubjectDetail({ payload, onRangeChange }) {
     templates,
     recent_texts: recentTexts,
     concerning_patterns: concerns,
+    notes,
   } = payload;
   const language = profile?.preferred_language ?? 'en';
   return (
@@ -544,6 +783,7 @@ export default function SubjectDetail({ payload, onRangeChange }) {
       )}
 
       <RecentTexts texts={recentTexts} />
+      <NotesPanel notes={notes ?? []} personId={personId} onNoteCreated={onNoteCreated} />
     </div>
   );
 }

--- a/frontend/src/dashboards/subject/__tests__/SubjectDetail.test.jsx
+++ b/frontend/src/dashboards/subject/__tests__/SubjectDetail.test.jsx
@@ -1,7 +1,24 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import SubjectDetail from '../SubjectDetail';
+
+const createSubjectNoteMock = vi.fn();
+
+vi.mock('../../../api/subjects', () => ({
+  VISIBILITY_OPTIONS: [
+    { value: 'supervisors_only', label: 'Supervisors only (default)' },
+    { value: 'team', label: 'Team — all with dashboard access' },
+    { value: 'domain_only', label: 'Domain specialists and above' },
+    { value: 'admin_only', label: 'Admin only' },
+  ],
+  createSubjectNote: (...args) => createSubjectNoteMock(...args),
+}));
+
+beforeEach(() => {
+  createSubjectNoteMock.mockReset();
+});
 
 const payload = {
   subject: {
@@ -127,11 +144,11 @@ const payload = {
   concerning_patterns: [],
 };
 
-function renderDetail(extra = {}) {
+function renderDetail(extra = {}, props = {}) {
   const full = { ...payload, ...extra };
   return render(
     <MemoryRouter>
-      <SubjectDetail payload={full} />
+      <SubjectDetail payload={full} personId={221} {...props} />
     </MemoryRouter>,
   );
 }
@@ -183,5 +200,89 @@ describe('SubjectDetail', () => {
   it('renders the empty state when there are no templates', () => {
     renderDetail({ templates: [] });
     expect(screen.getByTestId('subject-empty')).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Notes panel
+  // -------------------------------------------------------------------------
+
+  it('renders notes panel with existing notes', () => {
+    const notes = [
+      {
+        id: 1,
+        body: 'Swam independently today.',
+        context: 'swim_instruction',
+        visibility: 'supervisors_only',
+        is_sensitive: false,
+        subject_visible: false,
+        amendment_of: null,
+        author: { id: 10, name: 'Jane Instructor' },
+        created_at: '2026-05-25T10:00:00Z',
+      },
+      {
+        id: 2,
+        body: 'Had a tough morning.',
+        context: '',
+        visibility: 'admin_only',
+        is_sensitive: true,
+        subject_visible: false,
+        amendment_of: null,
+        author: { id: 11, name: 'Alyson Admin' },
+        created_at: '2026-05-24T08:00:00Z',
+      },
+    ];
+    renderDetail({ notes });
+
+    const panel = screen.getByTestId('subject-notes-panel');
+    expect(within(panel).getByText('Notes')).toBeInTheDocument();
+    expect(within(panel).getByText('2')).toBeInTheDocument(); // count badge
+
+    const note1 = screen.getByTestId('subject-note-1');
+    expect(within(note1).getByText('Swam independently today.')).toBeInTheDocument();
+    expect(within(note1).getByText('Jane Instructor', { exact: false })).toBeInTheDocument();
+    expect(within(note1).getByText('swim_instruction')).toBeInTheDocument();
+    expect(within(note1).getByText('Supervisors')).toBeInTheDocument();
+
+    const note2 = screen.getByTestId('subject-note-2');
+    expect(within(note2).getByText('Had a tough morning.')).toBeInTheDocument();
+    expect(within(note2).getByText('Admin only')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no notes', () => {
+    renderDetail({ notes: [] });
+    expect(screen.getByTestId('subject-notes-empty')).toBeInTheDocument();
+  });
+
+  it('NoteForm submits and calls onNoteCreated on success', async () => {
+    createSubjectNoteMock.mockResolvedValue({ data: { id: 99 }, status: 201 });
+    const onNoteCreated = vi.fn();
+    renderDetail({ notes: [] }, { onNoteCreated });
+
+    await userEvent.click(screen.getByTestId('subject-note-add-btn'));
+    const form = screen.getByTestId('subject-note-form');
+    expect(form).toBeInTheDocument();
+
+    await userEvent.type(screen.getByTestId('subject-note-body'), 'Great swim session');
+    await userEvent.type(screen.getByTestId('subject-note-context'), 'swim');
+    await userEvent.click(screen.getByTestId('subject-note-submit'));
+
+    await waitFor(() => expect(createSubjectNoteMock).toHaveBeenCalledWith(
+      221,
+      expect.objectContaining({ body: 'Great swim session', context: 'swim' }),
+    ));
+    await waitFor(() => expect(onNoteCreated).toHaveBeenCalled());
+  });
+
+  it('shows error message when note creation fails', async () => {
+    createSubjectNoteMock.mockRejectedValue({
+      response: { data: { detail: 'Permission denied.' } },
+    });
+    renderDetail({ notes: [] });
+
+    await userEvent.click(screen.getByTestId('subject-note-add-btn'));
+    await userEvent.type(screen.getByTestId('subject-note-body'), 'Attempted note');
+    await userEvent.click(screen.getByTestId('subject-note-submit'));
+
+    await waitFor(() => expect(screen.getByText('Permission denied.')).toBeInTheDocument());
   });
 });

--- a/frontend/src/pages/dashboards/SubjectDetailPage.jsx
+++ b/frontend/src/pages/dashboards/SubjectDetailPage.jsx
@@ -79,7 +79,12 @@ export default function SubjectDetailPage() {
             <p className="text-rose-600 dark:text-rose-400 text-sm">{error}</p>
           )}
           {!loading && payload && (
-            <SubjectDetail payload={payload} onRangeChange={updateRange} />
+            <SubjectDetail
+              payload={payload}
+              onRangeChange={updateRange}
+              personId={personId}
+              onNoteCreated={load}
+            />
           )}
         </main>
       </div>


### PR DESCRIPTION
## Summary

- **`frontend/src/api/subjects.js`** — new module with `createSubjectNote`, `amendSubjectNote` wrappers and `VISIBILITY_OPTIONS` constant (mirrors the backend 4-level enum).
- **`SubjectDetail.jsx`** — three new components:
  - `NoteCard` — renders a single note with visibility badge (colour-coded per level), context tag, "visible to subject" indicator, and amendment label.
  - `NoteForm` — inline form with body textarea, optional context tag, visibility selector (all 4 levels), and subject-visible checkbox. Shows an inline error on API failure; clears and calls `onNoteCreated` on success.
  - `NotesPanel` — collapsible section at the bottom of the dashboard, consistent with `FormResponsesCard` chrome. Count badge in header. "+ Add note" button opens the form inline without navigating away.
- **`SubjectDetailPage.jsx`** — passes `personId` and `onNoteCreated={load}` to `SubjectDetail` so a successful note creation triggers a full dashboard reload (picks up the new note from the server).

## Test plan

- [ ] `make test-frontend` passes (582 tests)
- [ ] Notes panel renders with count badge when notes are present
- [ ] Visibility badge colour-codes correctly (emerald/sky/violet/rose)
- [ ] Context tag and "visible to subject" pill appear when set
- [ ] "+ Add note" opens the inline form; Cancel hides it
- [ ] Form submit calls `createSubjectNote` with correct args and triggers `onNoteCreated`
- [ ] API error is displayed inline without losing form content
- [ ] Subject without notes shows "No notes yet." empty state


Made with [Cursor](https://cursor.com)