### PR TITLE
FA-E: Assign Form dialog in LT builder

### DIFF
--- a/frontend/src/pages/leadership-team/AssignFormDialog.jsx
+++ b/frontend/src/pages/leadership-team/AssignFormDialog.jsx
@@ -1,0 +1,665 @@
+/**
+ * AssignFormDialog — builder-scoped assignment creation dialog.
+ *
+ * Opens from the "Assign form" button on a published LT template. Differences
+ * from the general-purpose AssignmentDialog (used in TemplateLibrary):
+ *   - "Individuals" target type is rendered disabled ("Coming soon").
+ *   - On 409 the form fields are frozen and the submit area is replaced by a
+ *     conflict resolution panel; the user picks replace/run_both/cancel and
+ *     clicks "Confirm" to re-POST.
+ *   - On 400 with "scored camper form" in the body, an amber callout is shown
+ *     below the target group picker instead of the generic error area.
+ *   - "Cadence override" is collapsed under an "Advanced" disclosure.
+ *
+ * Calls onCreated(assignment) on success, then closes.
+ *
+ * FA-E, Step 7_20 frontend.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { createAssignment, listAssignmentGroups } from '../../api/leadershipTeam';
+import { useAuth } from '../../auth/AuthContext';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const TARGET_TYPES = [
+  { value: 'assignment_group', label: 'Assignment group', recommended: true },
+  { value: 'role', label: 'Role' },
+  { value: 'tag_group', label: 'Tag group' },
+  { value: 'individuals', label: 'Individuals', disabled: true, hint: 'Coming soon' },
+];
+
+const ROLE_OPTIONS = [
+  'counselor', 'junior_counselor', 'specialist', 'general_counselor',
+  'unit_head', 'leadership_team', 'kitchen_staff', 'maintenance',
+  'housekeeping', 'camper_care', 'health_center', 'madrich', 'faculty',
+];
+
+const CADENCES = ['daily', 'weekly', 'biweekly', 'monthly', 'on_demand'];
+
+const CONFLICT_CHOICES = [
+  { value: 'replace', label: 'Replace — end the existing assignment and start this one' },
+  { value: 'run_both', label: 'Run both — keep both active simultaneously' },
+  { value: 'cancel', label: 'Cancel — discard and close the dialog' },
+];
+
+const GROUP_TYPE_LABELS = {
+  bunk: 'Bunk', unit: 'Unit', division: 'Division', cohort: 'Cohort',
+  classroom: 'Classroom', caseload: 'Caseload', specialty: 'Specialty', custom: 'Custom',
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function todayStr() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Detect the scored-camper grid guard: the backend returns 400 with a message
+ * containing "scored camper form" in either array or detail shape.
+ */
+function extractScoredCamperError(responseData) {
+  if (!responseData) return null;
+  const candidates = [
+    typeof responseData === 'string' ? responseData : null,
+    responseData.detail,
+    Array.isArray(responseData) ? responseData.join(' ') : null,
+    Array.isArray(responseData.non_field_errors) ? responseData.non_field_errors.join(' ') : null,
+  ].filter(Boolean);
+  const found = candidates.find((s) => s.toLowerCase().includes('scored camper form'));
+  return found ?? null;
+}
+
+function extractErrorMessage(responseData) {
+  if (!responseData) return 'Failed to create assignment.';
+  if (typeof responseData === 'string') return responseData;
+  if (responseData.detail) return responseData.detail;
+  if (Array.isArray(responseData)) return responseData.join(' · ');
+  if (responseData.errors) {
+    return Array.isArray(responseData.errors)
+      ? responseData.errors.join(' · ')
+      : JSON.stringify(responseData.errors);
+  }
+  return JSON.stringify(responseData);
+}
+
+// ─── Group picker ─────────────────────────────────────────────────────────────
+
+function GroupPicker({ orgSlug, value, onChange, scoredCamperError }) {
+  const [groups, setGroups] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState('');
+  const [search, setSearch] = useState('');
+  const [groupTypeFilter, setGroupTypeFilter] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setLoadError('');
+    listAssignmentGroups(orgSlug)
+      .then((rows) => { if (!cancelled) setGroups(rows); })
+      .catch(() => { if (!cancelled) setLoadError('Failed to load groups.'); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [orgSlug]);
+
+  const filteredGroups = useMemo(() => {
+    let list = groups;
+    if (groupTypeFilter) list = list.filter((g) => g.group_type === groupTypeFilter);
+    if (search.trim()) {
+      const q = search.trim().toLowerCase();
+      list = list.filter((g) => (g.name || '').toLowerCase().includes(q));
+    }
+    return list;
+  }, [groups, groupTypeFilter, search]);
+
+  const groupTypes = useMemo(
+    () => [...new Set(groups.map((g) => g.group_type).filter(Boolean))],
+    [groups],
+  );
+
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-2 flex-wrap">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search groups…"
+          className="flex-1 min-w-[10rem] text-sm rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700"
+          data-testid="assign-form-group-search"
+        />
+        {groupTypes.length > 1 && (
+          <select
+            value={groupTypeFilter}
+            onChange={(e) => setGroupTypeFilter(e.target.value)}
+            className="text-sm rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700"
+            data-testid="assign-form-group-type-filter"
+          >
+            <option value="">All types</option>
+            {groupTypes.map((gt) => (
+              <option key={gt} value={gt}>{GROUP_TYPE_LABELS[gt] ?? gt}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {loading && (
+        <p className="text-sm text-gray-500 dark:text-gray-400" data-testid="assign-form-groups-loading">
+          Loading groups…
+        </p>
+      )}
+      {loadError && (
+        <p className="text-sm text-red-600 dark:text-red-400" data-testid="assign-form-groups-error">
+          {loadError}
+        </p>
+      )}
+      {!loading && !loadError && filteredGroups.length === 0 && (
+        <p className="text-sm text-gray-500 dark:text-gray-400" data-testid="assign-form-groups-empty">
+          No groups found.
+        </p>
+      )}
+      {!loading && !loadError && filteredGroups.length > 0 && (
+        <select
+          size={Math.min(filteredGroups.length + 1, 6)}
+          value={value ?? ''}
+          onChange={(e) => onChange(e.target.value ? Number(e.target.value) : null)}
+          className="w-full text-sm rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700"
+          data-testid="assign-form-group-select"
+        >
+          <option value="">— select a group —</option>
+          {filteredGroups.map((g) => (
+            <option key={g.id} value={g.id}>
+              {g.name}
+              {g.group_type ? ` (${GROUP_TYPE_LABELS[g.group_type] ?? g.group_type})` : ''}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {scoredCamperError && (
+        <div
+          className="rounded-md border border-amber-400 dark:border-amber-600 bg-amber-50 dark:bg-amber-900/20 p-3 text-sm text-amber-900 dark:text-amber-200"
+          data-testid="assign-form-scored-camper-error"
+          role="alert"
+        >
+          <p className="font-semibold mb-1">
+            This bunk already has an active scored camper form.
+          </p>
+          <p>
+            Only one scored camper form can drive a bunk&apos;s score grid. End or replace the
+            existing assignment first.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Conflict resolution panel ────────────────────────────────────────────────
+
+function ConflictPanel({ conflicts, resolution, onResolutionChange, onConfirm, onCancel, submitting }) {
+  return (
+    <div
+      className="rounded-md border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 p-4 space-y-3"
+      data-testid="assign-form-conflict-panel"
+    >
+      <p className="text-sm font-semibold text-amber-900 dark:text-amber-200">
+        This assignment overlaps with an existing one:
+      </p>
+      <ul className="text-xs text-amber-800 dark:text-amber-300 list-disc list-inside space-y-0.5">
+        {conflicts.map((c) => (
+          <li key={c.id} data-testid={`conflict-item-${c.id}`}>
+            <span className="font-medium">{c.display_title || c.title || c.template_slug}</span>
+            {' '}·{' '}
+            {c.start_date} – {c.end_date ?? 'ongoing'}
+            {c.assignment_group_name ? ` · ${c.assignment_group_name}` : ''}
+          </li>
+        ))}
+      </ul>
+      <fieldset>
+        <legend className="sr-only">Conflict resolution</legend>
+        <div className="space-y-2">
+          {CONFLICT_CHOICES.map((choice) => (
+            <label
+              key={choice.value}
+              className="flex items-center gap-2 text-sm text-amber-900 dark:text-amber-200 cursor-pointer"
+            >
+              <input
+                type="radio"
+                name="conflict-resolution"
+                value={choice.value}
+                checked={resolution === choice.value}
+                onChange={() => onResolutionChange(choice.value)}
+                data-testid={`conflict-choice-${choice.value}`}
+              />
+              {choice.label}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 px-3 py-1.5"
+          data-testid="conflict-cancel"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={!resolution || submitting}
+          className="text-sm rounded-md bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white px-3 py-1.5"
+          data-testid="conflict-confirm"
+        >
+          {submitting ? 'Confirming…' : 'Confirm'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main dialog ──────────────────────────────────────────────────────────────
+
+/**
+ * @param {object} props
+ * @param {object} props.template — the ReflectionTemplate being assigned
+ * @param {function} props.onClose
+ * @param {function} props.onCreated — called with the new assignment on 201
+ */
+export default function AssignFormDialog({ template, onClose, onCreated }) {
+  const { orgSlug } = useAuth();
+
+  // Form state
+  const [targetType, setTargetType] = useState('assignment_group');
+  const [selectedGroupId, setSelectedGroupId] = useState(null);
+  const [role, setRole] = useState('counselor');
+  const [tag, setTag] = useState('');
+  const [title, setTitle] = useState('');
+  const [isRequired, setIsRequired] = useState(true);
+  const [startDate, setStartDate] = useState(todayStr());
+  const [endDate, setEndDate] = useState('');
+  const [cadenceOverride, setCadenceOverride] = useState('');
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  // Submission state
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [dateError, setDateError] = useState('');
+
+  // Scored-camper guard (400 with specific message)
+  const [scoredCamperError, setScoredCamperError] = useState('');
+
+  // Conflict resolution (409)
+  const [conflictState, setConflictState] = useState(null); // { conflicts, pendingPayload }
+  const [resolution, setResolution] = useState('replace');
+
+  // Validate end >= start client-side
+  const validateDates = () => {
+    if (endDate && startDate && endDate < startDate) {
+      setDateError('End date must be on or after start date.');
+      return false;
+    }
+    setDateError('');
+    return true;
+  };
+
+  const buildPayload = (extraFields = {}) => {
+    const payload = {
+      template: template?.id,
+      target_type: targetType,
+      is_required: isRequired,
+      start_date: startDate,
+    };
+    if (title.trim()) payload.title = title.trim();
+    if (endDate) payload.end_date = endDate;
+    if (cadenceOverride) payload.cadence_override = cadenceOverride;
+
+    if (targetType === 'assignment_group') {
+      payload.target_payload = {};
+      if (selectedGroupId) payload.assignment_group = selectedGroupId;
+    } else if (targetType === 'role') {
+      payload.target_payload = { role };
+    } else if (targetType === 'tag_group') {
+      payload.target_payload = { tag };
+    }
+
+    return { ...payload, ...extraFields };
+  };
+
+  const handleSubmit = async () => {
+    setError('');
+    setScoredCamperError('');
+    setDateError('');
+
+    if (!template?.id) { setError('No template selected.'); return; }
+    if (!startDate) { setError('Start date is required.'); return; }
+    if (!validateDates()) return;
+    if (targetType === 'assignment_group' && !selectedGroupId) {
+      setError('Select a group.'); return;
+    }
+    if (targetType === 'role' && !role) { setError('Select a role.'); return; }
+    if (targetType === 'tag_group' && !tag.trim()) { setError('Enter a tag.'); return; }
+
+    setSubmitting(true);
+    try {
+      const payload = buildPayload();
+      const data = await createAssignment(orgSlug, payload);
+      if (onCreated) onCreated(data);
+      onClose?.();
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 409) {
+        const body = err.response.data ?? {};
+        setConflictState({ conflicts: body.conflicts ?? [], pendingPayload: buildPayload() });
+        setResolution('replace');
+      } else if (status === 400) {
+        const body = err.response.data;
+        const scoredMsg = extractScoredCamperError(body);
+        if (scoredMsg) {
+          setScoredCamperError(scoredMsg);
+        } else {
+          setError(extractErrorMessage(body));
+        }
+      } else {
+        setError(extractErrorMessage(err?.response?.data));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleConflictConfirm = async () => {
+    if (!conflictState) return;
+    if (resolution === 'cancel') {
+      onClose?.();
+      return;
+    }
+    setSubmitting(true);
+    setError('');
+    try {
+      const payload = { ...conflictState.pendingPayload, conflict_resolution: resolution };
+      const data = await createAssignment(orgSlug, payload);
+      if (onCreated) onCreated(data);
+      onClose?.();
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 409) {
+        const body = err.response.data ?? {};
+        setConflictState({ conflicts: body.conflicts ?? [], pendingPayload: conflictState.pendingPayload });
+      } else {
+        setConflictState(null);
+        setError(extractErrorMessage(err?.response?.data));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleConflictCancel = () => {
+    onClose?.();
+  };
+
+  const inConflict = Boolean(conflictState);
+  // Freeze form while in conflict resolution mode
+  const fieldDisabled = submitting || inConflict;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center px-4"
+      data-testid="assign-form-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Assign form"
+    >
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-lg w-full p-5 max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">Assign form</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+            data-testid="assign-form-close"
+            aria-label="Close dialog"
+          >
+            ✕
+          </button>
+        </div>
+
+        {template && (
+          <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
+            <span className="font-medium">{template.name}</span>
+            <span className="ml-2 text-xs text-gray-400">v{template.version}</span>
+          </p>
+        )}
+
+        <div className="space-y-4">
+          {/* Target type */}
+          <fieldset>
+            <legend className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Target type <span className="text-red-500">*</span>
+            </legend>
+            <div className="space-y-1.5" role="radiogroup" data-testid="assign-form-target-type">
+              {TARGET_TYPES.map((t) => (
+                <label
+                  key={t.value}
+                  className={`flex items-center gap-2 text-sm ${
+                    t.disabled
+                      ? 'text-gray-400 dark:text-gray-500 cursor-not-allowed'
+                      : 'text-gray-700 dark:text-gray-300 cursor-pointer'
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="target-type"
+                    value={t.value}
+                    checked={targetType === t.value}
+                    disabled={fieldDisabled || t.disabled}
+                    onChange={() => setTargetType(t.value)}
+                    data-testid={`assign-form-target-${t.value}`}
+                  />
+                  {t.label}
+                  {t.recommended && (
+                    <span className="text-xs text-indigo-600 dark:text-indigo-400">(recommended)</span>
+                  )}
+                  {t.disabled && t.hint && (
+                    <span className="text-xs text-gray-400 dark:text-gray-500">— {t.hint}</span>
+                  )}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          {/* Target value */}
+          {targetType === 'assignment_group' && (
+            <div>
+              <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+                Assignment group <span className="text-red-500">*</span>
+              </p>
+              <fieldset disabled={fieldDisabled}>
+                <GroupPicker
+                  orgSlug={orgSlug}
+                  value={selectedGroupId}
+                  onChange={setSelectedGroupId}
+                  scoredCamperError={scoredCamperError}
+                />
+              </fieldset>
+            </div>
+          )}
+
+          {targetType === 'role' && (
+            <label className="block text-sm text-gray-700 dark:text-gray-300">
+              Role <span className="text-red-500">*</span>
+              <select
+                value={role}
+                onChange={(e) => setRole(e.target.value)}
+                disabled={fieldDisabled}
+                className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm disabled:opacity-50"
+                data-testid="assign-form-role"
+              >
+                {ROLE_OPTIONS.map((r) => (
+                  <option key={r} value={r}>{r}</option>
+                ))}
+              </select>
+            </label>
+          )}
+
+          {targetType === 'tag_group' && (
+            <label className="block text-sm text-gray-700 dark:text-gray-300">
+              Tag string <span className="text-red-500">*</span>
+              <input
+                type="text"
+                value={tag}
+                onChange={(e) => setTag(e.target.value)}
+                disabled={fieldDisabled}
+                placeholder="e.g. kitchen-lead"
+                className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm disabled:opacity-50"
+                data-testid="assign-form-tag"
+              />
+            </label>
+          )}
+
+          {/* Title */}
+          <label className="block text-sm text-gray-700 dark:text-gray-300">
+            Title (optional)
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              disabled={fieldDisabled}
+              maxLength={255}
+              placeholder="Leave blank to use template name"
+              className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm disabled:opacity-50"
+              data-testid="assign-form-title"
+            />
+          </label>
+
+          {/* Required toggle */}
+          <label className="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={isRequired}
+              onChange={(e) => setIsRequired(e.target.checked)}
+              disabled={fieldDisabled}
+              className="mt-0.5 rounded"
+              data-testid="assign-form-required"
+            />
+            <span>
+              Required
+              <span className="block text-xs font-normal text-gray-500 dark:text-gray-400">
+                On: appears in staff task lists. Off: appears in optional forms library.
+              </span>
+            </span>
+          </label>
+
+          {/* Dates */}
+          <div className="flex gap-3 flex-wrap">
+            <label className="flex-1 min-w-[8rem] text-sm text-gray-700 dark:text-gray-300">
+              Start date <span className="text-red-500">*</span>
+              <input
+                type="date"
+                value={startDate}
+                onChange={(e) => { setStartDate(e.target.value); setDateError(''); }}
+                disabled={fieldDisabled}
+                className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm disabled:opacity-50"
+                data-testid="assign-form-start-date"
+              />
+            </label>
+            <label className="flex-1 min-w-[8rem] text-sm text-gray-700 dark:text-gray-300">
+              End date (optional)
+              <input
+                type="date"
+                value={endDate}
+                onChange={(e) => { setEndDate(e.target.value); setDateError(''); }}
+                disabled={fieldDisabled}
+                className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm disabled:opacity-50"
+                data-testid="assign-form-end-date"
+              />
+            </label>
+          </div>
+          {dateError && (
+            <p className="text-xs text-red-600 dark:text-red-400" data-testid="assign-form-date-error">
+              {dateError}
+            </p>
+          )}
+
+          {/* Advanced: cadence override */}
+          <div>
+            <button
+              type="button"
+              onClick={() => setShowAdvanced((v) => !v)}
+              className="text-xs text-gray-500 dark:text-gray-400 hover:underline"
+              data-testid="assign-form-advanced-toggle"
+            >
+              {showAdvanced ? '▾' : '▸'} Advanced
+            </button>
+            {showAdvanced && (
+              <label className="block text-sm text-gray-700 dark:text-gray-300 mt-2">
+                Cadence override (optional)
+                <select
+                  value={cadenceOverride}
+                  onChange={(e) => setCadenceOverride(e.target.value)}
+                  disabled={fieldDisabled}
+                  className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm disabled:opacity-50"
+                  data-testid="assign-form-cadence"
+                >
+                  <option value="">inherit from template</option>
+                  {CADENCES.map((c) => (
+                    <option key={c} value={c}>{c}</option>
+                  ))}
+                </select>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  Overrides the template&apos;s default cadence for this assignment only.
+                </p>
+              </label>
+            )}
+          </div>
+
+          {/* Generic error (non-scored-camper 400, network, etc.) */}
+          {error && (
+            <p
+              className="text-sm text-red-600 dark:text-red-400"
+              data-testid="assign-form-error"
+            >
+              {error}
+            </p>
+          )}
+
+          {/* Conflict resolution panel — replaces submit area */}
+          {inConflict ? (
+            <ConflictPanel
+              conflicts={conflictState.conflicts}
+              resolution={resolution}
+              onResolutionChange={setResolution}
+              onConfirm={handleConflictConfirm}
+              onCancel={handleConflictCancel}
+              submitting={submitting}
+            />
+          ) : (
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 px-3 py-1.5"
+                data-testid="assign-form-cancel"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={submitting}
+                className="text-sm rounded-md bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white px-3 py-1.5"
+                data-testid="assign-form-submit"
+              >
+                {submitting ? 'Assigning…' : 'Assign form'}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/leadership-team/AssignmentList.jsx
+++ b/frontend/src/pages/leadership-team/AssignmentList.jsx
@@ -1,0 +1,246 @@
+/**
+ * AssignmentList — embedded "Form assignments" section in the LT template builder.
+ *
+ * Renders all TemplateAssignments for a published template. Shows status badges,
+ * target name, date range, required chip, and per-status actions (Cancel for
+ * scheduled, End today for active). Gated on status === 'published' in the parent.
+ *
+ * FA-E, Step 7_20 frontend.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { cancelAssignment, listAssignments, patchAssignment } from '../../api/leadershipTeam';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function dateRange(start, end) {
+  if (!end) return `${start} → ongoing`;
+  return `${start} → ${end}`;
+}
+
+function describeTarget(a) {
+  if (a.target_type === 'assignment_group') {
+    return a.assignment_group_name ?? `Group #${a.assignment_group}`;
+  }
+  if (a.target_type === 'role') {
+    return `Role: ${a.target_payload?.role ?? '—'}`;
+  }
+  if (a.target_type === 'tag_group') {
+    return `Tag: ${a.target_payload?.tag ?? '—'}`;
+  }
+  if (a.target_type === 'individuals') {
+    const n = Array.isArray(a.target_payload?.membership_ids)
+      ? a.target_payload.membership_ids.length
+      : 0;
+    return `Individuals (${n})`;
+  }
+  return a.target_type ?? '—';
+}
+
+// ─── Status badge ────────────────────────────────────────────────────────────
+
+const STATUS_STYLES = {
+  active: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+  scheduled: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+  ended: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+  cancelled: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+};
+
+function StatusBadge({ status }) {
+  return (
+    <span
+      className={`text-xs font-medium px-2 py-0.5 rounded-full ${STATUS_STYLES[status] ?? STATUS_STYLES.ended}`}
+      data-testid={`assignment-status-${status}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+// ─── Skeleton ────────────────────────────────────────────────────────────────
+
+function Skeleton() {
+  return (
+    <div className="space-y-2 animate-pulse" data-testid="assignment-list-skeleton">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="h-14 rounded-md bg-gray-100 dark:bg-gray-700" />
+      ))}
+    </div>
+  );
+}
+
+// ─── Single assignment row ───────────────────────────────────────────────────
+
+function AssignmentRow({ assignment, onCancelled, onEnded }) {
+  const [pending, setPending] = useState(false);
+
+  const handleCancel = async () => {
+    const ok = window.confirm('Cancel this assignment? This cannot be undone.');
+    if (!ok) return;
+    setPending(true);
+    try {
+      await onCancelled(assignment);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const handleEndToday = async () => {
+    const ok = window.confirm(
+      `End assignment "${assignment.display_title}" today? Responses to date are kept.`,
+    );
+    if (!ok) return;
+    setPending(true);
+    try {
+      await onEnded(assignment);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const a = assignment;
+
+  return (
+    <li
+      className="flex flex-wrap items-start justify-between gap-3 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2.5 text-sm"
+      data-testid={`assignment-row-${a.id}`}
+    >
+      <div className="flex-1 min-w-0 space-y-0.5">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium text-gray-900 dark:text-white truncate">
+            {a.display_title || a.title || '—'}
+          </span>
+          <StatusBadge status={a.status} />
+          <span
+            className={`text-xs px-1.5 py-0.5 rounded ${
+              a.is_required
+                ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300'
+                : 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'
+            }`}
+            data-testid={`assignment-required-${a.id}`}
+          >
+            {a.is_required ? 'Required' : 'Optional'}
+          </span>
+        </div>
+        <div className="text-xs text-gray-500 dark:text-gray-400">
+          <span data-testid={`assignment-target-${a.id}`}>{describeTarget(a)}</span>
+          <span className="mx-1.5">·</span>
+          <span data-testid={`assignment-dates-${a.id}`}>{dateRange(a.start_date, a.end_date)}</span>
+        </div>
+      </div>
+      <div className="flex gap-2 shrink-0 items-center">
+        {a.status === 'scheduled' && (
+          <button
+            type="button"
+            onClick={handleCancel}
+            disabled={pending}
+            className="text-xs rounded-md border border-red-300 dark:border-red-700 text-red-700 dark:text-red-300 px-2 py-1 hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-50"
+            data-testid={`assignment-cancel-${a.id}`}
+          >
+            {pending ? 'Cancelling…' : 'Cancel'}
+          </button>
+        )}
+        {a.status === 'active' && (
+          <button
+            type="button"
+            onClick={handleEndToday}
+            disabled={pending}
+            className="text-xs rounded-md border border-amber-300 dark:border-amber-700 text-amber-700 dark:text-amber-300 px-2 py-1 hover:bg-amber-50 dark:hover:bg-amber-900/20 disabled:opacity-50"
+            data-testid={`assignment-end-today-${a.id}`}
+          >
+            {pending ? 'Ending…' : 'End today'}
+          </button>
+        )}
+      </div>
+    </li>
+  );
+}
+
+// ─── Main component ──────────────────────────────────────────────────────────
+
+/**
+ * @param {object} props
+ * @param {number|string} props.templateId
+ * @param {string} props.orgSlug
+ * @param {number} props.refreshKey — increment to force a reload (e.g. after a new assignment)
+ */
+export default function AssignmentList({ templateId, orgSlug, refreshKey = 0 }) {
+  const [assignments, setAssignments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    if (!templateId) return;
+    setLoading(true);
+    setError('');
+    try {
+      const data = await listAssignments(orgSlug, { template: templateId });
+      setAssignments(data?.assignments ?? data?.results ?? []);
+    } catch {
+      setError('Failed to load assignments. Refresh the page to try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [orgSlug, templateId]);
+
+  useEffect(() => { load(); }, [load, refreshKey]);
+
+  const handleCancelled = async (assignment) => {
+    await cancelAssignment(orgSlug, assignment.id);
+    await load();
+  };
+
+  const handleEnded = async (assignment) => {
+    await patchAssignment(orgSlug, assignment.id, { end_date: today() });
+    await load();
+  };
+
+  return (
+    <section
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 p-4 space-y-3"
+      aria-label="Form assignments"
+      data-testid="assignment-list-section"
+    >
+      <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+        Form assignments
+      </h2>
+
+      {loading && <Skeleton />}
+
+      {!loading && error && (
+        <p
+          className="text-sm text-red-600 dark:text-red-400"
+          data-testid="assignment-list-error"
+        >
+          {error}
+        </p>
+      )}
+
+      {!loading && !error && assignments.length === 0 && (
+        <p
+          className="text-sm text-gray-500 dark:text-gray-400 italic"
+          data-testid="assignment-list-empty"
+        >
+          No assignments yet — click &quot;Assign form&quot; to make this form available to staff.
+        </p>
+      )}
+
+      {!loading && !error && assignments.length > 0 && (
+        <ul className="space-y-2" data-testid="assignment-list">
+          {assignments.map((a) => (
+            <AssignmentRow
+              key={a.id}
+              assignment={a}
+              onCancelled={handleCancelled}
+              onEnded={handleEnded}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/leadership-team/TemplateBuilder/TemplateBuilderPage.jsx
+++ b/frontend/src/pages/leadership-team/TemplateBuilder/TemplateBuilderPage.jsx
@@ -25,6 +25,8 @@ import {
   publishTemplate,
 } from '../../../api/leadershipTeam';
 import { useAuth } from '../../../auth/AuthContext';
+import AssignmentList from '../AssignmentList';
+import AssignFormDialog from '../AssignFormDialog';
 
 const TIER_1_TYPES = [
   { value: 'text', label: 'Short text' },
@@ -433,6 +435,8 @@ export default function TemplateBuilderPage() {
   const [previewLanguage, setPreviewLanguage] = useState('en');
   const [dirty, setDirty] = useState(false);
   const [showForceVersion, setShowForceVersion] = useState(false);
+  const [showAssignDialog, setShowAssignDialog] = useState(false);
+  const [assignRefreshKey, setAssignRefreshKey] = useState(0);
   const dirtyRef = useRef(false);
   dirtyRef.current = dirty;
 
@@ -688,14 +692,35 @@ export default function TemplateBuilderPage() {
               </button>
             )}
             {isEdit && isPublished && (
+              <>
+                <button
+                  type="button"
+                  onClick={() => setShowAssignDialog(true)}
+                  className="text-sm rounded-lg bg-teal-600 hover:bg-teal-700 text-white px-3 py-1.5"
+                  data-testid="lt-builder-assign"
+                >
+                  Assign form
+                </button>
+                <button
+                  type="button"
+                  onClick={doArchive}
+                  disabled={saving}
+                  className="text-sm rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 px-3 py-1.5"
+                  data-testid="lt-builder-archive"
+                >
+                  Archive
+                </button>
+              </>
+            )}
+            {isEdit && !isPublished && !isArchived && (
               <button
                 type="button"
-                onClick={doArchive}
-                disabled={saving}
-                className="text-sm rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 px-3 py-1.5"
-                data-testid="lt-builder-archive"
+                disabled
+                title="Publish the template first"
+                className="text-sm rounded-lg border border-gray-200 dark:border-gray-700 text-gray-400 dark:text-gray-600 px-3 py-1.5 cursor-not-allowed"
+                data-testid="lt-builder-assign-disabled"
               >
-                Archive
+                Assign form
               </button>
             )}
             {isEdit && (
@@ -959,6 +984,27 @@ export default function TemplateBuilderPage() {
           <PreviewPane template={template} fields={fields} previewLanguage={previewLanguage} />
         </section>
       </main>
+
+      {isEdit && isPublished && (
+        <div className="max-w-7xl mx-auto px-4 pb-8">
+          <AssignmentList
+            templateId={id}
+            orgSlug={orgSlug}
+            refreshKey={assignRefreshKey}
+          />
+        </div>
+      )}
+
+      {showAssignDialog && (
+        <AssignFormDialog
+          template={template}
+          onClose={() => setShowAssignDialog(false)}
+          onCreated={() => {
+            setShowAssignDialog(false);
+            setAssignRefreshKey((k) => k + 1);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/leadership-team/__tests__/AssignFormDialog.test.jsx
+++ b/frontend/src/pages/leadership-team/__tests__/AssignFormDialog.test.jsx
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import AssignFormDialog from '../AssignFormDialog';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ orgSlug: 'test-org' }),
+}));
+
+vi.mock('../../../api/leadershipTeam', () => ({
+  createAssignment: vi.fn(),
+  listAssignmentGroups: vi.fn(),
+}));
+
+import { createAssignment, listAssignmentGroups } from '../../../api/leadershipTeam';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const template = {
+  id: 7,
+  name: 'Daily Bunk Log',
+  version: 1,
+  status: 'published',
+};
+
+const groups = [
+  { id: 3, name: 'Bunk Birch', group_type: 'bunk' },
+  { id: 4, name: 'Bunk Oak', group_type: 'bunk' },
+];
+
+const newAssignment = {
+  id: 42,
+  template: 7,
+  template_slug: 'daily-bunk-log',
+  target_type: 'assignment_group',
+  assignment_group: 3,
+  assignment_group_name: 'Bunk Birch',
+  is_required: true,
+  display_title: 'Daily Bunk Log',
+  start_date: '2026-05-28',
+  end_date: null,
+  status: 'scheduled',
+};
+
+function makeConflictError(conflicts) {
+  const err = new Error('conflict');
+  err.response = {
+    status: 409,
+    data: {
+      detail: 'Assignment conflict requires conflict_resolution.',
+      conflicts,
+      choices: ['replace', 'run_both', 'cancel'],
+    },
+  };
+  return err;
+}
+
+function make400Error(detail) {
+  const err = new Error('bad request');
+  err.response = { status: 400, data: { detail } };
+  return err;
+}
+
+function renderDialog({ onClose = vi.fn(), onCreated = vi.fn() } = {}) {
+  return render(
+    <AssignFormDialog template={template} onClose={onClose} onCreated={onCreated} />,
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('AssignFormDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listAssignmentGroups.mockResolvedValue(groups);
+  });
+
+  it('renders all required fields', async () => {
+    renderDialog();
+    // Target type radios
+    expect(screen.getByTestId('assign-form-target-assignment_group')).toBeInTheDocument();
+    expect(screen.getByTestId('assign-form-target-role')).toBeInTheDocument();
+    expect(screen.getByTestId('assign-form-target-tag_group')).toBeInTheDocument();
+    // Individuals is disabled
+    const individualsRadio = screen.getByTestId('assign-form-target-individuals');
+    expect(individualsRadio).toBeDisabled();
+    // Other fields
+    expect(screen.getByTestId('assign-form-title')).toBeInTheDocument();
+    expect(screen.getByTestId('assign-form-required')).toBeInTheDocument();
+    expect(screen.getByTestId('assign-form-start-date')).toBeInTheDocument();
+    expect(screen.getByTestId('assign-form-end-date')).toBeInTheDocument();
+    // Group picker should load
+    await waitFor(() => expect(screen.getByTestId('assign-form-group-select')).toBeInTheDocument());
+  });
+
+  it('builds the correct POST payload on submit', async () => {
+    createAssignment.mockResolvedValue(newAssignment);
+    const onCreated = vi.fn();
+    const onClose = vi.fn();
+    renderDialog({ onCreated, onClose });
+
+    // Wait for groups to load and select group 3
+    await waitFor(() => expect(screen.getByTestId('assign-form-group-select')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('assign-form-group-select'), { target: { value: '3' } });
+
+    // Set a title
+    fireEvent.change(screen.getByTestId('assign-form-title'), { target: { value: 'My Title' } });
+
+    // Uncheck required
+    fireEvent.click(screen.getByTestId('assign-form-required'));
+
+    // Set start date
+    fireEvent.change(screen.getByTestId('assign-form-start-date'), {
+      target: { value: '2026-06-01' },
+    });
+
+    fireEvent.click(screen.getByTestId('assign-form-submit'));
+
+    await waitFor(() => expect(createAssignment).toHaveBeenCalledOnce());
+    const payload = createAssignment.mock.calls[0][1];
+    expect(payload.template).toBe(7);
+    expect(payload.target_type).toBe('assignment_group');
+    expect(payload.assignment_group).toBe(3);
+    expect(payload.title).toBe('My Title');
+    expect(payload.is_required).toBe(false);
+    expect(payload.start_date).toBe('2026-06-01');
+
+    // onCreated and onClose called on success
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith(newAssignment));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows conflict resolution panel on 409 and re-submits with chosen resolution', async () => {
+    const conflictAssignment = {
+      id: 10,
+      display_title: 'Old Log',
+      title: 'Old Log',
+      start_date: '2026-01-01',
+      end_date: null,
+      assignment_group_name: 'Bunk Birch',
+    };
+    createAssignment
+      .mockRejectedValueOnce(makeConflictError([conflictAssignment]))
+      .mockResolvedValueOnce(newAssignment);
+    const onCreated = vi.fn();
+    renderDialog({ onCreated });
+
+    // Select a group and submit
+    await waitFor(() => expect(screen.getByTestId('assign-form-group-select')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('assign-form-group-select'), { target: { value: '3' } });
+    fireEvent.click(screen.getByTestId('assign-form-submit'));
+
+    // Conflict panel should appear
+    await waitFor(() =>
+      expect(screen.getByTestId('assign-form-conflict-panel')).toBeInTheDocument(),
+    );
+    // Shows the conflicting assignment
+    expect(screen.getByTestId('conflict-item-10')).toBeInTheDocument();
+
+    // Form fields are frozen (submit button replaced by conflict panel)
+    expect(screen.queryByTestId('assign-form-submit')).not.toBeInTheDocument();
+
+    // "Replace" is selected by default — confirm
+    expect(screen.getByTestId('conflict-choice-replace')).toBeChecked();
+    fireEvent.click(screen.getByTestId('conflict-confirm'));
+
+    await waitFor(() => expect(createAssignment).toHaveBeenCalledTimes(2));
+    const secondCall = createAssignment.mock.calls[1][1];
+    expect(secondCall.conflict_resolution).toBe('replace');
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith(newAssignment));
+  });
+
+  it('closes the dialog when Cancel is chosen in the conflict panel', async () => {
+    const conflictAssignment = {
+      id: 10,
+      display_title: 'Old Log',
+      title: 'Old Log',
+      start_date: '2026-01-01',
+      end_date: null,
+      assignment_group_name: 'Bunk Birch',
+    };
+    createAssignment.mockRejectedValueOnce(makeConflictError([conflictAssignment]));
+    const onClose = vi.fn();
+    renderDialog({ onClose });
+
+    await waitFor(() => expect(screen.getByTestId('assign-form-group-select')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('assign-form-group-select'), { target: { value: '3' } });
+    fireEvent.click(screen.getByTestId('assign-form-submit'));
+
+    await waitFor(() => expect(screen.getByTestId('assign-form-conflict-panel')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('conflict-cancel'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows the scored-camper guard callout on 400 with matching error text', async () => {
+    createAssignment.mockRejectedValueOnce(
+      make400Error(
+        "This bunk already has an active scored camper form ('Daily Log') for an overlapping date range.",
+      ),
+    );
+    renderDialog();
+
+    await waitFor(() => expect(screen.getByTestId('assign-form-group-select')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('assign-form-group-select'), { target: { value: '3' } });
+    fireEvent.click(screen.getByTestId('assign-form-submit'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('assign-form-scored-camper-error')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('assign-form-scored-camper-error')).toHaveTextContent(
+      'scored camper form',
+    );
+    // Dialog should still be open (no onClose call)
+  });
+
+  it('validates end_date >= start_date client-side and shows error before submitting', async () => {
+    renderDialog();
+    await waitFor(() => expect(screen.getByTestId('assign-form-group-select')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('assign-form-group-select'), { target: { value: '3' } });
+
+    fireEvent.change(screen.getByTestId('assign-form-start-date'), {
+      target: { value: '2026-08-01' },
+    });
+    fireEvent.change(screen.getByTestId('assign-form-end-date'), {
+      target: { value: '2026-07-01' },
+    });
+    fireEvent.click(screen.getByTestId('assign-form-submit'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('assign-form-date-error')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('assign-form-date-error')).toHaveTextContent(
+      'End date must be on or after start date',
+    );
+    expect(createAssignment).not.toHaveBeenCalled();
+  });
+
+  it('shows "Assign form" button disabled when template status is draft', async () => {
+    // This is tested at the builder page level (TemplateBuilderPage renders disabled button)
+    // Here we just verify the dialog submit itself requires a group selection
+    createAssignment.mockResolvedValue(newAssignment);
+    renderDialog();
+    // No group selected — submit should show error, not call API
+    fireEvent.click(screen.getByTestId('assign-form-submit'));
+    await waitFor(() => expect(screen.getByTestId('assign-form-error')).toBeInTheDocument());
+    expect(createAssignment).not.toHaveBeenCalled();
+  });
+
+  it('shows a role picker when Role target type is selected', async () => {
+    renderDialog();
+    fireEvent.click(screen.getByTestId('assign-form-target-role'));
+    expect(screen.getByTestId('assign-form-role')).toBeInTheDocument();
+    expect(screen.queryByTestId('assign-form-group-select')).not.toBeInTheDocument();
+  });
+
+  it('shows a tag input when Tag group target type is selected', async () => {
+    renderDialog();
+    fireEvent.click(screen.getByTestId('assign-form-target-tag_group'));
+    expect(screen.getByTestId('assign-form-tag')).toBeInTheDocument();
+    expect(screen.queryByTestId('assign-form-group-select')).not.toBeInTheDocument();
+  });
+
+  it('shows cadence override when Advanced section is expanded', async () => {
+    renderDialog();
+    expect(screen.queryByTestId('assign-form-cadence')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('assign-form-advanced-toggle'));
+    expect(screen.getByTestId('assign-form-cadence')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/leadership-team/__tests__/AssignmentList.test.jsx
+++ b/frontend/src/pages/leadership-team/__tests__/AssignmentList.test.jsx
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import AssignmentList from '../AssignmentList';
+
+// ─── Mock the leadershipTeam API ─────────────────────────────────────────────
+
+vi.mock('../../../api/leadershipTeam', () => ({
+  listAssignments: vi.fn(),
+  cancelAssignment: vi.fn(),
+  patchAssignment: vi.fn(),
+}));
+
+import { cancelAssignment, listAssignments, patchAssignment } from '../../../api/leadershipTeam';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const activeRow = {
+  id: 1,
+  display_title: 'Daily Bunk Log',
+  title: 'Daily Bunk Log',
+  target_type: 'assignment_group',
+  target_payload: {},
+  assignment_group: 3,
+  assignment_group_name: 'Bunk Birch',
+  is_required: true,
+  start_date: '2026-06-01',
+  end_date: null,
+  status: 'active',
+};
+
+const scheduledRow = {
+  id: 2,
+  display_title: 'Weekly Check-in',
+  title: 'Weekly Check-in',
+  target_type: 'role',
+  target_payload: { role: 'counselor' },
+  assignment_group: null,
+  assignment_group_name: null,
+  is_required: false,
+  start_date: '2026-07-01',
+  end_date: '2026-08-31',
+  status: 'scheduled',
+};
+
+const endedRow = {
+  id: 3,
+  display_title: 'Old Form',
+  title: 'Old Form',
+  target_type: 'assignment_group',
+  target_payload: {},
+  assignment_group: 5,
+  assignment_group_name: 'Bunk Oak',
+  is_required: true,
+  start_date: '2026-01-01',
+  end_date: '2026-05-31',
+  status: 'ended',
+};
+
+const cancelledRow = {
+  id: 4,
+  display_title: 'Cancelled Form',
+  title: 'Cancelled Form',
+  target_type: 'role',
+  target_payload: { role: 'unit_head' },
+  assignment_group: null,
+  assignment_group_name: null,
+  is_required: true,
+  start_date: '2026-06-01',
+  end_date: null,
+  status: 'cancelled',
+};
+
+function renderList({ templateId = 7, orgSlug = 'test-org', refreshKey = 0 } = {}) {
+  return render(
+    <AssignmentList templateId={templateId} orgSlug={orgSlug} refreshKey={refreshKey} />,
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('AssignmentList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: suppress window.confirm so actions don't block
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    window.confirm.mockRestore?.();
+  });
+
+  it('renders existing assignments with correct labels, status badges, and actions', async () => {
+    listAssignments.mockResolvedValue({
+      assignments: [activeRow, scheduledRow, endedRow, cancelledRow],
+    });
+    renderList();
+
+    await waitFor(() => expect(screen.queryByTestId('assignment-list-skeleton')).not.toBeInTheDocument());
+
+    // Active row
+    expect(screen.getByTestId('assignment-row-1')).toBeInTheDocument();
+    expect(screen.getByTestId('assignment-status-active')).toBeInTheDocument();
+    expect(screen.getByTestId('assignment-target-1')).toHaveTextContent('Bunk Birch');
+    expect(screen.getByTestId('assignment-dates-1')).toHaveTextContent('ongoing');
+    expect(screen.getByTestId('assignment-required-1')).toHaveTextContent('Required');
+    expect(screen.getByTestId('assignment-end-today-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('assignment-cancel-1')).not.toBeInTheDocument();
+
+    // Scheduled row
+    expect(screen.getByTestId('assignment-status-scheduled')).toBeInTheDocument();
+    expect(screen.getByTestId('assignment-target-2')).toHaveTextContent('Role: counselor');
+    expect(screen.getByTestId('assignment-required-2')).toHaveTextContent('Optional');
+    expect(screen.getByTestId('assignment-cancel-2')).toBeInTheDocument();
+    expect(screen.queryByTestId('assignment-end-today-2')).not.toBeInTheDocument();
+
+    // Ended row — no actions
+    expect(screen.queryByTestId('assignment-cancel-3')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('assignment-end-today-3')).not.toBeInTheDocument();
+
+    // Cancelled row — no actions
+    expect(screen.queryByTestId('assignment-cancel-4')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('assignment-end-today-4')).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when the list is empty', async () => {
+    listAssignments.mockResolvedValue({ assignments: [] });
+    renderList();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('assignment-list-empty')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('assignment-list')).not.toBeInTheDocument();
+  });
+
+  it('hides Cancel/End buttons for ended and cancelled rows', async () => {
+    listAssignments.mockResolvedValue({ assignments: [endedRow, cancelledRow] });
+    renderList();
+
+    await waitFor(() => expect(screen.queryByTestId('assignment-list-skeleton')).not.toBeInTheDocument());
+    expect(screen.queryByTestId('assignment-cancel-3')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('assignment-end-today-3')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('assignment-cancel-4')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('assignment-end-today-4')).not.toBeInTheDocument();
+  });
+
+  it('shows loading skeleton while fetching', () => {
+    // Never resolve
+    listAssignments.mockReturnValue(new Promise(() => {}));
+    renderList();
+    expect(screen.getByTestId('assignment-list-skeleton')).toBeInTheDocument();
+  });
+
+  it('shows inline error if the fetch fails', async () => {
+    listAssignments.mockRejectedValue(new Error('network error'));
+    renderList();
+    await waitFor(() => expect(screen.getByTestId('assignment-list-error')).toBeInTheDocument());
+  });
+
+  it('calls cancelAssignment and refreshes when Cancel is confirmed', async () => {
+    listAssignments
+      .mockResolvedValueOnce({ assignments: [scheduledRow] })
+      .mockResolvedValueOnce({ assignments: [] });
+    cancelAssignment.mockResolvedValue(undefined);
+
+    renderList();
+    await waitFor(() => expect(screen.getByTestId('assignment-cancel-2')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('assignment-cancel-2'));
+    await waitFor(() => expect(cancelAssignment).toHaveBeenCalledWith('test-org', scheduledRow.id));
+    // After refresh the list should be empty
+    await waitFor(() => expect(screen.getByTestId('assignment-list-empty')).toBeInTheDocument());
+  });
+
+  it('calls patchAssignment with today and refreshes when End today is confirmed', async () => {
+    listAssignments
+      .mockResolvedValueOnce({ assignments: [activeRow] })
+      .mockResolvedValueOnce({ assignments: [] });
+    patchAssignment.mockResolvedValue({});
+
+    renderList();
+    await waitFor(() => expect(screen.getByTestId('assignment-end-today-1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('assignment-end-today-1'));
+    await waitFor(() => {
+      expect(patchAssignment).toHaveBeenCalledWith(
+        'test-org',
+        activeRow.id,
+        expect.objectContaining({ end_date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/) }),
+      );
+    });
+    await waitFor(() => expect(screen.getByTestId('assignment-list-empty')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/pages/leadership-team/__tests__/TemplateBuilder.test.jsx
+++ b/frontend/src/pages/leadership-team/__tests__/TemplateBuilder.test.jsx
@@ -42,6 +42,27 @@ function renderNew() {
   );
 }
 
+/**
+ * Render the builder in edit mode with a given template fixture.
+ * getMock is pre-wired: first call returns the template, subsequent calls
+ * (assignment list, groups) return empty arrays / objects.
+ */
+function renderEdit(templateFixture) {
+  getMock.mockImplementation((url) => {
+    if (url.includes('/templates/')) return Promise.resolve({ data: templateFixture });
+    if (url.includes('/assignments/')) return Promise.resolve({ data: { assignments: [] } });
+    if (url.includes('/assignment-groups/')) return Promise.resolve({ data: [] });
+    return Promise.resolve({ data: {} });
+  });
+  return render(
+    <MemoryRouter initialEntries={[`/leadership-team/templates/${templateFixture.id}`]}>
+      <Routes>
+        <Route path="/leadership-team/templates/:id" element={<TemplateBuilderPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
 describe('TemplateBuilderPage', () => {
   it('lets the LT user add a text field and post the new draft', async () => {
     postMock.mockResolvedValue({ data: { id: 99 } });
@@ -115,5 +136,85 @@ describe('TemplateBuilderPage', () => {
     expect(screen.queryByTestId('lt-builder-add-yes_no')).not.toBeInTheDocument();
     expect(screen.queryByTestId('lt-builder-add-date')).not.toBeInTheDocument();
     expect(screen.queryByTestId('lt-builder-add-number')).not.toBeInTheDocument();
+  });
+
+  it('"Assign form" button is disabled (greyed out) when template status is draft', async () => {
+    const draftTemplate = {
+      id: 20,
+      name: 'Draft Template',
+      slug: 'draft-template',
+      role: 'counselor',
+      languages: ['en'],
+      cadence: 'daily',
+      subject_mode: 'self',
+      assignment_scope: 'none',
+      assignment_group_types: [],
+      status: 'draft',
+      is_active: false,
+      version: 1,
+      schema: { fields: [] },
+    };
+    renderEdit(draftTemplate);
+    // Wait for template to load
+    await waitFor(() =>
+      expect(screen.getByTestId('lt-builder-assign-disabled')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('lt-builder-assign-disabled')).toBeDisabled();
+    expect(screen.queryByTestId('lt-builder-assign')).not.toBeInTheDocument();
+  });
+
+  it('"Assign form" button is enabled on a published template and opens the dialog', async () => {
+    const publishedTemplate = {
+      id: 10,
+      name: 'Published Template',
+      slug: 'published-template',
+      role: 'counselor',
+      languages: ['en'],
+      cadence: 'daily',
+      subject_mode: 'self',
+      assignment_scope: 'none',
+      assignment_group_types: [],
+      status: 'published',
+      is_active: true,
+      version: 1,
+      schema: { fields: [] },
+    };
+    renderEdit(publishedTemplate);
+
+    // Wait for the template to load
+    await waitFor(() =>
+      expect(screen.getByTestId('lt-builder-assign')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('lt-builder-assign')).not.toBeDisabled();
+    expect(screen.queryByTestId('lt-builder-assign-disabled')).not.toBeInTheDocument();
+
+    // Clicking opens the dialog
+    fireEvent.click(screen.getByTestId('lt-builder-assign'));
+    await waitFor(() =>
+      expect(screen.getByTestId('assign-form-dialog')).toBeInTheDocument(),
+    );
+  });
+
+  it('shows the "Form assignments" section on a published template', async () => {
+    const publishedTemplate = {
+      id: 11,
+      name: 'Another Published',
+      slug: 'another-published',
+      role: 'counselor',
+      languages: ['en'],
+      cadence: 'daily',
+      subject_mode: 'self',
+      assignment_scope: 'none',
+      assignment_group_types: [],
+      status: 'published',
+      is_active: true,
+      version: 1,
+      schema: { fields: [] },
+    };
+    renderEdit(publishedTemplate);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('assignment-list-section')).toBeInTheDocument(),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Adds **AssignmentList** section to the published LT template builder — shows all `TemplateAssignment` rows with status badges, target names, date ranges, required/optional chips, and per-status actions (Cancel for `scheduled`, End today for `active`)
- Adds **AssignFormDialog** — a builder-scoped modal opened by the new "Assign form" header button; supports assignment-group, role, and tag-group targets; "Individuals" rendered disabled ("Coming soon")
- **409 conflict flow**: on conflict the form fields freeze and the submit area is replaced by a resolution panel (replace / run_both / cancel); "Cancel" in the panel closes the dialog without a second request
- **400 scored-camper guard**: when the response contains "scored camper form", an amber named callout appears below the group picker (not a generic error)
- **Client-side date validation**: end_date ≥ start_date checked before POST
- **"Assign form" button gating**: teal and enabled on `published`; greyed-out with title tooltip on `draft`

## Test plan

- [ ] All 636 frontend tests pass (`npm test`)
- [ ] `npm run build` succeeds (verified locally)
- [ ] No backend changes; pre-existing backend test failure (`test_migration_installs_the_periodic_task_row`) is unrelated to this PR
- [ ] Manual smoke test: open a published template, assign to a bunk (201 closes dialog + refreshes list), try a second scored-camper form on the same bunk and verify amber callout appears, try a conflicting assignment and verify the resolution panel

## Files changed

| File | Change |
|---|---|
| `frontend/src/pages/leadership-team/AssignmentList.jsx` | New — embedded section component |
| `frontend/src/pages/leadership-team/AssignFormDialog.jsx` | New — builder-scoped assign dialog |
| `frontend/src/pages/leadership-team/__tests__/AssignmentList.test.jsx` | New — 7 Vitest cases |
| `frontend/src/pages/leadership-team/__tests__/AssignFormDialog.test.jsx` | New — 8 Vitest cases |
| `frontend/src/pages/leadership-team/TemplateBuilder/TemplateBuilderPage.jsx` | Wire in button + section + dialog; add 3 test cases |
| `frontend/src/pages/leadership-team/__tests__/TemplateBuilder.test.jsx` | 3 new test cases for button gate, dialog open, section visibility |

Made with [Cursor](https://cursor.com)