### PR TITLE
Filter profile observations by date and improve presentation

### DIFF
--- a/backend/bunk_logs/api/dashboards/subject.py
+++ b/backend/bunk_logs/api/dashboards/subject.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 from collections import defaultdict
 from datetime import date
+from datetime import datetime
+from datetime import time
 from datetime import timedelta
 from typing import Any
 
@@ -29,6 +31,7 @@ from bunk_logs.core.models import Person
 from bunk_logs.core.models import Reflection
 from bunk_logs.core.permissions.observation_read import filter_observations_readable
 from bunk_logs.core.permissions.subject_dashboard import can_view_subject_dashboard
+from bunk_logs.core.time_utils import get_org_timezone
 from bunk_logs.notes.models import Observation
 
 DEFAULT_WINDOW_DAYS = 30
@@ -121,15 +124,26 @@ def _observations_for_viewer(
     subject: Person,
     org,
     user,
+    *,
+    start: date,
+    end: date,
     limit: int = 50,
 ) -> list[dict[str, Any]]:
     """Return Observations about ``subject`` the viewer may read, newest first.
 
     Step 7_23 Profile feed: every observation the viewer may read about this
-    person, replacing the SubjectNote block as callers migrate.
+    person within ``start``..``end`` (org-TZ day buckets on ``observed_at``).
     """
+    tz = get_org_timezone(org)
+    range_start = datetime.combine(start, time.min, tzinfo=tz)
+    range_end = datetime.combine(end, time.min, tzinfo=tz) + timedelta(days=1)
     base = (
-        Observation.all_objects.filter(organization=org, subject_links__subject=subject)
+        Observation.all_objects.filter(
+            organization=org,
+            subject_links__subject=subject,
+            observed_at__gte=range_start,
+            observed_at__lt=range_end,
+        )
         .select_related("author")
         .prefetch_related("subject_links__subject")
     )
@@ -370,7 +384,10 @@ class SubjectDetailView(APIView):
 
         concerns = _detect_concerning_patterns(all_series, today)
 
-        observations = _observations_for_viewer(viewer_person, subject, org, request.user)
+        observations = _observations_for_viewer(
+            viewer_person, subject, org, request.user,
+            start=cur_start, end=cur_end,
+        )
 
         return Response({
             "subject": {

--- a/backend/bunk_logs/api/tests/test_dashboards_subject.py
+++ b/backend/bunk_logs/api/tests/test_dashboards_subject.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 from datetime import date
+from datetime import datetime
+from datetime import time
 from datetime import timedelta
 
 import pytest
@@ -16,6 +18,10 @@ from bunk_logs.core.models import Person
 from bunk_logs.core.models import Program
 from bunk_logs.core.models import Reflection
 from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.time_utils import get_org_timezone
+from bunk_logs.core.time_utils import get_today
+from bunk_logs.notes.models import Observation
+from bunk_logs.notes.models import ObservationSubject
 
 User = get_user_model()
 pytestmark = pytest.mark.django_db
@@ -494,3 +500,53 @@ def test_subject_visible_true_allows_camper_self_view(api_client, org, program, 
     )
     body = r.json()
     assert any(t["template"]["id"] == visible_tpl.id for t in body["templates"])
+
+
+def test_subject_dashboard_observations_bucketed_by_observed_at_date(
+    api_client, org, program, setup,
+):
+    _, camper, counselor_user, counselor = setup
+    today = get_today(org)
+    yesterday = today - timedelta(days=1)
+    tz = get_org_timezone(org)
+    today_noon = datetime.combine(today, time(12, 0), tzinfo=tz)
+    yesterday_noon = datetime.combine(yesterday, time(12, 0), tzinfo=tz)
+
+    obs_today = Observation.all_objects.create(
+        organization=org,
+        program=program,
+        author=counselor,
+        author_role_at_write="counselor",
+        body="Note today",
+        observed_at=today_noon,
+    )
+    ObservationSubject.objects.create(observation=obs_today, subject=camper)
+    obs_yesterday = Observation.all_objects.create(
+        organization=org,
+        program=program,
+        author=counselor,
+        author_role_at_write="counselor",
+        body="Note yesterday",
+        observed_at=yesterday_noon,
+    )
+    ObservationSubject.objects.create(observation=obs_yesterday, subject=camper)
+
+    api_client.force_authenticate(user=counselor_user)
+    today_resp = api_client.get(
+        f"/api/v1/dashboards/subject/{camper.id}/"
+        f"?date_start={today.isoformat()}&date_end={today.isoformat()}",
+        **_hdr(org.slug),
+    )
+    yest_resp = api_client.get(
+        f"/api/v1/dashboards/subject/{camper.id}/"
+        f"?date_start={yesterday.isoformat()}&date_end={yesterday.isoformat()}",
+        **_hdr(org.slug),
+    )
+    assert today_resp.status_code == 200, today_resp.content
+    assert yest_resp.status_code == 200, yest_resp.content
+    today_ids = {o["id"] for o in today_resp.json().get("observations", [])}
+    yest_ids = {o["id"] for o in yest_resp.json().get("observations", [])}
+    assert obs_today.id in today_ids
+    assert obs_yesterday.id not in today_ids
+    assert obs_yesterday.id in yest_ids
+    assert obs_today.id not in yest_ids

--- a/frontend/src/dashboards/subject/SubjectDetail.jsx
+++ b/frontend/src/dashboards/subject/SubjectDetail.jsx
@@ -15,7 +15,7 @@
 import { useMemo, useState } from 'react';
 import RichText from '../../components/ui/RichText';
 import { Link, useNavigate } from 'react-router-dom';
-import { AlertTriangle, MessageSquarePlus } from 'lucide-react';
+import { MessageSquarePlus } from 'lucide-react';
 import {
   groupDashboardLink,
   observationThreadLink,
@@ -274,74 +274,6 @@ function PeriodStepper({ period, rangeStart, rangeEnd, onRangeChange, refreshing
 }
 
 // ---------------------------------------------------------------------------
-// Concerns
-// ---------------------------------------------------------------------------
-
-/** Map reflection id → assignment group (+ row date) from template blocks. */
-function buildReflectionGroupById(templates) {
-  const map = new Map();
-  for (const t of templates ?? []) {
-    for (const r of t.reflections ?? []) {
-      if (r.assignment_group?.id) {
-        map.set(r.id, r.assignment_group);
-      }
-    }
-  }
-  return map;
-}
-
-function ConcernsAlert({ concerns, reflectionGroupById }) {
-  if (!concerns || concerns.length === 0) return null;
-  return (
-    <section
-      className="mb-6 rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 p-4"
-      data-testid="subject-concerns"
-    >
-      <div className="flex items-start gap-2">
-        <AlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-300 shrink-0 mt-0.5" />
-        <div className="flex-1">
-          <h3 className="font-medium text-amber-900 dark:text-amber-100 mb-2">
-            Concerning patterns ({concerns.length})
-          </h3>
-          <ul className="text-sm text-amber-900 dark:text-amber-100 space-y-1">
-            {concerns.map((c, i) => {
-              const key = `${c.kind}-${c.field_label}-${i}`;
-              if (c.kind === 'low_rating') {
-                const ag = c.reflection_id ? reflectionGroupById?.get(c.reflection_id) : null;
-                return (
-                  <li key={key} className="flex flex-wrap items-center gap-2">
-                    <span>
-                      <strong>{c.field_label}</strong>: rating of {c.value} on {formatShortDate(c.date)}.
-                    </span>
-                    <PrivacyChip teamVisibility={c.team_visibility} />
-                    {ag?.id && (
-                      <Link
-                        to={`/dashboards/group/${ag.id}?date=${c.date}`}
-                        className="underline"
-                      >
-                        View {ag.name ?? 'group'}
-                      </Link>
-                    )}
-                  </li>
-                );
-              }
-              if (c.kind === 'downward_trend') {
-                return (
-                  <li key={key}>
-                    <strong>{c.field_label}</strong>: recent week ({c.recent_mean}) is lower than prior week ({c.prior_mean}) by more than 0.5.
-                  </li>
-                );
-              }
-              return <li key={key}>{c.kind}: {c.field_label}</li>;
-            })}
-          </ul>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Recent text responses
 // ---------------------------------------------------------------------------
 
@@ -387,6 +319,12 @@ const SENSITIVITY_LABEL = {
   domain: 'Domain',
   confidential: 'Confidential',
 };
+
+function formatObservationWhen(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? '' : d.toLocaleString();
+}
 
 function ObservationsPanel({ observations = [], onCompose, profileReturnTo = null }) {
   const [open, setOpen] = useState(true);
@@ -444,34 +382,46 @@ function ObservationsPanel({ observations = [], onCompose, profileReturnTo = nul
         <div className="p-4">
           {sorted.length === 0 ? (
             <p className="text-sm text-gray-500 dark:text-gray-400 italic" data-testid="observations-empty">
-              No observations yet.
+              No observations in this period.
             </p>
           ) : (
             <ul className="space-y-3">
-              {sorted.map((o) => (
-                <li key={o.id}>
-                  <Link
-                    to={observationThreadLink(o.id, profileReturnTo)}
-                    className="block rounded-lg border border-gray-200 dark:border-gray-700 p-3 hover:bg-gray-50 dark:hover:bg-gray-700/40"
-                  >
-                    <div className="flex items-center gap-2 mb-1">
-                      <span className="text-xs rounded-full bg-amber-50 dark:bg-amber-900/20 px-2 py-0.5 text-amber-800 dark:text-amber-200">
-                        {SENSITIVITY_LABEL[o.sensitivity] ?? o.sensitivity}
-                      </span>
-                      {o.context && (
-                        <span className="text-xs text-gray-400">{o.context}</span>
-                      )}
-                      {o.author && (
-                        <span className="text-xs text-gray-400 ml-auto">{o.author.name}</span>
-                      )}
-                    </div>
-                    <RichText
-                      html={o.body}
-                      className="text-sm text-gray-800 dark:text-gray-200 break-words [&_p]:mb-1 last:[&_p]:mb-0"
-                    />
-                  </Link>
-                </li>
-              ))}
+              {sorted.map((o) => {
+                const whenIso = o.observed_at || o.created_at;
+                const whenLabel = formatObservationWhen(whenIso);
+                return (
+                  <li key={o.id}>
+                    <Link
+                      to={observationThreadLink(o.id, profileReturnTo)}
+                      className="block rounded-lg border border-gray-200 dark:border-gray-700 p-3 hover:bg-gray-50 dark:hover:bg-gray-700/40"
+                    >
+                      <div className="flex items-center gap-2 mb-1 flex-wrap">
+                        <span className="text-xs rounded-full bg-amber-50 dark:bg-amber-900/20 px-2 py-0.5 text-amber-800 dark:text-amber-200">
+                          {SENSITIVITY_LABEL[o.sensitivity] ?? o.sensitivity}
+                        </span>
+                        {o.context && (
+                          <span className="text-xs text-gray-400">{o.context}</span>
+                        )}
+                        <div className="ml-auto flex items-center gap-2 shrink-0 text-xs text-gray-500 dark:text-gray-400">
+                          {whenLabel && (
+                            <time
+                              dateTime={whenIso}
+                              data-testid={`observation-when-${o.id}`}
+                            >
+                              {whenLabel}
+                            </time>
+                          )}
+                          {o.author && <span>{o.author.name}</span>}
+                        </div>
+                      </div>
+                      <RichText
+                        html={o.body}
+                        className="text-sm text-gray-800 dark:text-gray-200 break-words [&_p]:mb-1 last:[&_p]:mb-0"
+                      />
+                    </Link>
+                  </li>
+                );
+              })}
             </ul>
           )}
         </div>
@@ -500,14 +450,9 @@ export default function SubjectDetail({
     period,
     templates,
     recent_texts: recentTexts,
-    concerning_patterns: concerns,
     observations,
   } = payload;
   const language = profile?.preferred_language ?? 'en';
-  const reflectionGroupById = useMemo(
-    () => buildReflectionGroupById(templates),
-    [templates],
-  );
   const navigate = useNavigate();
   const [composeObservation, setComposeObservation] = useState(null);
 
@@ -515,6 +460,11 @@ export default function SubjectDetail({
     setComposeObservation({
       observedAtLocal: date ? dateOnlyToLocalDatetime(date) : null,
     });
+  };
+
+  const composeFromPanel = () => {
+    const singleDay = rangeStart && rangeStart === rangeEnd ? rangeEnd : null;
+    openCompose(singleDay);
   };
 
   return (
@@ -533,7 +483,6 @@ export default function SubjectDetail({
         onRangeChange={onRangeChange}
         refreshing={refreshing}
       />
-      <ConcernsAlert concerns={concerns} reflectionGroupById={reflectionGroupById} />
 
       {(!templates || templates.length === 0) ? (
         <p className="text-sm text-gray-500 dark:text-gray-400" data-testid="subject-empty">
@@ -554,7 +503,7 @@ export default function SubjectDetail({
       {/*<RecentTexts texts={recentTexts} />*/}
       <ObservationsPanel
         observations={observations ?? []}
-        onCompose={personId ? () => openCompose() : null}
+        onCompose={personId ? composeFromPanel : null}
         profileReturnTo={profileReturnTo}
       />
       {composeObservation && (

--- a/frontend/src/dashboards/subject/__tests__/SubjectDetail.test.jsx
+++ b/frontend/src/dashboards/subject/__tests__/SubjectDetail.test.jsx
@@ -288,4 +288,42 @@ describe('SubjectDetail', () => {
     expect(onRangeChange).toHaveBeenCalledWith('2026-05-21', '2026-05-31');
   });
 
+  it('shows observations empty state when none in the selected period', () => {
+    renderDetail({ observations: [] });
+    expect(screen.getByTestId('observations-empty')).toHaveTextContent(
+      'No observations in this period.',
+    );
+  });
+
+  it('renders observations returned for the selected period', () => {
+    renderDetail({
+      observations: [
+        {
+          id: 42,
+          body: '<p>Swim note</p>',
+          sensitivity: 'normal',
+          context: 'swim_instruction',
+          observed_at: '2026-05-23T15:00:00Z',
+          author: { id: 9, name: 'BulkCounselor #9' },
+        },
+      ],
+    });
+    const panel = screen.getByTestId('observations-panel');
+    expect(within(panel).getByText('Swim note')).toBeInTheDocument();
+    expect(within(panel).getByText('BulkCounselor #9')).toBeInTheDocument();
+    const when = within(panel).getByTestId('observation-when-42');
+    expect(when).toHaveAttribute('dateTime', '2026-05-23T15:00:00Z');
+    expect(when.textContent).toBeTruthy();
+  });
+
+  it('pre-fills observation date from panel when viewing a single day', async () => {
+    renderDetail({}, { rangeStart: '2026-05-23', rangeEnd: '2026-05-23' });
+    fireEvent.click(screen.getByTestId('observation-add-btn'));
+    await waitFor(() => {
+      expect(screen.getByTestId('observation-composer-observed-at')).toHaveValue(
+        '2026-05-23T12:00',
+      );
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary
- Filter profile observations by the selected date period on the subject dashboard API (`observed_at` in org timezone).
- Show observation date/time on profile cards and pre-fill the composer date when viewing a single day.
- Temporarily hide the profile `ConcernsAlert` section.

## Test plan
- [x] `make test-frontend` — SubjectDetail tests pass
- [x] Backend subject dashboard observation date-bucketing test added
- [ ] CI green on backend + frontend checks
- [ ] Manual: profile with `?date=` shows only that day's observations with visible timestamps


Made with [Cursor](https://cursor.com)