### PR TITLE
chore(frontend): remove legacy nav links and fix concerns inbox text

### DIFF
--- a/frontend/e2e/rbac-sidebar.spec.ts
+++ b/frontend/e2e/rbac-sidebar.spec.ts
@@ -3,8 +3,7 @@
  *
  * Asserts that the navigation links rendered by frontend/src/partials/Sidebar.jsx
  * match the capability each user signs in as. 3.32 introduced section
- * groupings (My work / Supervise / Admin / Crane Lake
- * legacy / Other) and switched the gates to `hasCapability` +
+ * groupings (My work / Supervise / Admin) and switched the gates to `hasCapability` +
  * `isSuperAdmin`. The seed command (`make seed-rbac`) maps
  * Membership.role to User.role so the legacy gate still works while
  * the capability helper is the actual source of truth.
@@ -43,7 +42,7 @@ const HREFS = {
   adminTemplates: '/admin/templates',
   adminGroups: '/admin/groups',
   adminFieldKeys: '/admin/field-keys',
-  // Crane Lake legacy
+  // Crane Lake legacy (retired from nav; routes kept for bookmarks)
   legacyBunkLogs: '/admin-bunk-logs',
   legacyStaffReflections: '/admin-dashboard',
 };
@@ -67,7 +66,7 @@ test.describe('Sidebar RBAC — capability tiers (3.32)', () => {
     expect(await hasLink(page, HREFS.counselorHome)).toBe(true);
     expect(await hasLink(page, HREFS.reflect)).toBe(true);
     expect(await hasLink(page, HREFS.myReflections)).toBe(true);
-    expect(await hasLink(page, HREFS.orders)).toBe(true);
+    expect(await hasLink(page, HREFS.orders)).toBe(false);
     expect(await hasLink(page, HREFS.dashboardsReflections)).toBe(true);
 
     // No Supervise / Dashboards / Admin / Legacy
@@ -85,7 +84,7 @@ test.describe('Sidebar RBAC — capability tiers (3.32)', () => {
     await readSidebarText(page);
 
     expect(await hasLink(page, HREFS.home)).toBe(true);
-    expect(await hasLink(page, HREFS.orders)).toBe(true);
+    expect(await hasLink(page, HREFS.orders)).toBe(false);
     expect(await hasLink(page, HREFS.groupsPerformance)).toBe(true);
     expect(await hasLink(page, HREFS.concernsInbox)).toBe(true);
 
@@ -130,7 +129,7 @@ test.describe('Sidebar RBAC — capability tiers (3.32)', () => {
     expect(await hasLink(page, HREFS.legacyBunkLogs)).toBe(false);
   });
 
-  test('admin: every section including Crane Lake legacy', async ({ page }) => {
+  test('admin: curated IA without Crane Lake legacy links', async ({ page }) => {
     await loginAs(page, 'admin');
     await readSidebarText(page);
 
@@ -142,8 +141,8 @@ test.describe('Sidebar RBAC — capability tiers (3.32)', () => {
     expect(await hasLink(page, HREFS.adminTemplates)).toBe(true);
     expect(await hasLink(page, HREFS.adminGroups)).toBe(true);
     expect(await hasLink(page, HREFS.adminFieldKeys)).toBe(true);
-    expect(await hasLink(page, HREFS.legacyBunkLogs)).toBe(true);
-    expect(await hasLink(page, HREFS.legacyStaffReflections)).toBe(true);
+    expect(await hasLink(page, HREFS.legacyBunkLogs)).toBe(false);
+    expect(await hasLink(page, HREFS.legacyStaffReflections)).toBe(false);
   });
 
   test('admin: /dashboards/logs and /dashboards/reflections appear exactly once (no duplicates)', async ({
@@ -172,10 +171,10 @@ test.describe('Sidebar RBAC — capability tiers (3.32)', () => {
 
     expect(await hasLink(page, HREFS.adminTemplates)).toBe(true);
     expect(await hasLink(page, HREFS.adminFieldKeys)).toBe(true);
-    expect(await hasLink(page, HREFS.legacyBunkLogs)).toBe(true);
+    expect(await hasLink(page, HREFS.legacyBunkLogs)).toBe(false);
   });
 
-  test('no_membership: only the everyone-visible items (Home, Orders) render', async ({
+  test('no_membership: only the everyone-visible items (Home) render', async ({
     page,
   }) => {
     await loginAs(page, 'no_membership');
@@ -183,7 +182,7 @@ test.describe('Sidebar RBAC — capability tiers (3.32)', () => {
 
     expect(await hasLink(page, HREFS.home)).toBe(true);
     expect(await hasLink(page, HREFS.tasks)).toBe(true);
-    expect(await hasLink(page, HREFS.orders)).toBe(true);
+    expect(await hasLink(page, HREFS.orders)).toBe(false);
 
     expect(await hasLink(page, HREFS.groupsPerformance)).toBe(false);
     expect(await hasLink(page, HREFS.dashboardsHome)).toBe(false);

--- a/frontend/src/components/ui/RichText.jsx
+++ b/frontend/src/components/ui/RichText.jsx
@@ -20,6 +20,22 @@ export function hasHtmlMarkup(value) {
   return typeof value === 'string' && HTML_TAG_RE.test(value);
 }
 
+/** Strip Quill/HTML markup for compact list previews (e.g. concerns inbox). */
+export function htmlToPlainText(value) {
+  if (value == null || value === '') return '';
+  const str = String(value);
+  if (!hasHtmlMarkup(str)) return str;
+  const normalized = str
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(p|div|li|h[1-6])\s*>/gi, '\n');
+  if (typeof document !== 'undefined') {
+    const el = document.createElement('div');
+    el.innerHTML = normalized;
+    return (el.innerText || el.textContent || '').replace(/\n{3,}/g, '\n\n').trim();
+  }
+  return normalized.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
 export default function RichText({ html, className = '', as: Tag = 'div', fallback = null }) {
   if (html == null || html === '') return fallback;
   const str = String(html);

--- a/frontend/src/components/ui/__tests__/RichText.test.js
+++ b/frontend/src/components/ui/__tests__/RichText.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { hasHtmlMarkup, htmlToPlainText } from '../RichText';
+
+describe('htmlToPlainText', () => {
+  it('returns plain strings unchanged', () => {
+    expect(htmlToPlainText('missed family')).toBe('missed family');
+    expect(htmlToPlainText('')).toBe('');
+  });
+
+  it('strips Quill HTML to readable text', () => {
+    expect(htmlToPlainText('<p>Great day</p>')).toBe('Great day');
+    expect(htmlToPlainText('<p>Line one</p><p>Line two</p>')).toBe('Line one\nLine two');
+  });
+});
+
+describe('hasHtmlMarkup', () => {
+  it('detects HTML tags', () => {
+    expect(hasHtmlMarkup('<p>x</p>')).toBe(true);
+    expect(hasHtmlMarkup('plain')).toBe(false);
+  });
+});

--- a/frontend/src/dashboards/concerns/ConcernsInbox.jsx
+++ b/frontend/src/dashboards/concerns/ConcernsInbox.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import api from '../../api';
 import PrivacyChip from '../../components/reflection/PrivacyChip';
+import { htmlToPlainText } from '../../components/ui/RichText';
 
 function shortDate(iso) {
   const d = new Date(iso + 'T00:00:00');
@@ -119,7 +120,7 @@ export default function ConcernsInbox({ payload, onChanged }) {
                   </p>
                   {it.kind === 'open_concern' ? (
                     <p className="mt-1 text-sm text-gray-800 dark:text-gray-100 whitespace-pre-wrap">
-                      {it.value}
+                      {htmlToPlainText(it.value)}
                     </p>
                   ) : (
                     <p className="mt-1 text-sm font-mono text-rose-700 dark:text-rose-300">

--- a/frontend/src/partials/Sidebar.jsx
+++ b/frontend/src/partials/Sidebar.jsx
@@ -59,13 +59,6 @@ const PROGRAM_LEAD_PLUS = ['program_lead'];
  *     Field keys          /admin/field-keys
  *     Settings            /admin/settings
  *
- *   CRANE LAKE LEGACY (transitional)
- *     Bunk logs         /admin-bunk-logs
- *     Staff reflections /admin-dashboard
- *
- *   OTHER
- *     Orders            /orders
- *
  * Admins land on /admin (see pages/Dashboard.jsx). My tasks / File a
  * reflection / My reflections are folded into the Admin dashboard
  * rather than the global nav. The Leadership Team group is intentionally
@@ -77,10 +70,6 @@ const PROGRAM_LEAD_PLUS = ['program_lead'];
  * Team (program_lead+). Gates use hasCapability(user, [...]) ||
  * isSuperAdmin(user); direct `user.role` references remain only for
  * per-role workspace deep links and reflection-form access.
- *
- * Crane Lake legacy section disappears in wave 5 once
- * /admin-bunk-logs and /admin-dashboard are retired (see
- * migration_prompts/5_*).
  */
 function Sidebar({
   sidebarOpen,
@@ -292,27 +281,6 @@ function Sidebar({
             <SubItem to="/admin/field-keys" label="Field keys" />
             <SubItem to="/admin/settings" label="Settings" />
           </CollapsibleSection>
-
-          <Section
-            heading="Crane Lake legacy"
-            headingTitle="Migrating to new schema in wave 5"
-            data-testid="sidebar-legacy"
-          >
-            <NavItem
-              to="/admin-bunk-logs"
-              label="Bunk logs"
-              icon={IconArchive}
-            />
-            <NavItem
-              to="/admin-dashboard"
-              label="Staff reflections"
-              icon={IconArchive}
-            />
-          </Section>
-
-          <Section heading="Other">
-            <NavItem to="/orders" label="Orders" icon={IconReceipt} end />
-          </Section>
           </>
           ) : (
           <>
@@ -434,10 +402,6 @@ function Sidebar({
               <SubItem to="/leadership-team/self-reflection" label="My reflection" />
             </CollapsibleSection>
           )}
-
-          <Section heading="Other">
-            <NavItem to="/orders" label="Orders" icon={IconReceipt} end />
-          </Section>
           </>
           )}
         </div>
@@ -688,13 +652,6 @@ function IconGear() {
     </svg>
   );
 }
-function IconArchive() {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" />
-    </svg>
-  );
-}
 function IconWrench() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
@@ -702,12 +659,4 @@ function IconWrench() {
     </svg>
   );
 }
-function IconReceipt() {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 6v.75m0 3v.75m0 3v.75m0 3V18m-9-5.25h5.25M7.5 15h3M3.375 5.25c-.621 0-1.125.504-1.125 1.125v3.026a2.999 2.999 0 0 1 0 5.198v3.026c0 .621.504 1.125 1.125 1.125h17.25c.621 0 1.125-.504 1.125-1.125v-3.026a2.999 2.999 0 0 1 0-5.198V6.375c0-.621-.504-1.125-1.125-1.125H3.375Z" />
-    </svg>
-  );
-}
-
 export default Sidebar;

--- a/frontend/src/partials/__tests__/Sidebar.test.jsx
+++ b/frontend/src/partials/__tests__/Sidebar.test.jsx
@@ -65,7 +65,7 @@ describe('Sidebar — section gating (3.32)', () => {
     expect(links).toContain('/counselor');
     expect(links).toContain('/reflect');
     expect(links).toContain('/my-reflections');
-    expect(links).toContain('/orders');
+    expect(links).not.toContain('/orders');
     expect(links).not.toContain('/admin');
     expect(links).not.toContain('/admin-bunk-logs');
   });
@@ -139,7 +139,7 @@ describe('Sidebar — section gating (3.32)', () => {
     expect(screen.getAllByText('Templates').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Supervise').length).toBeGreaterThan(0);
     expect(screen.queryByText('Dashboards')).not.toBeInTheDocument();
-    expect(screen.getAllByText('Crane Lake legacy').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Crane Lake legacy')).not.toBeInTheDocument();
 
     const links = hrefs();
     expect(links).toContain('/admin/home');
@@ -154,7 +154,9 @@ describe('Sidebar — section gating (3.32)', () => {
     expect(links).toContain('/groups/performance');
     expect(links).toContain('/dashboards/concerns');
     expect(links).toContain('/dashboards/authors');
-    expect(links).toContain('/orders');
+    expect(links).not.toContain('/orders');
+    expect(links).not.toContain('/admin-bunk-logs');
+    expect(links).not.toContain('/admin-dashboard');
 
     // Personal reflection flows + My tasks fold into the Admin dashboard,
     // not the nav. Leadership Team is the LT's own home, not the Admin IA.
@@ -171,7 +173,7 @@ describe('Sidebar — section gating (3.32)', () => {
 
     expect(screen.getAllByText('Admin').length).toBeGreaterThan(0);
     expect(screen.queryByText('Dashboards')).not.toBeInTheDocument();
-    expect(screen.getAllByText('Crane Lake legacy').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Crane Lake legacy')).not.toBeInTheDocument();
   });
 });
 
@@ -254,7 +256,7 @@ describe('Sidebar — Admin submenu items (3.32)', () => {
     );
   });
 
-  it('renders Admin submenu after Supervise and before Crane Lake legacy', () => {
+  it('renders Admin submenu after Supervise with no legacy links', () => {
     renderWith({ role: 'Admin' }, { path: '/admin/home' });
     const links = hrefs();
     const homeIdx = links.indexOf('/admin/home');
@@ -265,8 +267,6 @@ describe('Sidebar — Admin submenu items (3.32)', () => {
     const adminDashboardIdx = links.indexOf('/admin/dashboard');
     const templatesIdx = links.indexOf('/admin/templates');
     const peopleIdx = links.indexOf('/admin/people');
-    const legacyIdx = links.indexOf('/admin-bunk-logs');
-    const ordersIdx = links.indexOf('/orders');
     expect(homeIdx).toBeGreaterThanOrEqual(0);
     expect(performanceIdx).toBeGreaterThan(homeIdx);
     expect(logsIdx).toBeGreaterThan(performanceIdx);
@@ -274,29 +274,8 @@ describe('Sidebar — Admin submenu items (3.32)', () => {
     expect(authorsIdx).toBeLessThan(adminDashboardIdx);
     expect(templatesIdx).toBeGreaterThan(adminDashboardIdx);
     expect(peopleIdx).toBeGreaterThan(templatesIdx);
-    expect(legacyIdx).toBeGreaterThan(peopleIdx);
-    expect(ordersIdx).toBeGreaterThan(legacyIdx);
-  });
-});
-
-describe('Sidebar — Crane Lake legacy section (3.32)', () => {
-  it('keeps /admin-bunk-logs and /admin-dashboard reachable for admins', () => {
-    renderWith({ role: 'Admin' });
-    const links = hrefs();
-    expect(links).toContain('/admin-bunk-logs');
-    expect(links).toContain('/admin-dashboard');
-  });
-
-  it('does not render the legacy section for non-admins (counselor)', () => {
-    renderWith({ role: 'Counselor' });
-    const links = hrefs();
     expect(links).not.toContain('/admin-bunk-logs');
     expect(links).not.toContain('/admin-dashboard');
-    expect(screen.queryByText('Crane Lake legacy')).not.toBeInTheDocument();
-  });
-
-  it('does not render the legacy section for supervisors', () => {
-    renderWith({ role: 'Unit Head' });
     expect(screen.queryByText('Crane Lake legacy')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Remove legacy sidebar links for Crane Lake bunk logs (`/admin-bunk-logs`), orders (`/orders`), and staff reflections (`/admin-dashboard`); routes remain for bookmarks until data is deleted.
- Fix Concerns Inbox open-concern values showing raw Quill HTML by stripping markup to plain text via new `htmlToPlainText()` helper.

## Test plan
- [x] `npx vitest run src/partials/__tests__/Sidebar.test.jsx`
- [x] `npx vitest run src/components/ui/__tests__/RichText.test.js`
- [ ] Confirm admin sidebar no longer shows Crane Lake legacy / Other sections
- [ ] Confirm concerns inbox shows readable text for HTML-stored open concerns

Made with [Cursor](https://cursor.com)