### PR TITLE
Support Campminder camper and staff CSV imports

### DIFF
--- a/backend/bunk_logs/api/admin_flow/imports.py
+++ b/backend/bunk_logs/api/admin_flow/imports.py
@@ -19,8 +19,6 @@ because the underlying upsert logic in those commands keys on
 
 from __future__ import annotations
 
-import csv
-import io
 import tempfile
 from pathlib import Path
 
@@ -34,6 +32,11 @@ from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from bunk_logs.core.campminder_csv import normalize_campminder_row
+from bunk_logs.core.campminder_csv import read_campminder_csv_bytes
+from bunk_logs.core.campminder_person_match import MatchStrategy
+from bunk_logs.core.campminder_person_match import match_campminder_person
+from bunk_logs.core.campminder_person_match import strategy_is_duplicate
 from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Person
 from bunk_logs.core.models import Program
@@ -46,9 +49,10 @@ SUPPORTED_SOURCES = ("campminder", "tbe")
 VALID_ROLES = frozenset(role for role, _ in Membership.ROLES)
 
 
-def _read_csv_rows(raw_bytes: bytes) -> list[dict]:
-    text = raw_bytes.decode("utf-8-sig", errors="replace")
-    return list(csv.DictReader(io.StringIO(text)))
+def _normalize_row(source: str, row: dict) -> dict:
+    if source == "campminder":
+        return normalize_campminder_row(row)
+    return row
 
 
 def _normalize_external_id(source: str, row: dict) -> str:
@@ -57,11 +61,13 @@ def _normalize_external_id(source: str, row: dict) -> str:
 
 
 def _classify_row(*, source: str, org, program, row: dict) -> dict:
-    """Classify a single CSV row as add / change / skip / conflict."""
+    """Classify a single CSV row as add / change / merge / duplicate / skip."""
+    row = _normalize_row(source, row)
     external_id = _normalize_external_id(source, row)
     role = (row.get("role") or "").strip()
     first_name = (row.get("first_name") or "").strip()
     last_name = (row.get("last_name") or "").strip()
+    preferred_name = (row.get("preferred_name") or "").strip()
     email = (row.get("email") or "").strip()
 
     issues: list[str] = []
@@ -69,49 +75,102 @@ def _classify_row(*, source: str, org, program, row: dict) -> dict:
         issues.append(f"missing {source}_id")
     if role and role not in VALID_ROLES:
         issues.append(f"unknown role {role!r}")
-    if not first_name or not last_name:
-        issues.append("missing first_name or last_name")
+    if not last_name:
+        issues.append("missing last_name")
+    if not first_name:
+        issues.append("missing first_name or preferred_name")
 
-    classification = "skip" if issues else "noop"
+    classification = "skip"
     existing_person = None
-    if external_id:
-        existing_person = Person.all_objects.filter(
-            organization=org,
-            external_ids__contains={f"{source}_id": external_id},
-        ).first()
-    if existing_person is None and email:
-        existing_person = Person.all_objects.filter(
-            organization=org, email__iexact=email,
-        ).first()
-        if existing_person is not None:
-            issues.append(
-                f"email already attached to Person {existing_person.id} "
-                f"with no {source}_id — will merge",
-            )
+    merge_reason = None
+    candidate_person_ids: list[int] = []
 
-    if not issues:
-        if existing_person is None:
+    if issues:
+        return {
+            "external_id": external_id,
+            "role": role,
+            "full_name": f"{first_name} {last_name}".strip(),
+            "email": email,
+            "classification": classification,
+            "issues": issues,
+            "existing_person_id": None,
+            "merge_reason": merge_reason,
+            "candidate_person_ids": candidate_person_ids,
+        }
+
+    if source == "campminder":
+        person_match = match_campminder_person(
+            org,
+            campminder_id=external_id,
+            first_name=first_name,
+            last_name=last_name,
+            email=email,
+        )
+        existing_person = person_match.person
+        merge_reason = person_match.strategy.value
+        candidate_person_ids = person_match.candidate_ids
+
+        if strategy_is_duplicate(person_match.strategy):
+            classification = "duplicate"
+            if person_match.strategy == MatchStrategy.DUPLICATE_AMBIGUOUS_NAME:
+                issues.append(
+                    f"ambiguous name match — {len(candidate_person_ids)} existing "
+                    f"persons without Campminder ID",
+                )
+            elif person_match.strategy == MatchStrategy.DUPLICATE_EMAIL_CONFLICT:
+                issues.append(
+                    f"email already linked to Person {candidate_person_ids[0]} "
+                    f"with a different Campminder ID",
+                )
+            elif person_match.strategy == MatchStrategy.DUPLICATE_NAME_DIFFERENT_ID:
+                issues.append(
+                    f"same name as Person {candidate_person_ids[0]} with a "
+                    f"different Campminder ID — will create new person",
+                )
+                classification = "add"
+        elif person_match.strategy == MatchStrategy.NEW:
             classification = "add"
-        else:
+        elif person_match.strategy in {
+            MatchStrategy.MERGE_EMAIL,
+            MatchStrategy.MERGE_NAME,
+        }:
+            classification = "merge"
+            issues.append(
+                f"will merge Campminder ID onto existing Person "
+                f"{existing_person.id} via {person_match.strategy.value}",
+            )
+        elif existing_person is not None:
             changed = []
             if existing_person.first_name != first_name:
                 changed.append("first_name")
             if existing_person.last_name != last_name:
                 changed.append("last_name")
+            if preferred_name and existing_person.preferred_name != preferred_name:
+                changed.append("preferred_name")
             if email and existing_person.email != email:
                 changed.append("email")
+            if email and not existing_person.email:
+                changed.append("email")
             classification = "change" if changed else "noop"
-    elif existing_person is not None:
-        classification = "conflict"
+    else:
+        if email:
+            existing_person = Person.all_objects.filter(
+                organization=org, email__iexact=email,
+            ).first()
+        classification = "add" if existing_person is None else "noop"
 
     return {
         "external_id": external_id,
         "role": role,
         "full_name": f"{first_name} {last_name}".strip(),
         "email": email,
+        "position_type": (row.get("position_type") or "").strip(),
+        "position": (row.get("position") or "").strip(),
         "classification": classification,
         "issues": issues,
         "existing_person_id": existing_person.id if existing_person else None,
+        "merge_reason": merge_reason,
+        "candidate_person_ids": candidate_person_ids,
     }
 
 
@@ -146,7 +205,7 @@ class AdminBulkImportPreviewView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         try:
-            rows = _read_csv_rows(csv_file.read())
+            rows = read_campminder_csv_bytes(csv_file.read())
         except Exception as exc:
             return Response(
                 {"detail": f"Could not parse CSV: {exc}"},
@@ -162,8 +221,10 @@ class AdminBulkImportPreviewView(APIView):
             "row_count": len(classified),
             "add": sum(1 for r in classified if r["classification"] == "add"),
             "change": sum(1 for r in classified if r["classification"] == "change"),
+            "merge": sum(1 for r in classified if r["classification"] == "merge"),
             "noop": sum(1 for r in classified if r["classification"] == "noop"),
             "skip": sum(1 for r in classified if r["classification"] == "skip"),
+            "duplicate": sum(1 for r in classified if r["classification"] == "duplicate"),
             "conflict": sum(1 for r in classified if r["classification"] == "conflict"),
         }
         return Response({

--- a/backend/bunk_logs/core/campminder_csv.py
+++ b/backend/bunk_logs/core/campminder_csv.py
@@ -1,0 +1,241 @@
+"""Normalize Campminder CSV export column variants to canonical importer fields."""
+
+from __future__ import annotations
+
+import csv
+import io
+from pathlib import Path
+
+
+def _normalize_header(key: str) -> str:
+    return (
+        key.lstrip("\ufeff")
+        .strip()
+        .lower()
+        .replace("_", " ")
+        .replace("/", " ")
+    )
+
+
+def format_csv_headers(row: dict) -> str:
+    """Comma-separated normalized headers for import diagnostics."""
+    return ", ".join(sorted({_normalize_header(str(k)) for k in row if k}))
+
+
+def _indexed_row(row: dict) -> dict[str, str]:
+    """Build a case/spacing-insensitive lookup from raw CSV headers."""
+    indexed: dict[str, str] = {}
+    for key, value in row.items():
+        if key is None:
+            continue
+        normalized = _normalize_header(str(key))
+        if normalized and value is not None and str(value).strip():
+            indexed.setdefault(normalized, str(value).strip())
+    return indexed
+
+
+# Canonical field -> accepted normalized header variants.
+_HEADER_ALIASES: dict[str, tuple[str, ...]] = {
+    "campminder_id": (
+        "campminder id",
+        "campminder_id",
+        "personid",
+        "person id",
+        "person_id",
+    ),
+    "first_name": ("first name", "firstname", "first", "legal first name"),
+    "last_name": (
+        "last name",
+        "lastname",
+        "last",
+        "family name",
+        "surname",
+        "camper last name",
+        "legal last name",
+        "primary last name",
+    ),
+    "preferred_name": (
+        "preferred name",
+        "preferredname",
+        "preferred",
+        "nickname",
+        "nick name",
+        "goes by",
+    ),
+    "email": (
+        "email",
+        "email address",
+        "login email",
+        "login",
+    ),
+    "role": ("role",),
+    "position_type": ("position types", "position type", "positiontypes"),
+    "position": ("position", "title", "job title"),
+    "bunk_name": ("bunk name", "bunk", "bunk_name"),
+    "unit_name": ("unit name", "unit", "unit_name"),
+    "division_name": ("division name", "division", "division_name"),
+    "caseload_name": ("caseload name", "caseload", "caseload_name"),
+    "caseload_owner_campminder_id": (
+        "caseload owner campminder id",
+        "caseload owner id",
+        "caseload_owner_campminder_id",
+        "caseload_owner_id",
+    ),
+    "language_preference": ("language preference", "language", "language_preference"),
+    "tags": ("tags",),
+}
+
+
+def _field_value(indexed: dict[str, str], field: str) -> str:
+    for alias in _HEADER_ALIASES[field]:
+        value = indexed.get(alias)
+        if value:
+            return value
+    return ""
+
+
+def _position_key(value: str) -> str:
+    return value.strip().lower()
+
+
+def infer_role_from_position(position_type: str, position: str) -> str:
+    """Map Campminder staff ``Position Types`` / ``Position`` to Membership.role."""
+    pos = _position_key(position)
+    pos_type = _position_key(position_type)
+
+    if pos == "camper care associate":
+        return "camper_care"
+    if pos == "allergies and special food coordinator":
+        return "special_diets"
+    if pos == "driver":
+        return "maintenance"
+    if pos.startswith("director:"):
+        return "specialist"
+    if "camper care" in pos:
+        return "camper_care"
+    if "unit head" in pos:
+        return "unit_head"
+    if "junior counselor" in pos:
+        return "junior_counselor"
+    if "general counselor" in pos:
+        return "general_counselor"
+    if "counselor" in pos:
+        return "counselor"
+    if "kitchen" in pos:
+        return "kitchen_staff"
+    if "housekeeping" in pos:
+        return "housekeeping"
+    if "health" in pos or "nurse" in pos or "wellness" in pos:
+        return "health_center"
+    if "special diet" in pos or "allerg" in pos:
+        return "special_diets"
+    if "maintenance" in pos:
+        return "maintenance"
+
+    if pos_type == "leadership team":
+        return "leadership_team"
+    if pos_type == "administrative staff":
+        return "maintenance"
+    if pos_type == "counseling staff":
+        return "counselor"
+    if pos_type == "kitchen staff":
+        return "kitchen_staff"
+    if pos_type == "maintenance":
+        return "maintenance"
+    if pos_type == "housekeeping":
+        return "housekeeping"
+
+    return ""
+
+
+def _infer_default_role(
+    indexed: dict[str, str],
+    *,
+    first_name: str,
+    email: str,
+    position_type: str,
+    position: str,
+) -> str:
+    explicit_role = _field_value(indexed, "role")
+    if explicit_role:
+        return explicit_role
+
+    from_position = infer_role_from_position(position_type, position)
+    if from_position:
+        return from_position
+
+    if first_name and email:
+        return "counselor"
+    return "camper"
+
+
+def normalize_campminder_row(row: dict) -> dict:
+    """Map Campminder export headers to the fields expected by roster importers.
+
+    Supports the full roster format (``campminder_id``, ``first_name``, ``role``,
+    bunk columns, etc.) and minimal exports:
+
+    * Campers: ``Last Name``, ``Preferred Name``, ``PersonID``
+    * Staff: ``PersonID``, ``Last Name``, ``First Name``, ``Login/Email``,
+      ``Position Types``, ``Position``
+    """
+    indexed = _indexed_row(row)
+
+    campminder_id = _field_value(indexed, "campminder_id")
+    first_name = _field_value(indexed, "first_name")
+    last_name = _field_value(indexed, "last_name")
+    preferred_name = _field_value(indexed, "preferred_name")
+    email = _field_value(indexed, "email")
+    position_type = _field_value(indexed, "position_type")
+    position = _field_value(indexed, "position")
+    if not first_name and preferred_name:
+        first_name = preferred_name
+
+    role = _infer_default_role(
+        indexed,
+        first_name=first_name,
+        email=email,
+        position_type=position_type,
+        position=position,
+    )
+
+    return {
+        "campminder_id": campminder_id,
+        "first_name": first_name,
+        "last_name": last_name,
+        "preferred_name": preferred_name,
+        "email": email,
+        "role": role,
+        "position_type": position_type,
+        "position": position,
+        "bunk_name": _field_value(indexed, "bunk_name"),
+        "unit_name": _field_value(indexed, "unit_name"),
+        "division_name": _field_value(indexed, "division_name"),
+        "caseload_name": _field_value(indexed, "caseload_name"),
+        "caseload_owner_campminder_id": _field_value(indexed, "caseload_owner_campminder_id"),
+        "language_preference": _field_value(indexed, "language_preference"),
+        "tags": _field_value(indexed, "tags"),
+    }
+
+
+def read_campminder_csv_rows(source) -> list[dict]:
+    """Read a Campminder CSV from a path or text stream, sniffing comma/tab delimiters."""
+    if isinstance(source, (str, Path)):
+        with Path(source).open(newline="", encoding="utf-8-sig") as handle:
+            return _read_dict_rows(handle)
+    return _read_dict_rows(source)
+
+
+def read_campminder_csv_bytes(raw_bytes: bytes) -> list[dict]:
+    text = raw_bytes.decode("utf-8-sig", errors="replace")
+    return _read_dict_rows(io.StringIO(text))
+
+
+def _read_dict_rows(handle) -> list[dict]:
+    sample = handle.read(4096)
+    handle.seek(0)
+    try:
+        dialect = csv.Sniffer().sniff(sample, delimiters=",\t;")
+    except csv.Error:
+        dialect = csv.excel
+    return list(csv.DictReader(handle, dialect=dialect))

--- a/backend/bunk_logs/core/campminder_person_match.py
+++ b/backend/bunk_logs/core/campminder_person_match.py
@@ -1,0 +1,109 @@
+"""Match CSV rows to existing Person records for Campminder roster imports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from enum import Enum
+
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+
+
+class MatchStrategy(str, Enum):
+    CAMPMINDER_ID = "campminder_id"
+    MERGE_EMAIL = "merge_email"
+    MERGE_NAME = "merge_name"
+    NEW = "new"
+    DUPLICATE_AMBIGUOUS_NAME = "duplicate_ambiguous_name"
+    DUPLICATE_EMAIL_CONFLICT = "duplicate_email_conflict"
+    DUPLICATE_NAME_DIFFERENT_ID = "duplicate_name_different_id"
+
+
+@dataclass
+class PersonMatch:
+    person: Person | None
+    strategy: MatchStrategy
+    candidate_ids: list[int] = field(default_factory=list)
+
+
+def _existing_campminder_id(person: Person) -> str:
+    return str(person.external_ids.get("campminder_id") or "").strip()
+
+
+def match_campminder_person(
+    org: Organization,
+    *,
+    campminder_id: str,
+    first_name: str,
+    last_name: str,
+    email: str,
+) -> PersonMatch:
+    """Resolve a CSV row to an existing Person or classify how to create one."""
+    by_id = Person.all_objects.filter(
+        organization=org,
+        external_ids__campminder_id=campminder_id,
+    ).first()
+    if by_id is not None:
+        return PersonMatch(person=by_id, strategy=MatchStrategy.CAMPMINDER_ID)
+
+    if email:
+        by_email = Person.all_objects.filter(
+            organization=org,
+            email__iexact=email,
+        ).first()
+        if by_email is not None:
+            existing_id = _existing_campminder_id(by_email)
+            if not existing_id or existing_id == campminder_id:
+                return PersonMatch(person=by_email, strategy=MatchStrategy.MERGE_EMAIL)
+            return PersonMatch(
+                person=by_email,
+                strategy=MatchStrategy.DUPLICATE_EMAIL_CONFLICT,
+                candidate_ids=[by_email.id],
+            )
+
+    name_matches = list(
+        Person.all_objects.filter(
+            organization=org,
+            first_name__iexact=first_name,
+            last_name__iexact=last_name,
+        ),
+    )
+    without_id = [p for p in name_matches if not _existing_campminder_id(p)]
+    with_other_id = [
+        p for p in name_matches
+        if _existing_campminder_id(p) and _existing_campminder_id(p) != campminder_id
+    ]
+
+    if len(without_id) == 1:
+        return PersonMatch(person=without_id[0], strategy=MatchStrategy.MERGE_NAME)
+    if len(without_id) > 1:
+        return PersonMatch(
+            person=None,
+            strategy=MatchStrategy.DUPLICATE_AMBIGUOUS_NAME,
+            candidate_ids=[p.id for p in without_id],
+        )
+    if with_other_id:
+        return PersonMatch(
+            person=None,
+            strategy=MatchStrategy.DUPLICATE_NAME_DIFFERENT_ID,
+            candidate_ids=[p.id for p in with_other_id],
+        )
+
+    return PersonMatch(person=None, strategy=MatchStrategy.NEW)
+
+
+def strategy_is_merge(strategy: MatchStrategy) -> bool:
+    return strategy in {
+        MatchStrategy.CAMPMINDER_ID,
+        MatchStrategy.MERGE_EMAIL,
+        MatchStrategy.MERGE_NAME,
+    }
+
+
+def strategy_is_duplicate(strategy: MatchStrategy) -> bool:
+    return strategy in {
+        MatchStrategy.DUPLICATE_AMBIGUOUS_NAME,
+        MatchStrategy.DUPLICATE_EMAIL_CONFLICT,
+        MatchStrategy.DUPLICATE_NAME_DIFFERENT_ID,
+    }

--- a/backend/bunk_logs/core/management/commands/import_campminder_roster.py
+++ b/backend/bunk_logs/core/management/commands/import_campminder_roster.py
@@ -130,7 +130,6 @@ def _upsert_person(
     last_name = (row.get("last_name") or "").strip()
     preferred_name = (row.get("preferred_name") or "").strip()
     email = (row.get("email") or "").strip()
-    full_name = f"{first_name} {last_name}".strip()
 
     person_match = match_campminder_person(
         org,

--- a/backend/bunk_logs/core/management/commands/import_campminder_roster.py
+++ b/backend/bunk_logs/core/management/commands/import_campminder_roster.py
@@ -9,7 +9,6 @@ AssignmentGroups are keyed by (program, group_type, slugified-name).
 """
 from __future__ import annotations
 
-import csv
 import logging
 from pathlib import Path
 from typing import Any
@@ -19,6 +18,12 @@ from django.core.management.base import CommandError
 from django.db import transaction
 from django.utils.text import slugify
 
+from bunk_logs.core.campminder_csv import format_csv_headers
+from bunk_logs.core.campminder_csv import normalize_campminder_row
+from bunk_logs.core.campminder_csv import read_campminder_csv_rows
+from bunk_logs.core.campminder_person_match import MatchStrategy
+from bunk_logs.core.campminder_person_match import match_campminder_person
+from bunk_logs.core.campminder_person_match import strategy_is_duplicate
 from bunk_logs.core.models import AssignmentGroup
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
@@ -86,30 +91,100 @@ def _ensure_membership(
     return membership
 
 
-def _upsert_person(org: Organization, row: dict, campminder_id: str) -> tuple[Person, bool, bool]:
-    """Return (person, created, updated)."""
+def _duplicate_message(
+    *,
+    row_number: int,
+    campminder_id: str,
+    full_name: str,
+    match_strategy: MatchStrategy,
+    candidate_ids: list[int],
+) -> str:
+    if match_strategy == MatchStrategy.DUPLICATE_AMBIGUOUS_NAME:
+        return (
+            f"Row {row_number} ({full_name}, campminder_id={campminder_id}): "
+            f"ambiguous name match — {len(candidate_ids)} existing persons "
+            f"without Campminder ID (ids={candidate_ids}) — skipped"
+        )
+    if match_strategy == MatchStrategy.DUPLICATE_EMAIL_CONFLICT:
+        return (
+            f"Row {row_number} ({full_name}, campminder_id={campminder_id}): "
+            f"email already linked to Person {candidate_ids[0]} with a different "
+            f"Campminder ID — skipped"
+        )
+    return (
+        f"Row {row_number} ({full_name}, campminder_id={campminder_id}): "
+        f"same name as Person {candidate_ids[0]} who already has a different "
+        f"Campminder ID — created as new person"
+    )
+
+
+def _upsert_person(
+    org: Organization,
+    row: dict,
+    campminder_id: str,
+    *,
+    row_number: int,
+) -> tuple[Person | None, bool, bool, bool, MatchStrategy, list[int]]:
+    """Return (person, created, updated, merged, strategy, candidate_ids)."""
     first_name = (row.get("first_name") or "").strip()
     last_name = (row.get("last_name") or "").strip()
+    preferred_name = (row.get("preferred_name") or "").strip()
     email = (row.get("email") or "").strip()
+    full_name = f"{first_name} {last_name}".strip()
 
-    person = Person.all_objects.filter(
-        organization=org,
-        external_ids__campminder_id=campminder_id,
-    ).first()
+    person_match = match_campminder_person(
+        org,
+        campminder_id=campminder_id,
+        first_name=first_name,
+        last_name=last_name,
+        email=email,
+    )
+    if strategy_is_duplicate(person_match.strategy):
+        if person_match.strategy == MatchStrategy.DUPLICATE_NAME_DIFFERENT_ID:
+            person = Person.all_objects.create(
+                organization=org,
+                first_name=first_name,
+                last_name=last_name,
+                preferred_name=preferred_name,
+                email=email,
+                external_ids={"campminder_id": campminder_id},
+            )
+            return (
+                person,
+                True,
+                False,
+                False,
+                person_match.strategy,
+                person_match.candidate_ids,
+            )
+        return None, False, False, False, person_match.strategy, person_match.candidate_ids
 
-    if person is None:
+    if person_match.strategy == MatchStrategy.NEW:
         person = Person.all_objects.create(
             organization=org,
             first_name=first_name,
             last_name=last_name,
+            preferred_name=preferred_name,
             email=email,
             external_ids={"campminder_id": campminder_id},
         )
-        return person, True, False
+        return person, True, False, False, person_match.strategy, []
+
+    person = person_match.person
+    assert person is not None
+    merged = person_match.strategy in {
+        MatchStrategy.MERGE_EMAIL,
+        MatchStrategy.MERGE_NAME,
+    }
 
     changed: list[str] = []
-    for field, value in [("first_name", first_name), ("last_name", last_name), ("email", email)]:
-        if getattr(person, field) != value:
+    for field, value in [
+        ("first_name", first_name),
+        ("last_name", last_name),
+        ("preferred_name", preferred_name),
+        ("email", email),
+    ]:
+        if value and getattr(person, field) != value:
             setattr(person, field, value)
             changed.append(field)
     merged_ids = {**person.external_ids, "campminder_id": campminder_id}
@@ -118,8 +193,8 @@ def _upsert_person(org: Organization, row: dict, campminder_id: str) -> tuple[Pe
         changed.append("external_ids")
     if changed:
         person.save(update_fields=changed)
-        return person, False, True
-    return person, False, False
+        return person, False, True, merged, person_match.strategy, []
+    return person, False, False, merged, person_match.strategy, []
 
 
 class Command(BaseCommand):
@@ -169,8 +244,7 @@ class Command(BaseCommand):
         dry_run: bool = options["dry_run"]
         reconcile: bool = options["reconcile"]
 
-        with csv_path.open(newline="", encoding="utf-8") as f:
-            rows = list(csv.DictReader(f))
+        rows = read_campminder_csv_rows(csv_path)
 
         log: RosterImportLog | None = None
         if not dry_run:
@@ -182,32 +256,46 @@ class Command(BaseCommand):
                 csv_filename=csv_path.name,
             )
 
-        persons_created = persons_updated = persons_skipped = 0
+        persons_created = persons_updated = persons_skipped = persons_merged = 0
         memberships_created = memberships_reactivated = 0
         memberships_deactivated = 0
         warnings: list[str] = []
+        duplicates_flagged: list[dict[str, Any]] = []
 
         # Track (group_pk, role_in_group) → set of person_pks seen in this CSV
         seen_group_members: dict[tuple[int, str], set[int]] = {}
 
-        for i, row in enumerate(rows, start=2):
-            campminder_id = (row.get("campminder_id") or "").strip()
+        for i, raw_row in enumerate(rows, start=2):
+            row = normalize_campminder_row(raw_row)
+            campminder_id = row["campminder_id"]
             if not campminder_id:
                 warnings.append(f"Row {i}: missing campminder_id — skipped")
                 continue
 
-            role = (row.get("role") or "").strip()
+            role = row["role"]
             if role not in VALID_ROLES:
                 warnings.append(f"Row {i} (campminder_id={campminder_id}): unknown role {role!r} — skipped")
                 continue
 
-            bunk_name = (row.get("bunk_name") or "").strip()
-            unit_name = (row.get("unit_name") or "").strip()
-            division_name = (row.get("division_name") or "").strip()
-            caseload_name = (row.get("caseload_name") or "").strip()
-            caseload_owner_id = (row.get("caseload_owner_campminder_id") or "").strip()
-            lang_pref = (row.get("language_preference") or "").strip()
-            tags = _normalize_tags(row.get("tags") or "")
+            if not row["last_name"]:
+                msg = f"Row {i} (campminder_id={campminder_id}): missing last_name — skipped"
+                if i == 2:
+                    msg += f" (headers: {format_csv_headers(raw_row)})"
+                warnings.append(msg)
+                continue
+            if not row["first_name"]:
+                warnings.append(f"Row {i} (campminder_id={campminder_id}): missing first_name — skipped")
+                continue
+
+            bunk_name = row["bunk_name"]
+            unit_name = row["unit_name"]
+            division_name = row["division_name"]
+            caseload_name = row["caseload_name"]
+            caseload_owner_id = row["caseload_owner_campminder_id"]
+            lang_pref = row["language_preference"]
+            position_type = row.get("position_type") or ""
+            position = row.get("position") or ""
+            tags = _normalize_tags(row["tags"])
 
             if dry_run:
                 self.stdout.write(
@@ -218,9 +306,57 @@ class Command(BaseCommand):
                 continue
 
             with transaction.atomic():
-                person, created, updated = _upsert_person(org, row, campminder_id)
+                (
+                    person,
+                    created,
+                    updated,
+                    merged,
+                    match_strategy,
+                    candidate_ids,
+                ) = _upsert_person(
+                    org,
+                    row,
+                    campminder_id,
+                    row_number=i,
+                )
+                full_name = f"{row['first_name']} {row['last_name']}".strip()
+                if person is None:
+                    msg = _duplicate_message(
+                        row_number=i,
+                        campminder_id=campminder_id,
+                        full_name=full_name,
+                        match_strategy=match_strategy,
+                        candidate_ids=candidate_ids,
+                    )
+                    warnings.append(msg)
+                    duplicates_flagged.append({
+                        "row": i,
+                        "campminder_id": campminder_id,
+                        "full_name": full_name,
+                        "reason": match_strategy.value,
+                        "candidate_person_ids": candidate_ids,
+                    })
+                    continue
+                if match_strategy == MatchStrategy.DUPLICATE_NAME_DIFFERENT_ID:
+                    msg = _duplicate_message(
+                        row_number=i,
+                        campminder_id=campminder_id,
+                        full_name=full_name,
+                        match_strategy=match_strategy,
+                        candidate_ids=candidate_ids,
+                    )
+                    warnings.append(msg)
+                    duplicates_flagged.append({
+                        "row": i,
+                        "campminder_id": campminder_id,
+                        "full_name": full_name,
+                        "reason": match_strategy.value,
+                        "candidate_person_ids": candidate_ids,
+                    })
                 if created:
                     persons_created += 1
+                elif merged:
+                    persons_merged += 1
                 elif updated:
                     persons_updated += 1
                 else:
@@ -234,6 +370,10 @@ class Command(BaseCommand):
                 meta = {**membership.metadata}
                 if lang_pref:
                     meta["language_preference"] = lang_pref
+                if position_type:
+                    meta["campminder_position_type"] = position_type
+                if position:
+                    meta["campminder_position"] = position
                 membership.metadata = meta
                 membership.tags = tags
                 membership.save(update_fields=["tags", "metadata"])
@@ -308,10 +448,12 @@ class Command(BaseCommand):
         summary: dict[str, Any] = {
             "persons_created": persons_created,
             "persons_updated": persons_updated,
+            "persons_merged": persons_merged,
             "persons_unchanged": persons_skipped,
             "memberships_created": memberships_created,
             "memberships_reactivated": memberships_reactivated,
             "memberships_deactivated": memberships_deactivated,
+            "duplicates_flagged": duplicates_flagged,
             "warnings": warnings,
         }
 

--- a/backend/bunk_logs/core/test_roster_import.py
+++ b/backend/bunk_logs/core/test_roster_import.py
@@ -8,6 +8,8 @@ from io import StringIO
 import pytest
 from django.core.management import call_command
 
+from bunk_logs.core.campminder_csv import infer_role_from_position
+from bunk_logs.core.campminder_csv import normalize_campminder_row
 from bunk_logs.core.models import AssignmentGroup
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
@@ -100,6 +102,135 @@ CAMPMINDER_STAFF_ONLY_CSV = """
 campminder_id,first_name,last_name,role,email
 CM010,Dave,Park,unit_head,dave@example.com
 """
+
+CAMPMINDER_CAMPER_EXPORT_CSV = """
+Last Name,Preferred Name,PersonID
+Abraham,Allie,20476515
+Cohen,Sam,20476516
+"""
+
+CAMPMINDER_CAMPER_EXPORT_BOM_CSV = """
+\ufeffLast Name,Preferred Name,PersonID
+Abraham,Allie,20476515
+"""
+
+CAMPMINDER_CAMPER_EXPORT_ALT_HEADERS_CSV = """
+LastName,PreferredName,PersonID
+Abraham,Allie,20476515
+"""
+
+CAMPMINDER_STAFF_EXPORT_TSV = """
+PersonID\tLast Name\tFirst Name\tLogin/Email\tPosition Types\tPosition
+5927217\tAllen\tChristopher\tdrchrisa@gmail.com\tAdministrative Staff\tDriver
+5201139\tHermann\tCory\tCorysoop@aol.com\tLeadership Team\tAllergies and Special Food Coordinator
+6904465\tNadel\tJennifer\tjnadel13@gmail.com\tLeadership Team\tCamper Care Associate
+5927256\tHernandez\tNino Benjie\ttaongkahoy@gmail.com\tLeadership Team\tDirector: Arts & Crafts
+5200995\tFriedman\tShain\tshainfriedman11@gmail.com\tLeadership Team\tDirector: Athletics
+"""
+
+
+class TestCampminderCsvNormalization:
+    def test_bom_prefixed_header_key(self):
+        row = {"\ufeffLast Name": "Abraham", "Preferred Name": "Allie", "PersonID": "20476515"}
+        normalized = normalize_campminder_row(row)
+        assert normalized["last_name"] == "Abraham"
+        assert normalized["preferred_name"] == "Allie"
+        assert normalized["campminder_id"] == "20476515"
+
+    def test_login_email_header_maps_to_email(self):
+        row = {
+            "PersonID": "5927217",
+            "Last Name": "Allen",
+            "First Name": "Christopher",
+            "Login/Email": "drchrisa@gmail.com",
+            "Position Types": "Administrative Staff",
+            "Position": "Driver",
+        }
+        normalized = normalize_campminder_row(row)
+        assert normalized["email"] == "drchrisa@gmail.com"
+        assert normalized["role"] == "maintenance"
+        assert normalized["position_type"] == "Administrative Staff"
+        assert normalized["position"] == "Driver"
+
+    def test_position_role_mapping(self):
+        assert infer_role_from_position("Leadership Team", "Camper Care Associate") == "camper_care"
+        assert infer_role_from_position("Leadership Team", "Director: Athletics") == "specialist"
+        assert infer_role_from_position("Administrative Staff", "Driver") == "maintenance"
+        assert infer_role_from_position("Leadership Team", "Allergies and Special Food Coordinator") == "special_diets"
+
+
+@pytest.mark.django_db
+class TestCampminderCamperExport:
+    def test_imports_persons_with_preferred_name(self, tmp_path, program):
+        _run_campminder(tmp_path, CAMPMINDER_CAMPER_EXPORT_CSV)
+
+        allie = Person.all_objects.get(external_ids__campminder_id="20476515")
+        assert allie.last_name == "Abraham"
+        assert allie.preferred_name == "Allie"
+        assert allie.first_name == "Allie"
+        assert allie.full_name == "Allie Abraham"
+
+        sam = Person.all_objects.get(external_ids__campminder_id="20476516")
+        assert sam.last_name == "Cohen"
+        assert sam.preferred_name == "Sam"
+
+        assert Membership.all_objects.filter(program=program, role="camper").count() == 2
+
+    def test_idempotent_rerun(self, tmp_path, program):
+        _run_campminder(tmp_path, CAMPMINDER_CAMPER_EXPORT_CSV)
+        _run_campminder(tmp_path, CAMPMINDER_CAMPER_EXPORT_CSV)
+        assert Person.all_objects.filter(organization=program.organization).count() == 2
+
+    def test_bom_prefixed_first_header(self, tmp_path, program):
+        _run_campminder(tmp_path, CAMPMINDER_CAMPER_EXPORT_BOM_CSV)
+        allie = Person.all_objects.get(external_ids__campminder_id="20476515")
+        assert allie.last_name == "Abraham"
+        assert allie.preferred_name == "Allie"
+
+    def test_compact_header_names(self, tmp_path, program):
+        _run_campminder(tmp_path, CAMPMINDER_CAMPER_EXPORT_ALT_HEADERS_CSV)
+        allie = Person.all_objects.get(external_ids__campminder_id="20476515")
+        assert allie.last_name == "Abraham"
+        assert allie.preferred_name == "Allie"
+
+
+@pytest.mark.django_db
+class TestCampminderStaffExport:
+    def test_imports_staff_with_roles_and_email(self, tmp_path, program):
+        _run_campminder(tmp_path, CAMPMINDER_STAFF_EXPORT_TSV)
+
+        chris = Person.all_objects.get(external_ids__campminder_id="5927217")
+        assert chris.email == "drchrisa@gmail.com"
+        assert Membership.all_objects.filter(program=program, person=chris, role="maintenance").exists()
+
+        jennifer = Person.all_objects.get(external_ids__campminder_id="6904465")
+        membership = Membership.all_objects.get(program=program, person=jennifer)
+        assert membership.role == "camper_care"
+        assert membership.metadata["campminder_position"] == "Camper Care Associate"
+
+        shain = Person.all_objects.get(external_ids__campminder_id="5200995")
+        assert Membership.all_objects.get(program=program, person=shain).role == "specialist"
+
+    def test_merge_existing_person_by_name(self, tmp_path, program, org):
+        existing = Person.all_objects.create(
+            organization=org,
+            first_name="Christopher",
+            last_name="Allen",
+            email="",
+        )
+        _run_campminder(tmp_path, CAMPMINDER_STAFF_EXPORT_TSV)
+
+        chris = Person.all_objects.get(external_ids__campminder_id="5927217")
+        assert chris.id == existing.id
+        assert chris.email == "drchrisa@gmail.com"
+        assert Person.all_objects.filter(organization=org).count() == 5
+
+    def test_flags_ambiguous_name_duplicates(self, tmp_path, program, org):
+        Person.all_objects.create(organization=org, first_name="Christopher", last_name="Allen")
+        Person.all_objects.create(organization=org, first_name="Christopher", last_name="Allen")
+        out = _run_campminder(tmp_path, CAMPMINDER_STAFF_EXPORT_TSV)
+        assert "ambiguous name match" in out.getvalue()
+        assert not Person.all_objects.filter(external_ids__campminder_id="5927217").exists()
 
 
 @pytest.mark.django_db

--- a/frontend/src/components/admin/BulkImportModal.jsx
+++ b/frontend/src/components/admin/BulkImportModal.jsx
@@ -132,6 +132,23 @@ export default function BulkImportModal({ programs, onClose }) {
                 </li>
               ))}
             </ul>
+            {previewData.rows?.some((row) => ['merge', 'duplicate'].includes(row.classification)) && (
+              <div className="max-h-40 overflow-y-auto rounded-md border border-amber-200 bg-amber-50 p-2 text-xs space-y-1">
+                <p className="font-medium text-amber-900">Merges and duplicates</p>
+                {previewData.rows
+                  .filter((row) => ['merge', 'duplicate'].includes(row.classification))
+                  .map((row) => (
+                    <p key={`${row.external_id}-${row.full_name}`} className="text-amber-950">
+                      <span className="font-semibold capitalize">{row.classification}</span>
+                      {': '}
+                      {row.full_name || 'Unknown'}
+                      {row.email ? ` (${row.email})` : ''}
+                      {row.existing_person_id ? ` → Person #${row.existing_person_id}` : ''}
+                      {row.issues?.length ? ` — ${row.issues.join('; ')}` : ''}
+                    </p>
+                  ))}
+              </div>
+            )}
             <button
               type="button"
               onClick={handleCommit}
@@ -147,6 +164,18 @@ export default function BulkImportModal({ programs, onClose }) {
         {commitResult && (
           <section data-testid="bulk-import-commit-panel" className="rounded-md border border-emerald-300 bg-emerald-50 p-3 space-y-2">
             <h3 className="text-sm font-medium">Import complete</h3>
+            {commitResult.log?.summary?.duplicates_flagged?.length > 0 && (
+              <div className="rounded-md border border-amber-300 bg-amber-50 p-2 text-xs text-amber-950 space-y-1">
+                <p className="font-medium">
+                  {commitResult.log.summary.duplicates_flagged.length} duplicate(s) flagged
+                </p>
+                {commitResult.log.summary.duplicates_flagged.map((item) => (
+                  <p key={`${item.row}-${item.campminder_id}`}>
+                    Row {item.row}: {item.full_name} ({item.reason})
+                  </p>
+                ))}
+              </div>
+            )}
             <pre className="text-xs whitespace-pre-wrap">
               {JSON.stringify(commitResult.log?.summary || {}, null, 2)}
             </pre>


### PR DESCRIPTION
## Summary
- Normalize real Campminder export formats for campers (`Last Name`, `Preferred Name`, `PersonID`) and staff (`PersonID`, `Login/Email`, `Position Types`, `Position`), including tab-delimited files and BOM-prefixed headers.
- Infer membership roles from staff positions (e.g. Driver → maintenance, Camper Care Associate → camper_care) and store Campminder position metadata on memberships.
- Deduplicate by Campminder ID with name/email merge fallbacks; preview and import surfaces merge and duplicate flags in the admin bulk import UI.

## Test plan
- [x] `pytest bunk_logs/core/test_roster_import.py`
- [x] `pytest bunk_logs/api/tests/test_admin_flow_pr3.py::TestAdminBulkImportPreview`
- [ ] CI green on backend + frontend checks
- [ ] Manual: preview staff CSV in Admin → People → Bulk import; confirm roles, emails, and merge flags


Made with [Cursor](https://cursor.com)