### PR TITLE
Counselor workspace, maintenance queue, and observation subject search

### DIFF
--- a/backend/bunk_logs/api/counselor/dashboard.py
+++ b/backend/bunk_logs/api/counselor/dashboard.py
@@ -25,7 +25,7 @@ cross-counselor freshness contract in Story 2 criterion 5.
 
 from __future__ import annotations
 
-from datetime import date as date_type  # noqa: TC003 - used in helper type hints
+from datetime import date as date_type
 
 from django.core.cache import cache
 from rest_framework.permissions import IsAuthenticated

--- a/backend/bunk_logs/api/counselor/dashboard.py
+++ b/backend/bunk_logs/api/counselor/dashboard.py
@@ -1,25 +1,26 @@
 """``GET /api/v1/counselor/dashboard/`` — Story 2 + Story 9 (all set).
 
-Returns the three-section payload the counselor mobile app paints below
-the date header: camper reflections coverage, self-reflection state, and
-open requests.
+Returns the counselor home payload: viewer context, per-bunk tiles with
+form-assignment progress, aggregated section summaries (camper reflections,
+self-reflection, open requests), and all-set state.
 
 State computation:
 
 - ``camper_reflections``: count of campers (excluding off-camp) with a
-  submitted reflection for today's period.
-- ``self_reflection``: viewer's own daily self-reflection for today, with
-  ``day_off`` treated as "complete" (Story 5 criterion 3).
+  submitted reflection for the selected date's period.
+- ``self_reflection``: viewer's own self-reflection for the selected period,
+  with ``day_off`` treated as "complete" (Story 5 criterion 3).
 - ``requests``: open Orders + MaintenanceTickets the viewer or any
   co-counselor submitted on the viewer's bunks (decision C4).
+- ``bunks``: one tile per bunk the viewer authors, each listing active
+  form assignments with due/remaining copy and deep-link hints.
 
 All-set (Story 9 criterion 1) is true iff both camper-reflections and
 self-reflection sections are "complete". The Requests section is reactive,
 not required, and does NOT affect all-set (Story 9 criterion 2).
 
-Caching: a 30-second per-(org, viewer, day) TTL covers the cross-counselor
-freshness contract in Story 2 criterion 5. Read endpoints don't bust the
-cache; write endpoints in 7_6c will bump the per-viewer version key.
+Caching: a 30-second per-(org, viewer, selected-date) TTL covers the
+cross-counselor freshness contract in Story 2 criterion 5.
 """
 
 from __future__ import annotations
@@ -31,12 +32,18 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from bunk_logs.core.assignment_resolution import active_assignments_for
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import MaintenanceTicket
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Order
 from bunk_logs.core.models import Person
 from bunk_logs.core.models import Program
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.models import TemplateAssignment
 from bunk_logs.core.state_machine import OrderStateMachine
+from bunk_logs.core.time_utils import get_current_period
 from bunk_logs.core.time_utils import get_org_timezone
 from bunk_logs.core.time_utils import get_rollover_hour
 
@@ -49,7 +56,7 @@ from .common import is_day_off_answer
 from .common import latest_camper_reflection_per_subject
 from .common import latest_self_reflection
 from .common import off_camp_camper_ids
-from .common import viewer_bunk_groups
+from .common import person_display_name
 from .common import viewer_or_403
 
 DASHBOARD_CACHE_TTL_SECONDS = 30
@@ -66,8 +73,61 @@ def _section_state(*, covered: int, total: int) -> str:
     return "in_progress"
 
 
+def _parse_target_date(raw: str | None, default: date_type) -> date_type:
+    if not raw:
+        return default
+    try:
+        return date_type.fromisoformat(raw)
+    except ValueError:
+        return default
+
+
+def _template_cadence(template: ReflectionTemplate, assignment: TemplateAssignment | None) -> str:
+    if assignment is not None and assignment.cadence_override:
+        return assignment.cadence_override
+    return template.cadence or "daily"
+
+
+def _format_due_label(
+    *,
+    cadence: str,
+    remaining: int,
+    period_end: date_type,
+    target_date: date_type,
+) -> str:
+    cadence_key = (cadence or "daily").lower()
+    if cadence_key in ("daily", "on_demand"):
+        if remaining == 0:
+            if target_date == period_end:
+                return "All responses in for today"
+            return "All responses in for this day"
+        noun = "response" if remaining == 1 else "responses"
+        return f"{remaining} {noun} needed today"
+    end_label = period_end.strftime("%A, %b %d").replace(" 0", " ")
+    if remaining == 0:
+        return f"Complete for this period (through {end_label})"
+    noun = "response" if remaining == 1 else "responses"
+    return f"{remaining} {noun} due by {end_label}"
+
+
+def _assignment_action_path(
+    *,
+    bunk_id: int,
+    target_date: date_type,
+    org_today: date_type,
+    template: ReflectionTemplate,
+    cadence: str,
+) -> str:
+    cadence_key = (cadence or "daily").lower()
+    if template.subject_mode == "single_subject" and cadence_key in ("daily", "on_demand"):
+        if target_date == org_today:
+            return "/counselor/camper-reflections"
+        return f"/counselor/camper-reflections/{target_date.isoformat()}"
+    return f"/dashboards/group/{bunk_id}?date={target_date.isoformat()}"
+
+
 class CounselorDashboardView(APIView):
-    """Three-section counselor dashboard payload."""
+    """Counselor home dashboard payload."""
 
     permission_classes = [IsAuthenticated]
 
@@ -75,20 +135,16 @@ class CounselorDashboardView(APIView):
         ctx = viewer_or_403(request)
         viewer = ctx.person
         org = ctx.organization
-        today = ctx.today
+        org_today = ctx.today
+        target_date = _parse_target_date(request.query_params.get("date"), org_today)
 
-        # Honor an opt-out for tests + ops debugging. Production clients never
-        # set this; the dashboard auto-refreshes on a 30s interval.
         skip_cache = request.query_params.get("nocache") in {"1", "true"}
-        cache_key = _cache_key(viewer.id, org.id, today)
+        cache_key = _cache_key(viewer.id, org.id, target_date)
         if not skip_cache:
             cached = cache.get(cache_key)
             if cached is not None:
                 return Response(cached)
 
-        # Pick the viewer's "primary" program. Counselors in v1 are scoped to
-        # one program; if a person has multiple active memberships we take the
-        # most recent so the dashboard at least renders.
         primary_membership = (
             Membership.objects.filter(person=viewer, is_active=True)
             .select_related("program")
@@ -96,15 +152,30 @@ class CounselorDashboardView(APIView):
             .first()
         )
         if primary_membership is None or primary_membership.program is None:
-            payload = self._empty_payload(today, org)
+            payload = self._empty_payload(org_today, target_date, org, viewer)
             cache.set(cache_key, payload, DASHBOARD_CACHE_TTL_SECONDS)
             return Response(payload)
         program = primary_membership.program
 
-        bunks = viewer_bunk_groups(viewer)
-        camper_section = self._camper_section(org, program, viewer, bunks, today)
-        self_section = self._self_section(viewer, org, program, today)
+        bunk_ids = list(
+            AssignmentGroupMembership.objects.filter(
+                person=viewer,
+                role_in_group="author",
+                is_active=True,
+                group__is_active=True,
+                group__group_type="bunk",
+            ).values_list("group_id", flat=True),
+        )
+        bunks = list(
+            AssignmentGroup.objects.filter(id__in=bunk_ids)
+            .select_related("parent")
+            .order_by("name"),
+        )
+
+        camper_section = self._camper_section(org, program, viewer, bunks, target_date)
+        self_section = self._self_section(viewer, org, program, target_date)
         requests_section = self._requests_section(org, program, viewer, bunks)
+        bunk_tiles = self._bunks_section(org, program, viewer, bunks, target_date, org_today)
 
         all_set = (
             camper_section["state"] == "complete"
@@ -112,7 +183,15 @@ class CounselorDashboardView(APIView):
         )
 
         payload = {
-            "today": today.isoformat(),
+            "viewer": {
+                "id": viewer.id,
+                "name": person_display_name(viewer),
+                "full_name": viewer.full_name,
+                "role": primary_membership.role,
+            },
+            "selected_date": target_date.isoformat(),
+            "today": org_today.isoformat(),
+            "is_today": target_date == org_today,
             "rollover_hour": get_rollover_hour(org),
             "timezone": str(get_org_timezone(org)),
             "program": {
@@ -121,6 +200,7 @@ class CounselorDashboardView(APIView):
                 "name": program.name,
             },
             "all_set": all_set,
+            "bunks": bunk_tiles,
             "sections": {
                 "camper_reflections": camper_section,
                 "self_reflection": self_section,
@@ -130,13 +210,28 @@ class CounselorDashboardView(APIView):
         cache.set(cache_key, payload, DASHBOARD_CACHE_TTL_SECONDS)
         return Response(payload)
 
-    def _empty_payload(self, today: date_type, org) -> dict:
+    def _empty_payload(
+        self,
+        org_today: date_type,
+        target_date: date_type,
+        org,
+        viewer: Person,
+    ) -> dict:
         return {
-            "today": today.isoformat(),
+            "viewer": {
+                "id": viewer.id,
+                "name": person_display_name(viewer),
+                "full_name": viewer.full_name,
+                "role": None,
+            },
+            "selected_date": target_date.isoformat(),
+            "today": org_today.isoformat(),
+            "is_today": target_date == org_today,
             "rollover_hour": get_rollover_hour(org),
             "timezone": str(get_org_timezone(org)),
             "program": None,
             "all_set": False,
+            "bunks": [],
             "sections": {
                 "camper_reflections": {
                     "state": "complete",
@@ -153,6 +248,9 @@ class CounselorDashboardView(APIView):
                     "is_day_off": False,
                     "editable": False,
                     "template": None,
+                    "cadence": None,
+                    "period_start": None,
+                    "period_end": None,
                 },
                 "requests": {
                     "state": "none",
@@ -162,7 +260,156 @@ class CounselorDashboardView(APIView):
             },
         }
 
-    def _camper_section(self, org, program, viewer: Person, bunks, today) -> dict:
+    def _assignment_tile(
+        self,
+        *,
+        org,
+        program: Program,
+        viewer: Person,
+        bunk,
+        target_date: date_type,
+        org_today: date_type,
+        template: ReflectionTemplate,
+        assignment: TemplateAssignment | None,
+        expected_ids: set[int],
+    ) -> dict:
+        cadence = _template_cadence(template, assignment)
+        period_start, period_end = get_current_period(
+            cadence, org, program=program, anchor=target_date,
+        )
+        covered = 0
+        total = len(expected_ids)
+        if template.subject_mode == "single_subject" and total:
+            reflections = latest_camper_reflection_per_subject(
+                template, [bunk], period_start, period_end,
+            )
+            covered = sum(1 for sid in expected_ids if sid in reflections)
+        remaining = max(total - covered, 0)
+        title = (assignment.title if assignment and assignment.title else None) or template.name
+        return {
+            "assignment_id": assignment.id if assignment else None,
+            "template_id": template.id,
+            "template_name": title,
+            "cadence": cadence,
+            "subject_mode": template.subject_mode,
+            "state": _section_state(covered=covered, total=total),
+            "covered": covered,
+            "total": total,
+            "remaining": remaining,
+            "period_start": period_start.isoformat(),
+            "period_end": period_end.isoformat(),
+            "due_label": _format_due_label(
+                cadence=cadence,
+                remaining=remaining,
+                period_end=period_end,
+                target_date=target_date,
+            ),
+            "action_path": _assignment_action_path(
+                bunk_id=bunk.id,
+                target_date=target_date,
+                org_today=org_today,
+                template=template,
+                cadence=cadence,
+            ),
+        }
+
+    def _bunks_section(
+        self,
+        org,
+        program: Program,
+        viewer: Person,
+        bunks,
+        target_date: date_type,
+        org_today: date_type,
+    ) -> list[dict]:
+        if not bunks:
+            return []
+
+        roster_by_bunk = bunk_camper_persons(bunks)
+        co_rows = (
+            AssignmentGroupMembership.objects.filter(
+                group__in=bunks,
+                role_in_group="author",
+                is_active=True,
+            )
+            .exclude(person=viewer)
+            .select_related("person")
+            .order_by("group_id", "person__last_name", "person__first_name")
+        )
+        co_names_by_bunk: dict[int, list[str]] = {b.id: [] for b in bunks}
+        for row in co_rows:
+            if row.person:
+                co_names_by_bunk.setdefault(row.group_id, []).append(
+                    person_display_name(row.person),
+                )
+
+        tiles: list[dict] = []
+        for bunk in bunks:
+            campers = roster_by_bunk.get(bunk.id, [])
+            all_camper_ids = {p.id for p in campers}
+            off_camp_ids = off_camp_camper_ids(org, target_date, camper_ids=all_camper_ids)
+            expected_ids = all_camper_ids - off_camp_ids
+
+            seen_template_ids: set[int] = set()
+            assignments_out: list[dict] = []
+
+            for assignment in active_assignments_for(
+                viewer=viewer,
+                organization=org,
+                program=program,
+                as_of=target_date,
+                target_assignment_group=bunk,
+            ):
+                tpl = assignment.template
+                if tpl is None or tpl.subject_mode == "self" or tpl.id in seen_template_ids:
+                    continue
+                seen_template_ids.add(tpl.id)
+                assignments_out.append(
+                    self._assignment_tile(
+                        org=org,
+                        program=program,
+                        viewer=viewer,
+                        bunk=bunk,
+                        target_date=target_date,
+                        org_today=org_today,
+                        template=tpl,
+                        assignment=assignment,
+                        expected_ids=expected_ids,
+                    ),
+                )
+
+            camper_tpl = camper_reflection_template(
+                org, program, viewer=viewer, bunk=bunk, as_of=target_date,
+            )
+            if camper_tpl is not None and camper_tpl.id not in seen_template_ids:
+                seen_template_ids.add(camper_tpl.id)
+                assignments_out.append(
+                    self._assignment_tile(
+                        org=org,
+                        program=program,
+                        viewer=viewer,
+                        bunk=bunk,
+                        target_date=target_date,
+                        org_today=org_today,
+                        template=camper_tpl,
+                        assignment=None,
+                        expected_ids=expected_ids,
+                    ),
+                )
+
+            tiles.append({
+                "id": bunk.id,
+                "name": bunk.name,
+                "unit_name": bunk.parent.name if bunk.parent_id else None,
+                "camper_count": len(campers),
+                "off_camp_count": len(off_camp_ids),
+                "co_counselor_names": co_names_by_bunk.get(bunk.id, []),
+                "assignments": assignments_out,
+                "dashboard_path": f"/dashboards/group/{bunk.id}?date={target_date.isoformat()}",
+            })
+        return tiles
+
+    def _camper_section(self, org, program, viewer: Person, bunks, target_date) -> dict:
         if not bunks:
             return {
                 "state": "complete",
@@ -177,11 +424,13 @@ class CounselorDashboardView(APIView):
         for campers in roster_by_bunk.values():
             all_camper_ids.update(p.id for p in campers)
 
-        off_camp_ids = off_camp_camper_ids(org, today, camper_ids=all_camper_ids)
+        off_camp_ids = off_camp_camper_ids(org, target_date, camper_ids=all_camper_ids)
         expected_ids = all_camper_ids - off_camp_ids
         total = len(expected_ids)
 
-        template = camper_reflection_template(org, program)
+        template = camper_reflection_template(
+            org, program, viewer=viewer, as_of=target_date,
+        )
         if template is None or total == 0:
             return {
                 "state": "complete",
@@ -191,10 +440,12 @@ class CounselorDashboardView(APIView):
                 "bunk_count": len(bunks),
             }
 
-        # Daily cadence by definition for the bunk roster template — period
-        # collapses to (today, today) without needing the cadence helper.
+        cadence = template.cadence or "daily"
+        period_start, period_end = get_current_period(
+            cadence, org, program=program, anchor=target_date,
+        )
         reflections = latest_camper_reflection_per_subject(
-            template, bunks, today, today,
+            template, bunks, period_start, period_end,
         )
         covered = sum(1 for sid in expected_ids if sid in reflections)
 
@@ -206,11 +457,9 @@ class CounselorDashboardView(APIView):
             "bunk_count": len(bunks),
         }
 
-    def _self_section(self, viewer: Person, org, program: Program, today) -> dict:
-        template = counselor_self_template(viewer, org, program)
+    def _self_section(self, viewer: Person, org, program: Program, target_date) -> dict:
+        template = counselor_self_template(viewer, org, program, as_of=target_date)
         if template is None:
-            # No counselor self-reflection template configured — section is
-            # implicitly "complete" so it doesn't block all-set.
             return {
                 "state": "complete",
                 "submitted": False,
@@ -219,17 +468,30 @@ class CounselorDashboardView(APIView):
                 "is_day_off": False,
                 "editable": False,
                 "template": None,
+                "cadence": None,
+                "period_start": None,
+                "period_end": None,
             }
 
-        reflection = latest_self_reflection(viewer, template, today, today)
+        cadence = template.cadence or "daily"
+        period_start, period_end = get_current_period(
+            cadence, org, program=program, anchor=target_date,
+        )
+        reflection = latest_self_reflection(viewer, template, period_start, period_end)
         submitted = reflection is not None
         return {
             "state": "complete" if submitted else "none",
             "submitted": submitted,
             "reflection_id": reflection.id if reflection else None,
-            "submitted_at": reflection.submitted_at.isoformat() if reflection and reflection.submitted_at else None,
+            "submitted_at": (
+                reflection.submitted_at.isoformat()
+                if reflection and reflection.submitted_at else None
+            ),
             "is_day_off": is_day_off_answer(reflection),
             "editable": submitted,
+            "cadence": cadence,
+            "period_start": period_start.isoformat(),
+            "period_end": period_end.isoformat(),
             "template": {
                 "id": template.id,
                 "slug": template.slug,
@@ -239,14 +501,9 @@ class CounselorDashboardView(APIView):
         }
 
     def _requests_section(self, org, program, viewer: Person, bunks) -> dict:
-        # "My + my co-counselors' open requests" (decision C4). Without bunks
-        # the viewer has no co-counselors; they still see their own requests.
         co_ids = co_counselor_person_ids(viewer, bunks)
         eligible_person_ids = list(co_ids | {viewer.id})
 
-        # ``submitted_by`` is a Membership FK; gather the membership IDs for
-        # any of the eligible Persons in this program. We do this in one
-        # round-trip and reuse for both Orders and Maintenance tickets.
         eligible_membership_ids = list(
             Membership.all_objects.filter(
                 person_id__in=eligible_person_ids,
@@ -275,7 +532,6 @@ class CounselorDashboardView(APIView):
 
         total = camper_care_count + maintenance_count
         return {
-            # Requests section never reports "complete" (Story 9 criterion 2).
             "state": "in_progress" if total else "none",
             "open_count": total,
             "by_type": {

--- a/backend/bunk_logs/api/maintenance/views.py
+++ b/backend/bunk_logs/api/maintenance/views.py
@@ -54,7 +54,7 @@ STATUS_CLOSED = (
     MaintenanceTicket.Status.UNABLE_TO_FULFILL,
 )
 
-VALID_FILTERS = frozenset({"open", "new", "in_progress", "closed", "all"})
+VALID_FILTERS = frozenset({"open", "new", "in_progress", "closed", "all", "mine"})
 VALID_VISIBILITY = frozenset({"team_only", "submitter_visible"})
 
 
@@ -68,7 +68,9 @@ class MaintenanceQueueView(APIView):
 
     Query params:
 
-    * ``filter`` — ``open`` (default), ``new``, ``in_progress``, ``closed``, ``all``
+    * ``filter`` — ``open`` (default for maintenance team), ``mine`` (default for
+      other members — open tickets they submitted), ``new``, ``in_progress``,
+      ``closed``, ``all``
     * ``search`` — free-text search (description + note bodies); closed only
     * ``date_from`` / ``date_to`` — YYYY-MM-DD; closed filter date clamp
     """
@@ -77,18 +79,24 @@ class MaintenanceQueueView(APIView):
 
     def get(self, request, *args, **kwargs):
         ctx, scope = resolve_queue_viewer(request)
-        filt = (request.query_params.get("filter") or "open").lower()
+        default_filter = "mine" if scope == "viewer" else "open"
+        filt = (request.query_params.get("filter") or default_filter).lower()
         if filt not in VALID_FILTERS:
             raise ValidationError({"filter": f"Must be one of: {', '.join(sorted(VALID_FILTERS))}."})
 
-        # Everyone sees the full program queue; ``viewer`` scope just renders it
-        # read-only (transition actions are stripped in ``_ticket_row``).
+        # Maintenance team sees the full program queue; other members default to
+        # their own open tickets but can switch to the camp-wide open view.
         base = MaintenanceTicket.objects.select_related(
             "submitted_by__person", "last_transition_by__person",
         ).filter(program=ctx.program)
 
         qs = base
-        if filt == "open":
+        if filt == "mine":
+            qs = qs.filter(
+                submitted_by=ctx.membership,
+                status__in=STATUS_OPEN,
+            )
+        elif filt == "open":
             qs = qs.filter(status__in=STATUS_OPEN)
         elif filt == "new":
             qs = qs.filter(status=MaintenanceTicket.Status.NEW)
@@ -107,7 +115,10 @@ class MaintenanceQueueView(APIView):
             tickets.sort(key=lambda t: t.updated_at, reverse=True)
 
         counts = _build_counts(base)
-        rows = [_ticket_row(t, scope=scope) for t in tickets]
+        rows = [
+            _ticket_row(t, scope=scope, viewer_membership_id=ctx.membership.id)
+            for t in tickets
+        ]
 
         return Response({"tickets": rows, "counts": counts, "scope": scope})
 
@@ -161,7 +172,19 @@ def _build_counts(base_qs) -> dict:
     }
 
 
-def _ticket_row(ticket: MaintenanceTicket, *, scope: str = "team") -> dict:
+def _submitter_close_transitions(status: str) -> list[str]:
+    """Transitions a ticket submitter may apply to close their own request."""
+    if status in STATUS_OPEN:
+        return [MaintenanceTicket.Status.FULFILLED]
+    return []
+
+
+def _ticket_row(
+    ticket: MaintenanceTicket,
+    *,
+    scope: str = "team",
+    viewer_membership_id=None,
+) -> dict:
     submitter = ticket.submitted_by
     submitter_person = getattr(submitter, "person", None) if submitter else None
     age_seconds = int((timezone.now() - ticket.created_at).total_seconds()) if ticket.created_at else None
@@ -202,8 +225,20 @@ def _ticket_row(ticket: MaintenanceTicket, *, scope: str = "team") -> dict:
         "has_photos": has_photos,
         "acknowledger": acknowledger,
         "resolution": resolution,
-        # Non-team viewers get a read-only view — no transition actions.
-        "available_transitions": ticket.available_transitions() if scope == "team" else [],
+        "is_mine": bool(
+            viewer_membership_id
+            and ticket.submitted_by_id == viewer_membership_id,
+        ),
+        "available_transitions": (
+            ticket.available_transitions()
+            if scope == "team"
+            else (
+                _submitter_close_transitions(ticket.status)
+                if viewer_membership_id
+                and ticket.submitted_by_id == viewer_membership_id
+                else []
+            )
+        ),
         "is_within_correction_window": ticket.can_correct_last_transition(),
         "created_at": ticket.created_at.isoformat() if ticket.created_at else None,
         "updated_at": ticket.updated_at.isoformat() if ticket.updated_at else None,
@@ -249,7 +284,11 @@ class MaintenanceTicketDetailView(APIView):
             activity = [e for e in activity if not _is_team_only_note(e)]
 
         return Response({
-            "ticket": _ticket_detail_payload(ticket, scope=scope),
+            "ticket": _ticket_detail_payload(
+                ticket,
+                scope=scope,
+                viewer_membership_id=ctx.membership.id,
+            ),
             "photos": [_photo_payload(p) for p in photos],
             "activity": [_activity_event_payload(e) for e in activity],
             "scope": scope,
@@ -263,7 +302,12 @@ def _is_team_only_note(event: OrderActivityEvent) -> bool:
     return visibility == "team_only"
 
 
-def _ticket_detail_payload(ticket: MaintenanceTicket, *, scope: str = "team") -> dict:
+def _ticket_detail_payload(
+    ticket: MaintenanceTicket,
+    *,
+    scope: str = "team",
+    viewer_membership_id=None,
+) -> dict:
     submitter = ticket.submitted_by
     submitter_person = getattr(submitter, "person", None) if submitter else None
     return {
@@ -280,9 +324,23 @@ def _ticket_detail_payload(ticket: MaintenanceTicket, *, scope: str = "team") ->
             if submitter_person else None
         ),
         "submitted_by_membership_id": str(ticket.submitted_by_id) if ticket.submitted_by_id else None,
-        # Non-team viewers get a read-only payload — no transitions or undo.
-        "available_transitions": ticket.available_transitions() if scope == "team" else [],
-        "is_within_correction_window": ticket.can_correct_last_transition() if scope == "team" else False,
+        "is_mine": bool(
+            viewer_membership_id
+            and ticket.submitted_by_id == viewer_membership_id,
+        ),
+        "available_transitions": (
+            ticket.available_transitions()
+            if scope == "team"
+            else (
+                _submitter_close_transitions(ticket.status)
+                if viewer_membership_id
+                and ticket.submitted_by_id == viewer_membership_id
+                else []
+            )
+        ),
+        "is_within_correction_window": (
+            ticket.can_correct_last_transition() if scope == "team" else False
+        ),
         "last_transition_at": (
             ticket.last_transition_at.isoformat() if ticket.last_transition_at else None
         ),

--- a/backend/bunk_logs/api/observations/views.py
+++ b/backend/bunk_logs/api/observations/views.py
@@ -34,7 +34,7 @@ from rest_framework.views import APIView
 from bunk_logs.api.observations.common import viewer_or_403
 from bunk_logs.core import audit as audit_trail
 from bunk_logs.core.models import Person
-from bunk_logs.core.permissions.observation_authoring import authorable_subject_queryset
+from bunk_logs.core.permissions.observation_authoring import observation_authorable_subject_queryset
 from bunk_logs.core.permissions.observation_authoring import recipients_clearing_sensitivity
 from bunk_logs.core.permissions.observation_read import filter_observations_readable
 from bunk_logs.core.permissions.super_admin import is_super_admin
@@ -55,6 +55,31 @@ User = get_user_model()
 
 DEFAULT_SEARCH_LIMIT = 25
 MAX_SEARCH_LIMIT = 100
+
+
+def _filter_persons_by_name_query(qs, q: str):
+    """Match name tokens against first, last, and preferred name fields."""
+    q = q.strip()
+    if not q:
+        return qs
+    tokens = [t for t in q.split() if t]
+    if not tokens:
+        return qs
+    if len(tokens) == 1:
+        token = tokens[0]
+        return qs.filter(
+            Q(first_name__icontains=token)
+            | Q(last_name__icontains=token)
+            | Q(preferred_name__icontains=token),
+        )
+    combined = Q()
+    for token in tokens:
+        combined &= (
+            Q(first_name__icontains=token)
+            | Q(last_name__icontains=token)
+            | Q(preferred_name__icontains=token)
+        )
+    return qs.filter(combined)
 
 
 class ObservationsPagination(PageNumberPagination):
@@ -203,7 +228,9 @@ class ObservationCreateView(APIView):
 
         # Validate subjects against the viewer's authoring scope.
         authorable_ids = set(
-            authorable_subject_queryset(ctx.person, ctx.organization).values_list("id", flat=True),
+            observation_authorable_subject_queryset(
+                ctx.person, ctx.organization,
+            ).values_list("id", flat=True),
         )
         subject_ids = list(dict.fromkeys(data["subject_ids"]))
         bad_subjects = [sid for sid in subject_ids if sid not in authorable_ids]
@@ -412,9 +439,6 @@ class ObservationSubjectsView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        org = getattr(request, "organization", None)
-        if org is None:
-            return Response({"detail": "Organization context required."}, status=403)
         q = (request.query_params.get("q") or "").strip()
         try:
             limit = int(request.query_params.get("limit", DEFAULT_SEARCH_LIMIT))
@@ -422,18 +446,16 @@ class ObservationSubjectsView(APIView):
             limit = DEFAULT_SEARCH_LIMIT
         limit = max(1, min(limit, MAX_SEARCH_LIMIT))
 
-        viewer_person = Person.all_objects.filter(user=request.user).first()
         if is_super_admin(request.user):
+            org = getattr(request, "organization", None)
+            if org is None:
+                return Response({"detail": "Organization context required."}, status=403)
             base = Person.all_objects.filter(organization=org)
-        elif viewer_person is None:
-            base = Person.all_objects.none()
         else:
-            base = authorable_subject_queryset(viewer_person, org)
-        if q:
-            base = base.filter(
-                Q(first_name__icontains=q)
-                | Q(last_name__icontains=q)
-                | Q(preferred_name__icontains=q),
-            )
+            ctx = viewer_or_403(request)
+            base = observation_authorable_subject_queryset(
+                ctx.person, ctx.organization,
+            ).exclude(id=ctx.person.id)
+        base = _filter_persons_by_name_query(base, q)
         persons = list(base.order_by("last_name", "first_name")[:limit])
         return Response({"subjects": [{"id": p.id, "full_name": p.full_name} for p in persons]})

--- a/backend/bunk_logs/api/orders_state_machine.py
+++ b/backend/bunk_logs/api/orders_state_machine.py
@@ -59,12 +59,7 @@ def _actor_membership_for(request, *, content) -> Membership | None:
     )
 
 
-def _can_transition(request, *, content, fulfilling_role: str) -> bool:
-    """Whether ``request.user`` is allowed to transition ``content``.
-
-    Allowed when the user is a Super Admin, an org Admin, or an active
-    Membership in the program with the fulfilling role for this content type.
-    """
+def _is_fulfilling_team_member(request, *, content, fulfilling_role: str) -> bool:
     if is_super_admin(request.user):
         return True
     person = _person_for_request(request)
@@ -76,6 +71,33 @@ def _can_transition(request, *, content, fulfilling_role: str) -> bool:
         is_active=True,
         role__in=("admin", fulfilling_role),
     ).exists()
+
+
+def _submitter_may_close_ticket(request, ticket: MaintenanceTicket) -> bool:
+    """Whether a non-maintenance submitter may close their own open ticket."""
+    if _is_fulfilling_team_member(request, content=ticket, fulfilling_role="maintenance"):
+        return False
+    actor = _actor_membership_for(request, content=ticket)
+    if actor is None or ticket.submitted_by_id != actor.id:
+        return False
+    return ticket.status in (
+        MaintenanceTicket.Status.NEW,
+        MaintenanceTicket.Status.IN_PROGRESS,
+    )
+
+
+def _can_transition(request, *, content, fulfilling_role: str) -> bool:
+    """Whether ``request.user`` is allowed to transition ``content``.
+
+    Allowed when the user is a Super Admin, an org Admin, or an active
+    Membership in the program with the fulfilling role for this content type.
+    Maintenance ticket submitters may also mark their own open tickets fulfilled.
+    """
+    if _is_fulfilling_team_member(request, content=content, fulfilling_role=fulfilling_role):
+        return True
+    if fulfilling_role == "maintenance" and isinstance(content, MaintenanceTicket):
+        return _submitter_may_close_ticket(request, content)
+    return False
 
 
 def _activity_payload(events: Iterable[OrderActivityEvent]) -> list[dict]:
@@ -267,6 +289,19 @@ def _do_transition(request, instance, *, fulfilling_role: str) -> Response:
             {"detail": "No active Membership in this Program."},
             status=http_status.HTTP_403_FORBIDDEN,
         )
+
+    if (
+        fulfilling_role == "maintenance"
+        and isinstance(instance, MaintenanceTicket)
+        and not _is_fulfilling_team_member(request, content=instance, fulfilling_role=fulfilling_role)
+    ):
+        if to_state != MaintenanceTicket.Status.FULFILLED or not _submitter_may_close_ticket(
+            request, instance,
+        ):
+            return Response(
+                {"detail": "You may only mark your own open tickets as fulfilled."},
+                status=http_status.HTTP_403_FORBIDDEN,
+            )
 
     try:
         instance.transition_to(to_state, actor=actor, note=note, reason=reason)

--- a/backend/bunk_logs/api/tests/test_counselor_dashboard.py
+++ b/backend/bunk_logs/api/tests/test_counselor_dashboard.py
@@ -773,6 +773,55 @@ def test_dashboard_does_not_leak_other_org_data(org, program):
 
 
 @pytest.mark.django_db
+def test_dashboard_returns_viewer_and_bunk_tiles(
+    org,
+    program,
+    counselor_user,
+    counselor_person,
+    counselor_membership,
+    bunk,
+    counselor_as_author,
+    campers,
+    camper_template,
+):
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get("/api/v1/counselor/dashboard/?nocache=1")
+    assert resp.status_code == 200
+    assert resp.data["viewer"]["full_name"] == counselor_person.full_name
+    assert len(resp.data["bunks"]) == 1
+    tile = resp.data["bunks"][0]
+    assert tile["id"] == bunk.id
+    assert tile["name"] == "Bunk Birch"
+    assert tile["camper_count"] == 3
+    assert len(tile["assignments"]) >= 1
+    assignment = tile["assignments"][0]
+    assert assignment["total"] == 3
+    assert assignment["remaining"] == 3
+    assert "needed today" in assignment["due_label"]
+
+
+@pytest.mark.django_db
+def test_dashboard_honors_date_query_param(
+    org,
+    program,
+    counselor_user,
+    counselor_person,
+    counselor_membership,
+    bunk,
+    counselor_as_author,
+    campers,
+    camper_template,
+):
+    today = get_today(org)
+    c = _client(counselor_user, org)
+    with organization_context(org):
+        resp = c.get(f"/api/v1/counselor/dashboard/?nocache=1&date={today.isoformat()}")
+    assert resp.data["selected_date"] == today.isoformat()
+    assert resp.data["is_today"] is True
+
+
+@pytest.mark.django_db
 def test_dashboard_returns_rollover_hour_and_timezone(
     org, program, counselor_user, counselor_person, counselor_membership,
 ):

--- a/backend/bunk_logs/api/tests/test_maintenance_queue.py
+++ b/backend/bunk_logs/api/tests/test_maintenance_queue.py
@@ -178,11 +178,9 @@ class TestMaintenanceQueueViewerScope:
         rows = r.json()["tickets"]
         assert any(row["available_transitions"] for row in rows)
 
-    def test_viewer_sees_full_queue(
+    def test_viewer_defaults_to_mine_filter(
         self, api, org, program, ticket, counselor_membership,
     ):
-        # A counselor (non-maintenance) sees every ticket in the program, even
-        # ones they did not file (the `ticket` fixture has no submitter).
         with organization_context(org):
             mine = MaintenanceTicket.objects.create(
                 organization=org,
@@ -195,21 +193,60 @@ class TestMaintenanceQueueViewerScope:
             )
         api.force_authenticate(user=counselor_membership.user)
         r = api.get("/api/v1/maintenance/queue/", **_hdr(org.slug))
-        assert r.status_code == 200, r.content
-        data = r.json()
-        assert data["scope"] == "viewer"
-        ids = [t["id"] for t in data["tickets"]]
+        assert r.status_code == 200
+        ids = [t["id"] for t in r.json()["tickets"]]
         assert str(mine.id) in ids
-        assert str(ticket.id) in ids
+        assert str(ticket.id) not in ids
 
-    def test_viewer_rows_are_read_only(
+    def test_viewer_can_see_all_open_with_filter(
         self, api, org, ticket, counselor_membership,
     ):
         api.force_authenticate(user=counselor_membership.user)
+        r = api.get("/api/v1/maintenance/queue/?filter=open", **_hdr(org.slug))
+        ids = [t["id"] for t in r.json()["tickets"]]
+        assert str(ticket.id) in ids
+
+    def test_viewer_can_close_own_ticket(
+        self, api, org, program, counselor_membership,
+    ):
+        with organization_context(org):
+            mine = MaintenanceTicket.objects.create(
+                organization=org,
+                program=program,
+                location="Bunk 5",
+                category=MaintenanceTicket.Category.PLUMBING,
+                description="My leak",
+                urgency=MaintenanceTicket.Urgency.NORMAL,
+                status=MaintenanceTicket.Status.NEW,
+                submitted_by=counselor_membership,
+            )
+        api.force_authenticate(user=counselor_membership.user)
         r = api.get("/api/v1/maintenance/queue/", **_hdr(org.slug))
-        rows = r.json()["tickets"]
-        assert rows
-        assert all(row["available_transitions"] == [] for row in rows)
+        row = next(t for t in r.json()["tickets"] if t["id"] == str(mine.id))
+        assert row["is_mine"] is True
+        assert "fulfilled" in row["available_transitions"]
+
+        tr = api.post(
+            f"/api/v1/maintenance/{mine.id}/transition/",
+            {"to_state": "fulfilled"},
+            format="json",
+            **_hdr(org.slug),
+        )
+        assert tr.status_code == 200, tr.content
+        mine.refresh_from_db()
+        assert mine.status == MaintenanceTicket.Status.FULFILLED
+
+    def test_viewer_cannot_close_others_ticket(
+        self, api, org, ticket, counselor_membership,
+    ):
+        api.force_authenticate(user=counselor_membership.user)
+        r = api.post(
+            f"/api/v1/maintenance/{ticket.id}/transition/",
+            {"to_state": "fulfilled"},
+            format="json",
+            **_hdr(org.slug),
+        )
+        assert r.status_code == 403
 
     def test_unauthenticated_rejected(self, api, org):
         r = api.get("/api/v1/maintenance/queue/", **_hdr(org.slug))

--- a/backend/bunk_logs/core/admin.py
+++ b/backend/bunk_logs/core/admin.py
@@ -196,6 +196,43 @@ class ProgramAdmin(admin.ModelAdmin):
     autocomplete_fields = ["organization"]
 
 
+class AssignmentGroupAdminForm(forms.ModelForm):
+    class Meta:
+        model = AssignmentGroup
+        fields = (
+            "organization",
+            "program",
+            "name",
+            "slug",
+            "group_type",
+            "parent",
+            "metadata",
+            "is_active",
+        )
+
+    def clean(self):
+        cleaned = super().clean()
+        org = cleaned.get("organization")
+        program = cleaned.get("program")
+        parent = cleaned.get("parent")
+        if org and program and program.organization_id != org.pk:
+            self.add_error(
+                "program",
+                "Program must belong to the selected organization.",
+            )
+        if parent and program and parent.program_id != program.pk:
+            self.add_error(
+                "parent",
+                "Parent group must belong to the same program.",
+            )
+        if parent and org and parent.organization_id != org.pk:
+            self.add_error(
+                "parent",
+                "Parent group must belong to the selected organization.",
+            )
+        return cleaned
+
+
 class AssignmentGroupMembershipInline(admin.TabularInline):
     model = AssignmentGroupMembership
     extra = 0
@@ -205,6 +242,18 @@ class AssignmentGroupMembershipInline(admin.TabularInline):
     def get_queryset(self, request):
         return AssignmentGroupMembership.all_objects.select_related("person")
 
+    def get_formset(self, request, obj=None, **kwargs):
+        """Pass ``all_objects`` into the formset so inline PK validation works without tenant context."""
+        FormSet = super().get_formset(request, obj, **kwargs)
+        membership_qs = AssignmentGroupMembership.all_objects.select_related("person")
+
+        class AdminMembershipInlineFormSet(FormSet):
+            def __init__(self, *args, **kwargs):
+                kwargs.setdefault("queryset", membership_qs)
+                super().__init__(*args, **kwargs)
+
+        return AdminMembershipInlineFormSet
+
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         if db_field.name == "person":
             kwargs.setdefault("queryset", Person.all_objects.order_by("last_name", "first_name"))
@@ -213,8 +262,28 @@ class AssignmentGroupMembershipInline(admin.TabularInline):
 
 @admin.register(AssignmentGroup)
 class AssignmentGroupAdmin(admin.ModelAdmin):
+    form = AssignmentGroupAdminForm
+
     def get_queryset(self, request):
         return AssignmentGroup.all_objects.select_related("organization", "program", "parent")
+
+    def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
+        """Pin tenant context to the group being edited (inline membership validation)."""
+        from bunk_logs.core.context import clear_current_organization
+        from bunk_logs.core.context import set_current_organization
+
+        org = None
+        if object_id:
+            obj = self.get_object(request, object_id)
+            if obj is not None:
+                org = obj.organization
+        if org is not None:
+            set_current_organization(org)
+        try:
+            return super().changeform_view(request, object_id, form_url, extra_context)
+        finally:
+            if org is not None:
+                clear_current_organization()
 
     list_display = ["name", "group_type", "program", "organization", "parent", "is_active"]
     list_filter = ["group_type", "program__organization", "is_active"]

--- a/backend/bunk_logs/core/permissions/observation_authoring.py
+++ b/backend/bunk_logs/core/permissions/observation_authoring.py
@@ -1,10 +1,12 @@
 """Observation authoring scope (Step 7_23).
 
-Who may *write* an observation about whom reuses the SubjectNote authoring
-primitives unchanged (``max_author_scope`` / ``authorable_subject_queryset`` /
-``can_author_subject_note``). The one addition is the recipient sensitivity
-gate: a recipient can only be tagged at a sensitivity tier their capability
-clears, so a sensitive observation can never out-run who it is sent to.
+Subject tagging for observations is intentionally broader than SubjectNotes:
+any staff member who may write observations at all can tag any ``Person`` in
+the organization. Roster assignment (``AssignmentGroupMembership``) still
+governs who sees what on dashboards; sensitivity + recipient gates constrain
+distribution after submit.
+
+Recipient tagging still uses the capability / sensitivity map.
 """
 
 from __future__ import annotations
@@ -12,11 +14,35 @@ from __future__ import annotations
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
 from bunk_logs.core.permissions.observation_read import view_by_capability_for_org
+from bunk_logs.core.permissions.subject_note_authoring import max_author_scope
+from bunk_logs.core.permissions.super_admin import is_super_admin
 
-# Re-exported for callers that want the authoring primitives from one module.
+# Subject-note primitives (unchanged) — used outside the observations API.
 from bunk_logs.core.permissions.subject_note_authoring import authorable_subject_queryset
 from bunk_logs.core.permissions.subject_note_authoring import can_author_subject_note
-from bunk_logs.core.permissions.subject_note_authoring import max_author_scope
+
+
+def observation_authorable_subject_queryset(viewer_person: Person, org):
+    """Person queryset taggable as subjects on an observation."""
+    if max_author_scope(viewer_person, org) == "none":
+        return Person.all_objects.none()
+    return Person.all_objects.filter(organization=org)
+
+
+def can_author_observation(
+    viewer_person: Person | None,
+    subject: Person,
+    org,
+    user,
+) -> bool:
+    """Return True if ``viewer_person`` may tag ``subject`` on an observation."""
+    if is_super_admin(user):
+        return True
+    if viewer_person is None:
+        return False
+    if subject.organization_id != org.id:
+        return False
+    return max_author_scope(viewer_person, org) != "none"
 
 
 def recipients_clearing_sensitivity(viewer_person: Person, org, sensitivity: str):
@@ -51,8 +77,10 @@ def can_tag_recipient(viewer_person: Person, recipient: Person, org, sensitivity
 
 __all__ = [
     "authorable_subject_queryset",
+    "can_author_observation",
     "can_author_subject_note",
     "can_tag_recipient",
     "max_author_scope",
+    "observation_authorable_subject_queryset",
     "recipients_clearing_sensitivity",
 ]

--- a/backend/bunk_logs/core/permissions/observation_authoring.py
+++ b/backend/bunk_logs/core/permissions/observation_authoring.py
@@ -14,12 +14,10 @@ from __future__ import annotations
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
 from bunk_logs.core.permissions.observation_read import view_by_capability_for_org
-from bunk_logs.core.permissions.subject_note_authoring import max_author_scope
-from bunk_logs.core.permissions.super_admin import is_super_admin
-
-# Subject-note primitives (unchanged) — used outside the observations API.
 from bunk_logs.core.permissions.subject_note_authoring import authorable_subject_queryset
 from bunk_logs.core.permissions.subject_note_authoring import can_author_subject_note
+from bunk_logs.core.permissions.subject_note_authoring import max_author_scope
+from bunk_logs.core.permissions.super_admin import is_super_admin
 
 
 def observation_authorable_subject_queryset(viewer_person: Person, org):

--- a/backend/bunk_logs/core/permissions/subject_note_authoring.py
+++ b/backend/bunk_logs/core/permissions/subject_note_authoring.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 from typing import Literal
 
-from bunk_logs.core.models import AssignmentGroup
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person

--- a/backend/bunk_logs/core/permissions/subject_note_authoring.py
+++ b/backend/bunk_logs/core/permissions/subject_note_authoring.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from typing import Literal
 
+from bunk_logs.core.models import AssignmentGroup
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
@@ -176,6 +177,25 @@ def authorable_subject_queryset(viewer_person: Person, org):
             supervised_ids = set(
                 AssignmentGroupMembership.all_objects.filter(
                     group_id__in=group_ids,
+                    role_in_group="subject",
+                    is_active=True,
+                    group__organization_id=org.id,
+                ).values_list("person_id", flat=True),
+            )
+        bunk_ids = list(
+            AssignmentGroupMembership.all_objects.filter(
+                person=viewer_person,
+                role_in_group="author",
+                is_active=True,
+                group__is_active=True,
+                group__group_type="bunk",
+                group__organization_id=org.id,
+            ).values_list("group_id", flat=True),
+        )
+        if bunk_ids:
+            supervised_ids.update(
+                AssignmentGroupMembership.all_objects.filter(
+                    group_id__in=bunk_ids,
                     role_in_group="subject",
                     is_active=True,
                 ).values_list("person_id", flat=True),

--- a/backend/bunk_logs/core/permissions/test_observation_authoring.py
+++ b/backend/bunk_logs/core/permissions/test_observation_authoring.py
@@ -1,0 +1,69 @@
+"""Observation subject tagging is org-wide for anyone who may write observations."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.permissions.observation_authoring import can_author_observation
+from bunk_logs.core.permissions.observation_authoring import observation_authorable_subject_queryset
+from bunk_logs.core.permissions.subject_note_authoring import can_author_subject_note
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="Obs Org", slug="obs-org")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="Obs Org Summer",
+        slug="obs-summer",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+def _person(org, first, last):
+    return Person.all_objects.create(organization=org, first_name=first, last_name=last)
+
+
+def _membership(program, person, role):
+    return Membership.all_objects.create(
+        program=program, person=person, role=role, is_active=True,
+    )
+
+
+def test_counselor_can_tag_any_org_person_on_observation(org, program):
+    counselor = _person(org, "Ann", "Counselor")
+    _membership(program, counselor, "counselor")
+    distant_camper = _person(org, "Far", "Away")
+    _membership(program, distant_camper, "camper")
+
+    assert can_author_observation(counselor, distant_camper, org, user=None) is True
+    assert can_author_subject_note(counselor, distant_camper, org, user=None) is False
+
+    searchable = observation_authorable_subject_queryset(counselor, org)
+    assert distant_camper.id in set(searchable.values_list("id", flat=True))
+
+
+def test_kitchen_staff_cannot_tag_observation_subjects(org, program):
+    staff = _person(org, "Kit", "Chen")
+    _membership(program, staff, "kitchen_staff")
+    camper = _person(org, "Pat", "Camper")
+    _membership(program, camper, "camper")
+
+    assert can_author_observation(staff, camper, org, user=None) is False
+    assert observation_authorable_subject_queryset(staff, org).count() == 0

--- a/backend/bunk_logs/core/permissions/test_observation_authoring.py
+++ b/backend/bunk_logs/core/permissions/test_observation_authoring.py
@@ -6,8 +6,6 @@ from datetime import date
 
 import pytest
 
-from bunk_logs.core.models import AssignmentGroup
-from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Organization
 from bunk_logs.core.models import Person

--- a/backend/bunk_logs/core/test_admin_assignment_group.py
+++ b/backend/bunk_logs/core/test_admin_assignment_group.py
@@ -1,0 +1,141 @@
+"""Regression: AssignmentGroup admin must save for staff without a Person and with membership inlines."""
+
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+
+User = get_user_model()
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="AG Admin Org", slug="ag-admin-org")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="AG Admin Org Summer",
+        slug="ag-admin-prog",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def person(org):
+    return Person.all_objects.create(organization=org, first_name="Sam", last_name="Staff")
+
+
+@pytest.fixture
+def group(org, program):
+    return AssignmentGroup.all_objects.create(
+        organization=org,
+        program=program,
+        name="Bunk Test",
+        slug="bunk-test",
+        group_type="bunk",
+    )
+
+
+@pytest.fixture
+def membership(group, person):
+    return AssignmentGroupMembership.all_objects.create(
+        group=group,
+        person=person,
+        role_in_group="author",
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def superuser_without_person(db):
+    return User.objects.create_superuser(email="ag-admin-su@example.test", password="pw")
+
+
+def _assignment_group_post(group, memberships):
+    post = {
+        "organization": str(group.organization_id),
+        "program": str(group.program_id),
+        "name": group.name,
+        "slug": group.slug,
+        "group_type": group.group_type,
+        "parent": str(group.parent_id) if group.parent_id else "",
+        "metadata": "{}",
+        "is_active": "on",
+        "_save": "Save",
+        "memberships-TOTAL_FORMS": str(len(memberships)),
+        "memberships-INITIAL_FORMS": str(len(memberships)),
+        "memberships-MIN_NUM_FORMS": "0",
+        "memberships-MAX_NUM_FORMS": "1000",
+    }
+    for i, m in enumerate(memberships):
+        post[f"memberships-{i}-id"] = str(m.id)
+        post[f"memberships-{i}-person"] = str(m.person_id)
+        post[f"memberships-{i}-role_in_group"] = m.role_in_group
+        post[f"memberships-{i}-is_active"] = "on" if m.is_active else ""
+        post[f"memberships-{i}-start_date"] = ""
+        post[f"memberships-{i}-end_date"] = ""
+    return post
+
+
+@pytest.mark.django_db
+def test_change_assignment_group_with_memberships_for_superuser_without_person(
+    superuser_without_person,
+    group,
+    membership,
+):
+    memberships = list(AssignmentGroupMembership.all_objects.filter(group=group))
+    client = Client()
+    client.force_login(superuser_without_person)
+    url = f"/admin/core/assignmentgroup/{group.id}/change/"
+
+    get_resp = client.get(url)
+    assert get_resp.status_code == 200, get_resp.content
+
+    post = _assignment_group_post(group, memberships)
+    post["name"] = "Bunk Test Updated"
+    post_resp = client.post(url, post)
+    assert post_resp.status_code == 302, post_resp.content
+
+    group.refresh_from_db()
+    assert group.name == "Bunk Test Updated"
+
+
+@pytest.mark.django_db
+def test_assignment_group_admin_rejects_program_from_other_org(
+    superuser_without_person,
+    org,
+    program,
+    group,
+    membership,
+):
+    other = Organization.objects.create(name="Other AG Org", slug="other-ag-org")
+    other_program = Program.all_objects.create(
+        organization=other,
+        name="Other AG Org Summer",
+        slug="other-ag-prog",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+    memberships = list(AssignmentGroupMembership.all_objects.filter(group=group))
+    client = Client()
+    client.force_login(superuser_without_person)
+    url = f"/admin/core/assignmentgroup/{group.id}/change/"
+    post = _assignment_group_post(group, memberships)
+    post["program"] = str(other_program.id)
+
+    post_resp = client.post(url, post)
+    assert post_resp.status_code == 200, post_resp.content
+    assert b"Program must belong to the selected organization" in post_resp.content

--- a/backend/bunk_logs/notes/tests/test_observations_api.py
+++ b/backend/bunk_logs/notes/tests/test_observations_api.py
@@ -252,6 +252,25 @@ class TestCandidatesAndSearch:
         ids = [s["id"] for s in resp.json()["subjects"]]
         assert camper.id in ids
 
+    def test_subjects_search_full_name(
+        self, org, program, counselor_user, counselor_membership, counselor_in_bunk, camper,
+    ):
+        client = _auth_client(counselor_user, org)
+        resp = client.get("/api/v1/observations/subjects/?q=Cam%20Per")
+        assert resp.status_code == 200
+        ids = [s["id"] for s in resp.json()["subjects"]]
+        assert camper.id in ids
+
+    def test_subjects_search_without_bunk_author_agm(
+        self, org, program, counselor_user, counselor_membership, camper,
+    ):
+        """Observations subjects are org-wide — no counselor AGM author required."""
+        client = _auth_client(counselor_user, org)
+        resp = client.get("/api/v1/observations/subjects/?q=Cam")
+        assert resp.status_code == 200
+        ids = [s["id"] for s in resp.json()["subjects"]]
+        assert camper.id in ids
+
     def test_cross_org_thread_not_found(
         self, org, other_org, other_program, program, counselor_person, counselor_membership, camper,
     ):

--- a/backend/bunk_logs/notes/tests/test_observations_api.py
+++ b/backend/bunk_logs/notes/tests/test_observations_api.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 from rest_framework.test import APIClient
 
 from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
 from bunk_logs.notes.models import Observation
 from bunk_logs.notes.models import ObservationArchive
@@ -75,12 +76,33 @@ class TestCreate:
         assert [s["id"] for s in data["subjects"]] == [camper.id]
         assert any(r["person"]["id"] == uh_person.id for r in data["recipients"])
 
-    def test_rejects_unauthorized_subject(
+    def test_allows_org_person_without_bunk_agm(
         self, org, program, counselor_user, counselor_membership,
     ):
-        # Camper not in any group the counselor authors -> not authorable.
+        """Observation subjects are org-wide for staff who may write observations."""
         stranger = Person.all_objects.create(organization=org, first_name="No", last_name="Reach")
         client = _auth_client(counselor_user, org)
+        resp = client.post(
+            "/api/v1/observations/",
+            {"subject_ids": [stranger.id], "body": "x", "sensitivity": "normal"},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.json()
+
+    def test_rejects_subject_when_author_scope_none(self, org, program):
+        from bunk_logs.users.models import User
+
+        kitchen_user = User.objects.create_user(
+            email="kitchen-obs@t.test", password="pw",
+        )
+        kitchen_person = Person.all_objects.create(
+            organization=org, first_name="Kit", last_name="Chen", user=kitchen_user,
+        )
+        Membership.all_objects.create(
+            program=program, person=kitchen_person, role="kitchen_staff", is_active=True,
+        )
+        stranger = Person.all_objects.create(organization=org, first_name="No", last_name="Reach")
+        client = _auth_client(kitchen_user, org)
         resp = client.post(
             "/api/v1/observations/",
             {"subject_ids": [stranger.id], "body": "x", "sensitivity": "normal"},

--- a/frontend/e2e/rbac-sidebar.spec.ts
+++ b/frontend/e2e/rbac-sidebar.spec.ts
@@ -21,7 +21,9 @@ const HREFS = {
   tasks: '/tasks',
   reflect: '/reflect',
   myReflections: '/my-reflections',
-  counselorHome: '/counselor-dashboard',
+  counselorHome: '/counselor',
+  unitHeadHome: '/unit-head',
+  camperCareHome: '/camper-care',
   orders: '/orders',
   // Supervise
   groupsPerformance: '/groups/performance',
@@ -60,14 +62,15 @@ test.describe('Sidebar RBAC — capability tiers (3.32)', () => {
     await loginAs(page, 'counselor');
     await readSidebarText(page);
 
-    // My work entries
-    expect(await hasLink(page, HREFS.home)).toBe(true);
-    expect(await hasLink(page, HREFS.tasks)).toBe(true);
+    // My work entries — Home goes straight to the counselor workspace
     expect(await hasLink(page, HREFS.counselorHome)).toBe(true);
-    expect(await hasLink(page, HREFS.reflect)).toBe(true);
+    expect(await countLinks(page, HREFS.counselorHome)).toBe(1);
+    expect(await hasLink(page, HREFS.home)).toBe(false);
+    expect(await hasLink(page, HREFS.tasks)).toBe(true);
+    expect(await hasLink(page, HREFS.reflect)).toBe(false);
     expect(await hasLink(page, HREFS.myReflections)).toBe(true);
     expect(await hasLink(page, HREFS.orders)).toBe(false);
-    expect(await hasLink(page, HREFS.dashboardsReflections)).toBe(true);
+    expect(await hasLink(page, HREFS.dashboardsReflections)).toBe(false);
 
     // No Supervise / Dashboards / Admin / Legacy
     expect(await hasLink(page, HREFS.groupsPerformance)).toBe(false);
@@ -83,7 +86,9 @@ test.describe('Sidebar RBAC — capability tiers (3.32)', () => {
     await loginAs(page, 'unit_head');
     await readSidebarText(page);
 
-    expect(await hasLink(page, HREFS.home)).toBe(true);
+    expect(await hasLink(page, HREFS.unitHeadHome)).toBe(true);
+    expect(await countLinks(page, HREFS.unitHeadHome)).toBe(1);
+    expect(await hasLink(page, HREFS.home)).toBe(false);
     expect(await hasLink(page, HREFS.orders)).toBe(false);
     expect(await hasLink(page, HREFS.groupsPerformance)).toBe(true);
     expect(await hasLink(page, HREFS.concernsInbox)).toBe(true);
@@ -91,7 +96,6 @@ test.describe('Sidebar RBAC — capability tiers (3.32)', () => {
     expect(await hasLink(page, HREFS.dashboardsHome)).toBe(false);
     expect(await hasLink(page, HREFS.adminMemberships)).toBe(false);
     expect(await hasLink(page, HREFS.legacyBunkLogs)).toBe(false);
-    // No role-specific Counselor home for unit heads.
     expect(await hasLink(page, HREFS.counselorHome)).toBe(false);
   });
 

--- a/frontend/src/api/__tests__/counselor.test.js
+++ b/frontend/src/api/__tests__/counselor.test.js
@@ -66,6 +66,9 @@ describe('counselor API helpers', () => {
 
     await fetchCounselorDashboard({ noCache: true });
     expect(getMock.mock.calls[1][1]).toEqual({ params: { nocache: '1' } });
+
+    await fetchCounselorDashboard({ date: '2026-07-01' });
+    expect(getMock.mock.calls[2][1]).toEqual({ params: { date: '2026-07-01' } });
   });
 
   it('fetchCamperReflections forwards the date param', async () => {

--- a/frontend/src/api/counselor.js
+++ b/frontend/src/api/counselor.js
@@ -36,8 +36,10 @@ export function newClientSubmissionId() {
 }
 
 /** Counselor dashboard payload (Story 2 + 9). */
-export async function fetchCounselorDashboard({ noCache = false } = {}) {
-  const params = noCache ? { nocache: '1' } : {};
+export async function fetchCounselorDashboard({ noCache = false, date } = {}) {
+  const params = {};
+  if (noCache) params.nocache = '1';
+  if (date) params.date = date;
   const { data } = await api.get('/api/v1/counselor/dashboard/', { params });
   return data;
 }

--- a/frontend/src/components/observations/ObservationComposer.jsx
+++ b/frontend/src/components/observations/ObservationComposer.jsx
@@ -32,6 +32,8 @@ export default function ObservationComposer({ onClose, onSent, initialSubjects =
   const [query, setQuery] = useState('');
   const [results, setResults] = useState([]);
   const [searching, setSearching] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [searchError, setSearchError] = useState(null);
   const [subjects, setSubjects] = useState(initialSubjects);
   const [body, setBody] = useState('');
   const [observedAtLocal, setObservedAtLocal] = useState(defaultObservedAtLocal);
@@ -50,13 +52,24 @@ export default function ObservationComposer({ onClose, onSent, initialSubjects =
     if (!query.trim()) {
       setResults([]);
       setSearching(false);
+      setHasSearched(false);
+      setSearchError(null);
       return undefined;
     }
     setSearching(true);
+    setSearchError(null);
     debounceRef.current = setTimeout(() => {
       searchObservationSubjects(query.trim())
-        .then(setResults)
-        .catch(() => setResults([]))
+        .then((items) => {
+          setResults(items);
+          setHasSearched(true);
+        })
+        .catch((err) => {
+          setResults([]);
+          setHasSearched(true);
+          const detail = err.response?.data?.detail;
+          setSearchError(detail || 'Could not search campers. Try again.');
+        })
         .finally(() => setSearching(false));
     }, SEARCH_DEBOUNCE_MS);
     return () => clearTimeout(debounceRef.current);
@@ -85,6 +98,8 @@ export default function ObservationComposer({ onClose, onSent, initialSubjects =
     setSubjects((prev) => (prev.some((p) => p.id === s.id) ? prev : [...prev, s]));
     setQuery('');
     setResults([]);
+    setHasSearched(false);
+    setSearchError(null);
   }
 
   function removeSubject(id) {
@@ -187,13 +202,19 @@ export default function ObservationComposer({ onClose, onSent, initialSubjects =
                 className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
                 data-testid="observation-composer-search"
               />
-              {(searching || results.length > 0) && (
+              {query.trim() && (searching || hasSearched) && (
                 <ul
                   className="absolute z-10 mt-1 w-full rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg max-h-56 overflow-y-auto"
                   data-testid="observation-composer-results"
                 >
-                  {searching && results.length === 0 && (
+                  {searching && results.length === 0 && !searchError && (
                     <li className="px-3 py-2 text-xs text-gray-400">Searching…</li>
+                  )}
+                  {searchError && (
+                    <li className="px-3 py-2 text-xs text-rose-600 dark:text-rose-400">{searchError}</li>
+                  )}
+                  {hasSearched && !searching && !searchError && results.length === 0 && (
+                    <li className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">No matching campers.</li>
                   )}
                   {results.map((s) => (
                     <li key={s.id}>

--- a/frontend/src/dashboards/performance/PerformanceDashboard.jsx
+++ b/frontend/src/dashboards/performance/PerformanceDashboard.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import api from '../../api';
 import GroupPerformanceCard from './GroupPerformanceCard';
 
@@ -31,13 +32,34 @@ function formatDisplayDate(iso) {
 }
 
 export default function PerformanceDashboard() {
-  const [groupType, setGroupType] = useState('bunk');
-  const [program, setProgram] = useState('');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const dateParam = searchParams.get('date') || '';
+  const groupTypeParam = searchParams.get('group_type') ?? 'bunk';
+  const programParam = searchParams.get('program') || '';
+
+  const selectedDate = dateParam || todayIso();
+  const groupType = groupTypeParam;
+  const program = programParam;
+
   const [programOptions, setProgramOptions] = useState([]);
-  const [selectedDate, setSelectedDate] = useState(todayIso);
   const [payload, setPayload] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+
+  const syncParams = useCallback((next) => {
+    const params = new URLSearchParams(searchParams);
+    if (next.date) params.set('date', next.date);
+    else if (next.date === '') params.delete('date');
+    if (next.group_type !== undefined) {
+      if (next.group_type) params.set('group_type', next.group_type);
+      else params.delete('group_type');
+    }
+    if (next.program !== undefined) {
+      if (next.program) params.set('program', next.program);
+      else params.delete('program');
+    }
+    setSearchParams(params, { replace: true });
+  }, [searchParams, setSearchParams]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -105,7 +127,7 @@ export default function PerformanceDashboard() {
             <span>Program</span>
             <select
               value={program}
-              onChange={(e) => setProgram(e.target.value)}
+              onChange={(e) => syncParams({ program: e.target.value })}
               className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-sm"
             >
               <option value="">All programs</option>
@@ -118,7 +140,7 @@ export default function PerformanceDashboard() {
             <span>Group type</span>
             <select
               value={groupType}
-              onChange={(e) => setGroupType(e.target.value)}
+              onChange={(e) => syncParams({ group_type: e.target.value })}
               className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-sm"
             >
               {GROUP_TYPES.map((g) => (
@@ -131,7 +153,8 @@ export default function PerformanceDashboard() {
             <input
               type="date"
               value={selectedDate}
-              onChange={(e) => setSelectedDate(e.target.value)}
+              onChange={(e) => syncParams({ date: e.target.value })}
+              data-testid="performance-date-picker"
               className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-sm"
             />
           </label>

--- a/frontend/src/dashboards/performance/__tests__/PerformanceDashboard.test.jsx
+++ b/frontend/src/dashboards/performance/__tests__/PerformanceDashboard.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import PerformanceDashboard from '../PerformanceDashboard';
 
 vi.mock('../../../api', () => ({
@@ -44,8 +44,10 @@ describe('PerformanceDashboard', () => {
   it('renders filters, group cards, and program name when a program is selected', async () => {
     const user = userEvent.setup();
     render(
-      <MemoryRouter>
-        <PerformanceDashboard />
+      <MemoryRouter initialEntries={['/groups/performance?date=2026-07-10&group_type=bunk']}>
+        <Routes>
+          <Route path="/groups/performance" element={<PerformanceDashboard />} />
+        </Routes>
       </MemoryRouter>,
     );
 
@@ -68,8 +70,11 @@ describe('PerformanceDashboard', () => {
     expect(api.get).toHaveBeenCalledWith(
       '/api/v1/dashboards/groups/performance/',
       expect.objectContaining({
-        params: expect.objectContaining({ group_type: 'bunk' }),
+        params: expect.objectContaining({ group_type: 'bunk', date: '2026-07-10' }),
       }),
     );
+
+    const dateInput = screen.getByTestId('performance-date-picker');
+    expect(dateInput).toHaveValue('2026-07-10');
   });
 });

--- a/frontend/src/pages/TasksPage.test.jsx
+++ b/frontend/src/pages/TasksPage.test.jsx
@@ -156,7 +156,7 @@ describe('TasksPage', () => {
     });
     getMock.mockResolvedValue({ data: { tasks: [task] } });
     renderPage();
-    await waitFor(() => expect(screen.getByText(/submitted/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/Submitted \d/i)).toBeInTheDocument());
   });
 
   // Roster section (single_subject)
@@ -217,18 +217,19 @@ describe('TasksPage', () => {
     const pendingTask = rosterTask([sarahSubject]);
     getMock.mockResolvedValue({ data: { tasks: [completedTask, pendingTask] } });
     renderPage();
-    await waitFor(() => expect(screen.getByText(/1 task waiting/i)).toBeInTheDocument());
-    expect(screen.getByText(/1\/2 completed/i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText(/1 remaining/i)).toBeInTheDocument());
+    expect(screen.getByText(/\/ 2 assignments/i)).toBeInTheDocument();
   });
 
-  it('summary bar shows all done when everything complete', async () => {
+  it('shows celebration when all tasks are complete', async () => {
     const task = selfTask({
       completion: { covered: 1, total: 1, my_count: 1 },
       self_status: { submitted: true, reflection_id: 1, submitted_at: null },
     });
     getMock.mockResolvedValue({ data: { tasks: [task] } });
     renderPage();
-    await waitFor(() => expect(screen.getByText(/all done/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('tasks-all-done-celebration')).toBeInTheDocument());
+    expect(screen.getByText(/all caught up/i)).toBeInTheDocument();
   });
 
   // multi_subject: renders same as single_subject in v1

--- a/frontend/src/pages/camper-care/SelfReflectionPage.jsx
+++ b/frontend/src/pages/camper-care/SelfReflectionPage.jsx
@@ -16,6 +16,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import ReflectionField from '../../components/templates/ReflectionField';
 import {
   buildDefaultAnswers,
+  prepareReflectionAnswersForSubmit,
   validateReflectionAnswers,
 } from '../../utils/reflection/reflectionFormValidation';
 import {
@@ -221,7 +222,9 @@ export default function CamperCareSelfReflectionPage() {
     try {
       const payloadAnswers = (() => {
         if (dayOff) return undefined;
-        const next = { ...answers };
+        const next = prepareReflectionAnswersForSubmit(schema, answers, {
+          omitKeys: [DAY_OFF_FIELD_KEY],
+        });
         const raw = next[BUNK_CONCERNS_FIELD_KEY];
         if (Array.isArray(raw)) {
           next[BUNK_CONCERNS_FIELD_KEY] = raw

--- a/frontend/src/pages/counselor/CounselorMobileDashboard.jsx
+++ b/frontend/src/pages/counselor/CounselorMobileDashboard.jsx
@@ -1,130 +1,185 @@
 /**
- * Counselor dashboard — Step 7_6d (Stories 2 + 9).
+ * Counselor home dashboard at `/counselor`.
  *
- * Renders the three-section payload from
- * `GET /api/v1/counselor/dashboard/`:
- *
- *   1. Camper reflections — covered / total, off-camp count, deep link
- *      into the roster page.
- *   2. Self-reflection — submitted/missing state, day-off badge, edit
- *      link.
- *   3. Open requests — combined camper-care + maintenance count from
- *      the viewer + co-counselors (decision C4).
- *
- * "All set" banner appears when the first two sections are complete.
- * The Requests section never blocks all-set (Story 9 criterion 2).
- *
- * Layout: mobile-first single column (matches the approved mockup);
- * on desktop the three task cards lay out as an equal-height 3-up grid
- * in the shared dashboard design language (rounded-xl cards, shadow-sm,
- * uppercase context line + large date header) used by the Bunk/Unit
- * dashboards.
- *
- * Auto-refresh on a 60-second interval so co-counselor submissions
- * surface without a manual reload (matches dashboard cache TTL of 30s
- * with one round-trip of buffer).
+ * Renders viewer context, a date picker (defaults to org "today"), bunk
+ * tiles for groups the counselor authors (with form-assignment progress),
+ * self-reflection status, quick actions (requests + observations), and
+ * the all-set banner when camper + self work is complete.
  */
 
-import { useCallback, useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
-import { CheckCircle } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import {
+  CheckCircle,
+  ClipboardList,
+  ClipboardCheck,
+  Home,
+  MessageSquarePlus,
+  Users,
+  Wrench,
+  HeartHandshake,
+} from 'lucide-react';
 import { fetchCounselorDashboard } from '../../api/counselor';
 
 const REFRESH_INTERVAL_MS = 60_000;
 
-function SectionCard({ title, state, children, actionLabel, actionTo, dataTestid }) {
-  const stateBadge = (() => {
-    switch (state) {
-      case 'complete':
-        return { label: 'Done', className: 'border border-green-200 dark:border-green-900 bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-300' };
-      case 'in_progress':
-        return { label: 'In progress', className: 'border border-amber-200 dark:border-amber-900 bg-amber-50 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300' };
-      case 'none':
-      default:
-        return { label: 'Not started', className: 'border border-gray-200 dark:border-gray-700 bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300' };
-    }
-  })();
+const STATE_BADGE = {
+  complete: {
+    label: 'Done',
+    className:
+      'border border-green-200 dark:border-green-900 bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-300',
+  },
+  in_progress: {
+    label: 'In progress',
+    className:
+      'border border-amber-200 dark:border-amber-900 bg-amber-50 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
+  },
+  none: {
+    label: 'Not started',
+    className:
+      'border border-gray-200 dark:border-gray-700 bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300',
+  },
+};
 
+function formatDisplayDate(iso) {
+  if (!iso) return '';
+  const parsed = new Date(`${iso}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return iso;
+  return parsed.toLocaleDateString(undefined, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function titleCaseRole(role) {
+  if (!role) return '';
+  return role.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function AssignmentRow({ assignment }) {
+  const badge = STATE_BADGE[assignment.state] || STATE_BADGE.none;
   return (
-    <section
-      data-testid={dataTestid}
-      data-state={state}
-      className="flex flex-col h-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-5 shadow-sm"
+    <div
+      className="rounded-lg border border-gray-100 dark:border-gray-800 bg-gray-50/80 dark:bg-gray-800/40 px-3 py-2.5"
+      data-testid={`bunk-assignment-${assignment.template_id}`}
+      data-state={assignment.state}
     >
-      <div className="flex items-start justify-between gap-2 mb-2">
-        <h2 className="text-base font-semibold text-gray-900 dark:text-white">{title}</h2>
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+            {assignment.template_name}
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            {assignment.due_label}
+            {assignment.total > 0 && assignment.cadence === 'daily' ? (
+              <span className="text-gray-400 dark:text-gray-500">
+                {' '}
+                · {assignment.covered}/{assignment.total}
+              </span>
+            ) : null}
+          </p>
+        </div>
         <span
-          className={`shrink-0 text-xs font-semibold px-2 py-0.5 rounded-full ${stateBadge.className}`}
-          data-testid={`${dataTestid}-state`}
+          className={`shrink-0 text-[10px] font-semibold px-2 py-0.5 rounded-full ${badge.className}`}
         >
-          {stateBadge.label}
+          {badge.label}
         </span>
       </div>
-      <div className="text-sm text-gray-700 dark:text-gray-300">{children}</div>
-      {actionTo ? (
-        <div className="mt-auto pt-4">
-          <Link
-            to={actionTo}
-            data-testid={`${dataTestid}-action`}
-            className="inline-flex items-center justify-center min-h-[44px] px-4 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 transition-colors"
-          >
-            {actionLabel}
-          </Link>
-        </div>
+      {assignment.action_path ? (
+        <Link
+          to={assignment.action_path}
+          className="mt-2 inline-flex items-center justify-center min-h-[36px] px-3 rounded-md bg-blue-600 text-white text-xs font-medium hover:bg-blue-700 transition-colors"
+          data-testid={`bunk-assignment-action-${assignment.template_id}`}
+        >
+          {assignment.state === 'complete' ? 'Review' : 'Complete assignment'}
+        </Link>
       ) : null}
-    </section>
+    </div>
   );
 }
 
-function CamperSection({ section }) {
-  const { covered = 0, total = 0, off_camp: offCamp = 0, state } = section || {};
-  const remaining = Math.max(total - covered, 0);
-
-  let summary;
-  if (total === 0) {
-    summary = (
-      <p className="text-gray-600 dark:text-gray-400">
-        No campers on roster today.
-      </p>
-    );
-  } else if (state === 'complete') {
-    summary = (
-      <p>
-        All <span className="font-medium">{total}</span> campers covered.
-      </p>
-    );
-  } else {
-    summary = (
-      <p>
-        <span className="font-medium">{remaining}</span> camper{remaining === 1 ? '' : 's'} still need{remaining === 1 ? 's' : ''} a reflection.
-        {' '}
-        <span className="text-gray-500 dark:text-gray-400">
-          ({covered}/{total})
-        </span>
-      </p>
-    );
-  }
+function BunkTile({ bunk }) {
+  const complete =
+    bunk.assignments?.length > 0
+    && bunk.assignments.every((a) => a.state === 'complete');
 
   return (
-    <SectionCard
-      title="Camper reflections"
-      state={state}
-      actionLabel={state === 'complete' ? 'Review' : 'Start reflections'}
-      actionTo="/counselor/camper-reflections"
-      dataTestid="counselor-section-campers"
+    <article
+      data-testid={`counselor-bunk-tile-${bunk.id}`}
+      className={[
+        'flex flex-col rounded-2xl border shadow-sm overflow-hidden transition-shadow hover:shadow-md',
+        complete
+          ? 'border-emerald-200 dark:border-emerald-800 bg-gradient-to-br from-emerald-50/80 to-white dark:from-emerald-950/30 dark:to-gray-900'
+          : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900',
+      ].join(' ')}
     >
-      {summary}
-      {offCamp > 0 ? (
-        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-          {offCamp} camper{offCamp === 1 ? '' : 's'} off-camp today (not counted).
-        </p>
-      ) : null}
-    </SectionCard>
+      <div className="h-1.5 bg-gradient-to-r from-emerald-500 via-blue-500 to-indigo-500" aria-hidden="true" />
+      <div className="p-5 flex flex-col gap-4 flex-1">
+        <div className="flex items-start gap-3">
+          <div className="shrink-0 w-10 h-10 rounded-xl bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 shadow-sm flex items-center justify-center">
+            <Home className="w-5 h-5 text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white truncate">
+              {bunk.name}
+            </h2>
+            {bunk.unit_name ? (
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{bunk.unit_name}</p>
+            ) : null}
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 flex items-center gap-1">
+              <Users className="w-3 h-3" aria-hidden="true" />
+              {bunk.camper_count} camper{bunk.camper_count === 1 ? '' : 's'}
+              {bunk.off_camp_count > 0 ? (
+                <span> · {bunk.off_camp_count} off-camp</span>
+              ) : null}
+            </p>
+            {bunk.co_counselor_names?.length > 0 ? (
+              <p className="text-xs text-gray-400 dark:text-gray-500 mt-1 truncate">
+                Co-counselor{bunk.co_counselor_names.length === 1 ? '' : 's'}:{' '}
+                {bunk.co_counselor_names.join(', ')}
+              </p>
+            ) : null}
+          </div>
+          {complete ? (
+            <span className="shrink-0 text-[10px] font-bold uppercase tracking-wide text-emerald-700 dark:text-emerald-300 bg-emerald-100/90 dark:bg-emerald-900/50 px-2 py-1 rounded-full">
+              Complete
+            </span>
+          ) : null}
+        </div>
+
+        {bunk.assignments?.length > 0 ? (
+          <div className="space-y-2">
+            {bunk.assignments.map((assignment) => (
+              <AssignmentRow key={assignment.template_id} assignment={assignment} />
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            No form assignments for this bunk on the selected date.
+          </p>
+        )}
+
+        <div className="mt-auto pt-1">
+          <Link
+            to={bunk.dashboard_path}
+            className="text-sm font-medium text-blue-700 dark:text-blue-300 hover:underline"
+            data-testid={`counselor-bunk-dashboard-${bunk.id}`}
+          >
+            Open bunk dashboard →
+          </Link>
+        </div>
+      </div>
+    </article>
   );
 }
 
-function SelfSection({ section }) {
-  const { state, submitted, is_day_off: isDayOff, template, reflection_id: reflectionId } = section || {};
+function SelfReflectionCard({ section, isToday, selectedDateLabel }) {
+  const { state, submitted, is_day_off: isDayOff, template, reflection_id: reflectionId } =
+    section || {};
+  const badge = STATE_BADGE[state === 'complete' ? 'complete' : 'none'];
+
   let summary;
   let actionLabel;
   let actionTo;
@@ -136,109 +191,166 @@ function SelfSection({ section }) {
     );
   } else if (state === 'complete') {
     summary = isDayOff ? (
-      <p>Day off recorded — nothing else to do here.</p>
+      <p>Day off recorded for {isToday ? 'today' : selectedDateLabel}.</p>
     ) : (
-      <p>Your self-reflection is in.</p>
+      <p>
+        Your self-reflection is in for {isToday ? 'today' : selectedDateLabel}.
+      </p>
     );
-    if (reflectionId) {
-      actionLabel = 'Edit';
-      actionTo = `/counselor/self-reflection/${reflectionId}/edit`;
-    }
+    actionLabel = 'Edit reflection';
+    actionTo = reflectionId
+      ? `/counselor/self-reflection/${reflectionId}/edit`
+      : '/counselor/self-reflection';
   } else {
-    summary = <p>You haven&apos;t submitted your self-reflection yet.</p>;
+    summary = (
+      <p>
+        You haven&apos;t submitted your self-reflection for{' '}
+        {isToday ? 'today' : selectedDateLabel} yet.
+      </p>
+    );
     actionLabel = 'Open self-reflection';
     actionTo = '/counselor/self-reflection';
   }
 
   return (
-    <SectionCard
-      title="My self-reflection"
-      state={state}
-      actionLabel={actionLabel}
-      actionTo={actionTo}
-      dataTestid="counselor-section-self"
+    <section
+      data-testid="counselor-section-self"
+      data-state={state}
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-5 shadow-sm"
     >
-      {summary}
-    </SectionCard>
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+          My self-reflection
+        </h2>
+        {template !== null ? (
+          <span
+            className={`shrink-0 text-xs font-semibold px-2 py-0.5 rounded-full ${badge.className}`}
+            data-testid="counselor-section-self-state"
+          >
+            {badge.label}
+          </span>
+        ) : null}
+      </div>
+      <div className="text-sm text-gray-700 dark:text-gray-300">{summary}</div>
+      {actionTo && template !== null ? (
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <Link
+            to={actionTo}
+            data-testid="counselor-section-self-action"
+            className="inline-flex items-center justify-center min-h-[44px] px-4 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 transition-colors"
+          >
+            {actionLabel}
+          </Link>
+          <Link
+            to="/counselor/self-reflection/history"
+            className="text-sm font-medium text-blue-700 dark:text-blue-300 hover:underline"
+          >
+            View history
+          </Link>
+        </div>
+      ) : null}
+    </section>
   );
 }
 
-function RequestsSection({ section }) {
-  const { open_count: openCount = 0, by_type: byType = {}, state } = section || {};
-  const camperCare = byType.camper_care || 0;
-  const maintenance = byType.maintenance || 0;
-
-  const summary = openCount === 0 ? (
-    <p className="text-gray-600 dark:text-gray-400">
-      No open requests on your bunks right now.
-    </p>
-  ) : (
-    <p>
-      <span className="font-medium">{openCount}</span> open request{openCount === 1 ? '' : 's'} — {camperCare} camper care, {maintenance} maintenance.
-    </p>
-  );
-
+function QuickActionButton({ to, icon: Icon, label, sublabel, testid, badge }) {
   return (
-    <SectionCard
-      title="Open requests"
-      state={state}
-      actionLabel="View requests"
-      actionTo="/counselor/requests"
-      dataTestid="counselor-section-requests"
+    <Link
+      to={to}
+      data-testid={testid}
+      className="relative flex flex-col items-center justify-center gap-2 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 shadow-sm hover:shadow-md hover:border-blue-200 dark:hover:border-blue-800 transition-all min-h-[108px] text-center"
     >
-      {summary}
-    </SectionCard>
+      {badge ? (
+        <span className="absolute top-2 right-2 text-xs font-bold rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-200 px-2 py-0.5">
+          {badge}
+        </span>
+      ) : null}
+      <Icon className="w-6 h-6 text-blue-600 dark:text-blue-400" aria-hidden="true" />
+      <span className="text-sm font-semibold text-gray-900 dark:text-white">{label}</span>
+      {sublabel ? (
+        <span className="text-[11px] text-gray-500 dark:text-gray-400 leading-tight">{sublabel}</span>
+      ) : null}
+    </Link>
   );
 }
 
 export default function CounselorMobileDashboard() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const dateParam = searchParams.get('date') || '';
+
   const [data, setData] = useState(null);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
 
-  const load = useCallback(async ({ background = false } = {}) => {
-    if (background) {
-      setRefreshing(true);
-    } else {
-      setLoading(true);
-    }
-    setError('');
-    try {
-      const payload = await fetchCounselorDashboard({ noCache: background });
-      setData(payload);
-    } catch (err) {
-      const detail = err?.response?.data?.detail;
-      const status = err?.response?.status;
-      if (status === 403) {
-        setError(typeof detail === 'string' ? detail : 'You do not have access to the counselor dashboard.');
-      } else {
-        setError(typeof detail === 'string' ? detail : 'Could not load your dashboard.');
-      }
-    } finally {
+  const load = useCallback(
+    async ({ background = false } = {}) => {
       if (background) {
-        setRefreshing(false);
+        setRefreshing(true);
       } else {
-        setLoading(false);
+        setLoading(true);
       }
-    }
-  }, []);
+      setError('');
+      try {
+        const payload = await fetchCounselorDashboard({
+          noCache: background,
+          date: dateParam || undefined,
+        });
+        setData(payload);
+      } catch (err) {
+        const detail = err?.response?.data?.detail;
+        const status = err?.response?.status;
+        if (status === 403) {
+          setError(typeof detail === 'string' ? detail : 'You do not have access to the counselor dashboard.');
+        } else {
+          setError(typeof detail === 'string' ? detail : 'Could not load your dashboard.');
+        }
+      } finally {
+        if (background) {
+          setRefreshing(false);
+        } else {
+          setLoading(false);
+        }
+      }
+    },
+    [dateParam],
+  );
 
   useEffect(() => {
     load();
   }, [load]);
 
+  const isToday = data?.is_today ?? true;
+
   useEffect(() => {
-    if (!data) return undefined;
+    if (!data || !isToday) return undefined;
     const id = setInterval(() => {
       load({ background: true });
     }, REFRESH_INTERVAL_MS);
     return () => clearInterval(id);
-  }, [data, load]);
+  }, [data, isToday, load]);
+
+  const selectedDateIso = data?.selected_date || dateParam || data?.today || '';
+  const selectedDateLabel = useMemo(
+    () => formatDisplayDate(selectedDateIso),
+    [selectedDateIso],
+  );
+
+  const handleDateChange = (next) => {
+    const params = new URLSearchParams(searchParams);
+    if (next) params.set('date', next);
+    else params.delete('date');
+    setSearchParams(params, { replace: true });
+  };
+
+  const maxDate = data?.today || '';
 
   if (loading) {
     return (
-      <div className="px-4 sm:px-6 lg:px-8 py-8 w-full max-w-[96rem] mx-auto" data-testid="counselor-dashboard-loading">
+      <div
+        className="px-4 sm:px-6 lg:px-8 py-8 w-full max-w-[96rem] mx-auto"
+        data-testid="counselor-dashboard-loading"
+      >
         <p className="text-gray-600 dark:text-gray-400">Loading your dashboard…</p>
       </div>
     );
@@ -260,20 +372,30 @@ export default function CounselorMobileDashboard() {
 
   if (!data) return null;
 
-  const { today, all_set: allSet, sections, program } = data;
-  const camperSection = sections?.camper_reflections;
+  const { viewer, all_set: allSet, sections, program, bunks = [] } = data;
   const selfSection = sections?.self_reflection;
   const requestsSection = sections?.requests;
+  const openCount = requestsSection?.open_count ?? 0;
 
   return (
-    <div className="px-4 sm:px-6 lg:px-8 py-8 pb-24 w-full max-w-[80rem] mx-auto space-y-5">
-        <header>
+    <div className="px-4 sm:px-6 lg:px-8 py-8 pb-24 w-full max-w-[80rem] mx-auto space-y-6">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
           <p className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
-            {program?.name ? `${program.name} · ` : ''}Today
+            {program?.name || 'Counselor home'}
           </p>
-          <h1 className="text-2xl sm:text-3xl font-semibold text-gray-900 dark:text-white">
-            {today}
+          <h1 className="text-2xl sm:text-3xl font-semibold text-gray-900 dark:text-white mt-0.5">
+            {viewer?.full_name || viewer?.name || 'Welcome'}
           </h1>
+          <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
+            {titleCaseRole(viewer?.role)}
+            {selectedDateLabel ? (
+              <>
+                {' '}
+                · {isToday ? 'Today' : 'Viewing'}: {selectedDateLabel}
+              </>
+            ) : null}
+          </p>
           {refreshing ? (
             <p
               className="text-xs text-gray-400 dark:text-gray-500 mt-1"
@@ -282,31 +404,129 @@ export default function CounselorMobileDashboard() {
               Refreshing…
             </p>
           ) : null}
-        </header>
-
-        {allSet ? (
-          <div
-            className="flex items-start gap-3 rounded-xl border border-green-200 bg-green-50 dark:bg-green-950/40 dark:border-green-800 px-4 py-3"
-            data-testid="counselor-all-set"
-            role="status"
-          >
-            <CheckCircle className="h-5 w-5 shrink-0 text-green-600 dark:text-green-400 mt-0.5" aria-hidden="true" />
-            <div>
-              <p className="text-sm font-medium text-green-900 dark:text-green-100">
-                You&apos;re all set for today — nice work.
-              </p>
-              <p className="text-xs text-green-800 dark:text-green-200 mt-1">
-                Edits stay open until the day rolls over.
-              </p>
-            </div>
-          </div>
-        ) : null}
-
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 sm:gap-5 items-stretch">
-          <CamperSection section={camperSection} />
-          <SelfSection section={selfSection} />
-          <RequestsSection section={requestsSection} />
         </div>
+        <label className="flex flex-col gap-1 text-sm text-gray-700 dark:text-gray-300 shrink-0">
+          <span className="font-medium">Date</span>
+          <input
+            type="date"
+            value={selectedDateIso}
+            max={maxDate}
+            onChange={(e) => handleDateChange(e.target.value)}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm min-w-[11rem]"
+            data-testid="counselor-date-picker"
+          />
+        </label>
+      </header>
+
+      {allSet && isToday ? (
+        <div
+          className="flex items-start gap-3 rounded-xl border border-green-200 bg-green-50 dark:bg-green-950/40 dark:border-green-800 px-4 py-3"
+          data-testid="counselor-all-set"
+          role="status"
+        >
+          <CheckCircle
+            className="h-5 w-5 shrink-0 text-green-600 dark:text-green-400 mt-0.5"
+            aria-hidden="true"
+          />
+          <div>
+            <p className="text-sm font-medium text-green-900 dark:text-green-100">
+              You&apos;re all set for today — nice work.
+            </p>
+            <p className="text-xs text-green-800 dark:text-green-200 mt-1">
+              Edits stay open until the day rolls over.
+            </p>
+          </div>
+        </div>
+      ) : null}
+
+      <section data-testid="counselor-bunks-section">
+        <div className="flex items-baseline justify-between mb-3">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">My bunks</h2>
+          <span className="text-sm text-gray-500 dark:text-gray-400">
+            {bunks.length} bunk{bunks.length === 1 ? '' : 's'}
+          </span>
+        </div>
+        {bunks.length === 0 ? (
+          <p className="text-sm text-gray-600 dark:text-gray-400 rounded-xl border border-dashed border-gray-200 dark:border-gray-700 px-4 py-6 text-center">
+            You&apos;re not assigned as an author on any bunk yet. Once your camp
+            assigns you to a group, it will appear here.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-5">
+            {bunks.map((bunk) => (
+              <BunkTile key={bunk.id} bunk={bunk} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <SelfReflectionCard
+        section={selfSection}
+        isToday={isToday}
+        selectedDateLabel={selectedDateLabel}
+      />
+
+      <section data-testid="counselor-work-links" className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <Link
+          to="/tasks"
+          data-testid="counselor-action-tasks"
+          className="flex items-center gap-4 rounded-xl border border-indigo-200 dark:border-indigo-800 bg-gradient-to-r from-indigo-50/80 to-white dark:from-indigo-950/40 dark:to-gray-900 px-5 py-4 shadow-sm hover:shadow-md transition-all"
+        >
+          <ClipboardList className="w-8 h-8 text-indigo-600 dark:text-indigo-400 shrink-0" aria-hidden="true" />
+          <div>
+            <p className="text-base font-semibold text-gray-900 dark:text-white">My Tasks</p>
+            <p className="text-sm text-gray-600 dark:text-gray-300">Today&apos;s reflection assignments</p>
+          </div>
+        </Link>
+        <Link
+          to="/my-reflections"
+          data-testid="counselor-action-my-reflections"
+          className="flex items-center gap-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-5 py-4 shadow-sm hover:shadow-md hover:border-indigo-200 dark:hover:border-indigo-800 transition-all"
+        >
+          <ClipboardCheck className="w-8 h-8 text-emerald-600 dark:text-emerald-400 shrink-0" aria-hidden="true" />
+          <div>
+            <p className="text-base font-semibold text-gray-900 dark:text-white">My Reflections</p>
+            <p className="text-sm text-gray-600 dark:text-gray-300">History and streaks</p>
+          </div>
+        </Link>
+      </section>
+
+      <section data-testid="counselor-quick-actions">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
+          Requests & observations
+        </h2>
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
+          <QuickActionButton
+            to="/counselor/requests/camper-care/new"
+            icon={HeartHandshake}
+            label="Camper care"
+            sublabel="Submit a request"
+            testid="counselor-action-camper-care"
+          />
+          <QuickActionButton
+            to="/counselor/requests/maintenance/new"
+            icon={Wrench}
+            label="Maintenance"
+            sublabel="Report an issue"
+            testid="counselor-action-maintenance"
+          />
+          <QuickActionButton
+            to="/counselor/requests"
+            icon={ClipboardList}
+            label="My requests"
+            sublabel={openCount ? `${openCount} open` : 'View progress'}
+            testid="counselor-action-requests"
+            badge={openCount > 0 ? openCount : null}
+          />
+          <QuickActionButton
+            to="/observations"
+            icon={MessageSquarePlus}
+            label="Observation"
+            sublabel="Note about a camper"
+            testid="counselor-action-observation"
+          />
+        </div>
+      </section>
     </div>
   );
 }

--- a/frontend/src/pages/counselor/CounselorSelfReflectionPage.jsx
+++ b/frontend/src/pages/counselor/CounselorSelfReflectionPage.jsx
@@ -33,6 +33,7 @@ import AudienceDisclosure from '../../components/AudienceDisclosure';
 import ReflectionField from '../../components/templates/ReflectionField';
 import {
   buildDefaultAnswers,
+  prepareReflectionAnswersForSubmit,
   validateReflectionAnswers,
 } from '../../utils/reflection/reflectionFormValidation';
 import {
@@ -209,16 +210,21 @@ export default function CounselorSelfReflectionPage() {
 
     setSubmitting(true);
     try {
+      const payloadAnswers = dayOff
+        ? undefined
+        : prepareReflectionAnswersForSubmit(schema, answers, {
+            omitKeys: [DAY_OFF_FIELD_KEY],
+          });
       if (isEdit) {
         await patchSelfReflection(editReflectionId, {
           dayOff,
-          answers: dayOff ? undefined : answers,
+          answers: payloadAnswers,
           language,
         });
       } else {
         await createSelfReflection({
           dayOff,
-          answers: dayOff ? undefined : answers,
+          answers: payloadAnswers,
           language,
           clientSubmissionId: clientSubmissionIdRef.current,
         });

--- a/frontend/src/pages/counselor/__tests__/CounselorMobileDashboard.test.jsx
+++ b/frontend/src/pages/counselor/__tests__/CounselorMobileDashboard.test.jsx
@@ -13,11 +13,43 @@ vi.mock('../../../api', () => ({
 
 function makePayload(overrides = {}) {
   return {
+    viewer: {
+      id: 10,
+      name: 'Mira S.',
+      full_name: 'Mira Sandberg',
+      role: 'counselor',
+    },
+    selected_date: '2026-07-04',
     today: '2026-07-04',
+    is_today: true,
     rollover_hour: 4,
     timezone: 'America/New_York',
     program: { id: 1, slug: 'clc-summer-2026', name: 'CLC Summer 2026' },
     all_set: false,
+    bunks: [
+      {
+        id: 100,
+        name: 'Bunk Birch',
+        unit_name: 'Unit A',
+        camper_count: 5,
+        off_camp_count: 1,
+        co_counselor_names: ['Jordan P.'],
+        dashboard_path: '/dashboards/group/100?date=2026-07-04',
+        assignments: [
+          {
+            template_id: 7,
+            template_name: 'Bunk Log',
+            cadence: 'daily',
+            state: 'in_progress',
+            covered: 2,
+            total: 4,
+            remaining: 2,
+            due_label: '2 responses needed today',
+            action_path: '/counselor/camper-reflections',
+          },
+        ],
+      },
+    ],
     sections: {
       camper_reflections: {
         state: 'in_progress',
@@ -46,9 +78,9 @@ function makePayload(overrides = {}) {
   };
 }
 
-function renderPage() {
+function renderPage(initialEntry = '/counselor') {
   return render(
-    <MemoryRouter initialEntries={['/counselor']}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <CounselorMobileDashboard />
     </MemoryRouter>,
   );
@@ -59,29 +91,51 @@ describe('CounselorMobileDashboard', () => {
     getMock.mockReset();
   });
 
-  it('renders the three sections from the dashboard payload', async () => {
+  it('renders viewer header, bunk tile, self-reflection, and quick actions', async () => {
     getMock.mockResolvedValue({ data: makePayload() });
     renderPage();
 
-    await waitFor(() => expect(screen.getByText('2026-07-04')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Mira Sandberg')).toBeInTheDocument());
 
-    expect(screen.getByTestId('counselor-section-campers')).toBeInTheDocument();
+    expect(screen.getByTestId('counselor-bunk-tile-100')).toBeInTheDocument();
+    expect(screen.getByText('Bunk Birch')).toBeInTheDocument();
+    expect(screen.getByText(/2 responses needed today/i)).toBeInTheDocument();
     expect(screen.getByTestId('counselor-section-self')).toBeInTheDocument();
-    expect(screen.getByTestId('counselor-section-requests')).toBeInTheDocument();
+    expect(screen.getByTestId('counselor-action-tasks')).toBeInTheDocument();
+    expect(screen.getByTestId('counselor-action-my-reflections')).toBeInTheDocument();
+    expect(screen.getByTestId('counselor-action-camper-care')).toBeInTheDocument();
+    expect(screen.getByTestId('counselor-action-maintenance')).toBeInTheDocument();
+    expect(screen.getByTestId('counselor-action-requests')).toBeInTheDocument();
+    expect(screen.getByTestId('counselor-action-observation')).toBeInTheDocument();
+  });
 
-    expect(screen.getByTestId('counselor-section-campers-state')).toHaveTextContent('In progress');
-    expect(screen.getByTestId('counselor-section-campers')).toHaveTextContent(
-      /3\s*campers? still need/i,
-    );
-    expect(screen.getByTestId('counselor-section-campers')).toHaveTextContent(
-      /1 camper off-camp today/i,
-    );
+  it('passes the date query param to the dashboard API', async () => {
+    getMock.mockResolvedValue({
+      data: makePayload({ selected_date: '2026-07-01', is_today: false }),
+    });
+    renderPage('/counselor?date=2026-07-01');
+
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    const [, config] = getMock.mock.calls[0];
+    expect(config.params.date).toBe('2026-07-01');
   });
 
   it('shows the all-set banner when both required sections are complete', async () => {
     getMock.mockResolvedValue({
       data: makePayload({
         all_set: true,
+        bunks: [
+          {
+            id: 100,
+            name: 'Bunk Birch',
+            unit_name: null,
+            camper_count: 0,
+            off_camp_count: 0,
+            co_counselor_names: [],
+            dashboard_path: '/dashboards/group/100?date=2026-07-04',
+            assignments: [],
+          },
+        ],
         sections: {
           camper_reflections: { state: 'complete', covered: 5, total: 5, off_camp: 0, bunk_count: 1 },
           self_reflection: {
@@ -132,44 +186,29 @@ describe('CounselorMobileDashboard', () => {
     expect(screen.getByTestId('counselor-dashboard-error')).toHaveTextContent('boom');
   });
 
-  it('shows a friendly message for 403 without organization context', async () => {
-    getMock.mockRejectedValue({ response: { status: 403, data: { detail: 'Organization context required.' } } });
-    renderPage();
-    await waitFor(() => expect(screen.getByTestId('counselor-dashboard-error')).toBeInTheDocument());
-    expect(screen.getByTestId('counselor-dashboard-error')).toHaveTextContent('Organization context required.');
-  });
-
-  it('points the campers CTA at /counselor/camper-reflections', async () => {
+  it('points the bunk assignment CTA at camper reflections', async () => {
     getMock.mockResolvedValue({ data: makePayload() });
     renderPage();
-    await waitFor(() => expect(screen.getByTestId('counselor-section-campers-action')).toBeInTheDocument());
-    expect(screen.getByTestId('counselor-section-campers-action')).toHaveAttribute(
+    await waitFor(() => expect(screen.getByTestId('bunk-assignment-action-7')).toBeInTheDocument());
+    expect(screen.getByTestId('bunk-assignment-action-7')).toHaveAttribute(
       'href',
       '/counselor/camper-reflections',
     );
   });
 
-  it('renders a complete-no-action self section when template is null', async () => {
+  it('shows open-request badge on the requests quick action', async () => {
+    getMock.mockResolvedValue({ data: makePayload() });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('counselor-action-requests')).toBeInTheDocument());
+    expect(screen.getByTestId('counselor-action-requests')).toHaveTextContent('2');
+  });
+
+  it('renders empty bunk state when counselor has no bunks', async () => {
     getMock.mockResolvedValue({
-      data: makePayload({
-        sections: {
-          camper_reflections: { state: 'complete', covered: 0, total: 0, off_camp: 0, bunk_count: 0 },
-          self_reflection: {
-            state: 'complete',
-            submitted: false,
-            reflection_id: null,
-            submitted_at: null,
-            is_day_off: false,
-            editable: false,
-            template: null,
-          },
-          requests: { state: 'none', open_count: 0, by_type: { camper_care: 0, maintenance: 0 } },
-        },
-      }),
+      data: makePayload({ bunks: [] }),
     });
     renderPage();
-    await waitFor(() => expect(screen.getByTestId('counselor-section-self')).toBeInTheDocument());
-    expect(screen.getByText(/No self-reflection template is configured/i)).toBeInTheDocument();
-    expect(screen.queryByTestId('counselor-section-self-action')).toBeNull();
+    await waitFor(() => expect(screen.getByTestId('counselor-bunks-section')).toBeInTheDocument());
+    expect(screen.getByText(/not assigned as an author on any bunk/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/counselor/__tests__/CounselorSelfReflectionPage.test.jsx
+++ b/frontend/src/pages/counselor/__tests__/CounselorSelfReflectionPage.test.jsx
@@ -206,6 +206,7 @@ describe('CounselorSelfReflectionPage', () => {
 
       const body = postMock.mock.calls[0][1];
       expect(body.day_off).toBe(false);
+      expect(body.answers).not.toHaveProperty('day_off');
       expect(body.answers.overall_day).toBe(4);
       expect(body.answers.wins).toEqual(expect.arrayContaining(['lunchtime activity']));
     });

--- a/frontend/src/pages/maintenance/Queue.jsx
+++ b/frontend/src/pages/maintenance/Queue.jsx
@@ -13,6 +13,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../auth/AuthContext';
 import {
   fetchMaintenanceQueue,
   transitionTicket,
@@ -85,6 +86,11 @@ function PersonIcon({ className = 'w-3 h-3' }) {
   );
 }
 
+function transitionLabel(ticket, next) {
+  if (ticket.is_mine && next === 'fulfilled') return 'Mark closed';
+  return TRANSITION_LABEL[next] || next;
+}
+
 function TicketRow({ ticket, selectable, selected, onSelectToggle, onTransition, onClick }) {
   const aged = ticket.age_seconds != null && ticket.age_seconds >= AGE_THRESHOLD_SECONDS;
   const transitions = ticket.available_transitions ?? [];
@@ -104,7 +110,7 @@ function TicketRow({ ticket, selectable, selected, onSelectToggle, onTransition,
           : 'inline-flex items-center justify-center px-2 min-h-[32px] text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:underline whitespace-nowrap'
       }
     >
-      {TRANSITION_LABEL[next] || next}
+      {transitionLabel(ticket, next)}
     </button>
   );
 
@@ -245,29 +251,17 @@ function TransitionModal({ ticket, toState, onClose, onSubmitted }) {
         <form onSubmit={handleSubmit} className="mt-3 space-y-3">
           <label className="block text-sm">
             <span className="text-gray-700 dark:text-gray-200">
-              Note {reasonRequired ? '' : '(optional)'}
+              {reasonRequired ? 'Reason (required)' : 'Note (optional)'}
             </span>
             <textarea
               value={reasonRequired ? reason : note}
-              onChange={(e) => reasonRequired ? setReason(e.target.value) : setNote(e.target.value)}
+              onChange={(e) => (reasonRequired ? setReason : setNote)(e.target.value)}
               rows={3}
               required={reasonRequired}
               data-testid="ticket-transition-note"
               className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
             />
           </label>
-          {!reasonRequired && toState !== 'in_progress' && (
-            <label className="block text-sm">
-              <span className="text-gray-700 dark:text-gray-200">Optional closing note</span>
-              <textarea
-                value={note}
-                onChange={(e) => setNote(e.target.value)}
-                rows={2}
-                data-testid="ticket-transition-closing-note"
-                className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
-              />
-            </label>
-          )}
           {error && (
             <p role="alert" className="text-sm text-red-700 dark:text-red-300" data-testid="ticket-transition-error">
               {error}
@@ -297,15 +291,27 @@ function TransitionModal({ ticket, toState, onClose, onSubmitted }) {
   );
 }
 
-function FilterBar({ filter, search, dateFrom, dateTo, onChange }) {
+const FILTER_LABELS = {
+  mine: 'My tickets',
+  open: 'All open',
+  new: 'New',
+  in_progress: 'In Progress',
+  closed: 'Closed',
+  all: 'All',
+};
+
+function FilterBar({ filter, search, dateFrom, dateTo, showMineFilter, onChange }) {
   const isClosed = filter === 'closed';
+  const filters = showMineFilter
+    ? ['mine', 'open', 'new', 'in_progress', 'closed', 'all']
+    : ['open', 'new', 'in_progress', 'closed', 'all'];
   return (
     <div
       className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 shadow-sm space-y-2"
       data-testid="maint-queue-filter"
     >
       <div className="flex flex-wrap items-center gap-2">
-        {['open', 'new', 'in_progress', 'closed', 'all'].map((f) => (
+        {filters.map((f) => (
           <button
             key={f}
             type="button"
@@ -317,7 +323,7 @@ function FilterBar({ filter, search, dateFrom, dateTo, onChange }) {
                 : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-700'
             }`}
           >
-            {f === 'in_progress' ? 'In Progress' : f.charAt(0).toUpperCase() + f.slice(1)}
+            {FILTER_LABELS[f] || f}
           </button>
         ))}
       </div>
@@ -353,10 +359,12 @@ function FilterBar({ filter, search, dateFrom, dateTo, onChange }) {
 
 export default function MaintenanceQueue() {
   const navigate = useNavigate();
+  const { user } = useAuth();
+  const isCounselorViewer = user?.role === 'Counselor';
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const [filter, setFilter] = useState('open');
+  const [filter, setFilter] = useState(isCounselorViewer ? 'mine' : 'open');
   const [search, setSearch] = useState('');
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
@@ -423,7 +431,9 @@ export default function MaintenanceQueue() {
 
   const tickets = data?.tickets ?? [];
   const counts = data?.counts ?? { new: 0, in_progress: 0, urgent_open: 0 };
-  const isReadOnly = data?.scope && data.scope !== 'team';
+  const isTeamScope = data?.scope === 'team';
+  const isReadOnly = data?.scope && !isTeamScope;
+  const canCloseOwnTickets = !isTeamScope && tickets.some((t) => t.is_mine && t.available_transitions?.length);
   const inProgressTickets = tickets.filter((t) => t.status === 'in_progress');
   const eligibleSelected = useMemo(
     () => inProgressTickets.filter((t) => selected.has(t.id)),
@@ -455,9 +465,14 @@ export default function MaintenanceQueue() {
         <p className="text-sm text-gray-600 dark:text-gray-400" data-testid="maint-queue-counts">
           {counts.new} new&nbsp;·&nbsp;{counts.in_progress} in progress&nbsp;·&nbsp;{counts.urgent_open} urgent
         </p>
-        {isReadOnly && (
+        {isReadOnly && !canCloseOwnTickets && (
           <p className="text-sm text-gray-500 dark:text-gray-400" data-testid="maint-queue-readonly-note">
             Read-only view — only the maintenance team can update tickets.
+          </p>
+        )}
+        {isReadOnly && canCloseOwnTickets && (
+          <p className="text-sm text-gray-500 dark:text-gray-400" data-testid="maint-queue-submitter-note">
+            You can mark your own tickets closed once they are resolved. Use &quot;All open&quot; to see camp-wide requests.
           </p>
         )}
       </header>
@@ -467,6 +482,7 @@ export default function MaintenanceQueue() {
         search={search}
         dateFrom={dateFrom}
         dateTo={dateTo}
+        showMineFilter={isReadOnly || isCounselorViewer}
         onChange={handleFilterChange}
       />
 
@@ -486,7 +502,7 @@ export default function MaintenanceQueue() {
             <TicketRow
               key={t.id}
               ticket={t}
-              selectable={!isReadOnly && t.status === 'in_progress'}
+              selectable={isTeamScope && t.status === 'in_progress'}
               selected={selected.has(t.id)}
               onSelectToggle={handleSelectToggle}
               onTransition={handleTransition}

--- a/frontend/src/pages/maintenance/__tests__/Queue.test.jsx
+++ b/frontend/src/pages/maintenance/__tests__/Queue.test.jsx
@@ -4,6 +4,11 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import MaintenanceQueue from '../Queue';
 
+const mockUseAuth = vi.fn(() => ({ user: { role: 'Maintenance' } }));
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
 const getMock = vi.fn();
 const postMock = vi.fn();
 
@@ -23,6 +28,7 @@ vi.mock('react-router-dom', async (importOriginal) => {
 beforeEach(() => {
   getMock.mockReset();
   postMock.mockReset();
+  mockUseAuth.mockReturnValue({ user: { role: 'Maintenance' } });
 });
 
 const sampleTickets = [
@@ -61,7 +67,11 @@ const sampleTickets = [
 ];
 
 const emptyPayload = { tickets: [], counts: { new: 0, in_progress: 0, urgent_open: 0 } };
-const samplePayload = { tickets: sampleTickets, counts: { new: 1, in_progress: 1, urgent_open: 1 } };
+const samplePayload = {
+  tickets: sampleTickets,
+  counts: { new: 1, in_progress: 1, urgent_open: 1 },
+  scope: 'team',
+};
 
 function renderQueue() {
   return render(
@@ -96,7 +106,7 @@ describe('MaintenanceQueue', () => {
   });
 
   it('status filters reload the queue', async () => {
-    getMock.mockResolvedValue({ data: emptyPayload });
+    getMock.mockResolvedValue({ data: { ...emptyPayload, scope: 'team' } });
     renderQueue();
     await waitFor(() => screen.getByTestId('filter-closed'));
     await userEvent.click(screen.getByTestId('filter-closed'));
@@ -120,9 +130,11 @@ describe('MaintenanceQueue', () => {
     expect(screen.getByTestId('maint-queue-error').textContent).toMatch(/Network error/);
   });
 
-  it('renders a read-only view of the full queue for viewer scope', async () => {
+  it('renders viewer scope without team bulk actions', async () => {
+    mockUseAuth.mockReturnValue({ user: { role: 'Counselor' } });
     const viewerTicket = {
       ...sampleTickets[0],
+      is_mine: false,
       available_transitions: [],
     };
     getMock.mockResolvedValueOnce({
@@ -134,8 +146,26 @@ describe('MaintenanceQueue', () => {
     });
     renderQueue();
     await waitFor(() => screen.getByTestId('maint-queue-readonly-note'));
-    // No transition actions and no select checkbox for read-only viewers.
     expect(screen.queryByTestId(`ticket-action-in_progress-${viewerTicket.id}`)).toBeNull();
     expect(screen.queryByTestId(`ticket-select-${viewerTicket.id}`)).toBeNull();
+  });
+
+  it('lets counselors mark their own tickets closed', async () => {
+    mockUseAuth.mockReturnValue({ user: { role: 'Counselor' } });
+    const mine = {
+      ...sampleTickets[0],
+      is_mine: true,
+      available_transitions: ['fulfilled'],
+    };
+    getMock.mockResolvedValueOnce({
+      data: {
+        tickets: [mine],
+        counts: { new: 1, in_progress: 0, urgent_open: 0 },
+        scope: 'viewer',
+      },
+    });
+    renderQueue();
+    await waitFor(() => screen.getByTestId(`ticket-action-fulfilled-${mine.id}`));
+    expect(screen.getByTestId(`ticket-action-fulfilled-${mine.id}`)).toHaveTextContent('Mark closed');
   });
 });

--- a/frontend/src/pages/observations/Observations.test.jsx
+++ b/frontend/src/pages/observations/Observations.test.jsx
@@ -279,6 +279,27 @@ describe('ObservationComposer', () => {
     });
   });
 
+  it('shows a message when subject search has no matches', async () => {
+    getMock.mockImplementation((url) => {
+      if (url.includes('recipient-candidates')) {
+        return Promise.resolve({ data: { persons: [] } });
+      }
+      if (url.includes('observations/subjects')) {
+        return Promise.resolve({ data: { subjects: [] } });
+      }
+      return Promise.resolve({ data: {} });
+    });
+    render(
+      <MemoryRouter>
+        <ObservationComposer onClose={vi.fn()} />
+      </MemoryRouter>,
+    );
+    await userEvent.type(screen.getByTestId('observation-composer-search'), 'Nobody');
+    await waitFor(() => {
+      expect(screen.getByText('No matching campers.')).toBeDefined();
+    });
+  });
+
   it('blocks submit with no subject', async () => {
     render(
       <MemoryRouter>

--- a/frontend/src/pages/unit-head/UnitHeadSelfReflectionPage.jsx
+++ b/frontend/src/pages/unit-head/UnitHeadSelfReflectionPage.jsx
@@ -23,6 +23,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import ReflectionField from '../../components/templates/ReflectionField';
 import {
   buildDefaultAnswers,
+  prepareReflectionAnswersForSubmit,
   validateReflectionAnswers,
 } from '../../utils/reflection/reflectionFormValidation';
 import {
@@ -222,9 +223,9 @@ export default function UnitHeadSelfReflectionPage() {
     try {
       const payloadAnswers = (() => {
         if (dayOff) return undefined;
-        // Coerce bunk_concerns_bunks values to integers since the backend
-        // validates against integer bunk IDs.
-        const next = { ...answers };
+        const next = prepareReflectionAnswersForSubmit(schema, answers, {
+          omitKeys: [DAY_OFF_FIELD_KEY],
+        });
         const raw = next[BUNK_CONCERNS_FIELD_KEY];
         if (Array.isArray(raw)) {
           next[BUNK_CONCERNS_FIELD_KEY] = raw

--- a/frontend/src/partials/Sidebar.jsx
+++ b/frontend/src/partials/Sidebar.jsx
@@ -16,6 +16,24 @@ import CampLogo from "../../src/images/clc-logo.jpeg";
 // off legacy role.
 const REFLECTION_FORM_ROLES = ['Counselor', 'Admin', 'Unit Head', 'Camper Care'];
 
+// Direct home targets for roles that have a dedicated workspace (mirrors
+// Dashboard.jsx ROLE_DESTINATIONS). Everyone else keeps /dashboard.
+const ROLE_HOME_PATH = {
+  Counselor: '/counselor',
+  'Unit Head': '/unit-head',
+  'Camper Care': '/camper-care',
+  Leadership: '/leadership-team',
+  'Leadership Team': '/leadership-team',
+  'Kitchen Staff': '/kitchen-staff',
+  Specialist: '/specialist',
+  Madrich: '/madrich',
+  Maintenance: '/maintenance',
+};
+
+function homePathFor(role) {
+  return ROLE_HOME_PATH[role] ?? '/dashboard';
+}
+
 // Capability shortcuts. SUPERVISOR_PLUS == "supervisor or stronger"
 // because hasCapability(user, 'supervisor') is already inclusive of
 // program_lead and admin (see capability.js docs). Listing them here
@@ -64,12 +82,13 @@ const PROGRAM_LEAD_PLUS = ['program_lead'];
  * rather than the global nav. The Leadership Team group is intentionally
  * absent from the Admin IA (it's the Leadership Team's own home).
  *
- * Default nav (non-admin): My work (Home/tasks/role-home/reflections/
+ * Default nav (non-admin): My work (Home/tasks/reflections/
  * observations/maintenance), Supervise (supervisor+; program_lead+ also
  * gets performance / log entries / reflections / authors there). Leadership
  * Team (program_lead+). Gates use hasCapability(user, [...]) ||
  * isSuperAdmin(user); direct `user.role` references remain only for
- * per-role workspace deep links and reflection-form access.
+ * reflection-form access. Role workspaces are the Home link target (no
+ * duplicate "Counselor home" entries).
  */
 function Sidebar({
   sidebarOpen,
@@ -145,8 +164,11 @@ function Sidebar({
   const canSeeLeadershipTeam = hasCapability(user, PROGRAM_LEAD_PLUS) || isSuperAdmin(user);
   const canAdmin = hasCapability(user, 'admin') || isSuperAdmin(user);
   const canFileReflection = REFLECTION_FORM_ROLES.includes(user.role);
+  const isCounselor = user.role === 'Counselor';
+  const canSeeFileReflectionNav = canFileReflection && !isCounselor;
   const canSeeLogs = canSupervise || canAdmin;
-  const canSeeReflectionsDashboard = canSeeLogs || canFileReflection;
+  // Counselors see assigned/submitted work via My tasks + My reflections, not the org-wide dashboard.
+  const canSeeReflectionsDashboard = (canSeeLogs || canFileReflection) && !isCounselor;
   // Maintenance staff get a stripped-down nav: just the queue + notes. The
   // canonical role lives on Membership (legacy User.role has no maintenance
   // value), surfaced via `membership_roles` on the profile payload.
@@ -285,30 +307,9 @@ function Sidebar({
           ) : (
           <>
           <Section heading="My work">
-            <NavItem to="/dashboard" label="Home" icon={IconHome} end />
+            <NavItem to={homePathFor(user.role)} label="Home" icon={IconHome} end />
             <NavItem to="/tasks" label="My tasks" icon={IconTasks} />
-            {user.role === 'Counselor' && (
-              <NavItem
-                to="/counselor"
-                label="Counselor home"
-                icon={IconCounselor}
-              />
-            )}
-            {user.role === 'Unit Head' && (
-              <NavItem
-                to="/unit-head"
-                label="Unit Head home"
-                icon={IconCounselor}
-              />
-            )}
-            {user.role === 'Camper Care' && (
-              <NavItem
-                to="/camper-care"
-                label="Camper Care home"
-                icon={IconHeart}
-              />
-            )}
-            {canFileReflection && (
+            {canSeeFileReflectionNav && (
               <NavItem to="/reflect" label="File a reflection" icon={IconPencil} />
             )}
             {canFileReflection && (

--- a/frontend/src/partials/__tests__/Sidebar.test.jsx
+++ b/frontend/src/partials/__tests__/Sidebar.test.jsx
@@ -60,11 +60,13 @@ describe('Sidebar — section gating (3.32)', () => {
     expect(screen.queryByText('Crane Lake legacy')).not.toBeInTheDocument();
 
     const links = hrefs();
-    expect(links).toContain('/dashboard');
-    expect(links).toContain('/tasks');
     expect(links).toContain('/counselor');
-    expect(links).toContain('/reflect');
+    expect(links.filter((h) => h === '/counselor')).toHaveLength(1);
+    expect(links).not.toContain('/dashboard');
+    expect(links).toContain('/tasks');
+    expect(links).not.toContain('/reflect');
     expect(links).toContain('/my-reflections');
+    expect(links).not.toContain('/dashboards/reflections');
     expect(links).not.toContain('/orders');
     expect(links).not.toContain('/admin');
     expect(links).not.toContain('/admin-bunk-logs');
@@ -74,7 +76,8 @@ describe('Sidebar — section gating (3.32)', () => {
     renderWith({ role: 'Kitchen Staff' });
 
     const links = hrefs();
-    expect(links).toContain('/dashboard');
+    expect(links).toContain('/kitchen-staff');
+    expect(links).not.toContain('/dashboard');
     expect(links).toContain('/tasks');
     expect(links).not.toContain('/counselor');
     expect(links).not.toContain('/reflect');
@@ -90,9 +93,11 @@ describe('Sidebar — section gating (3.32)', () => {
     expect(screen.queryByText('Admin')).not.toBeInTheDocument();
 
     const links = hrefs();
+    expect(links).toContain('/unit-head');
+    expect(links.filter((h) => h === '/unit-head')).toHaveLength(1);
+    expect(links).not.toContain('/dashboard');
     expect(links).toContain('/groups/performance');
     expect(links).toContain('/dashboards/concerns');
-    // Supervisors don't get the role-specific Counselor-home link.
     expect(links).not.toContain('/counselor');
   });
 
@@ -101,6 +106,9 @@ describe('Sidebar — section gating (3.32)', () => {
 
     expect(screen.getAllByText('Supervise').length).toBeGreaterThan(0);
     const links = hrefs();
+    expect(links).toContain('/camper-care');
+    expect(links.filter((h) => h === '/camper-care')).toHaveLength(1);
+    expect(links).not.toContain('/dashboard');
     expect(links).toContain('/groups/performance');
     expect(links).toContain('/dashboards/concerns');
     expect(links).toContain('/reflect');

--- a/frontend/src/partials/tasks/ReflectionTasksPanel.jsx
+++ b/frontend/src/partials/tasks/ReflectionTasksPanel.jsx
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { CheckCircle2, Circle, ClipboardList } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 import api from '../../api';
+
+const CARD_BASE =
+  'rounded-2xl border bg-white dark:bg-gray-900 shadow-sm overflow-hidden';
+const CARD_PENDING =
+  'border-gray-200 dark:border-gray-700 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-md transition-all';
+const CARD_DONE =
+  'border-emerald-200 dark:border-emerald-800 bg-emerald-50/60 dark:bg-emerald-950/25';
 
 // ---------------------------------------------------------------------------
 // Icons (inline SVG to avoid extra deps)
@@ -107,12 +115,12 @@ function SubjectPill({ subject, onTap }) {
 
   function pillStyle() {
     if (subject.covered_by_me) {
-      return 'border-blue-400 bg-blue-50 dark:bg-blue-950/40 text-blue-900 dark:text-blue-100';
+      return 'border-indigo-400 bg-indigo-50 dark:bg-indigo-950/50 text-indigo-950 dark:text-indigo-100 shadow-sm';
     }
     if (subject.covered) {
-      return 'border-green-400 bg-green-50 dark:bg-green-950/40 text-green-900 dark:text-green-100';
+      return 'border-emerald-400 bg-emerald-50 dark:bg-emerald-950/50 text-emerald-950 dark:text-emerald-100 shadow-sm';
     }
-    return 'border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100';
+    return 'border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 hover:border-indigo-300 dark:hover:border-indigo-500';
   }
 
   function statusIcon() {
@@ -149,7 +157,7 @@ function SubjectPill({ subject, onTap }) {
         type="button"
         aria-label={ariaLabel()}
         onClick={handleClick}
-        className={`min-h-[44px] min-w-[44px] w-full flex items-center justify-center gap-1 px-2 py-2 rounded-lg border text-sm font-medium transition-colors ${pillStyle()}`}
+        className={`min-h-[48px] min-w-[48px] w-full flex items-center justify-center gap-1.5 px-2.5 py-2.5 rounded-xl border-2 text-sm font-semibold transition-colors ${pillStyle()}`}
       >
         {statusIcon()}
         <span className="truncate">{subject.preferred_name}</span>
@@ -169,17 +177,20 @@ function SubjectPill({ subject, onTap }) {
 // Section: self
 // ---------------------------------------------------------------------------
 
+function TaskStatusIcon({ done, star = false }) {
+  if (done) {
+    return star ? <IconCheck star /> : <CheckCircle2 className="w-5 h-5 text-emerald-600 dark:text-emerald-400 shrink-0" aria-hidden="true" />;
+  }
+  return <Circle className="w-5 h-5 text-gray-400 dark:text-gray-500 shrink-0" aria-hidden="true" />;
+}
+
 function SelfSection({ task, onNavigate }) {
   const ss = task.self_status;
   const done = ss?.submitted;
 
   return (
-    <div
-      className={`rounded-xl border p-4 cursor-pointer transition-colors ${
-        done
-          ? 'border-green-300 bg-green-50 dark:bg-green-950/30 dark:border-green-800'
-          : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:border-blue-300 dark:hover:border-blue-600'
-      }`}
+    <article
+      className={`${CARD_BASE} ${done ? CARD_DONE : CARD_PENDING} ${!done ? 'cursor-pointer' : ''}`}
       role="button"
       tabIndex={0}
       aria-label={`${task.template.name} — ${done ? 'completed' : 'not yet submitted'}`}
@@ -191,19 +202,29 @@ function SelfSection({ task, onNavigate }) {
         }
       }}
     >
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex-1 min-w-0">
-          <p className="font-medium text-sm text-gray-900 dark:text-white">{task.template.name}</p>
-          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Your reflection</p>
+      <div
+        className={`h-1 ${done ? 'bg-emerald-500' : 'bg-gradient-to-r from-indigo-500 via-blue-500 to-violet-500'}`}
+        aria-hidden="true"
+      />
+      <div className="p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex-1 min-w-0">
+            <p className="font-semibold text-base text-gray-900 dark:text-white">{task.template.name}</p>
+            <p className="text-sm text-gray-600 dark:text-gray-300 mt-0.5">Your reflection</p>
+          </div>
+          <TaskStatusIcon done={done} />
         </div>
-        <span className="shrink-0 mt-0.5">{done ? <IconCheck /> : <span className="text-gray-400"><IconCircle /></span>}</span>
+        {done && ss.submitted_at ? (
+          <p className="text-sm font-medium text-emerald-800 dark:text-emerald-300 mt-3">
+            Submitted {new Date(ss.submitted_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+          </p>
+        ) : (
+          <p className="text-sm text-indigo-700 dark:text-indigo-300 mt-3 font-medium">
+            Tap to open form →
+          </p>
+        )}
       </div>
-      {done && ss.submitted_at && (
-        <p className="text-xs text-green-700 dark:text-green-400 mt-2">
-          Submitted {new Date(ss.submitted_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-        </p>
-      )}
-    </div>
+    </article>
   );
 }
 
@@ -215,20 +236,27 @@ function SubjectSection({ task, onPillTap }) {
   const { covered, total } = task.completion;
   const remaining = total - covered;
 
+  const complete = remaining === 0;
+
   return (
-    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
-      <div className="flex items-center justify-between mb-3">
-        <div>
-          <p className="font-medium text-sm text-gray-900 dark:text-white">{task.template.name}</p>
+    <article className={`${CARD_BASE} ${complete ? CARD_DONE : 'border-gray-200 dark:border-gray-700'}`}>
+      <div
+        className={`h-1 ${complete ? 'bg-emerald-500' : 'bg-gradient-to-r from-indigo-500 via-blue-500 to-violet-500'}`}
+        aria-hidden="true"
+      />
+      <div className="p-5">
+      <div className="flex items-center justify-between mb-4 gap-3">
+        <div className="min-w-0">
+          <p className="font-semibold text-base text-gray-900 dark:text-white">{task.template.name}</p>
           {task.assignment_group && (
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{task.assignment_group.name}</p>
+            <p className="text-sm text-gray-600 dark:text-gray-300 mt-0.5">{task.assignment_group.name}</p>
           )}
         </div>
         <span
-          className={`text-xs font-medium px-2 py-0.5 rounded-full ${
-            remaining === 0
-              ? 'bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-300'
-              : 'bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300'
+          className={`shrink-0 text-xs font-bold px-2.5 py-1 rounded-full tabular-nums ${
+            complete
+              ? 'bg-emerald-100 dark:bg-emerald-900/60 text-emerald-800 dark:text-emerald-200'
+              : 'bg-amber-100 dark:bg-amber-900/60 text-amber-900 dark:text-amber-200'
           }`}
         >
           {covered}/{total}
@@ -236,14 +264,15 @@ function SubjectSection({ task, onPillTap }) {
       </div>
 
       <div
-        className="grid gap-2"
-        style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(80px, 1fr))' }}
+        className="grid gap-2.5"
+        style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(88px, 1fr))' }}
       >
         {task.subjects.map((subject) => (
           <SubjectPill key={subject.person_id} subject={subject} onTap={() => onPillTap(task, subject)} />
         ))}
       </div>
-    </div>
+      </div>
+    </article>
   );
 }
 
@@ -255,12 +284,8 @@ function GroupSection({ task, onNavigate }) {
   const done = task.completion.covered === task.completion.total;
 
   return (
-    <div
-      className={`rounded-xl border p-4 cursor-pointer transition-colors ${
-        done
-          ? 'border-green-300 bg-green-50 dark:bg-green-950/30 dark:border-green-800'
-          : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:border-blue-300 dark:hover:border-blue-600'
-      }`}
+    <article
+      className={`${CARD_BASE} ${done ? CARD_DONE : CARD_PENDING} ${!done ? 'cursor-pointer' : ''}`}
       role="button"
       tabIndex={0}
       aria-label={`${task.template.name} for ${task.assignment_group?.name} — ${done ? 'completed' : 'pending'}`}
@@ -272,16 +297,27 @@ function GroupSection({ task, onNavigate }) {
         }
       }}
     >
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex-1 min-w-0">
-          <p className="font-medium text-sm text-gray-900 dark:text-white">{task.template.name}</p>
-          {task.assignment_group && (
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{task.assignment_group.name}</p>
-          )}
+      <div
+        className={`h-1 ${done ? 'bg-emerald-500' : 'bg-gradient-to-r from-indigo-500 via-blue-500 to-violet-500'}`}
+        aria-hidden="true"
+      />
+      <div className="p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex-1 min-w-0">
+            <p className="font-semibold text-base text-gray-900 dark:text-white">{task.template.name}</p>
+            {task.assignment_group && (
+              <p className="text-sm text-gray-600 dark:text-gray-300 mt-0.5">{task.assignment_group.name}</p>
+            )}
+          </div>
+          <TaskStatusIcon done={done} />
         </div>
-        <span className="shrink-0 mt-0.5">{done ? <IconCheck /> : <span className="text-gray-400"><IconCircle /></span>}</span>
+        {!done ? (
+          <p className="text-sm text-indigo-700 dark:text-indigo-300 mt-3 font-medium">
+            Tap to complete group reflection →
+          </p>
+        ) : null}
       </div>
-    </div>
+    </article>
   );
 }
 
@@ -289,34 +325,75 @@ function GroupSection({ task, onNavigate }) {
 // Summary bar
 // ---------------------------------------------------------------------------
 
+function AllDoneCelebration() {
+  return (
+    <div
+      className="flex items-start gap-4 rounded-2xl border border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-950/40 px-5 py-5 shadow-sm"
+      data-testid="tasks-all-done-celebration"
+      role="status"
+    >
+      <CheckCircle2 className="w-8 h-8 shrink-0 text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
+      <div>
+        <p className="text-lg font-semibold text-emerald-950 dark:text-emerald-50">
+          You&apos;re all caught up — thank you!
+        </p>
+        <p className="text-sm text-emerald-900 dark:text-emerald-200 mt-1">
+          Every reflection for today is submitted. Your camp team appreciates you showing up.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 function SummaryBar({ tasks }) {
   const total = tasks.length;
   const completed = tasks.filter((t) => t.completion.covered >= t.completion.total).length;
   const waiting = total - completed;
   const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
+  const allDone = total > 0 && waiting === 0;
 
   return (
-    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 mb-6">
-      <div className="flex items-center justify-between mb-2">
-        <p className="text-sm font-medium text-gray-900 dark:text-white">
-          {waiting > 0 ? `${waiting} task${waiting !== 1 ? 's' : ''} waiting` : 'All done!'}
-        </p>
-        <span className="text-xs text-gray-500 dark:text-gray-400">
-          {completed}/{total} completed
-        </span>
+    <section className="mb-6 space-y-4" aria-label="Today's progress">
+      {allDone ? <AllDoneCelebration /> : null}
+      <div className={`${CARD_BASE} border-gray-200 dark:border-gray-700 p-5`}>
+        <div className="flex flex-wrap items-end justify-between gap-3 mb-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Today&apos;s progress
+            </p>
+            <p className="text-xl font-semibold text-gray-900 dark:text-white mt-0.5 tabular-nums">
+              {completed}
+              <span className="text-gray-500 dark:text-gray-400 font-medium text-base">
+                {' '}
+                / {total} assignments
+              </span>
+            </p>
+          </div>
+          <p className="text-sm font-medium text-gray-700 dark:text-gray-200">
+            {waiting > 0 ? (
+              <span className="text-amber-800 dark:text-amber-200">
+                {waiting} remaining
+              </span>
+            ) : (
+              <span className="text-emerald-800 dark:text-emerald-200">Complete</span>
+            )}
+          </p>
+        </div>
+        <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-3 overflow-hidden">
+          <div
+            className={`h-3 rounded-full transition-all duration-500 ${
+              allDone ? 'bg-emerald-500' : 'bg-indigo-600 dark:bg-indigo-500'
+            }`}
+            style={{ width: `${pct}%` }}
+            role="progressbar"
+            aria-valuenow={pct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`${pct}% complete`}
+          />
+        </div>
       </div>
-      <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
-        <div
-          className="bg-blue-500 h-2 rounded-full transition-all"
-          style={{ width: `${pct}%` }}
-          role="progressbar"
-          aria-valuenow={pct}
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-label={`${pct}% complete`}
-        />
-      </div>
-    </div>
+    </section>
   );
 }
 
@@ -343,28 +420,28 @@ function ObservationsRequiringResponseSection() {
   if (items.length === 0) return null;
 
   return (
-    <div className="mt-6">
-      <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
+    <section className="mt-8">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
         Observations requiring response
       </h2>
-      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden">
+      <div className={`${CARD_BASE} border-gray-200 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-800`}>
         {items.map(item => (
           <Link
             key={item.id}
             to={`/observations/${item.id}`}
-            className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors border-b border-gray-100 dark:border-gray-700/50 last:border-0"
+            className="flex items-center gap-3 px-5 py-4 hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors"
           >
-            <span className="w-2 h-2 rounded-full bg-violet-500 shrink-0" />
-            <span className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate flex-1">
+            <span className="w-2.5 h-2.5 rounded-full bg-violet-600 dark:bg-violet-400 shrink-0" />
+            <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate flex-1">
               {item.preview ?? item.body?.slice(0, 80) ?? 'Observation'}
             </span>
-            <span className="text-xs text-gray-400 shrink-0">
+            <span className="text-xs font-medium text-gray-600 dark:text-gray-400 shrink-0">
               From {item.author?.name ?? item.author?.full_name}
             </span>
           </Link>
         ))}
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -449,24 +526,49 @@ export default function ReflectionTasksPanel({ variant = 'page' }) {
   const inner = (
     <>
       {!embedded && (
-        <header className="mb-6 flex items-start justify-between gap-3">
-          <div>
-            <h1 className="text-xl font-semibold text-gray-900 dark:text-white">Today</h1>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{headingLabel}</p>
+        <header className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex gap-4 min-w-0">
+            <div className="hidden sm:flex shrink-0 w-12 h-12 rounded-xl bg-indigo-100 dark:bg-indigo-950/60 border border-indigo-200 dark:border-indigo-800 items-center justify-center">
+              <ClipboardList className="w-6 h-6 text-indigo-700 dark:text-indigo-300" aria-hidden="true" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                My work
+              </p>
+              <h1 className="text-2xl sm:text-3xl font-semibold text-gray-900 dark:text-white mt-0.5">
+                My Tasks
+              </h1>
+              <p className="text-sm font-medium text-gray-700 dark:text-gray-200 mt-1">{headingLabel}</p>
+              <p className="text-sm text-gray-600 dark:text-gray-300 mt-2 max-w-2xl">
+                Tap a camper or assignment below to file today&apos;s reflections. Completed work
+                stays visible so you can review or edit.
+              </p>
+            </div>
           </div>
-          {showCoverageLink && (
+          <div className="flex flex-wrap gap-2 shrink-0 sm:pt-1">
             <Link
-              to="/groups/performance"
-              data-testid="tasks-coverage-link"
-              className="shrink-0 inline-flex items-center gap-1 mt-1 rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+              to="/my-reflections"
+              data-testid="tasks-my-reflections-link"
+              className="inline-flex items-center rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-4 py-2 text-sm font-medium text-gray-800 dark:text-gray-100 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
             >
-              Performance →
+              My reflections
             </Link>
-          )}
+            {showCoverageLink && (
+              <Link
+                to="/groups/performance"
+                data-testid="tasks-coverage-link"
+                className="inline-flex items-center rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-4 py-2 text-sm font-medium text-gray-800 dark:text-gray-100 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+              >
+                Performance →
+              </Link>
+            )}
+          </div>
         </header>
       )}
 
-      {loading && <p className="text-gray-500 dark:text-gray-400 text-sm">Loading tasks…</p>}
+      {loading && (
+        <p className="text-gray-700 dark:text-gray-300 text-sm font-medium">Loading tasks…</p>
+      )}
 
       {error && (
         <div
@@ -482,10 +584,19 @@ export default function ReflectionTasksPanel({ variant = 'page' }) {
           <SummaryBar tasks={tasks} />
 
           {tasks.length === 0 && (
-            <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-12">No tasks for today.</p>
+            <p className="text-sm text-gray-700 dark:text-gray-300 text-center py-16 rounded-2xl border border-dashed border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900">
+              No tasks for today.
+            </p>
           )}
 
-          <div className={`space-y-4 ${embedded ? 'lg:grid lg:grid-cols-2 lg:gap-4 lg:space-y-0' : ''}`} data-testid="tasks-list">
+          <div
+            className={
+              embedded
+                ? 'grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-5'
+                : 'grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-5'
+            }
+            data-testid="tasks-list"
+          >
             {tasks.map((task) => {
               if (task.subject_mode === 'self') {
                 return <SelfSection key={task.id} task={task} onNavigate={handleSelfNavigate} />;
@@ -507,13 +618,9 @@ export default function ReflectionTasksPanel({ variant = 'page' }) {
     return <div className="w-full">{inner}</div>;
   }
 
-  // 3.33: AppLayout owns the outer scroll container and chrome.
-  // We keep the centered single-column treatment for the page
-  // variant because the task home was designed as a focused
-  // single-column experience.
   return (
-    <div className="px-4 py-6 pb-24">
-      <div className="max-w-lg mx-auto">{inner}</div>
+    <div className="px-4 sm:px-6 lg:px-8 py-8 pb-24 w-full max-w-[80rem] mx-auto">
+      {inner}
     </div>
   );
 }

--- a/frontend/src/utils/reflection/reflectionFormValidation.js
+++ b/frontend/src/utils/reflection/reflectionFormValidation.js
@@ -204,11 +204,37 @@ export function buildDefaultAnswers(schema) {
       out[key] = {};
     } else if (ftype === 'number' || ftype === 'single_rating') {
       out[key] = '';
-    } else if (ftype === 'yes_no') {
-      out[key] = '';
     }
+    // yes_no: intentionally omitted — empty string fails backend validation.
+    // Optional fields may be absent; required yes/no fields must be set by the user.
   }
   return out;
+}
+
+/**
+ * Normalize answers before POST/PATCH so optional yes/no fields left at their
+ * default (missing) are not sent as empty strings. Also drops keys the UI
+ * manages separately (e.g. counselor self-reflection ``day_off`` toggle).
+ */
+export function prepareReflectionAnswersForSubmit(schema, answers, options = {}) {
+  const omitKeys = options.omitKeys ?? [];
+  if (!answers || typeof answers !== 'object' || Array.isArray(answers)) {
+    return answers;
+  }
+  const next = { ...answers };
+  for (const key of omitKeys) {
+    delete next[key];
+  }
+  const fields = schema?.fields;
+  if (!Array.isArray(fields)) return next;
+  for (const field of fields) {
+    if (field?.type !== 'yes_no' || !field?.key) continue;
+    const value = next[field.key];
+    if (value === '' || value === null || value === undefined) {
+      delete next[field.key];
+    }
+  }
+  return next;
 }
 
 export function ratingScaleValues(field) {

--- a/frontend/src/utils/reflection/reflectionFormValidation.test.js
+++ b/frontend/src/utils/reflection/reflectionFormValidation.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   validateReflectionAnswers,
   buildDefaultAnswers,
+  prepareReflectionAnswersForSubmit,
   ratingScaleValues,
   localizedOptionLabel,
 } from './reflectionFormValidation';
@@ -151,6 +152,23 @@ describe('validateReflectionAnswers — extended field types', () => {
   });
 });
 
+describe('prepareReflectionAnswersForSubmit', () => {
+  it('drops empty yes_no values and omitted keys', () => {
+    const schema = {
+      fields: [
+        { key: 'day_off', type: 'yes_no', required: false, prompts: { en: 'Off?' } },
+        { key: 'note', type: 'textarea', required: false, prompts: { en: 'N' } },
+      ],
+    };
+    const out = prepareReflectionAnswersForSubmit(
+      schema,
+      { day_off: '', note: 'hello' },
+      { omitKeys: ['day_off'] },
+    );
+    expect(out).toEqual({ note: 'hello' });
+  });
+});
+
 describe('buildDefaultAnswers — extended field types', () => {
   it('seeds empty defaults for new types and skips meta fields', () => {
     const schema = {
@@ -166,7 +184,7 @@ describe('buildDefaultAnswers — extended field types', () => {
     const a = buildDefaultAnswers(schema);
     expect(a.n).toBe('');
     expect(a.d).toBe('');
-    expect(a.y).toBe('');
+    expect(a.y).toBeUndefined();
     expect(a.s).toBe('');
     expect(a.sec).toBeUndefined();
     expect(a.inst).toBeUndefined();


### PR DESCRIPTION
## Summary
- Counselor home and My Tasks: full-width task panel, completion celebration, quick links for tasks and reflections; sidebar consolidates to a single Home link and removes counselor-only File a Reflection / Reflections dashboard entries.
- Maintenance queue: counselors default to "My tickets", can mark their own tickets closed; submitter close permission on the state machine; single closing-note field in the modal.
- Observations: subject search uses org-wide taggable persons (no legacy CounselorBunkAssignment), multi-token name matching, empty/error states in the composer; subject notes keep existing supervised scope.
- Group Performance dashboard syncs date/filters with URL query params.
- Assignment group admin regression test and bunk-scoped supervised subject resolution for AGM rosters.

## Test plan
- [ ] Counselor: open observation composer, search camper by first name, last name, and full name; confirm matches appear and self is not listed.
- [ ] Counselor: maintenance queue defaults to My tickets; close own ticket with optional note.
- [ ] Counselor home: My Tasks and My Reflections cards; sidebar shows single Home.
- [ ] Group Performance: change date and confirm URL updates.
- [ ] CI: backend pytest + ruff, frontend vitest + build, e2e rbac-sidebar.


Made with [Cursor](https://cursor.com)