### PR TITLE
Improve Camper Care workspace, bunk dashboards, and counselor flows

### DIFF
--- a/backend/bunk_logs/api/admin_flow/search.py
+++ b/backend/bunk_logs/api/admin_flow/search.py
@@ -5,11 +5,11 @@ content type, ranked by Postgres ``SearchVector`` similarity.
 
 Scope:
 
-* People       -- ``full_name``, ``email``, ``external_ids`` (JSON text-cast)
-* Reflections  -- ``answers`` (JSONField, text-cast)
-* Orders       -- ``item``, ``item_note``, ``description``
-* Tickets      -- ``title``, ``location``, ``description``
-* Templates    -- ``name``, ``schema`` (JSON text-cast)
+* People       -- viewable campers (permission-scoped); links to profile
+* Reflections  -- ``answers`` (org admin only)
+* Orders       -- org admin only
+* Tickets      -- org admin only
+* Templates    -- org admin only
 
 Org isolation is enforced via the existing ``OrgScopedManager`` (or
 ``Membership.program__organization`` for memberships) — never the
@@ -30,6 +30,7 @@ from django.contrib.postgres.search import SearchRank
 from django.contrib.postgres.search import SearchVector
 from django.db.models import F
 from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -39,8 +40,8 @@ from bunk_logs.core.models import Person
 from bunk_logs.core.models import Reflection
 from bunk_logs.core.models import ReflectionTemplate
 from bunk_logs.core.permissions import IsOrgAdminOrSuperuser
-
-from .common import viewer_or_403
+from bunk_logs.core.permissions.subject_dashboard import viewable_camper_queryset
+from bunk_logs.core.person_search import filter_persons_by_name_query
 
 PER_GROUP_LIMIT = 25
 MIN_QUERY_LEN = 2
@@ -49,28 +50,37 @@ MIN_QUERY_LEN = 2
 class AdminGlobalSearchView(APIView):
     """Cross-content search for the admin global search header."""
 
-    permission_classes = [IsOrgAdminOrSuperuser]
+    permission_classes = [IsAuthenticated]
 
     def get(self, request, *args, **kwargs):
-        ctx = viewer_or_403(request)
+        org = getattr(request, "organization", None)
+        if org is None:
+            return Response(
+                {"detail": "Organization context required."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         q = (request.query_params.get("q") or "").strip()
         if len(q) < MIN_QUERY_LEN:
             return Response(
                 {"detail": f"q must be at least {MIN_QUERY_LEN} characters."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        viewer = Person.all_objects.filter(user=request.user).first()
         query = SearchQuery(q)
         groups: dict[str, list[dict]] = {
-            "people": _search_people(ctx, query, q),
-            "reflections": _search_reflections(ctx, query),
-            "orders": _search_orders(ctx, query),
-            "tickets": _search_tickets(ctx, query),
-            "templates": _search_templates(ctx, query),
+            "people": _search_people(org, viewer, request.user, query, q),
         }
+        if IsOrgAdminOrSuperuser().has_permission(request, self):
+            groups["reflections"] = _search_reflections(org, query)
+            groups["orders"] = _search_orders(org, query)
+            groups["tickets"] = _search_tickets(org, query)
+            groups["templates"] = _search_templates(org, query)
         return Response({"query": q, "groups": groups})
 
 
-def _search_people(ctx, query, raw: str) -> list[dict]:
+def _search_people(org, viewer, user, query, raw: str) -> list[dict]:
+    """Campers the viewer may open on profile, ranked by name similarity."""
+    base = viewable_camper_queryset(viewer, org, user)
     vector = (
         SearchVector("first_name")
         + SearchVector("last_name")
@@ -78,19 +88,15 @@ def _search_people(ctx, query, raw: str) -> list[dict]:
         + SearchVector("email")
     )
     qs = (
-        Person.all_objects.filter(organization=ctx.organization)
-        .annotate(rank=SearchRank(vector, query))
+        base.annotate(rank=SearchRank(vector, query))
         .filter(rank__gt=0)
         .order_by(F("rank").desc())[:PER_GROUP_LIMIT]
     )
     rows = list(qs)
-    # JSON external_ids isn't easily castable inside SearchVector; do
-    # a complementary ``icontains`` pass and union the results so the
-    # admin can still find Persons by external CampMinder / TBE id.
     if len(rows) < PER_GROUP_LIMIT:
         seen = {p.id for p in rows}
         extra = (
-            Person.all_objects.filter(organization=ctx.organization)
+            filter_persons_by_name_query(base, raw)
             .filter(external_ids__icontains=raw)
             .exclude(id__in=seen)[: (PER_GROUP_LIMIT - len(rows))]
         )
@@ -100,16 +106,16 @@ def _search_people(ctx, query, raw: str) -> list[dict]:
             "id": p.id,
             "label": p.full_name,
             "secondary": p.email or "",
-            "deep_link": f"/admin/people?id={p.id}",
+            "deep_link": f"/profile/{p.id}",
         }
         for p in rows
     ]
 
 
-def _search_reflections(ctx, query) -> list[dict]:
+def _search_reflections(org, query) -> list[dict]:
     vector = SearchVector("answers")
     qs = (
-        Reflection.all_objects.filter(organization=ctx.organization)
+        Reflection.all_objects.filter(organization=org)
         .annotate(rank=SearchRank(vector, query))
         .filter(rank__gt=0)
         .select_related("subject", "template")
@@ -129,14 +135,14 @@ def _search_reflections(ctx, query) -> list[dict]:
     ]
 
 
-def _search_orders(ctx, query) -> list[dict]:
+def _search_orders(org, query) -> list[dict]:
     vector = (
         SearchVector("item")
         + SearchVector("item_note")
         + SearchVector("description")
     )
     qs = (
-        Order.all_objects.filter(organization=ctx.organization)
+        Order.all_objects.filter(organization=org)
         .annotate(rank=SearchRank(vector, query))
         .filter(rank__gt=0)
         .order_by(F("rank").desc())[:PER_GROUP_LIMIT]
@@ -152,14 +158,14 @@ def _search_orders(ctx, query) -> list[dict]:
     ]
 
 
-def _search_tickets(ctx, query) -> list[dict]:
+def _search_tickets(org, query) -> list[dict]:
     vector = (
         SearchVector("title")
         + SearchVector("location")
         + SearchVector("description")
     )
     qs = (
-        MaintenanceTicket.all_objects.filter(organization=ctx.organization)
+        MaintenanceTicket.all_objects.filter(organization=org)
         .annotate(rank=SearchRank(vector, query))
         .filter(rank__gt=0)
         .order_by(F("rank").desc())[:PER_GROUP_LIMIT]
@@ -175,10 +181,10 @@ def _search_tickets(ctx, query) -> list[dict]:
     ]
 
 
-def _search_templates(ctx, query) -> list[dict]:
+def _search_templates(org, query) -> list[dict]:
     vector = SearchVector("name") + SearchVector("description")
     qs = (
-        ReflectionTemplate.all_objects.filter(organization=ctx.organization)
+        ReflectionTemplate.all_objects.filter(organization=org)
         .annotate(rank=SearchRank(vector, query))
         .filter(rank__gt=0)
         .order_by(F("rank").desc())[:PER_GROUP_LIMIT]

--- a/backend/bunk_logs/api/camper_care/dashboard.py
+++ b/backend/bunk_logs/api/camper_care/dashboard.py
@@ -27,7 +27,9 @@ from bunk_logs.api.unit_head.common import compute_attention_badges
 from bunk_logs.api.unit_head.common import expected_by_passed
 from bunk_logs.api.unit_head.common import help_requested_camper_ids_from
 from bunk_logs.api.unit_head.common import off_camp_camper_ids
-from bunk_logs.core.models import Flag
+from bunk_logs.core.flags import active_flags_for_program_day
+from bunk_logs.core.flags import flagged_camper_ids_for_date
+from bunk_logs.core.flags import sync_missing_camper_care_help_flags
 from bunk_logs.core.models import Order
 
 from .common import bunk_camper_ids
@@ -57,6 +59,10 @@ class CamperCareDashboardView(APIView):
             msg = "Future dates are not selectable."
             raise ValidationError(msg)
 
+        sync_missing_camper_care_help_flags(
+            program=ctx.program, target_date=target_date,
+        )
+
         bypass = (request.query_params.get("nocache") or "").lower() in {"1", "true"}
         cache_key = _cache_key(
             viewer_id=ctx.person.id, organization_id=ctx.organization.id,
@@ -69,10 +75,8 @@ class CamperCareDashboardView(APIView):
 
         units_payload = _build_caseload_tree(ctx, target_date=target_date)
 
-        flag_count = Flag.objects.filter(
-            program=ctx.program,
-            flagged_for_role="camper_care",
-            status__in=(Flag.Status.ACTIVE, Flag.Status.FOLLOWED_UP),
+        flag_count = active_flags_for_program_day(
+            program=ctx.program, target_date=target_date,
         ).count()
 
         order_count = Order.objects.filter(
@@ -172,14 +176,13 @@ def _build_caseload_tree(ctx, *, target_date) -> list[dict]:
             all_camper_ids.update(ids)
 
     flagged_camper_ids = (
-        set(
-            Flag.objects.filter(
-                program=ctx.program,
-                subject_camper_id__in=all_camper_ids,
-                flagged_for_role="camper_care",
-                status__in=(Flag.Status.ACTIVE, Flag.Status.FOLLOWED_UP),
-            ).values_list("subject_camper_id", flat=True),
-        ) if all_camper_ids else set()
+        flagged_camper_ids_for_date(
+            program=ctx.program,
+            target_date=target_date,
+            camper_ids=all_camper_ids,
+        )
+        if all_camper_ids
+        else set()
     )
     ordered_camper_ids = (
         set(

--- a/backend/bunk_logs/api/camper_care/flags.py
+++ b/backend/bunk_logs/api/camper_care/flags.py
@@ -23,6 +23,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from bunk_logs.core.flags import sync_missing_camper_care_help_flags
 from bunk_logs.core.models import AuditEvent
 from bunk_logs.core.models import Flag
 from bunk_logs.notes.models import Observation
@@ -59,6 +60,7 @@ class FlagListView(APIView):
 
     def get(self, request, *args, **kwargs):
         ctx = viewer_or_403(request)
+        sync_missing_camper_care_help_flags(program=ctx.program)
         status_q = (request.query_params.get("status") or "").strip().lower()
         if status_q and status_q not in ALL_STATUSES:
             return Response(
@@ -296,9 +298,9 @@ def _trigger_detail(flag: Flag) -> dict:
             from bunk_logs.core.models import Reflection
             refl = Reflection.all_objects.filter(id=flag.trigger_content_id).first()
             if refl is not None:
-                detail["created_at"] = (
-                    refl.created_at.isoformat() if refl.created_at else None
-                )
+                submitted = getattr(refl, "submitted_at", None)
+                detail["created_at"] = submitted.isoformat() if submitted else None
+                detail["author"] = _person_name(refl.author)
                 if isinstance(refl.answers, dict):
                     parts = [
                         v.strip()

--- a/backend/bunk_logs/api/camper_care/orders.py
+++ b/backend/bunk_logs/api/camper_care/orders.py
@@ -29,6 +29,7 @@ from rest_framework.views import APIView
 
 from bunk_logs.api.orders_state_machine import OrderBulkTransitionView
 from bunk_logs.api.orders_state_machine import OrderTransitionView
+from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Order
 from bunk_logs.core.models import OrderActivityEvent
 
@@ -64,7 +65,7 @@ class CamperCareOrdersListView(APIView):
             raise ValidationError({"filter": msg})
 
         qs = Order.objects.filter(program=ctx.program).select_related(
-            "subject", "submitted_by__person",
+            "subject", "submitted_by__person", "submitted_from_bunk",
         )
         if filt == "my_caseload":
             camper_ids = caseload_camper_ids(ctx.membership)
@@ -97,11 +98,29 @@ class CamperCareOrdersListView(APIView):
         resolved_until = _parse_optional_date(request.query_params.get("resolved_until"))
 
         rows = list(qs.order_by("-created_at"))
+        subject_ids = {o.subject_id for o in rows if o.subject_id}
+        submitter_person_ids = {
+            o.submitted_by.person_id
+            for o in rows
+            if o.submitted_by_id and o.submitted_by.person_id
+        }
+        bunk_by_subject = _bunk_by_subject_ids(
+            subject_ids=subject_ids,
+            program_id=ctx.program.id,
+        )
+        bunk_by_submitter = _bunk_by_author_person_ids(
+            person_ids=submitter_person_ids,
+            program_id=ctx.program.id,
+        )
         new_items: list[dict] = []
         in_progress: list[dict] = []
         resolved: list[dict] = []
         for o in rows:
-            payload = _order_payload(o)
+            payload = _order_payload(
+                o,
+                bunk_by_subject=bunk_by_subject,
+                bunk_by_submitter=bunk_by_submitter,
+            )
             if o.status == Order.Status.NEW:
                 new_items.append(payload)
             elif o.status == Order.Status.IN_PROGRESS:
@@ -157,7 +176,82 @@ def _parse_optional_date(raw: str | None):
     return parsed
 
 
-def _order_payload(order: Order) -> dict:
+def _bunk_by_subject_ids(*, subject_ids: set[int], program_id: int) -> dict[int, dict]:
+    """Active bunk membership per camper in ``program_id`` (first match wins)."""
+    return _bunk_lookup(
+        person_ids=subject_ids,
+        program_id=program_id,
+        role_in_group="subject",
+    )
+
+
+def _bunk_by_author_person_ids(*, person_ids: set[int], program_id: int) -> dict[int, dict]:
+    """Active author bunk per counselor Person in ``program_id``."""
+    return _bunk_lookup(
+        person_ids=person_ids,
+        program_id=program_id,
+        role_in_group="author",
+    )
+
+
+def _bunk_lookup(
+    *,
+    person_ids: set[int],
+    program_id: int,
+    role_in_group: str,
+) -> dict[int, dict]:
+    if not person_ids:
+        return {}
+    rows = AssignmentGroupMembership.objects.filter(
+        person_id__in=person_ids,
+        role_in_group=role_in_group,
+        is_active=True,
+        group__group_type="bunk",
+        group__is_active=True,
+        group__program_id=program_id,
+    ).values("person_id", "group_id", "group__name")
+    out: dict[int, dict] = {}
+    for row in rows:
+        person_id = row["person_id"]
+        if person_id in out:
+            continue
+        out[person_id] = {
+            "id": row["group_id"],
+            "name": row["group__name"] or "",
+        }
+    return out
+
+
+def _resolve_order_bunk(
+    order: Order,
+    *,
+    bunk_by_subject: dict[int, dict] | None,
+    bunk_by_submitter: dict[int, dict] | None,
+) -> dict | None:
+    if order.submitted_from_bunk_id and order.submitted_from_bunk:
+        return {
+            "id": order.submitted_from_bunk_id,
+            "name": order.submitted_from_bunk.name or "",
+        }
+    if (
+        bunk_by_submitter
+        and order.submitted_by_id
+        and order.submitted_by.person_id
+    ):
+        bunk = bunk_by_submitter.get(order.submitted_by.person_id)
+        if bunk:
+            return bunk
+    if bunk_by_subject and order.subject_id:
+        return bunk_by_subject.get(order.subject_id)
+    return None
+
+
+def _order_payload(
+    order: Order,
+    *,
+    bunk_by_subject: dict[int, dict] | None = None,
+    bunk_by_submitter: dict[int, dict] | None = None,
+) -> dict:
     submitter = order.submitted_by
     submitter_person = getattr(submitter, "person", None) if submitter else None
     age_seconds = None
@@ -169,12 +263,18 @@ def _order_payload(order: Order) -> dict:
             content_type="order", content_id=order.id,
         ).order_by("-created_at").first()
     )
+    bunk = _resolve_order_bunk(
+        order,
+        bunk_by_subject=bunk_by_subject,
+        bunk_by_submitter=bunk_by_submitter,
+    )
     return {
         "id": str(order.id),
         "status": order.status,
         "available_transitions": order.available_transitions(),
         "is_within_correction_window": order.can_correct_last_transition(),
         "subject": _camper_brief(order.subject),
+        "bunk": bunk,
         "item": order.item,
         "item_note": order.item_note,
         "description": order.description,

--- a/backend/bunk_logs/api/counselor/camper_care_requests.py
+++ b/backend/bunk_logs/api/counselor/camper_care_requests.py
@@ -23,6 +23,7 @@ from bunk_logs.core.models import OrderItemSuggestion
 from .common import co_counselor_person_ids
 from .common import find_existing_by_client_submission_id
 from .common import invalidate_dashboard_for_viewers
+from .common import resolve_submitted_from_bunk
 from .common import viewer_bunk_groups
 from .common import viewer_or_403
 from .responses import order_response
@@ -118,12 +119,19 @@ class CamperCareRequestCreateView(APIView):
                     {"subject_id": "Camper is not on any of your bunks."},
                 )
 
+        submitted_from_bunk = resolve_submitted_from_bunk(
+            viewer=viewer,
+            subject_id=subject_id,
+            bunk_id=payload.get("bunk_id"),
+        )
+
         with transaction.atomic():
             order = Order(
                 organization=org,
                 program=program,
                 subject_id=subject_id,
                 submitted_by=primary_membership,
+                submitted_from_bunk=submitted_from_bunk,
                 item=payload["item"],
                 item_note=payload.get("item_note", ""),
                 description=payload.get("description", ""),

--- a/backend/bunk_logs/api/counselor/camper_reflections.py
+++ b/backend/bunk_logs/api/counselor/camper_reflections.py
@@ -23,6 +23,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from bunk_logs.core import audit as audit_module
+from bunk_logs.core.flags import raise_flag_from_camper_reflection
 from bunk_logs.core.models import AssignmentGroup
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
@@ -218,6 +219,9 @@ class CamperReflectionListView(APIView):
             client_submission_id=payload["client_submission_id"],
         )
         if existing is not None:
+            raise_flag_from_camper_reflection(
+                existing, raised_by_membership=primary_membership,
+            )
             return Response(reflection_response(existing), status=status.HTTP_200_OK)
 
         bunk = AssignmentGroup.all_objects.filter(
@@ -293,6 +297,9 @@ class CamperReflectionListView(APIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
             reflection.save()
+            raise_flag_from_camper_reflection(
+                reflection, raised_by_membership=primary_membership,
+            )
 
         audit_module.created(
             primary_membership,
@@ -365,14 +372,18 @@ class CamperReflectionDetailView(APIView):
         reflection.save()
         after = reflection_snapshot(reflection)
 
-        if before != after:
-            actor_membership = (
-                Membership.objects.filter(
-                    person=viewer, program=reflection.program, is_active=True,
-                )
-                .order_by("-created_at")
-                .first()
+        actor_membership = (
+            Membership.objects.filter(
+                person=viewer, program=reflection.program, is_active=True,
             )
+            .order_by("-created_at")
+            .first()
+        )
+        raise_flag_from_camper_reflection(
+            reflection, raised_by_membership=actor_membership,
+        )
+
+        if before != after:
             audit_module.edited(
                 actor_membership or request.user,
                 reflection,

--- a/backend/bunk_logs/api/counselor/common.py
+++ b/backend/bunk_logs/api/counselor/common.py
@@ -68,6 +68,38 @@ def viewer_or_403(request) -> ViewerContext:
     return ViewerContext(person=person, organization=org, today=get_today(org))
 
 
+def resolve_submitted_from_bunk(
+    *,
+    viewer: Person,
+    subject_id: int | None = None,
+    bunk_id: int | None = None,
+) -> AssignmentGroup | None:
+    """Pick the bunk context for a counselor-filed Camper Care request.
+
+    When a camper is selected, prefer the bunk where that camper is on the
+    viewer's roster. Otherwise honor an explicit ``bunk_id`` from the client,
+    or fall back to the viewer's only bunk.
+    """
+    bunks = viewer_bunk_groups(viewer)
+    if not bunks:
+        return None
+    by_id = {b.id: b for b in bunks}
+    if bunk_id is not None and bunk_id in by_id:
+        return by_id[bunk_id]
+    if subject_id is not None:
+        for bunk in bunks:
+            if AssignmentGroupMembership.objects.filter(
+                group=bunk,
+                person_id=subject_id,
+                role_in_group="subject",
+                is_active=True,
+            ).exists():
+                return bunk
+    if len(bunks) == 1:
+        return bunks[0]
+    return None
+
+
 def viewer_bunk_groups(viewer: Person) -> list[AssignmentGroup]:
     """Active bunk AssignmentGroups the viewer is an author on.
 

--- a/backend/bunk_logs/api/counselor/serializers.py
+++ b/backend/bunk_logs/api/counselor/serializers.py
@@ -129,6 +129,7 @@ class CamperCareRequestCreateSerializer(serializers.Serializer):
     """
 
     subject_id = serializers.IntegerField(required=False, allow_null=True)
+    bunk_id = serializers.IntegerField(required=False, allow_null=True)
     item = serializers.CharField(max_length=120)
     item_note = serializers.CharField(
         required=False, allow_blank=True, default="",

--- a/backend/bunk_logs/api/dashboards/subject.py
+++ b/backend/bunk_logs/api/dashboards/subject.py
@@ -28,9 +28,7 @@ from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
 from bunk_logs.core.models import Reflection
 from bunk_logs.core.permissions.observation_read import filter_observations_readable
-from bunk_logs.core.permissions.subject_note_authoring import can_author_subject_note
-from bunk_logs.core.permissions.super_admin import is_super_admin
-from bunk_logs.core.permissions.visibility import author_group_ids_with_descendants
+from bunk_logs.core.permissions.subject_dashboard import can_view_subject_dashboard
 from bunk_logs.notes.models import Observation
 
 DEFAULT_WINDOW_DAYS = 30
@@ -116,67 +114,6 @@ def _is_yes_no_field(field: dict) -> bool:
         return False
     values = {str(o.get("value", "")).lower() for o in options if isinstance(o, dict)}
     return values == {"yes", "no"}
-
-
-def _viewer_capability(person: Person, org) -> str | None:
-    """Highest-privilege capability the person holds in this org (across all programs)."""
-    caps = set(
-        Membership.all_objects.filter(
-            person=person,
-            is_active=True,
-            program__organization=org,
-        ).values_list("capability", flat=True),
-    )
-    for cap in ("admin", "program_lead", "domain_specialist", "supervisor"):
-        if cap in caps:
-            return cap
-    if "participant" in caps:
-        return "participant"
-    return None
-
-
-def _viewer_supervises_subject(viewer: Person, subject: Person) -> bool:
-    """True if viewer authors a group (or any ancestor group) that contains subject."""
-    group_ids = author_group_ids_with_descendants(viewer)
-    if not group_ids:
-        return False
-    return AssignmentGroupMembership.all_objects.filter(
-        person=subject,
-        group_id__in=group_ids,
-        role_in_group="subject",
-        is_active=True,
-    ).exists()
-
-
-def _can_view_subject_dashboard(
-    viewer_person: Person | None,
-    subject: Person,
-    org,
-    user,
-) -> bool:
-    """Explicit capability gate for the subject dashboard.
-
-    Allowed paths:
-    - Super admin (no Person required)
-    - admin / program_lead / domain_specialist membership in org
-    - supervisor capability with a supervises-subject relationship
-    - participant capability with a supervises-subject relationship (covers
-      counselors accessing their campers) or self-view
-    - program-scoped authoring roles (e.g. activity specialists) via
-      ``can_author_subject_note`` org role defaults
-    """
-    if is_super_admin(user):
-        return True
-    if viewer_person is None:
-        return False
-    cap = _viewer_capability(viewer_person, org)
-    if cap in ("admin", "program_lead", "domain_specialist"):
-        return True
-    if cap in ("supervisor", "participant"):
-        if viewer_person.id == subject.id or _viewer_supervises_subject(viewer_person, subject):
-            return True
-    # Program-scoped roles (e.g. activity specialists) and per-membership overrides.
-    return can_author_subject_note(viewer_person, subject, org, user)
 
 
 def _observations_for_viewer(
@@ -283,7 +220,7 @@ class SubjectDetailView(APIView):
             return Response({"detail": "Subject not found."}, status=404)
 
         viewer_person = Person.all_objects.filter(user=request.user).first()
-        if not _can_view_subject_dashboard(viewer_person, subject, org, request.user):
+        if not can_view_subject_dashboard(viewer_person, subject, org, request.user):
             return Response(
                 {"detail": "You do not have permission to view this subject's dashboard."},
                 status=403,

--- a/backend/bunk_logs/api/observations/serializers.py
+++ b/backend/bunk_logs/api/observations/serializers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from rest_framework import serializers
 
+from bunk_logs.core.models import Person
+from bunk_logs.core.permissions.subject_dashboard import can_view_subject_dashboard
 from bunk_logs.notes.models import Observation
 from bunk_logs.notes.models import ObservationReply
 
@@ -113,11 +115,32 @@ class ObservationThreadSerializer(serializers.ModelSerializer):
             "read_summary",
         ]
 
+    def _viewer_person(self, request, org, user):
+        viewer = self.context.get("viewer_person")
+        if viewer is not None:
+            return viewer
+        if not (request and org and user and user.is_authenticated):
+            return None
+        return Person.objects.filter(user=user).first()
+
     def get_subjects(self, obs: Observation) -> list[dict]:
-        return [
-            {"id": link.subject_id, "full_name": link.subject.full_name}
-            for link in obs.subject_links.select_related("subject").all()
-        ]
+        request = self.context.get("request")
+        org = getattr(request, "organization", None) if request else None
+        user = getattr(request, "user", None) if request else None
+        viewer = self._viewer_person(request, org, user)
+        rows = []
+        for link in obs.subject_links.select_related("subject").all():
+            can_view = False
+            if org is not None and link.subject is not None:
+                can_view = can_view_subject_dashboard(
+                    viewer, link.subject, org, user,
+                )
+            rows.append({
+                "id": link.subject_id,
+                "full_name": link.subject.full_name,
+                "can_view_profile": can_view,
+            })
+        return rows
 
     def get_recipients(self, obs: Observation) -> list[dict]:
         return [

--- a/backend/bunk_logs/api/observations/views.py
+++ b/backend/bunk_logs/api/observations/views.py
@@ -34,11 +34,11 @@ from rest_framework.views import APIView
 from bunk_logs.api.observations.common import viewer_or_403
 from bunk_logs.core import audit as audit_trail
 from bunk_logs.core.models import Person
-from bunk_logs.core.person_search import filter_persons_by_name_query
 from bunk_logs.core.permissions.observation_authoring import observation_authorable_subject_queryset
 from bunk_logs.core.permissions.observation_authoring import recipients_clearing_sensitivity
 from bunk_logs.core.permissions.observation_read import filter_observations_readable
 from bunk_logs.core.permissions.super_admin import is_super_admin
+from bunk_logs.core.person_search import filter_persons_by_name_query
 from bunk_logs.notes.models import Observation
 from bunk_logs.notes.models import ObservationArchive
 from bunk_logs.notes.models import ObservationReadReceipt

--- a/backend/bunk_logs/api/observations/views.py
+++ b/backend/bunk_logs/api/observations/views.py
@@ -34,6 +34,7 @@ from rest_framework.views import APIView
 from bunk_logs.api.observations.common import viewer_or_403
 from bunk_logs.core import audit as audit_trail
 from bunk_logs.core.models import Person
+from bunk_logs.core.person_search import filter_persons_by_name_query
 from bunk_logs.core.permissions.observation_authoring import observation_authorable_subject_queryset
 from bunk_logs.core.permissions.observation_authoring import recipients_clearing_sensitivity
 from bunk_logs.core.permissions.observation_read import filter_observations_readable
@@ -55,31 +56,6 @@ User = get_user_model()
 
 DEFAULT_SEARCH_LIMIT = 25
 MAX_SEARCH_LIMIT = 100
-
-
-def _filter_persons_by_name_query(qs, q: str):
-    """Match name tokens against first, last, and preferred name fields."""
-    q = q.strip()
-    if not q:
-        return qs
-    tokens = [t for t in q.split() if t]
-    if not tokens:
-        return qs
-    if len(tokens) == 1:
-        token = tokens[0]
-        return qs.filter(
-            Q(first_name__icontains=token)
-            | Q(last_name__icontains=token)
-            | Q(preferred_name__icontains=token),
-        )
-    combined = Q()
-    for token in tokens:
-        combined &= (
-            Q(first_name__icontains=token)
-            | Q(last_name__icontains=token)
-            | Q(preferred_name__icontains=token)
-        )
-    return qs.filter(combined)
 
 
 class ObservationsPagination(PageNumberPagination):
@@ -213,7 +189,11 @@ class ObservationThreadView(APIView):
         if obs is None:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
         update_read_receipt(obs, ctx.person)
-        return Response(ObservationThreadSerializer(obs, context={"request": request}).data)
+        return Response(
+            ObservationThreadSerializer(
+                obs, context={"request": request, "viewer_person": ctx.person},
+            ).data,
+        )
 
 
 class ObservationCreateView(APIView):
@@ -291,7 +271,9 @@ class ObservationCreateView(APIView):
             .get(pk=obs.pk)
         )
         return Response(
-            ObservationThreadSerializer(obs, context={"request": request}).data,
+            ObservationThreadSerializer(
+                obs, context={"request": request, "viewer_person": ctx.person},
+            ).data,
             status=status.HTTP_201_CREATED,
         )
 
@@ -374,7 +356,9 @@ class ObservationAmendView(APIView):
             .get(pk=amendment.pk)
         )
         return Response(
-            ObservationThreadSerializer(amendment, context={"request": request}).data,
+            ObservationThreadSerializer(
+                amendment, context={"request": request, "viewer_person": ctx.person},
+            ).data,
             status=status.HTTP_201_CREATED,
         )
 
@@ -456,6 +440,6 @@ class ObservationSubjectsView(APIView):
             base = observation_authorable_subject_queryset(
                 ctx.person, ctx.organization,
             ).exclude(id=ctx.person.id)
-        base = _filter_persons_by_name_query(base, q)
+        base = filter_persons_by_name_query(base, q)
         persons = list(base.order_by("last_name", "first_name")[:limit])
         return Response({"subjects": [{"id": p.id, "full_name": p.full_name} for p in persons]})

--- a/backend/bunk_logs/api/tests/test_admin_flow_pr3.py
+++ b/backend/bunk_logs/api/tests/test_admin_flow_pr3.py
@@ -15,6 +15,8 @@ from django.utils import timezone
 from rest_framework.test import APIClient
 
 from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import AuditEvent
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Organization
@@ -116,19 +118,25 @@ class TestAdminGlobalSearch:
         self, api, org, program, admin_user,
     ):
         with organization_context(org):
-            Person.all_objects.create(
+            camper = Person.all_objects.create(
                 organization=org, first_name="Hermione",
                 last_name="Granger", email="hg@example.com",
+            )
+            bunk = AssignmentGroup.all_objects.create(
+                organization=org, program=program, name="Bunk A",
+                slug="pr3-bunk-a", group_type="bunk",
+            )
+            AssignmentGroupMembership.all_objects.create(
+                group=bunk, person=camper, role_in_group="subject", is_active=True,
             )
         api.force_authenticate(user=admin_user)
         with organization_context(org):
             r = api.get(f"{self.URL}?q=hermione", **_hdr(org.slug))
         assert r.status_code == 200, r.content
         body = r.json()
-        assert any(
-            row["label"].startswith("Hermione")
-            for row in body["groups"]["people"]
-        )
+        people = body["groups"]["people"]
+        assert any(row["label"].startswith("Hermione") for row in people)
+        assert people[0]["deep_link"] == f"/profile/{camper.id}"
 
     def test_does_not_leak_cross_org(
         self, api, org, other_org, admin_user, other_program,
@@ -153,11 +161,49 @@ class TestAdminGlobalSearch:
                 for row in group
             )
 
-    def test_non_admin_blocked(self, api, org, non_admin_user):
+    def test_counselor_search_scoped_to_supervised_campers(
+        self, api, org, program, non_admin_user,
+    ):
+        counselor = Person.all_objects.get(user=non_admin_user)
+        bunk = AssignmentGroup.all_objects.create(
+            organization=org, program=program, name="Mine",
+            slug="pr3-bunk-mine", group_type="bunk",
+        )
+        other_bunk = AssignmentGroup.all_objects.create(
+            organization=org, program=program, name="Other",
+            slug="pr3-bunk-other", group_type="bunk",
+        )
+        mine = Person.all_objects.create(
+            organization=org, first_name="My", last_name="Camper",
+        )
+        distant = Person.all_objects.create(
+            organization=org, first_name="Far", last_name="Camper",
+        )
+        AssignmentGroupMembership.all_objects.create(
+            group=bunk, person=counselor, role_in_group="author", is_active=True,
+        )
+        AssignmentGroupMembership.all_objects.create(
+            group=bunk, person=mine, role_in_group="subject", is_active=True,
+        )
+        AssignmentGroupMembership.all_objects.create(
+            group=other_bunk, person=distant, role_in_group="subject", is_active=True,
+        )
         api.force_authenticate(user=non_admin_user)
         with organization_context(org):
-            r = api.get(f"{self.URL}?q=anything", **_hdr(org.slug))
-        assert r.status_code == 403
+            r = api.get(f"{self.URL}?q=Camper", **_hdr(org.slug))
+        assert r.status_code == 200, r.content
+        labels = [row["label"] for row in r.json()["groups"]["people"]]
+        assert "My Camper" in labels
+        assert "Far Camper" not in labels
+        assert r.json()["groups"].get("reflections", []) == []
+
+    def test_non_admin_can_search_people_only(self, api, org, program, non_admin_user):
+        api.force_authenticate(user=non_admin_user)
+        with organization_context(org):
+            r = api.get(f"{self.URL}?q=Co", **_hdr(org.slug))
+        assert r.status_code == 200
+        assert "people" in r.json()["groups"]
+        assert "reflections" not in r.json()["groups"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/bunk_logs/api/tests/test_camper_care_endpoints.py
+++ b/backend/bunk_logs/api/tests/test_camper_care_endpoints.py
@@ -35,6 +35,7 @@ from bunk_logs.core.models import Program
 from bunk_logs.core.models import Reflection
 from bunk_logs.core.models import ReflectionTemplate
 from bunk_logs.core.models import Supervision
+from bunk_logs.core.time_utils import get_today
 from bunk_logs.notes.models import Observation
 from bunk_logs.notes.models import ObservationSubject
 
@@ -238,6 +239,65 @@ class TestCamperCareDashboard:
         assert body["summary"]["flag_count"] == 0
         assert body["summary"]["order_count"] == 0
 
+    def test_dashboard_syncs_flags_from_camper_care_help_reflection(
+        self, api, org, program, cc_person_user, cc_membership, cc_caseload,
+        bunk, unit, camper, camper_in_bunk, counselor_person_user,
+        counselor_membership,
+    ):
+        """Reflection help requests backfill ``core.Flag`` rows for the workspace."""
+        counselor_person, _ = counselor_person_user
+        today = get_today(org)
+        template = ReflectionTemplate.all_objects.create(
+            organization=org,
+            name="Camper log",
+            slug="cc-sync-camper-log",
+            cadence="daily",
+            subject_mode="single_subject",
+            assignment_scope="per_subject_in_group",
+            assignment_group_types=["bunk"],
+            schema={
+                "fields": [
+                    {
+                        "key": "request_camper_care_help",
+                        "type": "yes_no",
+                        "required": False,
+                        "dashboard_role": "help_request_camper_care",
+                    },
+                ],
+            },
+            languages=["en"],
+            is_active=True,
+            author_role_filter=["counselor"],
+        )
+        refl = Reflection.all_objects.create(
+            organization=org,
+            program=program,
+            template=template,
+            assignment_group=bunk,
+            subject=camper,
+            author=counselor_person,
+            period_start=today,
+            period_end=today,
+            answers={"request_camper_care_help": "yes"},
+            is_complete=True,
+        )
+        assert not Flag.all_objects.filter(
+            trigger_content_type="reflection",
+            trigger_content_id=str(refl.id),
+        ).exists()
+
+        _, user = cc_person_user
+        api.force_authenticate(user=user)
+        with organization_context(org):
+            dash = api.get("/api/v1/camper-care/dashboard/", **_hdr(org.slug))
+            flags = api.get("/api/v1/camper-care/flags/", **_hdr(org.slug))
+        assert dash.status_code == 200
+        assert dash.json()["summary"]["flag_count"] == 1
+        assert flags.status_code == 200
+        items = flags.json()["items"]
+        assert len(items) == 1
+        assert items[0]["subject_camper"]["id"] == camper.id
+
     def test_requires_camper_care_role(
         self, api, org, counselor_person_user, counselor_membership,
     ):
@@ -266,17 +326,47 @@ class TestCamperCareDashboard:
 
     def test_unresolved_flag_count_in_summary(
         self, api, org, program, cc_person_user, cc_membership, cc_caseload,
-        camper, camper_in_bunk,
+        bunk, camper, camper_in_bunk, counselor_person_user,
     ):
+        counselor_person, _ = counselor_person_user
+        today = get_today(org)
+        template = ReflectionTemplate.all_objects.create(
+            organization=org,
+            name="Count test log",
+            slug="cc-count-test-log",
+            cadence="daily",
+            subject_mode="single_subject",
+            assignment_scope="per_subject_in_group",
+            assignment_group_types=["bunk"],
+            schema={"fields": []},
+            languages=["en"],
+            is_active=True,
+        )
+        refl = Reflection.all_objects.create(
+            organization=org,
+            program=program,
+            template=template,
+            assignment_group=bunk,
+            subject=camper,
+            author=counselor_person,
+            period_start=today,
+            period_end=today,
+            answers={},
+            is_complete=True,
+        )
         Flag.all_objects.create(
             organization=org, program=program, subject_camper=camper,
             flagged_for_role="camper_care",
             status=Flag.Status.ACTIVE,
+            trigger_content_type="reflection",
+            trigger_content_id=str(refl.id),
         )
         Flag.all_objects.create(
             organization=org, program=program, subject_camper=camper,
             flagged_for_role="camper_care",
             status=Flag.Status.RESOLVED, resolved_at=timezone.now(),
+            trigger_content_type="reflection",
+            trigger_content_id=str(refl.id),
         )
         _, user = cc_person_user
         api.force_authenticate(user=user)
@@ -284,6 +374,61 @@ class TestCamperCareDashboard:
             r = api.get("/api/v1/camper-care/dashboard/", **_hdr(org.slug))
         assert r.status_code == 200
         assert r.json()["summary"]["flag_count"] == 1
+
+    def test_dashboard_flag_count_scoped_to_selected_date(
+        self, api, org, program, cc_person_user, cc_membership, cc_caseload,
+        bunk, camper, camper_in_bunk, counselor_person_user,
+    ):
+        """Flags from yesterday's help requests must not appear on today's dashboard."""
+        counselor_person, _ = counselor_person_user
+        today = get_today(org)
+        yesterday = today - timedelta(days=1)
+        template = ReflectionTemplate.all_objects.create(
+            organization=org,
+            name="Date scope log",
+            slug="cc-date-scope-log",
+            cadence="daily",
+            subject_mode="single_subject",
+            assignment_scope="per_subject_in_group",
+            assignment_group_types=["bunk"],
+            schema={"fields": []},
+            languages=["en"],
+            is_active=True,
+        )
+        refl = Reflection.all_objects.create(
+            organization=org,
+            program=program,
+            template=template,
+            assignment_group=bunk,
+            subject=camper,
+            author=counselor_person,
+            period_start=yesterday,
+            period_end=yesterday,
+            answers={},
+            is_complete=True,
+        )
+        Flag.all_objects.create(
+            organization=org, program=program, subject_camper=camper,
+            flagged_for_role="camper_care",
+            status=Flag.Status.ACTIVE,
+            trigger_content_type="reflection",
+            trigger_content_id=str(refl.id),
+        )
+        _, user = cc_person_user
+        api.force_authenticate(user=user)
+        with organization_context(org):
+            r_today = api.get(
+                f"/api/v1/camper-care/dashboard/?date={today.isoformat()}",
+                **_hdr(org.slug),
+            )
+            r_yesterday = api.get(
+                f"/api/v1/camper-care/dashboard/?date={yesterday.isoformat()}",
+                **_hdr(org.slug),
+            )
+        assert r_today.status_code == 200
+        assert r_today.json()["summary"]["flag_count"] == 0
+        assert r_yesterday.status_code == 200
+        assert r_yesterday.json()["summary"]["flag_count"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -432,6 +577,33 @@ class TestCamperCareOrdersTeamShared:
             r = api.get("/api/v1/camper-care/orders/", **_hdr(org.slug))
         assert r.status_code == 200, r.content
         assert len(r.json()["new"]) == 1
+
+    def test_order_payload_includes_submitter_bunk(
+        self, api, org, program, cc_person_user, cc_membership,
+        counselor_person_user, counselor_membership,
+        camper, camper_in_bunk, bunk,
+    ):
+        counselor_person, _ = counselor_person_user
+        AssignmentGroupMembership.all_objects.create(
+            group=bunk,
+            person=counselor_person,
+            role_in_group="author",
+            is_active=True,
+        )
+        Order.all_objects.create(
+            organization=org,
+            program=program,
+            subject=camper,
+            submitted_by=counselor_membership,
+            item="Towel",
+        )
+        _, user = cc_person_user
+        api.force_authenticate(user=user)
+        with organization_context(org):
+            r = api.get("/api/v1/camper-care/orders/", **_hdr(org.slug))
+        assert r.status_code == 200, r.content
+        row = r.json()["new"][0]
+        assert row["bunk"] == {"id": bunk.id, "name": bunk.name}
 
     def test_both_cc_members_see_same_orders(
         self, api, org, program, cc_person_user, cc_membership,
@@ -985,6 +1157,134 @@ class TestFlagDetail:
                 f"/api/v1/camper-care/flags/{uuid4()}/", **_hdr(org.slug),
             )
         assert r.status_code == 404
+
+    def test_detail_returns_reflection_trigger_without_error(
+        self, api, org, program, cc_person_user, cc_membership,
+        bunk, camper, camper_in_bunk, counselor_person_user,
+    ):
+        """Reflection triggers must not 500 (Reflection has no ``created_at``)."""
+        counselor_person, _ = counselor_person_user
+        today = get_today(org)
+        template = ReflectionTemplate.all_objects.create(
+            organization=org,
+            name="Detail reflection log",
+            slug="cc-detail-reflection-log",
+            cadence="daily",
+            subject_mode="single_subject",
+            assignment_scope="per_subject_in_group",
+            assignment_group_types=["bunk"],
+            schema={
+                "fields": [
+                    {
+                        "key": "request_camper_care_help",
+                        "type": "yes_no",
+                        "required": False,
+                        "dashboard_role": "help_request_camper_care",
+                    },
+                    {"key": "notes", "type": "text", "required": False},
+                ],
+            },
+            languages=["en"],
+            is_active=True,
+        )
+        refl = Reflection.all_objects.create(
+            organization=org,
+            program=program,
+            template=template,
+            assignment_group=bunk,
+            subject=camper,
+            author=counselor_person,
+            period_start=today,
+            period_end=today,
+            answers={
+                "request_camper_care_help": "yes",
+                "notes": "Camper asked to call home.",
+            },
+            is_complete=True,
+        )
+        flag = Flag.all_objects.create(
+            organization=org,
+            program=program,
+            subject_camper=camper,
+            flagged_for_role="camper_care",
+            trigger_content_type="reflection",
+            trigger_content_id=str(refl.id),
+            status=Flag.Status.ACTIVE,
+        )
+        _, user = cc_person_user
+        api.force_authenticate(user=user)
+        with organization_context(org):
+            r = api.get(
+                f"/api/v1/camper-care/flags/{flag.id}/", **_hdr(org.slug),
+            )
+        assert r.status_code == 200, r.content
+        assert "Camper asked to call home." in r.json()["trigger"]["body"]
+        assert r.json()["trigger"]["created_at"] is not None
+
+    def test_resolved_flag_not_recreated_on_flags_list_sync(
+        self, api, org, program, cc_person_user, cc_membership,
+        bunk, camper, camper_in_bunk, counselor_person_user,
+    ):
+        counselor_person, _ = counselor_person_user
+        today = get_today(org)
+        template = ReflectionTemplate.all_objects.create(
+            organization=org,
+            name="Sync guard log",
+            slug="cc-sync-guard-log",
+            cadence="daily",
+            subject_mode="single_subject",
+            assignment_scope="per_subject_in_group",
+            assignment_group_types=["bunk"],
+            schema={
+                "fields": [
+                    {
+                        "key": "request_camper_care_help",
+                        "type": "yes_no",
+                        "required": False,
+                        "dashboard_role": "help_request_camper_care",
+                    },
+                ],
+            },
+            languages=["en"],
+            is_active=True,
+        )
+        refl = Reflection.all_objects.create(
+            organization=org,
+            program=program,
+            template=template,
+            assignment_group=bunk,
+            subject=camper,
+            author=counselor_person,
+            period_start=today,
+            period_end=today,
+            answers={"request_camper_care_help": "yes"},
+            is_complete=True,
+        )
+        resolved = Flag.all_objects.create(
+            organization=org,
+            program=program,
+            subject_camper=camper,
+            flagged_for_role="camper_care",
+            status=Flag.Status.RESOLVED,
+            resolved_at=timezone.now(),
+            trigger_content_type="reflection",
+            trigger_content_id=str(refl.id),
+        )
+        _, user = cc_person_user
+        api.force_authenticate(user=user)
+        with organization_context(org):
+            r = api.get("/api/v1/camper-care/flags/", **_hdr(org.slug))
+        assert r.status_code == 200
+        assert r.json()["items"] == []
+        assert (
+            Flag.all_objects.filter(
+                program=program,
+                subject_camper=camper,
+                status=Flag.Status.ACTIVE,
+            ).count()
+            == 0
+        )
+        assert Flag.all_objects.filter(pk=resolved.pk).exists()
 
 
 class TestCamperDashboardFlagHistory:

--- a/backend/bunk_logs/api/tests/test_counselor_camper_care_writes.py
+++ b/backend/bunk_logs/api/tests/test_counselor_camper_care_writes.py
@@ -115,6 +115,7 @@ def test_create_camper_care_request_201(
     order = Order.all_objects.get(id=resp.data["id"])
     assert order.subject == camper
     assert order.submitted_by == counselor_membership
+    assert order.submitted_from_bunk == bunk
     assert order.status == "new"
 
 

--- a/backend/bunk_logs/api/tests/test_counselor_camper_reflection_writes.py
+++ b/backend/bunk_logs/api/tests/test_counselor_camper_reflection_writes.py
@@ -20,8 +20,8 @@ from bunk_logs.core.context import organization_context
 from bunk_logs.core.models import AssignmentGroup
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import AuditEvent
-from bunk_logs.core.models import Flag
 from bunk_logs.core.models import CamperDayState
+from bunk_logs.core.models import Flag
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Organization
 from bunk_logs.core.models import Person

--- a/backend/bunk_logs/api/tests/test_counselor_camper_reflection_writes.py
+++ b/backend/bunk_logs/api/tests/test_counselor_camper_reflection_writes.py
@@ -20,6 +20,7 @@ from bunk_logs.core.context import organization_context
 from bunk_logs.core.models import AssignmentGroup
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import AuditEvent
+from bunk_logs.core.models import Flag
 from bunk_logs.core.models import CamperDayState
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Organization
@@ -186,6 +187,46 @@ def test_create_camper_reflection_201_and_persists(
     row = Reflection.all_objects.get(id=resp.data["id"])
     assert row.author == counselor_person
     assert row.is_complete is True
+
+
+@pytest.mark.django_db
+def test_create_with_camper_care_help_raises_flag(
+    org, program, counselor_user, counselor_person, counselor_membership,
+    bunk, counselor_as_author, campers, camper_template,
+):
+    """Story 20 — counselor reflection help request creates a CC flag row."""
+    camper_template.schema = {
+        "fields": [
+            {"key": "note", "type": "textarea", "required": False, "prompts": {"en": "Notes"}},
+            {
+                "key": "request_camper_care_help",
+                "type": "yes_no",
+                "required": False,
+                "dashboard_role": "help_request_camper_care",
+                "prompts": {"en": "Request Camper Care help?"},
+            },
+        ],
+    }
+    camper_template.save(update_fields=["schema"])
+
+    sarah = campers[0]
+    c = _client(counselor_user, org)
+    payload = _post_payload(subject=sarah, bunk=bunk)
+    payload["answers"] = {"note": "Rough day", "request_camper_care_help": "yes"}
+    with organization_context(org):
+        resp = c.post("/api/v1/counselor/camper-reflections/", payload, format="json")
+    assert resp.status_code == 201, resp.data
+
+    flag = Flag.all_objects.filter(
+        program=program,
+        subject_camper=sarah,
+        trigger_content_type="reflection",
+        trigger_content_id=str(resp.data["id"]),
+        flagged_for_role="camper_care",
+        status=Flag.Status.ACTIVE,
+    ).first()
+    assert flag is not None
+    assert flag.raised_by_membership_id == counselor_membership.id
 
 
 @pytest.mark.django_db

--- a/backend/bunk_logs/api/tests/test_dashboards_concerns.py
+++ b/backend/bunk_logs/api/tests/test_dashboards_concerns.py
@@ -16,6 +16,7 @@ from bunk_logs.core.models import Person
 from bunk_logs.core.models import Program
 from bunk_logs.core.models import Reflection
 from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.models import Supervision
 
 User = get_user_model()
 pytestmark = pytest.mark.django_db
@@ -264,6 +265,47 @@ def test_unmark_read_restores_item(api_client, org, program, setup):
 
 
 # ── Visibility ────────────────────────────────────────────────────────────────
+
+
+def test_camper_care_concerns_limited_to_caseload_bunks(
+    api_client, org, program, setup,
+):
+    bunk, camper, counselor_user, counselor = setup
+    other_bunk = AssignmentGroup.all_objects.create(
+        organization=org, program=program, name="Other",
+        slug="cn-other", group_type="bunk",
+    )
+    other_camper = _person(org, "Ot", "Her")
+    AssignmentGroupMembership.all_objects.create(
+        group=other_bunk, person=other_camper, role_in_group="subject", is_active=True,
+    )
+    tpl = _bunk_obs(org)
+    today = date.today()
+    _make_reflection(
+        org, program, tpl, subject=camper, author=counselor, group=bunk,
+        day=today, answers={"overall": 4, "concerns": "on caseload"},
+    )
+    _make_reflection(
+        org, program, tpl, subject=other_camper, author=counselor, group=other_bunk,
+        day=today, answers={"overall": 4, "concerns": "off caseload"},
+    )
+    cc_user = _user("cc-cn@a.com")
+    cc_person = _person(org, "Cc", "Care", cc_user)
+    cc_membership = Membership.all_objects.create(
+        program=program, person=cc_person, role="camper_care", is_active=True,
+    )
+    Supervision.all_objects.create(
+        supervisor_membership=cc_membership,
+        target_type="bunk",
+        target_bunk=bunk,
+        start_date=date(2026, 1, 1),
+    )
+    api_client.force_authenticate(user=cc_user)
+    r = api_client.get("/api/v1/dashboards/concerns/", **_hdr(org.slug))
+    body = r.json()
+    values = [i["value"] for i in body["items"] if i["kind"] == "open_concern"]
+    assert "on caseload" in values
+    assert "off caseload" not in values
 
 
 def test_invisible_concerns_not_listed(api_client, org, program, setup):

--- a/backend/bunk_logs/core/flags.py
+++ b/backend/bunk_logs/core/flags.py
@@ -1,6 +1,208 @@
 """Flag creation helpers (Step 7_8).
 
-Specialist-note → flag creation was removed with legacy ``core.Note`` (Step 7_24).
-New observation flows should raise flags via the Observations API when that
-path lands.
+Raise ``core.Flag`` rows when upstream content requests Camper Care triage.
+The flagged campers workspace and dashboard badges read these rows only;
+group/bunk dashboards surface help requests directly from reflection
+answers via :func:`camper_care_help_requested_camper_ids_from`.
 """
+
+from __future__ import annotations
+
+from datetime import date
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from django.core.cache import cache
+
+from bunk_logs.core.models import Flag
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Reflection
+
+if TYPE_CHECKING:
+    from bunk_logs.core.models import Program
+
+
+def _is_truthy_yes_no(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"yes", "true", "1"}
+    return False
+
+
+def reflection_requests_camper_care_help(reflection: Reflection) -> bool:
+    """True when this reflection's answers request Camper Care help."""
+    if not reflection.subject_id:
+        return False
+    answers = reflection.answers or {}
+    if _is_truthy_yes_no(answers.get("request_camper_care_help")):
+        return True
+    schema = reflection.template.schema if reflection.template_id else {}
+    for field in (schema or {}).get("fields") or []:
+        if not isinstance(field, dict):
+            continue
+        if field.get("dashboard_role") != "help_request_camper_care":
+            continue
+        key = field.get("key")
+        if isinstance(key, str) and _is_truthy_yes_no(answers.get(key)):
+            return True
+    return False
+
+
+def _author_membership_for_reflection(reflection: Reflection) -> Membership | None:
+    if not reflection.author_id:
+        return None
+    return (
+        Membership.all_objects.filter(
+            person_id=reflection.author_id,
+            program_id=reflection.program_id,
+            is_active=True,
+        )
+        .order_by("-created_at")
+        .first()
+    )
+
+
+def raise_flag_from_camper_reflection(
+    reflection: Reflection,
+    *,
+    raised_by_membership: Membership | None = None,
+) -> Flag | None:
+    """Create an ACTIVE CC flag for this reflection, idempotently.
+
+    Returns ``None`` when the reflection does not request help. Reuses an
+    existing active/followed-up flag for the same reflection trigger.
+    """
+    if not reflection_requests_camper_care_help(reflection):
+        return None
+
+    trigger_id = str(reflection.id)
+    existing = (
+        Flag.all_objects.filter(
+            program_id=reflection.program_id,
+            flagged_for_role="camper_care",
+            trigger_content_type="reflection",
+            trigger_content_id=trigger_id,
+        )
+        .order_by("-created_at")
+        .first()
+    )
+    if existing is not None:
+        if existing.status in (Flag.Status.ACTIVE, Flag.Status.FOLLOWED_UP):
+            return existing
+        # Resolved/reopened history stays tied to this reflection; do not
+        # mint a duplicate ACTIVE row when the flags workspace re-syncs.
+        return None
+
+    raiser = raised_by_membership or _author_membership_for_reflection(reflection)
+    flag = Flag.all_objects.create(
+        organization_id=reflection.organization_id,
+        program_id=reflection.program_id,
+        subject_camper_id=reflection.subject_id,
+        raised_by_membership=raiser,
+        flagged_for_role="camper_care",
+        trigger_content_type="reflection",
+        trigger_content_id=trigger_id,
+        status=Flag.Status.ACTIVE,
+    )
+    bust_camper_care_dashboard_cache_for_program(reflection.program, reflection.period_start)
+    return flag
+
+
+def sync_missing_camper_care_help_flags(
+    *,
+    program: Program,
+    target_date: date | None = None,
+    lookback_days: int = 30,
+) -> int:
+    """Backfill flags for completed reflections that requested Camper Care help.
+
+    When ``target_date`` is set (dashboard date picker), only that camp day is
+    scanned. When omitted (flags workspace), scans the last ``lookback_days``
+    so older help requests still materialize as flags.
+
+    Idempotent — safe to call on every Camper Care dashboard / flags load.
+    """
+    reflections = Reflection.all_objects.filter(
+        program=program,
+        is_complete=True,
+        subject_id__isnull=False,
+    )
+    if target_date is not None:
+        reflections = reflections.filter(
+            period_start=target_date,
+            period_end=target_date,
+        )
+    else:
+        from bunk_logs.core.time_utils import get_today
+
+        today = get_today(program.organization)
+        reflections = reflections.filter(
+            period_end__gte=today - timedelta(days=lookback_days),
+            period_start__lte=today,
+        )
+    reflections = reflections.select_related("template", "author")
+
+    created = 0
+    for reflection in reflections:
+        before_ids = set(
+            Flag.all_objects.filter(
+                program=program,
+                trigger_content_type="reflection",
+                trigger_content_id=str(reflection.id),
+                flagged_for_role="camper_care",
+                status__in=(Flag.Status.ACTIVE, Flag.Status.FOLLOWED_UP),
+            ).values_list("id", flat=True),
+        )
+        flag = raise_flag_from_camper_reflection(reflection)
+        if flag is not None and flag.id not in before_ids:
+            created += 1
+    return created
+
+
+def active_flags_for_program_day(*, program: Program, target_date: date):
+    """Unresolved CC flags whose trigger reflection is for ``target_date``.
+
+    Dashboard date navigation is anchored to the camp day on the reflection,
+    not the calendar day the ``Flag`` row was created (backfill may create
+    flags a day after the reflection was submitted).
+    """
+    reflection_ids = Reflection.all_objects.filter(
+        program=program,
+        period_start=target_date,
+        period_end=target_date,
+    ).values_list("id", flat=True)
+    trigger_ids = [str(rid) for rid in reflection_ids]
+    if not trigger_ids:
+        return Flag.objects.none()
+    return Flag.objects.filter(
+        program=program,
+        flagged_for_role="camper_care",
+        status__in=(Flag.Status.ACTIVE, Flag.Status.FOLLOWED_UP),
+        trigger_content_type="reflection",
+        trigger_content_id__in=trigger_ids,
+    )
+
+
+def flagged_camper_ids_for_date(
+    *,
+    program: Program,
+    target_date: date,
+    camper_ids: set[int] | None = None,
+) -> set[int]:
+    """Subject IDs with an unresolved CC flag for help requested on ``target_date``."""
+    qs = active_flags_for_program_day(program=program, target_date=target_date)
+    if camper_ids is not None:
+        qs = qs.filter(subject_camper_id__in=camper_ids)
+    return set(qs.values_list("subject_camper_id", flat=True))
+
+
+def bust_camper_care_dashboard_cache_for_program(program: Program, target_date: date) -> None:
+    """Invalidate cached CC dashboards after flag changes for ``target_date``."""
+    org_id = program.organization_id
+    person_ids = Membership.all_objects.filter(
+        program=program, role="camper_care", is_active=True,
+    ).values_list("person_id", flat=True)
+    key_date = target_date.isoformat()
+    for person_id in person_ids:
+        cache.delete(f"camper_care_dashboard:{org_id}:{person_id}:{key_date}")

--- a/backend/bunk_logs/core/migrations/0046_order_submitted_from_bunk.py
+++ b/backend/bunk_logs/core/migrations/0046_order_submitted_from_bunk.py
@@ -1,0 +1,28 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0045_assignmentdashboardgrant"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="order",
+            name="submitted_from_bunk",
+            field=models.ForeignKey(
+                blank=True,
+                help_text=(
+                    "Bunk the submitter was authoring when the request was filed. "
+                    "Persisted at creation so Camper Care can route the ticket even "
+                    "when the subject camper is unknown or off-roster."
+                ),
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="cc_orders_submitted_from",
+                to="core.assignmentgroup",
+            ),
+        ),
+    ]

--- a/backend/bunk_logs/core/models.py
+++ b/backend/bunk_logs/core/models.py
@@ -1420,6 +1420,18 @@ class Order(OrderableContent):
         related_name="cc_orders_submitted",
         help_text="Membership of the counselor / submitter.",
     )
+    submitted_from_bunk = models.ForeignKey(
+        AssignmentGroup,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="cc_orders_submitted_from",
+        help_text=(
+            "Bunk the submitter was authoring when the request was filed. "
+            "Persisted at creation so Camper Care can route the ticket even "
+            "when the subject camper is unknown or off-roster."
+        ),
+    )
     item = models.CharField(
         max_length=120,
         blank=True,

--- a/backend/bunk_logs/core/permissions/subject_dashboard.py
+++ b/backend/bunk_logs/core/permissions/subject_dashboard.py
@@ -1,0 +1,186 @@
+"""Subject profile dashboard visibility (view permission).
+
+Who may open ``GET /api/v1/dashboards/subject/{id}/`` is separate from
+observation read access and from observation authoring scope.
+"""
+
+from __future__ import annotations
+
+from bunk_logs.core.models import ROLE_TO_CAPABILITY
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Person
+from bunk_logs.core.permissions.subject_note_authoring import authorable_subject_queryset
+from bunk_logs.core.permissions.subject_note_authoring import can_author_subject_note
+from bunk_logs.core.permissions.super_admin import is_super_admin
+from bunk_logs.core.permissions.visibility import author_group_ids_with_descendants
+
+
+def _membership_capabilities(person: Person, org) -> set[str]:
+    """Capability tiers for active memberships in ``org`` (stored + role-derived)."""
+    caps: set[str] = set()
+    for role, capability in Membership.all_objects.filter(
+        person=person,
+        is_active=True,
+        program__organization=org,
+    ).values_list("role", "capability"):
+        if capability:
+            caps.add(capability)
+        mapped = ROLE_TO_CAPABILITY.get(role)
+        if mapped:
+            caps.add(mapped)
+    return caps
+
+
+def _has_org_admin_membership(person: Person, org) -> bool:
+    return Membership.all_objects.filter(
+        person=person,
+        role="admin",
+        is_active=True,
+        program__organization=org,
+    ).exists()
+
+
+def _has_legacy_user_role_admin(user, person: Person, org) -> bool:
+    """Bridge legacy ``User.role`` until auth exposes ``Membership.capability``."""
+    role = (getattr(user, "role", None) or "").strip().lower()
+    if role != "admin":
+        return False
+    return Membership.all_objects.filter(
+        person=person,
+        is_active=True,
+        program__organization=org,
+    ).exists()
+
+
+def viewer_capability(person: Person, org) -> str | None:
+    """Highest-privilege capability the person holds in this org."""
+    caps = _membership_capabilities(person, org)
+    for cap in ("admin", "program_lead", "domain_specialist", "supervisor"):
+        if cap in caps:
+            return cap
+    if "participant" in caps:
+        return "participant"
+    return None
+
+
+def viewer_supervises_subject(viewer: Person, subject: Person) -> bool:
+    """True if viewer authors a group (or descendant) that contains subject."""
+    group_ids = author_group_ids_with_descendants(viewer)
+    if not group_ids:
+        return False
+    return AssignmentGroupMembership.all_objects.filter(
+        person=subject,
+        group_id__in=group_ids,
+        role_in_group="subject",
+        is_active=True,
+    ).exists()
+
+
+def can_view_subject_dashboard(
+    viewer_person: Person | None,
+    subject: Person,
+    org,
+    user,
+) -> bool:
+    """Explicit capability gate for the subject dashboard."""
+    if is_super_admin(user):
+        return True
+    if viewer_person is None:
+        return False
+    if _has_org_admin_membership(viewer_person, org):
+        return True
+    if _has_legacy_user_role_admin(user, viewer_person, org):
+        return True
+    cap = viewer_capability(viewer_person, org)
+    if cap in ("admin", "program_lead", "domain_specialist"):
+        return True
+    if cap in ("supervisor", "participant"):
+        if viewer_person.id == subject.id or viewer_supervises_subject(viewer_person, subject):
+            return True
+    return can_author_subject_note(viewer_person, subject, org, user)
+
+
+def _supervised_subject_ids(viewer_person: Person, org) -> set[int]:
+    """Person ids the viewer supervises via group hierarchy (+ self)."""
+    ids: set[int] = {viewer_person.id}
+    group_ids = author_group_ids_with_descendants(viewer_person)
+    if group_ids:
+        ids.update(
+            AssignmentGroupMembership.all_objects.filter(
+                group_id__in=group_ids,
+                role_in_group="subject",
+                is_active=True,
+                group__organization_id=org.id,
+            ).values_list("person_id", flat=True),
+        )
+    bunk_ids = list(
+        AssignmentGroupMembership.all_objects.filter(
+            person=viewer_person,
+            role_in_group="author",
+            is_active=True,
+            group__is_active=True,
+            group__group_type="bunk",
+            group__organization_id=org.id,
+        ).values_list("group_id", flat=True),
+    )
+    if bunk_ids:
+        ids.update(
+            AssignmentGroupMembership.all_objects.filter(
+                group_id__in=bunk_ids,
+                role_in_group="subject",
+                is_active=True,
+            ).values_list("person_id", flat=True),
+        )
+    return ids
+
+
+def viewable_subject_queryset(viewer_person: Person | None, org, user):
+    """Person queryset whose profile dashboard the viewer may open."""
+    base = Person.all_objects.filter(organization=org)
+    if is_super_admin(user):
+        return base
+    if viewer_person is None:
+        return base.none()
+
+    cap = viewer_capability(viewer_person, org)
+    if cap in ("admin", "program_lead", "domain_specialist"):
+        return base
+
+    ids: set[int] = set()
+    if cap in ("supervisor", "participant"):
+        ids.update(_supervised_subject_ids(viewer_person, org))
+    ids.update(
+        authorable_subject_queryset(viewer_person, org).values_list("id", flat=True),
+    )
+    if not ids:
+        return base.none()
+    return base.filter(id__in=ids)
+
+
+def camper_subject_person_ids_subquery(org):
+    """Active assignment-group subjects (campers) in the org."""
+    return AssignmentGroupMembership.all_objects.filter(
+        role_in_group="subject",
+        is_active=True,
+        group__organization_id=org.id,
+        group__is_active=True,
+    ).values("person_id")
+
+
+def viewable_camper_queryset(viewer_person: Person | None, org, user):
+    """Viewable persons who are active campers (assignment-group subjects)."""
+    camper_ids = camper_subject_person_ids_subquery(org)
+    return viewable_subject_queryset(viewer_person, org, user).filter(
+        id__in=camper_ids,
+    )
+
+
+__all__ = [
+    "camper_subject_person_ids_subquery",
+    "can_view_subject_dashboard",
+    "viewable_camper_queryset",
+    "viewable_subject_queryset",
+    "viewer_capability",
+    "viewer_supervises_subject",
+]

--- a/backend/bunk_logs/core/permissions/test_visibility.py
+++ b/backend/bunk_logs/core/permissions/test_visibility.py
@@ -17,6 +17,7 @@ from bunk_logs.core.models import Person
 from bunk_logs.core.models import Program
 from bunk_logs.core.models import Reflection
 from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.models import Supervision
 from bunk_logs.core.permissions.visibility import has_supervisor_role
 from bunk_logs.core.permissions.visibility import is_org_admin
 from bunk_logs.core.permissions.visibility import reflections_visible_to
@@ -512,12 +513,12 @@ class TestWellnessScope:
 class TestCamperCareScope:
     """Step 3.21 moves camper_care from domain_specialist -> supervisor.
 
-    Visibility now flows through ``Membership.metadata.assigned_unit_slugs``
-    (the leadership_team / faculty convention), NOT the wellness-template
-    shortcut. These cases pin that contract.
+    Visibility flows through ``assigned_unit_slugs`` metadata and/or the
+    ``Supervision`` caseload (bunks + expanded units). Camper Care no longer
+    gets program-wide visibility when both are empty.
     """
 
-    def test_unrestricted_camper_care_sees_all_program_reflections(
+    def test_camper_care_without_caseload_sees_nothing_extra(
         self, org_a, program_a,
     ):
         u = _make_user("cc@a.com")
@@ -526,15 +527,67 @@ class TestCamperCareScope:
             program=program_a, person=cc, role="camper_care", is_active=True,
             metadata={},
         )
-        # A reflection authored by someone the cc user has no AssignmentGroup
-        # or wellness path to. With an unrestricted unit-scope, cc still sees
-        # it because they're effectively a program-wide supervisor.
         author = _make_person(org_a, "Au", "Thor")
         subject = _make_person(org_a, "Sub", "Ject")
         tpl = _make_template(org_a, role="counselor")
         _make_reflection(org_a, program_a, tpl, subject=subject, author=author)
         with organization_context(org_a):
-            assert reflections_visible_to(u).count() == 1
+            assert reflections_visible_to(u).count() == 0
+
+    def test_camper_care_caseload_supervision_limits_to_assigned_bunks(
+        self, org_a, program_a,
+    ):
+        u = _make_user("cc@a.com")
+        cc = _make_person(org_a, "Cc", "User", u)
+        cc_membership = Membership.all_objects.create(
+            program=program_a, person=cc, role="camper_care", is_active=True,
+            metadata={},
+        )
+        unit = AssignmentGroup.all_objects.create(
+            organization=org_a, program=program_a, name="Unit",
+            slug="cc-unit", group_type="unit",
+        )
+        on_caseload = AssignmentGroup.all_objects.create(
+            organization=org_a, program=program_a, name="Bunk A",
+            slug="cc-bunk-a", group_type="bunk", parent=unit,
+        )
+        off_caseload = AssignmentGroup.all_objects.create(
+            organization=org_a, program=program_a, name="Bunk B",
+            slug="cc-bunk-b", group_type="bunk", parent=unit,
+        )
+        Supervision.all_objects.create(
+            supervisor_membership=cc_membership,
+            target_type="bunk",
+            target_bunk=on_caseload,
+            start_date=date(2026, 1, 1),
+        )
+        camper_on = _make_person(org_a, "On", "Caseload")
+        camper_off = _make_person(org_a, "Off", "Caseload")
+        AssignmentGroupMembership.all_objects.create(
+            group=on_caseload, person=camper_on, role_in_group="subject", is_active=True,
+        )
+        AssignmentGroupMembership.all_objects.create(
+            group=off_caseload, person=camper_off, role_in_group="subject", is_active=True,
+        )
+        counselor = _make_person(org_a, "Co", "Un")
+        tpl = _make_template(
+            org_a, slug="bunk-obs-cc",
+            role="counselor",
+            subject_mode="single_subject",
+            assignment_scope="per_subject_in_group",
+        )
+        _make_reflection(
+            org_a, program_a, tpl,
+            subject=camper_on, author=counselor, assignment_group=on_caseload,
+        )
+        _make_reflection(
+            org_a, program_a, tpl,
+            subject=camper_off, author=counselor, assignment_group=off_caseload,
+        )
+        with organization_context(org_a):
+            visible = reflections_visible_to(u)
+            assert visible.count() == 1
+            assert visible.first().assignment_group_id == on_caseload.id
 
     def test_unit_scoped_camper_care_only_sees_assigned_units(
         self, org_a, program_a,

--- a/backend/bunk_logs/core/permissions/visibility.py
+++ b/backend/bunk_logs/core/permissions/visibility.py
@@ -67,12 +67,12 @@ def _unit_scoped_supervisor_q(person: Person, organization_id: int | None) -> Q 
     """Q filter scoping reflections to the unit slugs a supervisor is assigned to.
 
     Applies to memberships in ``UNIT_SCOPED_SUPERVISOR_ROLES`` (faculty,
-    leadership_team, camper_care). Empty / missing ``assigned_unit_slugs`` is
-    interpreted as "no unit restriction" -- the supervisor sees every
-    reflection in the program. Otherwise we resolve each slug to the set of
-    Persons whose Membership in that program declares ``metadata.unit_slug``
-    matching one of those slugs, and scope visibility to reflections about
-    those subjects.
+    leadership_team, camper_care). For faculty / leadership_team, empty /
+    missing ``assigned_unit_slugs`` means no unit restriction (whole program).
+    ``camper_care`` never gets that unrestricted branch — caseload bunks come
+    from :func:`_camper_care_caseload_q` instead. When ``assigned_unit_slugs``
+    is set on a camper_care membership, reflections about subjects whose
+    ``metadata.unit_slug`` matches are included here as well.
     """
     qs = Membership.all_objects.filter(
         person=person,
@@ -92,6 +92,10 @@ def _unit_scoped_supervisor_q(person: Person, organization_id: int | None) -> Q 
         if raw is None:
             raw = m.metadata.get("unit_slugs")
         entry = program_specs.setdefault(pid, {"unrestricted": False, "units": set()})
+        if m.role == "camper_care":
+            if raw:
+                entry["units"].update(str(x) for x in raw)
+            continue
         if not raw:
             entry["unrestricted"] = True
         else:
@@ -112,6 +116,56 @@ def _unit_scoped_supervisor_q(person: Person, organization_id: int | None) -> Q 
         ]
         if person_ids:
             parts.append(Q(program_id=pid, subject_id__in=person_ids))
+
+    if not parts:
+        return None
+    return reduce(or_, parts)
+
+
+def _camper_care_caseload_q(
+    person: Person, organization_id: int | None,
+) -> Q | None:
+    """Q filter scoping camper_care to supervised units/bunks.
+
+    Resolves the same caseload as the Camper Care dashboard: direct bunk
+    supervisions, assignment-group supervisions expanded to descendant bunks,
+    and author memberships on groups within the program.
+    """
+    from django.utils import timezone
+
+    from bunk_logs.core.managers import _caseload_bunk_ids_for_membership
+    from bunk_logs.core.models import Supervision
+
+    today = timezone.now().date()
+    qs = Membership.all_objects.filter(
+        person=person,
+        role="camper_care",
+        is_active=True,
+    )
+    if organization_id is not None:
+        qs = qs.filter(program__organization_id=organization_id)
+
+    parts: list[Q] = []
+    for membership in qs:
+        bunk_ids = _caseload_bunk_ids_for_membership(
+            Supervision.objects, membership, today=today,
+        )
+        if not bunk_ids:
+            continue
+        parts.append(
+            Q(program_id=membership.program_id, assignment_group_id__in=bunk_ids),
+        )
+        camper_ids = list(
+            AssignmentGroupMembership.all_objects.filter(
+                group_id__in=bunk_ids,
+                role_in_group="subject",
+                is_active=True,
+            ).values_list("person_id", flat=True),
+        )
+        if camper_ids:
+            parts.append(
+                Q(program_id=membership.program_id, subject_id__in=camper_ids),
+            )
 
     if not parts:
         return None
@@ -283,8 +337,10 @@ def reflections_visible_to(
        entries opt out).
     5. Unit-scoped supervisor membership (faculty / leadership_team /
        camper_care) -> reflections about subjects whose Membership.metadata
-       declares one of the assigned unit slugs; or the whole program when
-       ``assigned_unit_slugs`` is empty.
+       declares one of the assigned unit slugs; faculty / leadership_team
+       with empty ``assigned_unit_slugs`` see the whole program.
+    5b. Camper Care caseload -> reflections on supervised bunks (via
+       ``Supervision`` / author memberships) or about campers in those bunks.
     6. Wellness membership (health_center / special_diets) -> reflections
        whose template carries one of the wellness roles AND
        ``team_visibility == "team"`` (private wellness entries are gated to
@@ -334,6 +390,10 @@ def reflections_visible_to(
     sq = _unit_scoped_supervisor_q(person, org_id)
     if sq is not None:
         parts.append(sq)
+
+    ccq = _camper_care_caseload_q(person, org_id)
+    if ccq is not None:
+        parts.append(ccq)
 
     # Supervision-based supervisor pipe (Step 7_3 / 7_7). Covers UH → Counselor,
     # LT → team-role, Camper Care → BUNK targets, etc. Independent of the

--- a/backend/bunk_logs/core/person_search.py
+++ b/backend/bunk_logs/core/person_search.py
@@ -1,0 +1,30 @@
+"""Shared name search helpers for Person querysets."""
+
+from __future__ import annotations
+
+from django.db.models import Q
+
+
+def filter_persons_by_name_query(qs, q: str):
+    """Match name tokens against first, last, and preferred name fields."""
+    q = q.strip()
+    if not q:
+        return qs
+    tokens = [t for t in q.split() if t]
+    if not tokens:
+        return qs
+    if len(tokens) == 1:
+        token = tokens[0]
+        return qs.filter(
+            Q(first_name__icontains=token)
+            | Q(last_name__icontains=token)
+            | Q(preferred_name__icontains=token),
+        )
+    combined = Q()
+    for token in tokens:
+        combined &= (
+            Q(first_name__icontains=token)
+            | Q(last_name__icontains=token)
+            | Q(preferred_name__icontains=token)
+        )
+    return qs.filter(combined)

--- a/backend/bunk_logs/notes/tests/test_observations_api.py
+++ b/backend/bunk_logs/notes/tests/test_observations_api.py
@@ -13,6 +13,7 @@ import pytest
 from django.utils import timezone
 from rest_framework.test import APIClient
 
+from bunk_logs.core.models import AssignmentGroup
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
@@ -212,6 +213,99 @@ class TestInboxAndThread:
         resp = client.get(f"/api/v1/observations/{obs.id}/")
         assert resp.status_code == 200
         assert obs.read_receipts.filter(person=uh_person).exists()
+
+    def test_thread_subject_can_view_profile_supervised_camper(
+        self, org, program, counselor_user, counselor_membership, counselor_person,
+        counselor_in_bunk, camper,
+    ):
+        obs = _make_observation(org, program, counselor_person, subjects=[camper])
+        client = _auth_client(counselor_user, org)
+        resp = client.get(f"/api/v1/observations/{obs.id}/")
+        assert resp.status_code == 200
+        subjects = resp.json()["subjects"]
+        assert subjects[0]["id"] == camper.id
+        assert subjects[0]["can_view_profile"] is True
+
+    def test_thread_subject_can_view_profile_false_outside_supervision(
+        self, org, program, counselor_user, counselor_membership, counselor_in_bunk, bunk,
+    ):
+        other_bunk = AssignmentGroup.all_objects.create(
+            organization=org, program=bunk.program, name="Bunk Oak",
+            slug="bunk-oak", group_type="bunk",
+        )
+        distant = Person.all_objects.create(organization=org, first_name="Far", last_name="Away")
+        AssignmentGroupMembership.all_objects.create(
+            group=other_bunk, person=distant, role_in_group="subject", is_active=True,
+        )
+        author = Person.all_objects.filter(user=counselor_user).first()
+        obs = _make_observation(org, program, author, subjects=[distant])
+        client = _auth_client(counselor_user, org)
+        resp = client.get(f"/api/v1/observations/{obs.id}/")
+        assert resp.status_code == 200
+        assert resp.json()["subjects"][0]["can_view_profile"] is False
+
+    def test_thread_subject_can_view_profile_true_for_supervisor(
+        self, org, program, uh_user, uh_membership, uh_person, bunk, camper,
+    ):
+        AssignmentGroupMembership.all_objects.create(
+            group=bunk, person=uh_person, role_in_group="author", is_active=True,
+        )
+        obs = _make_observation(org, program, uh_person, subjects=[camper])
+        client = _auth_client(uh_user, org)
+        resp = client.get(f"/api/v1/observations/{obs.id}/")
+        assert resp.status_code == 200
+        assert resp.json()["subjects"][0]["can_view_profile"] is True
+
+    def test_thread_subject_can_view_profile_true_for_org_admin(
+        self, org, program, camper,
+    ):
+        from bunk_logs.users.models import User
+
+        admin_user = User.objects.create_user(
+            email="org-admin-obs@t.test", password="pw", role=User.ADMIN,
+        )
+        admin_person = Person.all_objects.create(
+            organization=org, first_name="Org", last_name="Admin", user=admin_user,
+        )
+        Membership.all_objects.create(
+            program=program, person=admin_person, role="admin", is_active=True,
+        )
+        author = Person.all_objects.create(organization=org, first_name="Auth", last_name="Or")
+        obs = _make_observation(org, program, author, subjects=[camper])
+        client = _auth_client(admin_user, org)
+        resp = client.get(f"/api/v1/observations/{obs.id}/")
+        assert resp.status_code == 200
+        assert resp.json()["subjects"][0]["can_view_profile"] is True
+
+    def test_thread_subject_can_view_profile_true_for_legacy_user_role_admin(
+        self, org, program, counselor_in_bunk, camper,
+    ):
+        """User.role Admin with only counselor membership still sees profile links."""
+        from bunk_logs.users.models import User
+
+        admin_user = User.objects.create_user(
+            email="legacy-admin-obs@t.test", password="pw", role=User.ADMIN,
+        )
+        admin_person = Person.all_objects.create(
+            organization=org, first_name="Legacy", last_name="Admin", user=admin_user,
+        )
+        Membership.all_objects.create(
+            program=program, person=admin_person, role="counselor", is_active=True,
+        )
+        other_bunk = AssignmentGroup.all_objects.create(
+            organization=org, program=program, name="Bunk Pine",
+            slug="bunk-pine", group_type="bunk",
+        )
+        distant = Person.all_objects.create(organization=org, first_name="Far", last_name="Camper")
+        AssignmentGroupMembership.all_objects.create(
+            group=other_bunk, person=distant, role_in_group="subject", is_active=True,
+        )
+        author = Person.all_objects.filter(user=admin_user).first()
+        obs = _make_observation(org, program, author, subjects=[distant])
+        client = _auth_client(admin_user, org)
+        resp = client.get(f"/api/v1/observations/{obs.id}/")
+        assert resp.status_code == 200
+        assert resp.json()["subjects"][0]["can_view_profile"] is True
 
     def test_reply_appends(
         self, org, program, counselor_person, counselor_membership, uh_user, uh_membership, uh_person, camper,

--- a/frontend/src/api/__tests__/counselor.test.js
+++ b/frontend/src/api/__tests__/counselor.test.js
@@ -213,6 +213,7 @@ describe('counselor API helpers', () => {
     postMock.mockResolvedValue({ data: { id: 'order-1' }, status: 201 });
     await createCamperCareRequest({
       subjectId: 42,
+      bunkId: 11,
       item: 'Toothbrush',
       itemNote: 'purple',
       description: 'after lights out',
@@ -221,6 +222,7 @@ describe('counselor API helpers', () => {
     expect(postMock.mock.calls[0][0]).toBe('/api/v1/counselor/camper-care-requests/');
     expect(postMock.mock.calls[0][1]).toEqual({
       subject_id: 42,
+      bunk_id: 11,
       item: 'Toothbrush',
       item_note: 'purple',
       description: 'after lights out',

--- a/frontend/src/api/counselor.js
+++ b/frontend/src/api/counselor.js
@@ -266,6 +266,7 @@ export async function fetchCamperCareItemSuggestions() {
  */
 export async function createCamperCareRequest({
   subjectId,
+  bunkId,
   item,
   itemNote = '',
   description = '',
@@ -279,6 +280,9 @@ export async function createCamperCareRequest({
   };
   if (subjectId !== undefined && subjectId !== null) {
     payload.subject_id = subjectId;
+  }
+  if (bunkId !== undefined && bunkId !== null) {
+    payload.bunk_id = bunkId;
   }
   const res = await api.post(
     '/api/v1/counselor/camper-care-requests/', payload,

--- a/frontend/src/components/BunkDashboard.jsx
+++ b/frontend/src/components/BunkDashboard.jsx
@@ -10,14 +10,14 @@
  * Layout mirrors the production bunk page: header (name, date, counselors,
  * completion, view-only) → three attention summary cards (Not on Camp /
  * Unit Head Help / Camper Care Help) → Camper Daily Scores grid → Orders &
- * Tickets → Notes (bunk concerns + specialist reports). On the unified group
+ * Tickets → Notes (single chronological stream). On the unified group
  * dashboard page the score grid is omitted and orders/notes render after
  * template responses instead (see ``GroupDashboardPage``).
  */
 
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { profileLink } from '../utils/dashboardLinks';
+import { groupDashboardLink, observationThreadLink, profileLink } from '../utils/dashboardLinks';
 import ScoreGrid from './ScoreGrid';
 
 // Field types kept as grid columns. Triage single_choice/yes-no fields
@@ -201,23 +201,186 @@ function OrdersSection({ orders }) {
   );
 }
 
-function SpecialistNote({ note, toProfile }) {
-  const [expanded, setExpanded] = useState(false);
-  return (
-    <li data-testid={`specialist-note-${note.id}`} className="text-sm">
-      <p className="text-xs text-gray-500 dark:text-gray-400">
-        <Link
-          to={toProfile(note.subject.id)}
-          className="font-semibold text-blue-700 dark:text-blue-300 hover:underline"
+const SENSITIVITY_LABEL = {
+  normal: 'Normal',
+  sensitive: 'Sensitive',
+  domain: 'Domain',
+  confidential: 'Confidential',
+};
+
+const SOURCE_TAG = {
+  bunk_concern: {
+    label: 'Bunk concern',
+    cls: 'bg-amber-50 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200',
+  },
+  specialist: {
+    label: 'Specialist report',
+    cls: 'bg-indigo-50 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-200',
+  },
+};
+
+function formatRoleLabel(role) {
+  if (!role) return null;
+  return String(role).replace(/_/g, ' ');
+}
+
+function streamSortTime(iso) {
+  if (!iso) return 0;
+  const t = new Date(iso).getTime();
+  return Number.isNaN(t) ? 0 : t;
+}
+
+function buildNotesStream({
+  bunkConcerns,
+  specialistReports,
+  observations,
+  observationReturnTo = null,
+  observationReturnLabel = null,
+}) {
+  const today = specialistReports?.today || [];
+  const recent = specialistReports?.recent || [];
+  const items = [];
+
+  for (const concern of bunkConcerns || []) {
+    const body = [concern.note, concern.open_concern].filter(Boolean).join('\n\n');
+    if (!body) continue;
+    items.push({
+      key: `concern-${concern.reflection_id}`,
+      kind: 'bunk_concern',
+      sortAt: concern.submitted_at,
+      author: concern.author,
+      authorRole: concern.author_role,
+      body,
+      testid: `bunk-concern-${concern.reflection_id}`,
+    });
+  }
+
+  for (const obs of observations || []) {
+    if (!obs.body_preview) continue;
+    items.push({
+      key: `obs-${obs.id}`,
+      kind: 'observation',
+      sortAt: obs.observed_at,
+      author: obs.author_name,
+      body: obs.body_preview,
+      sensitivity: obs.sensitivity,
+      context: obs.context,
+      subjects: obs.subjects,
+      href: observationReturnTo
+        ? observationThreadLink(obs.id, observationReturnTo, {
+          contextLabel: observationReturnLabel,
+        })
+        : `/observations/${obs.id}`,
+      testid: `bunk-observation-${obs.id}`,
+    });
+  }
+
+  for (const note of [...today, ...recent]) {
+    items.push({
+      key: `spec-${note.id}`,
+      kind: 'specialist',
+      sortAt: note.created_at,
+      author: note.author,
+      subject: note.subject,
+      body: note.body,
+      preview: note.preview,
+      isLong: note.is_long,
+      testid: `specialist-note-${note.id}`,
+    });
+  }
+
+  items.sort((a, b) => streamSortTime(b.sortAt) - streamSortTime(a.sortAt));
+  return items;
+}
+
+function NoteStreamMeta({ item }) {
+  const tags = [];
+  if (item.kind === 'observation') {
+    if (item.sensitivity) {
+      tags.push(
+        <span
+          key="sensitivity"
+          className="text-xs rounded-full bg-amber-50 dark:bg-amber-900/20 px-2 py-0.5 text-amber-800 dark:text-amber-200"
         >
-          {camperDisplayName(note.subject)}
-        </Link>{' '}
-        · {note.author} · {new Date(note.created_at).toLocaleDateString()}
+          {SENSITIVITY_LABEL[item.sensitivity] ?? item.sensitivity}
+        </span>,
+      );
+    }
+    if (item.context) {
+      tags.push(
+        <span key="context" className="text-xs text-gray-500 dark:text-gray-400">
+          {item.context}
+        </span>,
+      );
+    }
+  } else {
+    const meta = SOURCE_TAG[item.kind];
+    if (meta) {
+      tags.push(
+        <span
+          key="source"
+          className={`text-xs rounded-full px-2 py-0.5 font-medium ${meta.cls}`}
+        >
+          {meta.label}
+        </span>,
+      );
+    }
+    if (item.authorRole) {
+      tags.push(
+        <span key="role" className="text-xs text-gray-500 dark:text-gray-400 capitalize">
+          {formatRoleLabel(item.authorRole)}
+        </span>,
+      );
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 min-w-0">
+      {tags}
+      {item.author && (
+        <span className="text-sm font-semibold text-gray-900 dark:text-white truncate">
+          {item.author}
+        </span>
+      )}
+      {item.sortAt && (
+        <span className="text-xs text-gray-400 dark:text-gray-500 ml-auto shrink-0">
+          {new Date(item.sortAt).toLocaleString()}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function NoteStreamItem({ item, toProfile }) {
+  const [expanded, setExpanded] = useState(false);
+  const subjectLabel = (item.subjects || []).map((s) => s.name).filter(Boolean).join(', ');
+  const bodyText = item.kind === 'specialist' && item.isLong && !expanded
+    ? item.preview
+    : item.body;
+
+  const content = (
+    <>
+      <NoteStreamMeta item={item} />
+      {item.kind === 'specialist' && item.subject?.id && (
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+          re:{' '}
+          <Link
+            to={toProfile(item.subject.id)}
+            className="font-medium text-blue-700 dark:text-blue-300 hover:underline"
+          >
+            {camperDisplayName(item.subject)}
+          </Link>
+        </p>
+      )}
+      {subjectLabel && item.kind === 'observation' && (
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+          re: {subjectLabel}
+        </p>
+      )}
+      <p className="mt-1.5 text-sm text-gray-700 dark:text-gray-200 whitespace-pre-wrap">
+        {bodyText}
       </p>
-      <p className="mt-1 text-gray-800 dark:text-gray-200 whitespace-pre-wrap">
-        {expanded || !note.is_long ? note.body : note.preview}
-      </p>
-      {note.is_long && (
+      {item.kind === 'specialist' && item.isLong && (
         <button
           type="button"
           onClick={() => setExpanded((v) => !v)}
@@ -226,49 +389,46 @@ function SpecialistNote({ note, toProfile }) {
           {expanded ? 'Show less' : 'Read more'}
         </button>
       )}
-    </li>
+    </>
   );
-}
 
-function ObservationRow({ item }) {
-  const subjectLabel = (item.subjects || []).map((s) => s.name).filter(Boolean).join(', ');
   return (
     <li
-      data-testid={`bunk-observation-${item.id}`}
-      className="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800/50"
+      data-testid={item.testid}
+      data-kind={item.kind}
+      className="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-800/40"
     >
-      <Link to={`/observations/${item.id}`} className="block">
-        <div className="flex flex-wrap items-center gap-2 mb-1">
-          {item.author_name && (
-            <span className="font-semibold text-gray-900 dark:text-white">{item.author_name}</span>
-          )}
-          {item.context && (
-            <span className="text-xs text-gray-400">{item.context}</span>
-          )}
-          {subjectLabel && (
-            <span className="text-xs text-gray-500 dark:text-gray-400 ml-auto truncate max-w-[50%]">
-              re: {subjectLabel}
-            </span>
-          )}
-        </div>
-        <p className="text-gray-700 dark:text-gray-200">{item.body_preview}</p>
-      </Link>
+      {item.href ? (
+        <Link to={item.href} className="block">
+          {content}
+        </Link>
+      ) : content}
     </li>
   );
 }
 
-function NotesSection({ bunkConcerns, specialistReports, observations = [], toProfile, notesLink }) {
-  const today = specialistReports?.today || [];
-  const recent = specialistReports?.recent || [];
+function NotesSection({
+  bunkConcerns,
+  specialistReports,
+  observations = [],
+  toProfile,
+  notesLink,
+  observationReturnTo = null,
+  observationReturnLabel = null,
+}) {
   const sensitiveCounts = specialistReports?.sensitive_counts_by_camper || {};
   const sensitiveTotal = Object.values(sensitiveCounts).reduce((s, n) => s + n, 0);
-  const specialistNotes = [...today, ...recent];
-  const dayObservations = observations || [];
-  const isEmpty =
-    bunkConcerns.length === 0
-    && specialistNotes.length === 0
-    && sensitiveTotal === 0
-    && dayObservations.length === 0;
+  const stream = useMemo(
+    () => buildNotesStream({
+      bunkConcerns,
+      specialistReports,
+      observations,
+      observationReturnTo,
+      observationReturnLabel,
+    }),
+    [bunkConcerns, specialistReports, observations, observationReturnTo, observationReturnLabel],
+  );
+  const isEmpty = stream.length === 0 && sensitiveTotal === 0;
 
   return (
     <SectionCard
@@ -286,80 +446,34 @@ function NotesSection({ bunkConcerns, specialistReports, observations = [], toPr
       {isEmpty ? (
         <p className="text-sm text-gray-500 dark:text-gray-400">No notes today.</p>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-          <div>
-            <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-2">
-              Bunk concerns
+        <>
+          <ul className="space-y-2.5" data-testid="notes-stream">
+            {stream.map((item) => (
+              <NoteStreamItem key={item.key} item={item} toProfile={toProfile} />
+            ))}
+          </ul>
+          {sensitiveTotal > 0 && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 italic mt-3">
+              {sensitiveTotal} sensitive note{sensitiveTotal === 1 ? '' : 's'} not visible
+              (Camper Care).
             </p>
-            {bunkConcerns.length === 0 ? (
-              <p className="text-sm text-gray-400 dark:text-gray-500">None today.</p>
-            ) : (
-              <ul className="space-y-2.5">
-                {bunkConcerns.map((item) => (
-                  <li
-                    key={item.reflection_id}
-                    data-testid={`bunk-concern-${item.reflection_id}`}
-                    className="rounded-lg border-l-2 border-amber-400 bg-amber-50 dark:bg-amber-900/20 px-3 py-2 text-sm"
-                  >
-                    <p className="font-semibold text-gray-900 dark:text-white">
-                      {item.author}
-                      {item.author_role && (
-                        <span className="ml-1.5 text-xs font-normal text-gray-500 dark:text-gray-400">
-                          · {item.author_role}
-                        </span>
-                      )}
-                    </p>
-                    {item.note && (
-                      <p className="text-gray-700 dark:text-gray-200 mt-1">{item.note}</p>
-                    )}
-                    {item.open_concern && (
-                      <p className="text-gray-600 dark:text-gray-300 mt-1 italic">
-                        {item.open_concern}
-                      </p>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-          <div>
-            <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-2">
-              Observations
-            </p>
-            {dayObservations.length === 0 ? (
-              <p className="text-sm text-gray-400 dark:text-gray-500">None on this date.</p>
-            ) : (
-              <ul className="space-y-2.5" data-testid="bunk-observations-list">
-                {dayObservations.map((o) => (
-                  <ObservationRow key={o.id} item={o} />
-                ))}
-              </ul>
-            )}
-          </div>
-          <div>
-            <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-2">
-              Specialist reports &amp; recent notes
-            </p>
-            {specialistNotes.length === 0 && sensitiveTotal === 0 ? (
-              <p className="text-sm text-gray-400 dark:text-gray-500">None today.</p>
-            ) : (
-              <ul className="space-y-3">
-                {specialistNotes.map((n) => (
-                  <SpecialistNote key={n.id} note={n} toProfile={toProfile} />
-                ))}
-                {sensitiveTotal > 0 && (
-                  <li className="text-xs text-gray-500 dark:text-gray-400 italic">
-                    {sensitiveTotal} sensitive note{sensitiveTotal === 1 ? '' : 's'} not visible
-                    (Camper Care).
-                  </li>
-                )}
-              </ul>
-            )}
-          </div>
-        </div>
+          )}
+        </>
       )}
     </SectionCard>
   );
+}
+
+function resolveObservationReturn(data, profileLinkContext) {
+  if (!profileLinkContext?.groupId) {
+    return { observationReturnTo: null, observationReturnLabel: null };
+  }
+  return {
+    observationReturnTo: groupDashboardLink(profileLinkContext.groupId, {
+      date: profileLinkContext.date || data?.header?.date,
+    }),
+    observationReturnLabel: data?.header?.bunk?.name || 'Group dashboard',
+  };
 }
 
 export function BunkDashboardOrdersAndNotes({
@@ -373,6 +487,10 @@ export function BunkDashboardOrdersAndNotes({
       ? profileLink(id, profileLinkContext)
       : `${camperDashboardPath}/${id}`
   );
+  const { observationReturnTo, observationReturnLabel } = resolveObservationReturn(
+    data,
+    profileLinkContext,
+  );
   return (
     <>
       <OrdersSection orders={data?.orders} />
@@ -382,6 +500,8 @@ export function BunkDashboardOrdersAndNotes({
         observations={data?.observations || []}
         toProfile={toProfile}
         notesLink={notesLink}
+        observationReturnTo={observationReturnTo}
+        observationReturnLabel={observationReturnLabel}
       />
     </>
   );
@@ -404,6 +524,10 @@ export default function BunkDashboard({
     profileLinkContext
       ? profileLink(id, profileLinkContext)
       : `${camperDashboardPath}/${id}`
+  );
+  const { observationReturnTo, observationReturnLabel } = resolveObservationReturn(
+    data,
+    profileLinkContext,
   );
   const today = data?.header?.today;
   const date = data?.header?.date;
@@ -557,6 +681,8 @@ export default function BunkDashboard({
           observations={data?.observations || []}
           toProfile={toProfile}
           notesLink={notesLink}
+          observationReturnTo={observationReturnTo}
+          observationReturnLabel={observationReturnLabel}
         />
       )}
     </div>

--- a/frontend/src/components/GroupTemplateResponses.jsx
+++ b/frontend/src/components/GroupTemplateResponses.jsx
@@ -8,17 +8,42 @@
  *
  * Reuses the per-subject dashboard card so the visual treatment matches
  * exactly; `showSubject` adds the Subject column since group rows span
- * multiple people.
+ * multiple people. Each row's **Note +** opens the same observation
+ * composer as the per-subject profile page, pre-filled with that camper
+ * and the row's camp day.
  */
 
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import FormResponsesCard from '../dashboards/subject/responseTable/FormResponsesCard';
-import { profileLink } from '../utils/dashboardLinks';
+import ObservationComposer, { dateOnlyToLocalDatetime } from './observations/ObservationComposer';
+import { groupDashboardLink, observationThreadLink, profileLink } from '../utils/dashboardLinks';
 
 export default function GroupTemplateResponses({
   templates = [],
   language = 'en',
   profileLinkContext = null,
+  groupLabel = null,
+  onNoteCreated = null,
 }) {
+  const navigate = useNavigate();
+  const [composeObservation, setComposeObservation] = useState(null);
+
+  const returnTo = useMemo(() => {
+    if (!profileLinkContext?.groupId) return null;
+    return groupDashboardLink(profileLinkContext.groupId, {
+      date: profileLinkContext.date,
+    });
+  }, [profileLinkContext]);
+
+  const openCompose = (date, subject) => {
+    if (!subject?.id) return;
+    setComposeObservation({
+      subject: { id: Number(subject.id), full_name: subject.name },
+      observedAtLocal: date ? dateOnlyToLocalDatetime(date) : null,
+    });
+  };
+
   if (!templates || templates.length === 0) return null;
   return (
     <section className="mt-8" data-testid="group-template-responses">
@@ -37,8 +62,23 @@ export default function GroupTemplateResponses({
               ? (id) => profileLink(id, profileLinkContext)
               : null
           }
+          onAddObservation={openCompose}
         />
       ))}
+      {composeObservation && (
+        <ObservationComposer
+          initialSubjects={[composeObservation.subject]}
+          initialObservedAtLocal={composeObservation.observedAtLocal}
+          onClose={() => setComposeObservation(null)}
+          onSent={(data) => {
+            setComposeObservation(null);
+            if (onNoteCreated) onNoteCreated();
+            if (data?.id) {
+              navigate(observationThreadLink(data.id, returnTo, { contextLabel: groupLabel }));
+            }
+          }}
+        />
+      )}
     </section>
   );
 }

--- a/frontend/src/components/__tests__/BunkDashboard.test.jsx
+++ b/frontend/src/components/__tests__/BunkDashboard.test.jsx
@@ -124,7 +124,7 @@ describe('BunkDashboard', () => {
     expect(screen.getByTestId('order-2')).toHaveTextContent('Lice check');
   });
 
-  it('renders bunk concerns and sensitive-note counts in the Notes section', () => {
+  it('renders notes in a single stream with tags and sensitive-note footnote', () => {
     const data = {
       ...baseData,
       bunk_concerns: [{
@@ -132,13 +132,55 @@ describe('BunkDashboard', () => {
         author: 'Pat L.',
         author_role: 'counselor',
         note: 'Worried about cabin dynamics',
+        submitted_at: '2026-07-04T14:00:00Z',
+      }],
+      observations: [{
+        id: 7,
+        body_preview: 'Checked in after lunch.',
+        author_name: 'Sam R.',
+        subjects: [{ id: 3, name: 'Jamie Pat' }],
+        sensitivity: 'sensitive',
+        context: 'mealtime',
+        observed_at: '2026-07-04T16:00:00Z',
       }],
       specialist_reports: { today: [], recent: [], sensitive_counts_by_camper: { 1: 1, 2: 2 } },
     };
     renderDash(data);
     const section = screen.getByTestId('section-notes');
     expect(section).toHaveAttribute('data-state', 'populated');
+    expect(screen.getByTestId('notes-stream')).toBeInTheDocument();
+    expect(screen.queryByText('Bunk concerns')).not.toBeInTheDocument();
+    expect(screen.queryByText('Specialist reports')).not.toBeInTheDocument();
+    expect(screen.getByTestId('bunk-observation-7')).toHaveTextContent('Checked in after lunch.');
+    expect(screen.getByRole('link', { name: /Checked in after lunch/ })).toHaveAttribute(
+      'href',
+      '/observations/7',
+    );
+    expect(screen.getByTestId('bunk-observation-7')).toHaveTextContent('Sensitive');
+    expect(screen.getByTestId('bunk-observation-7')).toHaveTextContent('mealtime');
     expect(screen.getByTestId('bunk-concern-42')).toHaveTextContent('Worried about cabin dynamics');
+    expect(screen.getByTestId('bunk-concern-42')).toHaveTextContent('Bunk concern');
     expect(section).toHaveTextContent('3 sensitive notes');
+  });
+
+  it('links observations back to the group dashboard when profileLinkContext is set', () => {
+    const data = {
+      ...baseData,
+      observations: [{
+        id: 12,
+        body_preview: 'Evening check-in.',
+        author_name: 'Pat L.',
+        subjects: [{ id: 3, name: 'Jamie Pat' }],
+        sensitivity: 'normal',
+        observed_at: '2026-07-04T20:00:00Z',
+      }],
+    };
+    renderDash(data, {
+      profileLinkContext: { groupId: 78, date: '2026-07-04' },
+    });
+    const link = screen.getByRole('link', { name: /Evening check-in/ });
+    expect(link.getAttribute('href')).toBe(
+      '/observations/12?from=%2Fdashboards%2Fgroup%2F78%3Fdate%3D2026-07-04&from_label=Bunk+Alpha',
+    );
   });
 });

--- a/frontend/src/components/__tests__/GroupTemplateResponses.test.jsx
+++ b/frontend/src/components/__tests__/GroupTemplateResponses.test.jsx
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import GroupTemplateResponses from '../GroupTemplateResponses';
+
+vi.mock('../../api/observations', () => ({
+  fetchRecipientCandidates: vi.fn(() => Promise.resolve([])),
+  searchObservationSubjects: vi.fn(() => Promise.resolve([])),
+  createObservation: vi.fn(),
+  SENSITIVITY_OPTIONS: [{ value: 'normal', label: 'Normal' }],
+}));
+
+const templates = [
+  {
+    template: { id: 16, name: 'Camper daily check-in', slug: 'camper-daily' },
+    schema_fields: [
+      { key: 'daily_report', type: 'textarea', prompts: { en: 'Daily report' } },
+    ],
+    summary: { total_reflections: 1, flag_counts: {} },
+    rating_series: [],
+    reflections: [
+      {
+        id: 228,
+        date: '2026-06-03',
+        language: 'en',
+        team_visibility: 'team',
+        subject: { id: 42, name: 'Alex Cohen' },
+        answers: { daily_report: 'Had a good day.' },
+      },
+    ],
+  },
+];
+
+describe('GroupTemplateResponses', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows Note + on form-response rows and opens the observation composer', async () => {
+    render(
+      <MemoryRouter>
+        <GroupTemplateResponses
+          templates={templates}
+          profileLinkContext={{ groupId: 78, date: '2026-06-03' }}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('group-template-add-observation-228')).toHaveTextContent('Note +');
+    fireEvent.click(screen.getByTestId('group-template-add-observation-228'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('observation-composer-observed-at')).toHaveValue('2026-06-03T12:00');
+    });
+    expect(screen.getByTestId('observation-subject-chips')).toHaveTextContent('Alex Cohen');
+  });
+});

--- a/frontend/src/components/admin/GlobalSearch.jsx
+++ b/frontend/src/components/admin/GlobalSearch.jsx
@@ -75,7 +75,7 @@ export default function GlobalSearch() {
         onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
         onFocus={() => setOpen(true)}
         onKeyDown={(e) => { if (e.key === 'Escape') setOpen(false); }}
-        placeholder="Search people, reflections, notes…"
+        placeholder="Search campers by name…"
         className="w-80 rounded-md border border-gray-300 bg-white p-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
         aria-label="Admin global search"
       />

--- a/frontend/src/components/admin/__tests__/GlobalSearch.test.jsx
+++ b/frontend/src/components/admin/__tests__/GlobalSearch.test.jsx
@@ -23,13 +23,13 @@ describe('GlobalSearch (7_13 PR3, Story 60)', () => {
       query: 'ada',
       groups: {
         people: [
-          { id: 1, label: 'Ada Lovelace', secondary: 'a@l.com', deep_link: '/admin/people?id=1' },
+          { id: 1, label: 'Ada Lovelace', secondary: 'a@l.com', deep_link: '/profile/1' },
         ],
         notes: [],
       },
     });
     renderWithRouter(<GlobalSearch />);
-    const input = screen.getByPlaceholderText(/Search people/i);
+    const input = screen.getByPlaceholderText(/Search campers/i);
     fireEvent.change(input, { target: { value: 'ada' } });
 
     // Wait for debounce + fetch to complete.
@@ -42,7 +42,7 @@ describe('GlobalSearch (7_13 PR3, Story 60)', () => {
 
   it('does not call the API for queries shorter than 2 chars', async () => {
     renderWithRouter(<GlobalSearch />);
-    const input = screen.getByPlaceholderText(/Search people/i);
+    const input = screen.getByPlaceholderText(/Search campers/i);
     fireEvent.change(input, { target: { value: 'a' } });
     // Give the debounce more than enough time.
     await new Promise((resolve) => setTimeout(resolve, 500));

--- a/frontend/src/components/observations/ObservationComposer.jsx
+++ b/frontend/src/components/observations/ObservationComposer.jsx
@@ -23,12 +23,24 @@ function defaultObservedAtLocal() {
   return d.toISOString().slice(0, 16);
 }
 
+/** Map a profile row date (YYYY-MM-DD) to a datetime-local default (midday). */
+export function dateOnlyToLocalDatetime(dateOnly) {
+  if (!dateOnly) return defaultObservedAtLocal();
+  const day = String(dateOnly).slice(0, 10);
+  return `${day}T12:00`;
+}
+
 function localDatetimeToIso(local) {
   if (!local) return null;
   return new Date(local).toISOString();
 }
 
-export default function ObservationComposer({ onClose, onSent, initialSubjects = [] }) {
+export default function ObservationComposer({
+  onClose,
+  onSent,
+  initialSubjects = [],
+  initialObservedAtLocal = null,
+}) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState([]);
   const [searching, setSearching] = useState(false);
@@ -36,7 +48,9 @@ export default function ObservationComposer({ onClose, onSent, initialSubjects =
   const [searchError, setSearchError] = useState(null);
   const [subjects, setSubjects] = useState(initialSubjects);
   const [body, setBody] = useState('');
-  const [observedAtLocal, setObservedAtLocal] = useState(defaultObservedAtLocal);
+  const [observedAtLocal, setObservedAtLocal] = useState(
+    () => initialObservedAtLocal || defaultObservedAtLocal(),
+  );
   const [context, setContext] = useState('');
   const [sensitivity, setSensitivity] = useState('normal');
   const [subjectVisible, setSubjectVisible] = useState(false);

--- a/frontend/src/dashboards/subject/SubjectDetail.jsx
+++ b/frontend/src/dashboards/subject/SubjectDetail.jsx
@@ -18,10 +18,11 @@ import { Link, useNavigate } from 'react-router-dom';
 import { AlertTriangle, MessageSquarePlus } from 'lucide-react';
 import {
   groupDashboardLink,
+  observationThreadLink,
   profileBackLabel,
   resolveProfileBackGroup,
 } from '../../utils/dashboardLinks';
-import ObservationComposer from '../../components/observations/ObservationComposer';
+import ObservationComposer, { dateOnlyToLocalDatetime } from '../../components/observations/ObservationComposer';
 import PrivacyChip from '../../components/reflection/PrivacyChip';
 import {
   formatShortDate,
@@ -387,10 +388,8 @@ const SENSITIVITY_LABEL = {
   confidential: 'Confidential',
 };
 
-function ObservationsPanel({ observations = [], subject, personId, onCreated }) {
-  const navigate = useNavigate();
+function ObservationsPanel({ observations = [], onCompose, profileReturnTo = null }) {
   const [open, setOpen] = useState(true);
-  const [composing, setComposing] = useState(false);
 
   const sorted = useMemo(
     () => [...observations].sort((a, b) => {
@@ -421,10 +420,10 @@ function ObservationsPanel({ observations = [], subject, personId, onCreated }) 
           )}
         </div>
         <div className="flex gap-2 items-center">
-          {personId && (
+          {onCompose && (
             <button
               type="button"
-              onClick={() => setComposing(true)}
+              onClick={() => onCompose()}
               className="text-xs font-medium px-3 py-1.5 rounded-md bg-indigo-50 dark:bg-indigo-900/30 border border-indigo-200 dark:border-indigo-800 text-indigo-700 dark:text-indigo-200 hover:bg-indigo-100 dark:hover:bg-indigo-900/50"
               data-testid="observation-add-btn"
             >
@@ -452,7 +451,7 @@ function ObservationsPanel({ observations = [], subject, personId, onCreated }) 
               {sorted.map((o) => (
                 <li key={o.id}>
                   <Link
-                    to={`/observations/${o.id}`}
+                    to={observationThreadLink(o.id, profileReturnTo)}
                     className="block rounded-lg border border-gray-200 dark:border-gray-700 p-3 hover:bg-gray-50 dark:hover:bg-gray-700/40"
                   >
                     <div className="flex items-center gap-2 mb-1">
@@ -478,17 +477,6 @@ function ObservationsPanel({ observations = [], subject, personId, onCreated }) 
         </div>
       )}
 
-      {composing && (
-        <ObservationComposer
-          initialSubjects={subject ? [{ id: personId, full_name: subject.name }] : []}
-          onClose={() => setComposing(false)}
-          onSent={(data) => {
-            setComposing(false);
-            if (onCreated) onCreated();
-            if (data?.id) navigate(`/observations/${data.id}`);
-          }}
-        />
-      )}
     </section>
   );
 }
@@ -503,6 +491,7 @@ export default function SubjectDetail({
   refreshing = false,
   backGroupId = null,
   backDate = '',
+  profileReturnTo = null,
 }) {
   if (!payload) return null;
   const {
@@ -519,6 +508,15 @@ export default function SubjectDetail({
     () => buildReflectionGroupById(templates),
     [templates],
   );
+  const navigate = useNavigate();
+  const [composeObservation, setComposeObservation] = useState(null);
+
+  const openCompose = (date) => {
+    setComposeObservation({
+      observedAtLocal: date ? dateOnlyToLocalDatetime(date) : null,
+    });
+  };
+
   return (
     <div>
       <ProfileBackLink
@@ -547,17 +545,30 @@ export default function SubjectDetail({
             key={t.template?.id ?? t.template?.slug}
             block={t}
             language={language}
+            personId={personId}
+            onAddObservation={personId ? openCompose : null}
           />
         ))
       )}
 
-      {/*<RecentTexts texts={recentTexts} />*/} 
+      {/*<RecentTexts texts={recentTexts} />*/}
       <ObservationsPanel
         observations={observations ?? []}
-        subject={subject}
-        personId={personId}
-        onCreated={onNoteCreated}
+        onCompose={personId ? () => openCompose() : null}
+        profileReturnTo={profileReturnTo}
       />
+      {composeObservation && (
+        <ObservationComposer
+          initialSubjects={subject ? [{ id: Number(personId), full_name: subject.name }] : []}
+          initialObservedAtLocal={composeObservation.observedAtLocal}
+          onClose={() => setComposeObservation(null)}
+          onSent={(data) => {
+            setComposeObservation(null);
+            if (onNoteCreated) onNoteCreated();
+            if (data?.id) navigate(observationThreadLink(data.id, profileReturnTo));
+          }}
+        />
+      )}
       {/* TODO(7_23): legacy SubjectNote panel removed in 7_24 */}
     </div>
   );

--- a/frontend/src/dashboards/subject/__tests__/SubjectDetail.test.jsx
+++ b/frontend/src/dashboards/subject/__tests__/SubjectDetail.test.jsx
@@ -1,7 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, within, fireEvent } from '@testing-library/react';
+import { render, screen, within, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import SubjectDetail from '../SubjectDetail';
+
+vi.mock('../../../api/observations', () => ({
+  fetchRecipientCandidates: vi.fn(() => Promise.resolve([])),
+  searchObservationSubjects: vi.fn(() => Promise.resolve([])),
+  createObservation: vi.fn(),
+  SENSITIVITY_OPTIONS: [
+    { value: 'normal', label: 'Normal' },
+  ],
+}));
 
 const payload = {
   subject: {
@@ -247,6 +256,20 @@ describe('SubjectDetail', () => {
   it('renders the empty state when there are no templates', () => {
     renderDetail({ templates: [] });
     expect(screen.getByTestId('subject-empty')).toBeInTheDocument();
+  });
+
+  it('shows Note + on form-response rows when personId is set', () => {
+    renderDetail();
+    expect(screen.getByTestId('subject-add-observation-228')).toHaveTextContent('Note +');
+  });
+
+  it('opens observation composer prepopulated from a form-response row', async () => {
+    renderDetail();
+    fireEvent.click(screen.getByTestId('subject-add-observation-228'));
+    await waitFor(() => {
+      expect(screen.getByTestId('observation-composer-observed-at')).toHaveValue('2026-05-23T12:00');
+    });
+    expect(screen.getByTestId('observation-subject-chips')).toHaveTextContent('BulkCamper5 #1');
   });
 
   it('calls onRangeChange when custom start/end dates are selected', () => {

--- a/frontend/src/dashboards/subject/responseTable/FormResponsesCard.jsx
+++ b/frontend/src/dashboards/subject/responseTable/FormResponsesCard.jsx
@@ -102,6 +102,8 @@ export default function FormResponsesCard({
   showSubject = false,
   subjectLinkBase = null,
   subjectProfileLink = null,
+  personId = null,
+  onAddObservation = null,
 }) {
   const tpl = block.template ?? {};
   const reflections = block.reflections ?? [];
@@ -279,22 +281,40 @@ export default function FormResponsesCard({
                     };
                     return (
                       <tr key={r.id} data-testid={`${testidPrefix}-row-${r.id}`}>
-                        <td className="px-3 py-3 whitespace-nowrap text-center border border-gray-300 dark:border-gray-700">
-                          <div className="text-sm text-gray-800 dark:text-gray-100">
-                            {formatShortDate(r.date)}
+                        <td className="px-3 py-3 whitespace-nowrap border border-gray-300 dark:border-gray-700">
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="min-w-0 text-center">
+                              <div className="text-sm text-gray-800 dark:text-gray-100">
+                                {formatShortDate(r.date)}
+                              </div>
+                              <div className="text-[10px] text-gray-500 dark:text-gray-400 mt-0.5 inline-flex items-center gap-1">
+                                {r.language ?? 'en'}
+                                <PrivacyChip teamVisibility={r.team_visibility} size="icon" />
+                              </div>
+                              {r.assignment_group?.id && (
+                                <Link
+                                  to={`/dashboards/group/${r.assignment_group.id}?date=${r.date}`}
+                                  className="block mt-1 text-[11px] text-indigo-600 dark:text-indigo-400 hover:underline"
+                                >
+                                  {r.assignment_group.name ?? 'View group'} →
+                                </Link>
+                              )}
+                            </div>
+                            {onAddObservation && (personId || (showSubject && r.subject?.id)) && (
+                              <button
+                                type="button"
+                                onClick={() => (
+                                  showSubject && r.subject?.id
+                                    ? onAddObservation(r.date, r.subject)
+                                    : onAddObservation(r.date)
+                                )}
+                                className="shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded border border-violet-200 dark:border-violet-800 text-violet-700 dark:text-violet-300 hover:bg-violet-50 dark:hover:bg-violet-900/30"
+                                data-testid={`${testidPrefix}-add-observation-${r.id}`}
+                              >
+                                Note +
+                              </button>
+                            )}
                           </div>
-                          <div className="text-[10px] text-gray-500 dark:text-gray-400 mt-0.5 inline-flex items-center gap-1">
-                            {r.language ?? 'en'}
-                            <PrivacyChip teamVisibility={r.team_visibility} size="icon" />
-                          </div>
-                          {r.assignment_group?.id && (
-                            <Link
-                              to={`/dashboards/group/${r.assignment_group.id}?date=${r.date}`}
-                              className="block mt-1 text-[11px] text-indigo-600 dark:text-indigo-400 hover:underline"
-                            >
-                              {r.assignment_group.name ?? 'View group'} →
-                            </Link>
-                          )}
                         </td>
                         {showSubject && (
                           <SubjectCell

--- a/frontend/src/pages/camper-care/Orders.jsx
+++ b/frontend/src/pages/camper-care/Orders.jsx
@@ -86,11 +86,29 @@ function OrderRow({ order, selectable, selected, onSelectToggle, onTransition })
                 {order.item}
                 {order.item_note ? ` — ${order.item_note}` : ''}
               </h3>
-              <p className="text-xs text-gray-600 dark:text-gray-300 mt-0.5 truncate">
-                For {camperLabel(order.subject)}
-                {order.submitter?.name ? ` · from ${order.submitter.name}` : ''}
-              </p>
+              <div className="flex flex-wrap items-center gap-2 mt-1">
+                {order.bunk?.name ? (
+                  <span
+                    className="text-xs font-semibold px-2 py-0.5 rounded-full bg-slate-100 text-slate-800 dark:bg-slate-800 dark:text-slate-100"
+                    data-testid={`order-bunk-${order.id}`}
+                  >
+                    {order.bunk.name}
+                  </span>
+                ) : (
+                  <span className="text-xs text-gray-400 dark:text-gray-500 italic">
+                    Bunk unknown
+                  </span>
+                )}
+                {order.subject && (
+                  <span className="text-xs text-gray-600 dark:text-gray-300">
+                    For {camperLabel(order.subject)}
+                  </span>
+                )}
+              </div>
               <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                {order.submitter?.name ? (
+                  <span>from {order.submitter.name} · </span>
+                ) : null}
                 {formatAge(order.age_seconds)}
                 {aged && (
                   <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded-full bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200 text-[10px] font-medium">

--- a/frontend/src/pages/camper-care/__tests__/Orders.test.jsx
+++ b/frontend/src/pages/camper-care/__tests__/Orders.test.jsx
@@ -27,6 +27,7 @@ const samplePayload = {
       available_transitions: ['in_progress', 'unable_to_fulfill'],
       is_within_correction_window: false,
       subject: { id: 1, first_name: 'Lila', last_name: 'Park', preferred_name: '' },
+      bunk: { id: 11, name: 'Bunk Birch' },
       item: 'Sunscreen',
       item_note: 'SPF 50',
       description: 'For Tuesday hike.',
@@ -44,6 +45,7 @@ const samplePayload = {
       available_transitions: ['fulfilled', 'unable_to_fulfill'],
       is_within_correction_window: true,
       subject: { id: 2, first_name: 'Jordan', last_name: 'Tate', preferred_name: 'Jo' },
+      bunk: { id: 12, name: 'Bunk Pine' },
       item: 'Inhaler',
       item_note: '',
       description: '',
@@ -59,6 +61,7 @@ const samplePayload = {
       available_transitions: ['fulfilled', 'unable_to_fulfill'],
       is_within_correction_window: false,
       subject: { id: 3, first_name: 'Avi', last_name: 'Klein', preferred_name: '' },
+      bunk: { id: 11, name: 'Bunk Birch' },
       item: 'Sunscreen',
       item_note: '',
       description: '',
@@ -88,6 +91,22 @@ describe('CamperCareOrders', () => {
     expect(screen.getByTestId('order-row-aaaa1111-aaaa-1111-aaaa-111111111111')).toBeInTheDocument();
     expect(screen.getByTestId('order-row-bbbb2222-bbbb-2222-bbbb-222222222222')).toBeInTheDocument();
     expect(screen.getByTestId('order-row-cccc3333-cccc-3333-cccc-333333333333')).toBeInTheDocument();
+  });
+
+  it('shows bunk prominently with submitter name secondary', async () => {
+    getMock.mockResolvedValueOnce({ data: samplePayload });
+    render(
+      <MemoryRouter>
+        <CamperCareOrders />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('order-bunk-aaaa1111-aaaa-1111-aaaa-111111111111')).toBeInTheDocument();
+    });
+    const row = screen.getByTestId('order-row-aaaa1111-aaaa-1111-aaaa-111111111111');
+    expect(row).toHaveTextContent('Bunk Birch');
+    expect(row).toHaveTextContent('For Lila Park');
+    expect(row).toHaveTextContent('from Pat L.');
   });
 
   it('bulk-fulfills selected In Progress orders', async () => {

--- a/frontend/src/pages/counselor/CamperCareRequestFormPage.jsx
+++ b/frontend/src/pages/counselor/CamperCareRequestFormPage.jsx
@@ -81,6 +81,7 @@ export default function CamperCareRequestFormPage() {
   const [suggestions, setSuggestions] = useState([]);
 
   const [subjectId, setSubjectId] = useState('');
+  const [bunkId, setBunkId] = useState('');
   const [item, setItem] = useState('');
   const [itemNote, setItemNote] = useState('');
   const [description, setDescription] = useState('');
@@ -138,6 +139,7 @@ export default function CamperCareRequestFormPage() {
     try {
       await createCamperCareRequest({
         subjectId: subjectId ? Number(subjectId) : null,
+        bunkId: bunkId ? Number(bunkId) : null,
         item: item.trim(),
         itemNote: itemNote.trim(),
         description: description.trim(),
@@ -227,7 +229,12 @@ export default function CamperCareRequestFormPage() {
                 id="cc-subject"
                 data-testid="camper-care-subject"
                 value={subjectId}
-                onChange={(e) => setSubjectId(e.target.value)}
+                onChange={(e) => {
+                  const nextId = e.target.value;
+                  setSubjectId(nextId);
+                  const row = campers.find((c) => String(c.id) === nextId);
+                  setBunkId(row?.bunkId ? String(row.bunkId) : '');
+                }}
                 className="block w-full min-h-[44px] rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
               >
                 <option value="">— bunk-wide / no specific camper —</option>

--- a/frontend/src/pages/dashboards/GroupDashboardPage.jsx
+++ b/frontend/src/pages/dashboards/GroupDashboardPage.jsx
@@ -189,6 +189,12 @@ export default function GroupDashboardPage() {
       <GroupTemplateResponses
         templates={data?.templates}
         profileLinkContext={profileLinkContext}
+        groupLabel={
+          data?.header?.bunk?.name
+          || data?.header?.group?.name
+          || null
+        }
+        onNoteCreated={load}
       />
     </div>
   );

--- a/frontend/src/pages/dashboards/SubjectDetailPage.jsx
+++ b/frontend/src/pages/dashboards/SubjectDetailPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import api from '../../api';
 import Header from '../../partials/Header';
@@ -65,6 +65,11 @@ export default function SubjectDetailPage() {
   const rangeStart = start || payload?.period?.start || '';
   const rangeEnd = end || payload?.period?.end || '';
 
+  const profileReturnTo = useMemo(() => {
+    const qs = searchParams.toString();
+    return qs ? `/profile/${personId}?${qs}` : `/profile/${personId}`;
+  }, [personId, searchParams]);
+
   return (
     <div className="flex h-screen overflow-hidden">
       <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
@@ -96,6 +101,7 @@ export default function SubjectDetailPage() {
               refreshing={loading}
               backGroupId={backGroupId}
               backDate={backDate}
+              profileReturnTo={profileReturnTo}
             />
           )}
         </main>

--- a/frontend/src/pages/observations/ObservationThread.jsx
+++ b/frontend/src/pages/observations/ObservationThread.jsx
@@ -3,8 +3,13 @@
  * reply composer (Step 7_23). Route: /observations/:observationId.
  */
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import RichText from '../../components/ui/RichText';
+import {
+  observationContextBackLabel,
+  safeInternalPath,
+  subjectProfileHref,
+} from '../../utils/dashboardLinks';
 import {
   archiveObservation,
   fetchObservationThread,
@@ -34,6 +39,14 @@ const SENSITIVITY_LABEL = {
 export default function ObservationThread() {
   const { observationId } = useParams();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const returnTo = safeInternalPath(searchParams.get('from'));
+  const contextReturnTo = returnTo && returnTo !== '/observations' ? returnTo : null;
+  const contextBackLabel = observationContextBackLabel(
+    contextReturnTo,
+    searchParams.get('from_label'),
+  );
+  const archiveReturnTo = contextReturnTo || '/observations';
   const [obs, setObs] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -73,7 +86,7 @@ export default function ObservationThread() {
     setArchiving(true);
     try {
       await archiveObservation(observationId);
-      navigate('/observations');
+      navigate(archiveReturnTo);
     } catch {
       setArchiving(false);
     }
@@ -86,33 +99,69 @@ export default function ObservationThread() {
     return <div className="flex h-screen items-center justify-center text-red-500">{error}</div>;
   }
 
+  const observedDate = obs.observed_at ? String(obs.observed_at).slice(0, 10) : '';
+
   return (
     <main className="grow">
       <div className="px-4 sm:px-6 lg:px-8 py-8 w-full max-w-3xl mx-auto">
-        <button
-          type="button"
-          onClick={() => navigate('/observations')}
-          className="mb-4 flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+        <nav
+          className="mb-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm"
+          data-testid="observation-thread-nav"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-          </svg>
-          Back to Observations
-        </button>
+          <Link
+            to="/observations"
+            className="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+            data-testid="observation-back-inbox"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            Back to Observations
+          </Link>
+          {contextReturnTo && (
+            <Link
+              to={contextReturnTo}
+              className="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+              data-testid="observation-back-context"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+              {contextBackLabel}
+            </Link>
+          )}
+        </nav>
 
         <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
           <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
             <div className="flex items-start justify-between gap-3">
               <div className="flex-1 min-w-0">
                 <div className="flex flex-wrap items-center gap-2">
-                  {(obs.subjects ?? []).map((s) => (
-                    <span
-                      key={s.id}
-                      className="inline-flex rounded-full bg-indigo-50 dark:bg-indigo-900/20 px-2.5 py-0.5 text-xs font-medium text-indigo-800 dark:text-indigo-100"
-                    >
-                      {s.full_name}
-                    </span>
-                  ))}
+                  {(obs.subjects ?? []).map((s) => {
+                    const chipClass =
+                      'inline-flex rounded-full bg-indigo-50 dark:bg-indigo-900/20 px-2.5 py-0.5 text-xs font-medium text-indigo-800 dark:text-indigo-100';
+                    const profileTo = subjectProfileHref(s.id, {
+                      observedDate,
+                      returnTo,
+                      canViewProfile: s.can_view_profile,
+                    });
+                    if (profileTo) {
+                      return (
+                        <Link
+                          key={s.id}
+                          to={profileTo}
+                          className={`${chipClass} hover:bg-indigo-100 dark:hover:bg-indigo-900/40 hover:underline`}
+                        >
+                          {s.full_name}
+                        </Link>
+                      );
+                    }
+                    return (
+                      <span key={s.id} className={chipClass}>
+                        {s.full_name}
+                      </span>
+                    );
+                  })}
                   <span className="inline-flex rounded-full bg-amber-50 dark:bg-amber-900/20 px-2.5 py-0.5 text-xs font-medium text-amber-800 dark:text-amber-200">
                     {SENSITIVITY_LABEL[obs.sensitivity] ?? obs.sensitivity}
                   </span>
@@ -123,6 +172,9 @@ export default function ObservationThread() {
                     <span className="text-xs ml-1 text-gray-400">({obs.author_role_at_write})</span>
                   </span>
                   <span className="text-xs text-gray-400">{timeAgo(obs.created_at)}</span>
+                  {observedDate && (
+                    <span className="text-xs text-gray-400">· observed {observedDate}</span>
+                  )}
                   {obs.context && (
                     <span className="text-xs text-gray-400">· {obs.context}</span>
                   )}

--- a/frontend/src/pages/observations/Observations.test.jsx
+++ b/frontend/src/pages/observations/Observations.test.jsx
@@ -54,8 +54,9 @@ const THREAD = {
   author_role_at_write: 'unit_head',
   sensitivity: 'sensitive',
   context: 'swim',
+  observed_at: '2026-06-02T15:00:00Z',
   created_at: new Date(Date.now() - 3600000).toISOString(),
-  subjects: [{ id: 5, full_name: 'Cam Per' }],
+  subjects: [{ id: 5, full_name: 'Cam Per', can_view_profile: true }],
   recipients: [],
   replies: [],
   read_summary: { read_count: 0, audience_count: 0 },
@@ -215,6 +216,94 @@ describe('ObservationThread', () => {
       expect(postMock).toHaveBeenCalledWith('/api/v1/observations/1/replies/', { body: 'Got it!' });
       expect(screen.getByText('Got it!')).toBeDefined();
     });
+  });
+
+  it('links subject to profile with observed date when can_view_profile', async () => {
+    getMock.mockResolvedValue({ data: THREAD });
+    render(
+      <MemoryRouter initialEntries={['/observations/1']}>
+        <Routes>
+          <Route path="/observations/:observationId" element={<ObservationThread />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: 'Cam Per' });
+      expect(link.getAttribute('href')).toBe('/profile/5?date=2026-06-02');
+    });
+  });
+
+  it('links subject to profile returnTo when from query matches subject', async () => {
+    getMock.mockResolvedValue({ data: THREAD });
+    const from = encodeURIComponent('/profile/5?date_start=2026-05-01&date_end=2026-05-31');
+    render(
+      <MemoryRouter initialEntries={[`/observations/1?from=${from}`]}>
+        <Routes>
+          <Route path="/observations/:observationId" element={<ObservationThread />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: 'Cam Per' });
+      expect(link.getAttribute('href')).toBe('/profile/5?date_start=2026-05-01&date_end=2026-05-31');
+    });
+  });
+
+  it('shows inbox and contextual back links when from query is set', async () => {
+    getMock.mockResolvedValue({ data: THREAD });
+    render(
+      <MemoryRouter initialEntries={['/observations/1?from=%2Fprofile%2F221%3Fdate%3D2026-05-23']}>
+        <Routes>
+          <Route path="/observations/:observationId" element={<ObservationThread />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('observation-back-inbox')).toHaveAttribute('href', '/observations');
+      const context = screen.getByTestId('observation-back-context');
+      expect(context).toHaveTextContent('Back to profile');
+      expect(context).toHaveAttribute('href', '/profile/221?date=2026-05-23');
+    });
+  });
+
+  it('shows a labeled group-dashboard back link when from_label is set', async () => {
+    getMock.mockResolvedValue({ data: THREAD });
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/observations/1?from=%2Fdashboards%2Fgroup%2F78%3Fdate%3D2026-06-03&from_label=Cabin+Birch',
+        ]}
+      >
+        <Routes>
+          <Route path="/observations/:observationId" element={<ObservationThread />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      const context = screen.getByTestId('observation-back-context');
+      expect(context).toHaveTextContent('Back to Cabin Birch');
+      expect(context).toHaveAttribute('href', '/dashboards/group/78?date=2026-06-03');
+    });
+  });
+
+  it('renders subject name without link when can_view_profile is false', async () => {
+    getMock.mockResolvedValue({
+      data: {
+        ...THREAD,
+        subjects: [{ id: 5, full_name: 'Cam Per', can_view_profile: false }],
+      },
+    });
+    render(
+      <MemoryRouter initialEntries={['/observations/1']}>
+        <Routes>
+          <Route path="/observations/:observationId" element={<ObservationThread />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Cam Per')).toBeDefined();
+    });
+    expect(screen.queryByRole('link', { name: 'Cam Per' })).toBeNull();
   });
 });
 

--- a/frontend/src/partials/Sidebar.jsx
+++ b/frontend/src/partials/Sidebar.jsx
@@ -85,10 +85,12 @@ const PROGRAM_LEAD_PLUS = ['program_lead'];
  * Default nav (non-admin): My work (Home/tasks/reflections/
  * observations/maintenance), Supervise (supervisor+; program_lead+ also
  * gets performance / log entries / reflections / authors there). Leadership
- * Team (program_lead+). Gates use hasCapability(user, [...]) ||
- * isSuperAdmin(user); direct `user.role` references remain only for
- * reflection-form access. Role workspaces are the Home link target (no
- * duplicate "Counselor home" entries).
+ * Team (program_lead+). Camper Care omits My tasks / File a reflection /
+ * My reflections / Bunk Logs — those live on the Camper Care home dashboard.
+ * Gates use
+ * hasCapability(user, [...]) || isSuperAdmin(user); direct `user.role`
+ * references remain only for reflection-form access. Role workspaces are the
+ * Home link target (no duplicate "Counselor home" entries).
  */
 function Sidebar({
   sidebarOpen,
@@ -165,7 +167,8 @@ function Sidebar({
   const canAdmin = hasCapability(user, 'admin') || isSuperAdmin(user);
   const canFileReflection = REFLECTION_FORM_ROLES.includes(user.role);
   const isCounselor = user.role === 'Counselor';
-  const canSeeFileReflectionNav = canFileReflection && !isCounselor;
+  const isCamperCare = user.role === 'Camper Care';
+  const canSeeFileReflectionNav = canFileReflection && !isCounselor && !isCamperCare;
   const canSeeLogs = canSupervise || canAdmin;
   // Counselors see assigned/submitted work via My tasks + My reflections, not the org-wide dashboard.
   const canSeeReflectionsDashboard = (canSeeLogs || canFileReflection) && !isCounselor;
@@ -308,11 +311,13 @@ function Sidebar({
           <>
           <Section heading="My work">
             <NavItem to={homePathFor(user.role)} label="Home" icon={IconHome} end />
-            <NavItem to="/tasks" label="My tasks" icon={IconTasks} />
+            {!isCamperCare && (
+              <NavItem to="/tasks" label="My tasks" icon={IconTasks} />
+            )}
             {canSeeFileReflectionNav && (
               <NavItem to="/reflect" label="File a reflection" icon={IconPencil} />
             )}
-            {canFileReflection && (
+            {canFileReflection && !isCamperCare && (
               <NavItem to="/my-reflections" label="My reflections" icon={IconClipboard} />
             )}
             <NavItem
@@ -326,19 +331,19 @@ function Sidebar({
               label="Maintenance Queue"
               icon={IconWrench}
             />
-            {canSupervise && !canSeeDashboards && canSeeLogs && (
-              <>
-                <NavItem
-                  to="/groups/performance"
-                  label="Group Performance"
-                  icon={IconGrid}
-                />
-                <NavItem
-                  to="/dashboards/logs"
-                  label="Bunk Logs"
-                  icon={IconBars}
-                />
-              </>
+            {canSupervise && !canSeeDashboards && (
+              <NavItem
+                to="/groups/performance"
+                label="Group Performance"
+                icon={IconGrid}
+              />
+            )}
+            {canSupervise && !canSeeDashboards && canSeeLogs && !isCamperCare && (
+              <NavItem
+                to="/dashboards/logs"
+                label="Bunk Logs"
+                icon={IconBars}
+              />
             )}
             {canSeeReflectionsDashboard && !canAdmin && (
               <NavItem

--- a/frontend/src/partials/__tests__/Sidebar.test.jsx
+++ b/frontend/src/partials/__tests__/Sidebar.test.jsx
@@ -101,7 +101,7 @@ describe('Sidebar — section gating (3.32)', () => {
     expect(links).not.toContain('/counselor');
   });
 
-  it('supervisor (camper_care) sees Supervise and reflection forms', () => {
+  it('supervisor (camper_care) sees Supervise without personal reflection nav', () => {
     renderWith({ role: 'Camper Care' });
 
     expect(screen.getAllByText('Supervise').length).toBeGreaterThan(0);
@@ -111,8 +111,10 @@ describe('Sidebar — section gating (3.32)', () => {
     expect(links).not.toContain('/dashboard');
     expect(links).toContain('/groups/performance');
     expect(links).toContain('/dashboards/concerns');
-    expect(links).toContain('/reflect');
-    expect(links).toContain('/my-reflections');
+    expect(links).not.toContain('/dashboards/logs');
+    expect(links).not.toContain('/tasks');
+    expect(links).not.toContain('/reflect');
+    expect(links).not.toContain('/my-reflections');
   });
 
   it('program_lead (leadership) sees Supervise dashboard links but not Admin or Dashboards menu', () => {

--- a/frontend/src/utils/dashboardLinks.js
+++ b/frontend/src/utils/dashboardLinks.js
@@ -38,3 +38,44 @@ export function profileBackLabel(group) {
   if (group.group_type === 'bunk') return '← Back to bunk dashboard';
   return '← Back to group dashboard';
 }
+
+/** Allow only same-origin app paths for observation ``from`` return links. */
+export function safeInternalPath(path) {
+  if (!path || typeof path !== 'string') return null;
+  if (!path.startsWith('/') || path.startsWith('//')) return null;
+  return path;
+}
+
+/** Link to an observation thread, optionally preserving a return URL. */
+export function observationThreadLink(observationId, returnTo, { contextLabel } = {}) {
+  const base = `/observations/${observationId}`;
+  const back = safeInternalPath(returnTo);
+  if (!back) return base;
+  const params = new URLSearchParams();
+  params.set('from', back);
+  if (contextLabel) params.set('from_label', contextLabel);
+  return `${base}?${params.toString()}`;
+}
+
+/** Label for the contextual back link on an observation thread (not the inbox). */
+export function observationContextBackLabel(returnTo, fromLabel) {
+  if (fromLabel) return `Back to ${fromLabel}`;
+  const path = safeInternalPath(returnTo);
+  if (path?.startsWith('/profile/')) return 'Back to profile';
+  if (path?.startsWith('/dashboards/group/')) return 'Back to group dashboard';
+  return 'Back';
+}
+
+/** @deprecated Use observationContextBackLabel for contextual nav. */
+export function observationBackLabel(returnTo) {
+  return observationContextBackLabel(returnTo);
+}
+
+/** Profile URL for a subject chip on an observation thread. */
+export function subjectProfileHref(subjectId, { observedDate, returnTo, canViewProfile } = {}) {
+  const from = safeInternalPath(returnTo);
+  const mayView = canViewProfile || (from?.startsWith(`/profile/${subjectId}`) ?? false);
+  if (!mayView) return null;
+  if (from?.startsWith(`/profile/${subjectId}`)) return from;
+  return profileLink(subjectId, observedDate ? { date: observedDate } : {});
+}

--- a/frontend/src/utils/dashboardLinks.test.js
+++ b/frontend/src/utils/dashboardLinks.test.js
@@ -1,11 +1,44 @@
 import { describe, expect, it } from 'vitest';
-import { profileLink, resolveProfileBackGroup } from './dashboardLinks';
+import {
+  observationBackLabel,
+  observationThreadLink,
+  profileLink,
+  resolveProfileBackGroup,
+  safeInternalPath,
+  subjectProfileHref,
+} from './dashboardLinks';
 
 describe('dashboardLinks', () => {
   it('builds profile URLs with group and date query params', () => {
     expect(profileLink(330, { groupId: 12, date: '2026-06-02' })).toBe(
       '/profile/330?group=12&date=2026-06-02',
     );
+  });
+
+  it('subjectProfileHref prefers returnTo when it matches the subject profile', () => {
+    const ret = '/profile/221?date_start=2026-05-21&date_end=2026-05-23';
+    expect(subjectProfileHref(221, { returnTo: ret, canViewProfile: false })).toBe(ret);
+    expect(subjectProfileHref(221, { observedDate: '2026-06-02', canViewProfile: true })).toBe(
+      '/profile/221?date=2026-06-02',
+    );
+    expect(subjectProfileHref(99, { canViewProfile: false })).toBeNull();
+  });
+
+  it('builds observation links with encoded return path', () => {
+    const ret = '/profile/221?date_start=2026-05-21&date_end=2026-05-23';
+    expect(observationThreadLink(9, ret)).toBe(
+      `/observations/9?from=${encodeURIComponent(ret)}`,
+    );
+    expect(observationBackLabel(ret)).toBe('Back to profile');
+    expect(safeInternalPath('//evil.com')).toBeNull();
+  });
+
+  it('builds observation links with a contextual label for group dashboards', () => {
+    const ret = '/dashboards/group/78?date=2026-06-03';
+    expect(observationThreadLink(9, ret, { contextLabel: 'Cabin Birch' })).toBe(
+      `/observations/9?from=${encodeURIComponent(ret)}&from_label=Cabin+Birch`,
+    );
+    expect(observationBackLabel(ret)).toBe('Back to group dashboard');
   });
 
   it('resolves back group from query param or single bunk', () => {


### PR DESCRIPTION
## Summary
- Scope Camper Care flags, concerns inbox, and dashboard counts to the staff member's supervised units/bunks instead of the whole program
- Persist counselor bunk on camper care orders (`submitted_from_bunk`) and show bunk clearly on the orders workspace
- Unify bunk/group dashboard notes into one chronological stream with contextual observation thread back-links
- Streamline Camper Care sidebar nav (remove My Tasks, reflections, Bunk Logs) and add group dashboard Note+

## Test plan
- [x] Backend: camper care endpoints, concerns visibility, counselor order writes, visibility tests
- [x] Frontend: Sidebar, BunkDashboard, Orders, Observations, dashboardLinks, GroupTemplateResponses
- [ ] Manual: CC home shows date-scoped flags; concerns inbox only lists caseload bunks; new orders show bunk name
- [ ] Run `make migrate` for `0046_order_submitted_from_bunk`


Made with [Cursor](https://cursor.com)