### PR TITLE
Group Performance program tabs and group dashboard score pies

### DIFF
--- a/backend/bunk_logs/api/dashboards/performance.py
+++ b/backend/bunk_logs/api/dashboards/performance.py
@@ -39,6 +39,65 @@ def _parse_date(s: str | None, default: date) -> date:
         return default
 
 
+def _program_options_from_qs(groups_qs) -> list[dict]:
+    opts: list[dict] = []
+    seen: set[int] = set()
+    for pid, name, start, end, is_active in (
+        groups_qs.values_list(
+            "program_id",
+            "program__name",
+            "program__start_date",
+            "program__end_date",
+            "program__is_active",
+        )
+        .distinct()
+        .order_by("-program__start_date")
+    ):
+        if pid in seen:
+            continue
+        seen.add(pid)
+        opts.append({
+            "id": pid,
+            "name": name,
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+            "is_active": is_active,
+        })
+    return opts
+
+
+def _current_program(program_options: list[dict], today: date) -> dict | None:
+    active = []
+    for prog in program_options:
+        if not prog.get("is_active"):
+            continue
+        start = date.fromisoformat(prog["start_date"])
+        end = date.fromisoformat(prog["end_date"])
+        if start <= today <= end:
+            active.append(prog)
+    if not active:
+        return None
+    return max(active, key=lambda p: p["start_date"])
+
+
+def _performance_response(
+    *,
+    target_date: date,
+    today: date,
+    program_options: list[dict],
+    selected_program: dict | None,
+    groups: list[dict],
+) -> dict:
+    return {
+        "date": target_date.isoformat(),
+        "today": today.isoformat(),
+        "current_program": _current_program(program_options, today),
+        "program": selected_program,
+        "programs": program_options,
+        "groups": groups,
+    }
+
+
 def _author_names_by_group(group_ids: list[int]) -> dict[int, list[str]]:
     rows = (
         AssignmentGroupMembership.objects.filter(
@@ -112,20 +171,16 @@ class GroupPerformanceDashboardView(APIView):
                 author_group_ids_with_descendants(viewer) if viewer else set()
             )
             if not visible_ids:
-                return Response({
-                    "date": target_date.isoformat(),
-                    "program": None,
-                    "programs": [],
-                    "groups": [],
-                })
+                return Response(_performance_response(
+                    target_date=target_date,
+                    today=today,
+                    program_options=[],
+                    selected_program=None,
+                    groups=[],
+                ))
             groups_qs = groups_qs.filter(id__in=visible_ids)
 
-        program_options = [
-            {"id": pid, "name": name}
-            for pid, name in groups_qs.values_list("program_id", "program__name")
-            .distinct()
-            .order_by("program__name")
-        ]
+        program_options = _program_options_from_qs(groups_qs)
 
         program_filter = (request.query_params.get("program") or "").strip()
         selected_program = None
@@ -136,15 +191,28 @@ class GroupPerformanceDashboardView(APIView):
                 if opt["id"] == pid:
                     selected_program = opt
                     break
+        else:
+            current = _current_program(program_options, today)
+            if current is None:
+                return Response(_performance_response(
+                    target_date=target_date,
+                    today=today,
+                    program_options=program_options,
+                    selected_program=None,
+                    groups=[],
+                ))
+            groups_qs = groups_qs.filter(program_id=current["id"])
+            selected_program = current
 
         groups = list(groups_qs.order_by("group_type", "name"))
         if not groups:
-            return Response({
-                "date": target_date.isoformat(),
-                "program": selected_program,
-                "programs": program_options,
-                "groups": [],
-            })
+            return Response(_performance_response(
+                target_date=target_date,
+                today=today,
+                program_options=program_options,
+                selected_program=selected_program,
+                groups=[],
+            ))
 
         group_ids = [g.id for g in groups]
         authors = _author_names_by_group(group_ids)
@@ -195,9 +263,10 @@ class GroupPerformanceDashboardView(APIView):
                 "scores": scores,
             })
 
-        return Response({
-            "date": target_date.isoformat(),
-            "program": selected_program,
-            "programs": program_options,
-            "groups": result_groups,
-        })
+        return Response(_performance_response(
+            target_date=target_date,
+            today=today,
+            program_options=program_options,
+            selected_program=selected_program,
+            groups=result_groups,
+        ))

--- a/backend/bunk_logs/api/tests/test_dashboards_performance.py
+++ b/backend/bunk_logs/api/tests/test_dashboards_performance.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import date
+from datetime import timedelta
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -16,6 +17,7 @@ from bunk_logs.core.models import Program
 from bunk_logs.core.models import Reflection
 from bunk_logs.core.models import ReflectionTemplate
 from bunk_logs.core.models import TemplateAssignment
+from bunk_logs.core.time_utils import get_today
 
 User = get_user_model()
 pytestmark = pytest.mark.django_db
@@ -172,3 +174,112 @@ def test_unauthorized_viewer_gets_empty_groups(api_client, org, program, unit_an
     resp = api_client.get(URL, **_hdr(org.slug))
     assert resp.status_code == 200
     assert resp.json()["groups"] == []
+
+
+def _setup_admin(api_client, org, program):
+    admin_user = _user("admin@perf.com")
+    admin = _person(org, "Ad", "Min", user=admin_user)
+    Membership.all_objects.create(
+        program=program, person=admin, role="admin", is_active=True,
+    )
+    api_client.force_authenticate(user=admin_user)
+    return admin_user
+
+
+def test_defaults_to_current_program_without_filter(
+    api_client, org, unit_and_bunks, scored_camper_template,
+):
+    """Omitting ?program= scopes groups to the program active today."""
+    unit, maple = unit_and_bunks
+    today = get_today(org)
+    program = maple.program
+    program.start_date = today - timedelta(days=5)
+    program.end_date = today + timedelta(days=10)
+    program.save(update_fields=["start_date", "end_date"])
+
+    program2 = Program.all_objects.create(
+        organization=org, name="Perf Org Session 2", slug="session-2",
+        program_type="summer_camp",
+        start_date=today - timedelta(days=30),
+        end_date=today + timedelta(days=10),
+    )
+    AssignmentGroup.all_objects.create(
+        organization=org, program=program2, name="Bunk Birch",
+        slug="bunk-birch", group_type="bunk",
+    )
+    _setup_admin(api_client, org, program)
+
+    resp = api_client.get(
+        URL, {"group_type": "bunk", "date": today.isoformat()}, **_hdr(org.slug),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["current_program"]["id"] == program.id
+    assert data["program"]["id"] == program.id
+    assert {g["name"] for g in data["groups"]} == {"Bunk Maple"}
+    assert data["today"] == today.isoformat()
+    prog = data["programs"][0]
+    assert "start_date" in prog
+    assert "end_date" in prog
+    assert "is_active" in prog
+
+
+def test_explicit_past_program_filter(
+    api_client, org, scored_camper_template,
+):
+    today = get_today(org)
+    past_program = Program.all_objects.create(
+        organization=org, name="Perf Org Past", slug="past-session",
+        program_type="summer_camp",
+        start_date=today - timedelta(days=60),
+        end_date=today - timedelta(days=31),
+    )
+    past_bunk = AssignmentGroup.all_objects.create(
+        organization=org, program=past_program, name="Bunk Past",
+        slug="bunk-past", group_type="bunk",
+    )
+    _assign_template(org, past_program, scored_camper_template, group=past_bunk)
+    _setup_admin(api_client, org, past_program)
+
+    resp = api_client.get(
+        URL,
+        {
+            "group_type": "bunk",
+            "program": past_program.id,
+            "date": past_program.end_date.isoformat(),
+        },
+        **_hdr(org.slug),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["program"]["id"] == past_program.id
+    assert data["current_program"] is None
+    assert {g["name"] for g in data["groups"]} == {"Bunk Past"}
+
+
+def test_no_current_program_returns_empty_groups(
+    api_client, org, scored_camper_template,
+):
+    today = get_today(org)
+    past_program = Program.all_objects.create(
+        organization=org, name="Perf Org Only Past", slug="only-past",
+        program_type="summer_camp",
+        start_date=today - timedelta(days=60),
+        end_date=today - timedelta(days=31),
+    )
+    past_bunk = AssignmentGroup.all_objects.create(
+        organization=org, program=past_program, name="Bunk Old",
+        slug="bunk-old", group_type="bunk",
+    )
+    _assign_template(org, past_program, scored_camper_template, group=past_bunk)
+    _setup_admin(api_client, org, past_program)
+
+    resp = api_client.get(
+        URL, {"group_type": "bunk", "date": today.isoformat()}, **_hdr(org.slug),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["current_program"] is None
+    assert data["program"] is None
+    assert data["groups"] == []
+    assert len(data["programs"]) == 1

--- a/frontend/src/components/GroupTemplateResponses.jsx
+++ b/frontend/src/components/GroupTemplateResponses.jsx
@@ -56,6 +56,7 @@ export default function GroupTemplateResponses({
           block={block}
           language={language}
           testidPrefix="group-template"
+          ratingChartMode="distribution"
           showSubject
           subjectProfileLink={
             profileLinkContext

--- a/frontend/src/components/__tests__/GroupTemplateResponses.test.jsx
+++ b/frontend/src/components/__tests__/GroupTemplateResponses.test.jsx
@@ -36,6 +36,37 @@ describe('GroupTemplateResponses', () => {
     vi.clearAllMocks();
   });
 
+  it('renders score distribution pies instead of sparklines for rating series', () => {
+    const withRatings = [{
+      ...templates[0],
+      schema_fields: [
+        {
+          key: 'overall',
+          type: 'single_rating',
+          scale: [1, 5],
+          prompts: { en: 'Overall' },
+        },
+      ],
+      rating_series: [{
+        label: 'overall',
+        scale_max: 5,
+        points: [
+          { date: '2026-06-03', value: 4, reflection_id: 228, scale_max: 5 },
+          { date: '2026-06-03', value: 5, reflection_id: 229, scale_max: 5 },
+        ],
+      }],
+    }];
+
+    render(
+      <MemoryRouter>
+        <GroupTemplateResponses templates={withRatings} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByLabelText(/Score distribution: 4: 1, 5: 1/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Rating trend/i)).not.toBeInTheDocument();
+  });
+
   it('shows Note + on form-response rows and opens the observation composer', async () => {
     render(
       <MemoryRouter>

--- a/frontend/src/dashboards/performance/GroupPerformanceCard.jsx
+++ b/frontend/src/dashboards/performance/GroupPerformanceCard.jsx
@@ -19,23 +19,31 @@ function ProgressBar({ percent, complete }) {
   );
 }
 
-export default function GroupPerformanceCard({ group, date }) {
+export default function GroupPerformanceCard({ group, date, program, tab }) {
   const { completion } = group;
   const complete = completion.is_complete;
-  const href = `/dashboards/group/${group.id}?date=${date}`;
+  const params = new URLSearchParams({ date });
+  if (program) params.set('program', program);
+  if (tab === 'past') params.set('tab', 'past');
+  const href = `/dashboards/group/${group.id}?${params.toString()}`;
 
   return (
     <Link
       to={href}
       data-testid={`performance-group-${group.id}`}
       className={[
-        'group block rounded-2xl border shadow-sm transition-all duration-200',
+        'group block rounded-2xl border shadow-sm overflow-hidden transition-all duration-200',
         'hover:shadow-md hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500',
         complete
-          ? 'border-emerald-300 dark:border-emerald-700 bg-gradient-to-br from-emerald-50 to-green-50 dark:from-emerald-950/40 dark:to-green-950/30'
-          : 'border-gray-200 dark:border-gray-700 bg-gradient-to-br from-white to-slate-50 dark:from-gray-900 dark:to-gray-800/80',
+          ? 'border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-950/30'
+          : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40',
       ].join(' ')}
     >
+      <div
+        className={`h-1.5 bg-gradient-to-r ${
+          complete ? 'from-emerald-500 to-green-500' : 'from-indigo-500 to-violet-500'
+        }`}
+      />
       <div className="p-5 flex flex-col gap-4 h-full">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">

--- a/frontend/src/dashboards/performance/PerformanceDashboard.jsx
+++ b/frontend/src/dashboards/performance/PerformanceDashboard.jsx
@@ -15,6 +15,18 @@ const GROUP_TYPES = [
   { value: 'custom', label: 'Custom' },
 ];
 
+const TABS = [
+  { id: 'current', label: 'Current' },
+  { id: 'past', label: 'Past' },
+];
+
+const PAST_PROGRAM_BANNERS = [
+  'from-indigo-500 to-violet-500',
+  'from-sky-500 to-indigo-500',
+  'from-violet-500 to-fuchsia-500',
+  'from-amber-500 to-orange-500',
+];
+
 function todayIso() {
   const d = new Date();
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
@@ -31,12 +43,41 @@ function formatDisplayDate(iso) {
   });
 }
 
+function formatProgramDate(iso) {
+  if (!iso) return '';
+  const parsed = new Date(`${iso}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return iso;
+  return parsed.toLocaleDateString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatProgramDateRange(start, end) {
+  if (!start || !end) return '';
+  return `${formatProgramDate(start)} → ${formatProgramDate(end)}`;
+}
+
+function isPastProgram(program, today) {
+  if (!program || !today) return false;
+  if (!program.is_active) return true;
+  return program.end_date < today;
+}
+
+function defaultDateForPastProgram(program, today) {
+  if (!program?.end_date || !today) return today || todayIso();
+  return program.end_date < today ? program.end_date : today;
+}
+
 export default function PerformanceDashboard() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const tabParam = searchParams.get('tab') || 'current';
   const dateParam = searchParams.get('date') || '';
   const groupTypeParam = searchParams.get('group_type') ?? 'bunk';
   const programParam = searchParams.get('program') || '';
 
+  const tab = tabParam === 'past' ? 'past' : 'current';
   const selectedDate = dateParam || todayIso();
   const groupType = groupTypeParam;
   const program = programParam;
@@ -48,6 +89,10 @@ export default function PerformanceDashboard() {
 
   const syncParams = useCallback((next) => {
     const params = new URLSearchParams(searchParams);
+    if (next.tab !== undefined) {
+      if (next.tab === 'past') params.set('tab', 'past');
+      else params.delete('tab');
+    }
     if (next.date) params.set('date', next.date);
     else if (next.date === '') params.delete('date');
     if (next.group_type !== undefined) {
@@ -61,7 +106,11 @@ export default function PerformanceDashboard() {
     setSearchParams(params, { replace: true });
   }, [searchParams, setSearchParams]);
 
+  const shouldFetchGroups = tab === 'current' || (tab === 'past' && program);
+
   const load = useCallback(async () => {
+    if (!shouldFetchGroups && programOptions.length > 0) return;
+
     setLoading(true);
     setError(null);
     try {
@@ -82,89 +131,159 @@ export default function PerformanceDashboard() {
     } finally {
       setLoading(false);
     }
-  }, [groupType, program, selectedDate]);
+  }, [groupType, program, selectedDate, shouldFetchGroups, programOptions.length]);
 
   useEffect(() => {
     load();
   }, [load]);
 
-  const programName = useMemo(() => {
-    if (!program) return null;
-    return (
-      payload?.program?.name
-      ?? programOptions.find((p) => String(p.id) === String(program))?.name
-      ?? null
-    );
-  }, [program, payload, programOptions]);
-  const groups = payload?.groups ?? [];
+  useEffect(() => {
+    if (!payload || tab !== 'current' || program) return;
+    if (payload.current_program?.id) {
+      syncParams({ program: String(payload.current_program.id) });
+    }
+  }, [payload, tab, program, syncParams]);
+
+  const orgToday = payload?.today ?? null;
+
+  const selectedProgramMeta = useMemo(() => {
+    if (program) {
+      return programOptions.find((p) => String(p.id) === String(program))
+        ?? (payload?.program && String(payload.program.id) === String(program) ? payload.program : null);
+    }
+    return payload?.current_program ?? payload?.program ?? null;
+  }, [payload, program, programOptions]);
+
+  const pastPrograms = useMemo(
+    () => programOptions.filter((p) => isPastProgram(p, orgToday)),
+    [programOptions, orgToday],
+  );
+
+  const showGroups = tab === 'current'
+    ? Boolean(payload?.current_program)
+    : Boolean(program);
+
+  const groups = showGroups ? (payload?.groups ?? []) : [];
   const completeCount = useMemo(
     () => groups.filter((g) => g.completion?.is_complete).length,
     [groups],
   );
 
+  const handleTabChange = (nextTab) => {
+    if (nextTab === 'current') {
+      const currentId = payload?.current_program?.id;
+      syncParams({
+        tab: 'current',
+        program: currentId ? String(currentId) : '',
+      });
+      return;
+    }
+    syncParams({ tab: 'past', program: '' });
+  };
+
+  const handlePastProgramSelect = (pastProgram) => {
+    const nextDate = defaultDateForPastProgram(pastProgram, orgToday);
+    syncParams({
+      tab: 'past',
+      program: String(pastProgram.id),
+      date: nextDate,
+    });
+  };
+
   return (
     <div className="px-4 sm:px-6 lg:px-8 py-8 w-full max-w-[96rem] mx-auto">
-      <header className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
-            Group Performance
-          </h1>
-          {programName && (
-            <p
-              data-testid="performance-program-name"
-              className="text-lg font-medium text-indigo-700 dark:text-indigo-300 mt-1"
-            >
-              {programName}
-            </p>
+      <header className="mb-6 flex flex-col gap-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
+              Group Performance
+            </h1>
+            {selectedProgramMeta && showGroups && (
+              <>
+                <p
+                  data-testid="performance-program-name"
+                  className="text-lg font-medium text-indigo-700 dark:text-indigo-300 mt-1"
+                >
+                  {selectedProgramMeta.name}
+                </p>
+                <p
+                  data-testid="performance-program-dates"
+                  className="text-sm text-gray-600 dark:text-gray-300 mt-0.5"
+                >
+                  {formatProgramDateRange(
+                    selectedProgramMeta.start_date,
+                    selectedProgramMeta.end_date,
+                  )}
+                </p>
+              </>
+            )}
+            {showGroups && (
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+                {formatDisplayDate(payload?.date || selectedDate)}
+              </p>
+            )}
+          </div>
+
+          {showGroups && (
+            <div className="flex flex-wrap items-center gap-3">
+              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                <span>Group type</span>
+                <select
+                  value={groupType}
+                  onChange={(e) => syncParams({ group_type: e.target.value })}
+                  className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-sm"
+                >
+                  {GROUP_TYPES.map((g) => (
+                    <option key={g.value} value={g.value}>{g.label}</option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                <span>Date</span>
+                <input
+                  type="date"
+                  value={selectedDate}
+                  onChange={(e) => syncParams({ date: e.target.value })}
+                  data-testid="performance-date-picker"
+                  className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-sm"
+                />
+              </label>
+              <button
+                type="button"
+                onClick={load}
+                className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500"
+              >
+                Refresh
+              </button>
+            </div>
           )}
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
-            {formatDisplayDate(payload?.date || selectedDate)}
-          </p>
         </div>
 
-        <div className="flex flex-wrap items-center gap-3">
-          <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-            <span>Program</span>
-            <select
-              value={program}
-              onChange={(e) => syncParams({ program: e.target.value })}
-              className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-sm"
-            >
-              <option value="">All programs</option>
-              {programOptions.map((p) => (
-                <option key={p.id} value={p.id}>{p.name}</option>
-              ))}
-            </select>
-          </label>
-          <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-            <span>Group type</span>
-            <select
-              value={groupType}
-              onChange={(e) => syncParams({ group_type: e.target.value })}
-              className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-sm"
-            >
-              {GROUP_TYPES.map((g) => (
-                <option key={g.value} value={g.value}>{g.label}</option>
-              ))}
-            </select>
-          </label>
-          <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-            <span>Date</span>
-            <input
-              type="date"
-              value={selectedDate}
-              onChange={(e) => syncParams({ date: e.target.value })}
-              data-testid="performance-date-picker"
-              className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-sm"
-            />
-          </label>
-          <button
-            type="button"
-            onClick={load}
-            className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500"
-          >
-            Refresh
-          </button>
+        <div
+          className="flex flex-wrap gap-2"
+          role="tablist"
+          aria-label="Program period"
+        >
+          {TABS.map((view) => {
+            const active = tab === view.id;
+            return (
+              <button
+                key={view.id}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                data-testid={`performance-tab-${view.id}`}
+                onClick={() => handleTabChange(view.id)}
+                className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                  active
+                    ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300'
+                    : 'bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                }`}
+              >
+                {view.label}
+              </button>
+            );
+          })}
         </div>
       </header>
 
@@ -180,8 +299,78 @@ export default function PerformanceDashboard() {
         <p className="text-rose-600 dark:text-rose-400 text-sm">{error}</p>
       )}
 
-      {!loading && payload && (
+      {!loading && payload && tab === 'current' && !payload.current_program && (
+        <div
+          className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-6 text-center"
+          data-testid="performance-no-current-program"
+        >
+          <p className="text-sm text-gray-700 dark:text-gray-300">
+            No program is active today.
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+            Browse past programs on the{' '}
+            <button
+              type="button"
+              onClick={() => handleTabChange('past')}
+              className="text-indigo-600 dark:text-indigo-400 font-medium hover:underline"
+            >
+              Past
+            </button>
+            {' '}tab.
+          </p>
+        </div>
+      )}
+
+      {!loading && payload && tab === 'past' && !program && (
         <>
+          {pastPrograms.length === 0 ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-12">
+              No past programs available.
+            </p>
+          ) : (
+            <div
+              className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4"
+              data-testid="past-program-tiles"
+            >
+              {pastPrograms.map((pastProgram, index) => (
+                <button
+                  key={pastProgram.id}
+                  type="button"
+                  data-testid={`past-program-tile-${pastProgram.id}`}
+                  onClick={() => handlePastProgramSelect(pastProgram)}
+                  className="text-left rounded-2xl border border-gray-200 dark:border-gray-700 bg-gradient-to-br from-white to-slate-50 dark:from-gray-900 dark:to-gray-800/80 shadow-sm overflow-hidden hover:shadow-md hover:-translate-y-0.5 transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                >
+                  <div
+                    className={`h-1.5 bg-gradient-to-r ${PAST_PROGRAM_BANNERS[index % PAST_PROGRAM_BANNERS.length]}`}
+                  />
+                  <div className="p-5">
+                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                      {pastProgram.name}
+                    </h3>
+                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                      {formatProgramDateRange(pastProgram.start_date, pastProgram.end_date)}
+                    </p>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {!loading && payload && showGroups && (
+        <>
+          {tab === 'past' && program && (
+            <button
+              type="button"
+              onClick={() => syncParams({ tab: 'past', program: '' })}
+              className="mb-4 text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:underline"
+              data-testid="past-programs-back"
+            >
+              ← Past programs
+            </button>
+          )}
+
           {groups.length > 0 && (
             <div className="mb-6 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 px-4 py-3">
               <p className="text-sm font-medium text-gray-900 dark:text-white">
@@ -205,7 +394,9 @@ export default function PerformanceDashboard() {
                 <GroupPerformanceCard
                   key={group.id}
                   group={group}
-                  date={payload.date}
+                  date={payload?.date || selectedDate}
+                  program={program}
+                  tab={tab}
                 />
               ))}
             </div>

--- a/frontend/src/dashboards/performance/__tests__/PerformanceDashboard.test.jsx
+++ b/frontend/src/dashboards/performance/__tests__/PerformanceDashboard.test.jsx
@@ -10,71 +10,153 @@ vi.mock('../../../api', () => ({
 
 import api from '../../../api';
 
-const payload = {
-  date: '2026-07-10',
-  program: null,
-  programs: [{ id: 1, name: 'Summer 2026' }],
-  groups: [
-    {
-      id: 5,
-      name: 'Bunk Maple',
-      group_type: 'bunk',
-      parent_name: 'Unit Aleph',
-      author_names: ['Sam Counselor'],
-      completion: { submitted: 2, expected: 3, percent: 67, is_complete: false },
-      scores: { scale_max: 5, distribution: { '4': 2, '5': 1 }, total_ratings: 3 },
-    },
-    {
-      id: 6,
-      name: 'Bunk Oak',
-      group_type: 'bunk',
-      parent_name: 'Unit Aleph',
-      author_names: ['Alex Counselor'],
-      completion: { submitted: 4, expected: 4, percent: 100, is_complete: true },
-      scores: { scale_max: 5, distribution: { '5': 4 }, total_ratings: 4 },
-    },
-  ],
+const currentProgram = {
+  id: 1,
+  name: 'Summer 2026',
+  start_date: '2026-06-01',
+  end_date: '2026-08-31',
+  is_active: true,
 };
+
+const pastProgram = {
+  id: 2,
+  name: 'Summer 2025',
+  start_date: '2025-06-01',
+  end_date: '2025-08-31',
+  is_active: false,
+};
+
+const groups = [
+  {
+    id: 5,
+    name: 'Bunk Maple',
+    group_type: 'bunk',
+    parent_name: 'Unit Aleph',
+    author_names: ['Sam Counselor'],
+    completion: { submitted: 2, expected: 3, percent: 67, is_complete: false },
+    scores: { scale_max: 5, distribution: { '4': 2, '5': 1 }, total_ratings: 3 },
+  },
+  {
+    id: 6,
+    name: 'Bunk Oak',
+    group_type: 'bunk',
+    parent_name: 'Unit Aleph',
+    author_names: ['Alex Counselor'],
+    completion: { submitted: 4, expected: 4, percent: 100, is_complete: true },
+    scores: { scale_max: 5, distribution: { '5': 4 }, total_ratings: 4 },
+  },
+];
+
+const payloadWithCurrent = {
+  date: '2026-07-10',
+  today: '2026-07-10',
+  current_program: currentProgram,
+  program: currentProgram,
+  programs: [currentProgram, pastProgram],
+  groups,
+};
+
+function renderDashboard(initialEntry = '/groups/performance?date=2026-07-10&group_type=bunk&program=1') {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/groups/performance" element={<PerformanceDashboard />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
 
 describe('PerformanceDashboard', () => {
   beforeEach(() => {
-    vi.mocked(api.get).mockResolvedValue({ data: payload });
+    vi.mocked(api.get).mockResolvedValue({ data: payloadWithCurrent });
   });
 
-  it('renders filters, group cards, and program name when a program is selected', async () => {
-    const user = userEvent.setup();
-    render(
-      <MemoryRouter initialEntries={['/groups/performance?date=2026-07-10&group_type=bunk']}>
-        <Routes>
-          <Route path="/groups/performance" element={<PerformanceDashboard />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+  it('renders current tab with program name, dates, filters, and group cards', async () => {
+    renderDashboard();
 
     await waitFor(() => {
       expect(screen.getByText('Bunk Maple')).toBeInTheDocument();
     });
 
-    expect(screen.queryByTestId('performance-program-name')).not.toBeInTheDocument();
-
-    await user.selectOptions(screen.getByDisplayValue('All programs'), '1');
-
-    await waitFor(() => {
-      expect(screen.getByTestId('performance-program-name')).toHaveTextContent('Summer 2026');
-    });
+    expect(screen.getByTestId('performance-program-name')).toHaveTextContent('Summer 2026');
+    expect(screen.getByTestId('performance-program-dates')).toHaveTextContent('June 1, 2026');
+    expect(screen.getByTestId('performance-tab-current')).toHaveAttribute('aria-selected', 'true');
     expect(screen.getByText('Sam Counselor')).toBeInTheDocument();
 
     const mapleLink = screen.getByTestId('performance-group-5');
-    expect(mapleLink).toHaveAttribute('href', '/dashboards/group/5?date=2026-07-10');
+    expect(mapleLink).toHaveAttribute('href', '/dashboards/group/5?date=2026-07-10&program=1');
 
     expect(api.get).toHaveBeenCalledWith(
       '/api/v1/dashboards/groups/performance/',
       expect.objectContaining({
-        params: expect.objectContaining({ group_type: 'bunk', date: '2026-07-10' }),
+        params: expect.objectContaining({
+          group_type: 'bunk',
+          date: '2026-07-10',
+          program: '1',
+        }),
       }),
     );
 
-    const dateInput = screen.getByTestId('performance-date-picker');
-    expect(dateInput).toHaveValue('2026-07-10');
+    expect(screen.getByTestId('performance-date-picker')).toHaveValue('2026-07-10');
+  });
+
+  it('shows past program tiles and drills into a selected program', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockImplementation(async (_url, config) => {
+      const programId = config?.params?.program;
+      if (String(programId) === '2') {
+        return {
+          data: {
+            ...payloadWithCurrent,
+            date: '2025-08-31',
+            program: pastProgram,
+            groups,
+          },
+        };
+      }
+      return { data: payloadWithCurrent };
+    });
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Bunk Maple')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('performance-tab-past'));
+
+    expect(screen.getByTestId('past-program-tile-2')).toBeInTheDocument();
+    expect(screen.queryByTestId('performance-groups')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('past-program-tile-2'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('performance-program-name')).toHaveTextContent('Summer 2025');
+    });
+    expect(screen.getByTestId('past-programs-back')).toBeInTheDocument();
+    expect(screen.getByTestId('performance-group-5')).toHaveAttribute(
+      'href',
+      '/dashboards/group/5?date=2025-08-31&program=2&tab=past',
+    );
+  });
+
+  it('shows empty state when no current program is active', async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: {
+        date: '2026-01-15',
+        today: '2026-01-15',
+        current_program: null,
+        program: null,
+        programs: [pastProgram],
+        groups: [],
+      },
+    });
+
+    renderDashboard('/groups/performance?date=2026-01-15&group_type=bunk');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('performance-no-current-program')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/No program is active today/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/dashboards/subject/responseTable/FormResponsesCard.jsx
+++ b/frontend/src/dashboards/subject/responseTable/FormResponsesCard.jsx
@@ -2,7 +2,8 @@
  * Shared per-template form-responses widget.
  *
  * Renders a collapsible card for one reflection template: KPI tiles,
- * rating-trend sparklines, and a schema-aware response table. Used by
+ * rating charts (sparklines on subject profiles, score distributions on
+ * single-day group views), and a schema-aware response table. Used by
  * the per-subject dashboard (`SubjectDetail`) and the unified group
  * dashboard (`GroupTemplateResponses`).
  *
@@ -18,6 +19,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { AlertTriangle, FileText, Users } from 'lucide-react';
 import PrivacyChip from '../../../components/reflection/PrivacyChip';
+import ScorePieChart from '../../performance/ScorePieChart';
 import { ratingColor } from '../../colors';
 import {
   deriveSchemaSections,
@@ -49,6 +51,34 @@ export function KpiTile({ icon: Icon, label, value, tone = 'neutral' }) {
           <p className="text-xl font-semibold text-gray-900 dark:text-white">{value}</p>
         </div>
       </div>
+    </div>
+  );
+}
+
+function pointsToDistribution(points) {
+  const dist = {};
+  for (const p of points) {
+    if (p.value == null) continue;
+    const key = String(Math.round(p.value));
+    dist[key] = (dist[key] || 0) + 1;
+  }
+  return dist;
+}
+
+export function RatingDistribution({ points, scaleMax = 5, ariaLabel }) {
+  const distribution = pointsToDistribution(points);
+  const total = Object.values(distribution).reduce((sum, count) => sum + count, 0);
+  if (total === 0) {
+    return <p className="text-xs text-gray-400 italic">No rating data in this window.</p>;
+  }
+  const legend = Object.entries(distribution)
+    .sort(([a], [b]) => Number(a) - Number(b))
+    .map(([value, count]) => `${value}: ${count}`)
+    .join(' · ');
+  return (
+    <div className="flex flex-col items-center gap-2" aria-label={ariaLabel}>
+      <ScorePieChart distribution={distribution} scaleMax={scaleMax} size={96} />
+      <p className="text-[10px] text-gray-500 dark:text-gray-400 text-center">{legend}</p>
     </div>
   );
 }
@@ -104,6 +134,7 @@ export default function FormResponsesCard({
   subjectProfileLink = null,
   personId = null,
   onAddObservation = null,
+  ratingChartMode = 'sparkline',
 }) {
   const tpl = block.template ?? {};
   const reflections = block.reflections ?? [];
@@ -209,18 +240,22 @@ export default function FormResponsesCard({
             })}
           </div>
 
-          {/* Trends */}
+          {/* Rating charts: trends on subject profiles, distributions on group day views */}
           {series.length > 0 && (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4" data-testid={`${testidPrefix}-trends-${tpl.id}`}>
               {series.map((s) => {
                 const displayLabel = seriesDisplayLabel(s.label, ratingCols);
+                const Chart = ratingChartMode === 'distribution' ? RatingDistribution : RatingSparkline;
+                const chartAriaLabel = ratingChartMode === 'distribution'
+                  ? `Rating distribution for ${displayLabel}`
+                  : `Rating trend for ${displayLabel}`;
                 return (
                   <div key={s.label} className="rounded-lg border border-gray-200 dark:border-gray-700 p-3">
                     <p className="text-xs text-center font-medium text-gray-700 dark:text-gray-200 mb-1">{displayLabel}</p>
-                    <RatingSparkline
+                    <Chart
                       points={s.points}
                       scaleMax={s.scale_max}
-                      ariaLabel={`Rating trend for ${displayLabel}`}
+                      ariaLabel={chartAriaLabel}
                     />
                   </div>
                 );

--- a/frontend/src/pages/dashboards/GroupDashboardPage.jsx
+++ b/frontend/src/pages/dashboards/GroupDashboardPage.jsx
@@ -37,11 +37,14 @@ const BACK_TO_BY_ROLE = Object.freeze({
 
 const ADMIN_BACK_TO = '/groups/performance';
 
-function backToFor(role, date) {
+function backToFor(role, { date, program, tab } = {}) {
   if (role === 'admin') {
-    return date
-      ? `${ADMIN_BACK_TO}?date=${encodeURIComponent(date)}`
-      : ADMIN_BACK_TO;
+    const params = new URLSearchParams();
+    if (date) params.set('date', date);
+    if (program) params.set('program', program);
+    if (tab === 'past') params.set('tab', 'past');
+    const query = params.toString();
+    return query ? `${ADMIN_BACK_TO}?${query}` : ADMIN_BACK_TO;
   }
   return BACK_TO_BY_ROLE[role] ?? FALLBACK_BACK_TO;
 }
@@ -159,7 +162,11 @@ export default function GroupDashboardPage() {
   const role = data?.role_context?.role;
   const groupType = data?.role_context?.group_type;
   const Dash = COMPONENT_BY_GROUP_TYPE[groupType];
-  const backTo = backToFor(role, dateParam || data?.header?.date);
+  const backTo = backToFor(role, {
+    date: dateParam || data?.header?.date,
+    program: searchParams.get('program') || '',
+    tab: searchParams.get('tab') || '',
+  });
 
   if (!Dash) {
     return (

--- a/frontend/src/pages/dashboards/__tests__/GroupDashboardPage.test.jsx
+++ b/frontend/src/pages/dashboards/__tests__/GroupDashboardPage.test.jsx
@@ -148,6 +148,16 @@ describe('GroupDashboardPage', () => {
     expect(backLink).toHaveAttribute('href', '/groups/performance?date=2026-06-03');
   });
 
+  it('routes admin back link preserving program and past tab', async () => {
+    getMock.mockResolvedValueOnce({ data: bunkPayload('admin') });
+    renderAt('/dashboards/group/11?date=2026-06-03&program=2&tab=past');
+    const backLink = await screen.findByRole('link', { name: /back/i });
+    expect(backLink).toHaveAttribute(
+      'href',
+      '/groups/performance?date=2026-06-03&program=2&tab=past',
+    );
+  });
+
   it('falls back to /dashboards when role_context is missing', async () => {
     const payload = bunkPayload('camper_care');
     delete payload.role_context;


### PR DESCRIPTION
## Summary
- Replace the Group Performance "All programs" dropdown with Current/Past tabs that auto-scope to the active program (by org date) and let users browse past programs via selectable tiles.
- Extend the performance API with program date metadata, `today`, `current_program`, and server-side default program filtering.
- Show score distribution pie charts on single-day group dashboards (`/dashboards/group/:id`) while keeping rating sparklines on person profile pages.

## Test plan
- [x] `pytest bunk_logs/api/tests/test_dashboards_performance.py`
- [x] `vitest` for PerformanceDashboard, GroupDashboardPage, GroupTemplateResponses
- [ ] Manual: land on `/groups/performance` → Current tab shows today's program groups
- [ ] Manual: Past tab → program tiles → drill into groups; back link preserves tab/program/date
- [ ] Manual: `/dashboards/group/:id` shows pie charts for rating fields; subject profile still shows sparklines


Made with [Cursor](https://cursor.com)