### PR TITLE
feat: Help center, template lifecycle UX, and concerns inbox bulk read

### DIFF
--- a/backend/bunk_logs/api/dashboards/concerns.py
+++ b/backend/bunk_logs/api/dashboards/concerns.py
@@ -1,6 +1,7 @@
 """Concerns Inbox dashboard.
 
 GET /api/v1/dashboards/concerns/?date_start=&date_end=&include_read=
+POST /api/v1/dashboards/concerns/bulk-read/  — mark many items read/unread
 POST /api/v1/dashboards/concerns/<reflection_id>/<field_key>/read/
 
 Surfaces every "concern" item (textarea answers on dashboard_role=open_concern
@@ -15,6 +16,7 @@ from __future__ import annotations
 from datetime import date
 from datetime import timedelta
 
+from django.db.models import Q
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -26,6 +28,7 @@ from bunk_logs.core.models import Reflection
 DEFAULT_WINDOW_DAYS = 14
 MAX_WINDOW_DAYS = 60
 LOW_RATING_THRESHOLD = 1
+BULK_READ_MAX_ITEMS = 200
 
 
 def _parse_date(s: str | None, default: date) -> date:
@@ -159,6 +162,83 @@ class ConcernsInboxView(APIView):
             "period": {"start": cur_start.isoformat(), "end": cur_end.isoformat()},
             "include_read": include_read,
             "items": items,
+        })
+
+
+def _normalize_bulk_items(raw_items) -> list[tuple[int, str]]:
+    """Parse and validate bulk-read payload entries."""
+    if not isinstance(raw_items, list):
+        return []
+    out: list[tuple[int, str]] = []
+    for it in raw_items:
+        if not isinstance(it, dict):
+            continue
+        rid = it.get("reflection_id")
+        fk = it.get("field_key")
+        if not isinstance(rid, int) or not isinstance(fk, str):
+            continue
+        fk = fk.strip()
+        if not fk or len(fk) > 64:
+            continue
+        out.append((rid, fk))
+    return out
+
+
+class ConcernBulkReadView(APIView):
+    """POST bulk mark-read / mark-unread for this viewer.
+
+    Body: ``{"items": [{"reflection_id": 1, "field_key": "concerns"}, ...], "read": true}``
+    ``read`` defaults to ``true``. Invisible reflections are skipped silently.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        items = _normalize_bulk_items(request.data.get("items"))
+        if not items:
+            return Response({"detail": "items required."}, status=400)
+        if len(items) > BULK_READ_MAX_ITEMS:
+            return Response(
+                {"detail": f"At most {BULK_READ_MAX_ITEMS} items per request."},
+                status=400,
+            )
+
+        read_flag = request.data.get("read", True)
+        if not isinstance(read_flag, bool):
+            read_flag = str(read_flag).lower() in ("1", "true", "yes")
+
+        ref_ids = {rid for rid, _ in items}
+        visible_ids = set(
+            reflections_visible_for_user(
+                request.user,
+                Reflection.objects.filter(id__in=ref_ids),
+            ).values_list("id", flat=True),
+        )
+        allowed = [(rid, fk) for rid, fk in items if rid in visible_ids]
+        skipped = len(items) - len(allowed)
+
+        if read_flag:
+            ConcernReadState.objects.bulk_create(
+                [
+                    ConcernReadState(
+                        user=request.user,
+                        reflection_id=rid,
+                        field_key=fk,
+                    )
+                    for rid, fk in allowed
+                ],
+                ignore_conflicts=True,
+            )
+        elif allowed:
+            q = Q()
+            for rid, fk in allowed:
+                q |= Q(reflection_id=rid, field_key=fk)
+            ConcernReadState.objects.filter(user=request.user).filter(q).delete()
+
+        return Response({
+            "read": read_flag,
+            "updated": len(allowed),
+            "skipped": skipped,
         })
 
 

--- a/backend/bunk_logs/api/leadership_team/templates.py
+++ b/backend/bunk_logs/api/leadership_team/templates.py
@@ -9,9 +9,10 @@ Endpoints under ``/api/v1/leadership-team/templates/``:
                               ``?force_new_version=true`` to bump version
                               regardless); creates a new version when
                               responses exist.
-* ``DELETE /<id>/``         — permanently delete a draft template
-                              (no responses allowed; published templates
-                              must be archived instead).
+* ``DELETE /<id>/``         — permanently delete a template with no
+                              responses (any status). Templates that
+                              already have submissions must be archived
+                              instead so answers are preserved.
 * ``POST   /<id>/publish/``   — ``draft -> published`` after validation.
 * ``POST   /<id>/unpublish/`` — ``published -> draft`` (no responses allowed).
 * ``POST   /<id>/clone/``   — clone any visible template as a new draft;
@@ -88,6 +89,7 @@ def _serialize(
     request,
     *,
     active_assignment_count: int | None = None,
+    reflection_count: int | None = None,
 ) -> dict[str, Any]:
     """Wrap the shared serializer + attach status + field-key warnings.
 
@@ -102,6 +104,8 @@ def _serialize(
     data["field_key_warnings"] = check_field_key_hints(template.schema or {}, org)
     if active_assignment_count is not None:
         data["active_assignment_count"] = active_assignment_count
+    if reflection_count is not None:
+        data["reflection_count"] = reflection_count
     return data
 
 
@@ -162,9 +166,10 @@ class LeadershipTeamTemplateListCreateView(APIView):
 
         templates = list(qs[:200])
         template_ids = [t.pk for t in templates]
-        counts: dict[int, int] = {}
+        assignment_counts: dict[int, int] = {}
+        reflection_counts: dict[int, int] = {}
         if template_ids:
-            counts_qs = (
+            assignment_counts_qs = (
                 TemplateAssignment.all_objects.filter(
                     organization=ctx.organization,
                     template_id__in=template_ids,
@@ -176,11 +181,22 @@ class LeadershipTeamTemplateListCreateView(APIView):
                 .values("template_id")
                 .annotate(n=models.Count("id"))
             )
-            counts = {row["template_id"]: row["n"] for row in counts_qs}
+            assignment_counts = {row["template_id"]: row["n"] for row in assignment_counts_qs}
+            reflection_counts_qs = (
+                Reflection.all_objects.filter(template_id__in=template_ids)
+                .values("template_id")
+                .annotate(n=models.Count("id"))
+            )
+            reflection_counts = {row["template_id"]: row["n"] for row in reflection_counts_qs}
         return Response(
             {
                 "templates": [
-                    _serialize(t, request, active_assignment_count=counts.get(t.pk, 0))
+                    _serialize(
+                        t,
+                        request,
+                        active_assignment_count=assignment_counts.get(t.pk, 0),
+                        reflection_count=reflection_counts.get(t.pk, 0),
+                    )
                     for t in templates
                 ],
             },
@@ -267,25 +283,24 @@ class LeadershipTeamTemplateDetailView(APIView):
 
     def get(self, request, pk: int, *args, **kwargs):
         tpl = self._get_template(request, pk)
-        return Response(_serialize(tpl, request))
+        reflection_count = Reflection.all_objects.filter(template=tpl).count()
+        return Response(_serialize(tpl, request, reflection_count=reflection_count))
 
     def delete(self, request, pk: int, *args, **kwargs):
-        """``DELETE /<id>/`` — permanently remove a draft template.
+        """``DELETE /<id>/`` — permanently remove a template with no responses.
 
-        Only draft templates with no responses can be deleted. Published
-        templates must be archived via ``POST /<id>/archive/`` instead.
+        Any status (draft, published, or archived) may be deleted when no
+        Reflection rows exist. Once staff have submitted answers, archive
+        the template instead so historical data is preserved.
         """
         ctx = viewer_or_403(request)
         tpl = self._get_template(request, pk)
         self._check_writable(ctx, tpl)
-        if tpl.status != ReflectionTemplate.Status.DRAFT:
-            msg = (
-                "Only draft templates may be deleted. "
-                "Archive published templates via POST /<id>/archive/ instead."
-            )
-            raise ValidationError(msg)
         if Reflection.all_objects.filter(template=tpl).exists():
-            msg = "Cannot delete a template that already has responses."
+            msg = (
+                "Cannot delete a template that already has responses. "
+                "Archive it instead to retire the form while keeping answers."
+            )
             raise ValidationError(msg)
         _audit_template(request=request, template=tpl, action="delete")
         tpl.delete()

--- a/backend/bunk_logs/api/reflections.py
+++ b/backend/bunk_logs/api/reflections.py
@@ -20,6 +20,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from bunk_logs.core import audit as audit_module
+from bunk_logs.core.assignment_resolution import list_required_assignments_for
 from bunk_logs.core.models import AssignmentGroup
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
@@ -27,6 +28,7 @@ from bunk_logs.core.models import Person
 from bunk_logs.core.models import Program
 from bunk_logs.core.models import Reflection
 from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.models import TemplateAssignment
 from bunk_logs.core.models import TranslationRecord
 from bunk_logs.core.models import reflection_snapshot
 from bunk_logs.core.models import validate_reflection_answers
@@ -176,6 +178,244 @@ def _current_period(today: date, cadence: str) -> tuple[date, date]:
 def _task_id(template_id: int, group_id: int | None, period_start: date) -> str:
     key = f"{template_id}:{group_id or ''}:{period_start.isoformat()}"
     return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+
+def _assignment_cadence(assignment: TemplateAssignment) -> str:
+    if assignment.cadence_override:
+        return assignment.cadence_override
+    return assignment.template.cadence or "daily"
+
+
+def _eligible_groups_for_assignment(
+    assignment: TemplateAssignment,
+    author_agms: list[AssignmentGroupMembership],
+) -> list[AssignmentGroup]:
+    """Assignment groups the viewer authors that this assignment applies to."""
+    tpl = assignment.template
+    allowed_types = set(tpl.assignment_group_types or [])
+    if assignment.target_type == TemplateAssignment.TargetType.ASSIGNMENT_GROUP:
+        group = assignment.assignment_group
+        if group is None or not group.is_active:
+            return []
+        if any(agm.group_id == group.id for agm in author_agms):
+            return [group]
+        return []
+    return [
+        agm.group
+        for agm in author_agms
+        if agm.group.is_active
+        and agm.group.program_id == assignment.program_id
+        and (not allowed_types or agm.group.group_type in allowed_types)
+    ]
+
+
+def _roster_subjects_data(
+    *,
+    viewer: Person,
+    template: ReflectionTemplate,
+    group: AssignmentGroup,
+    subject_persons: list[Person],
+    period_start: date,
+    period_end: date,
+) -> list[dict]:
+    person_ids = [p.id for p in subject_persons]
+    reflections = list(
+        Reflection.all_objects.filter(
+            template=template,
+            assignment_group=group,
+            period_start=period_start,
+            period_end=period_end,
+            subject_id__in=person_ids,
+        ).select_related("author"),
+    )
+    covered_map: dict[int, Reflection] = {}
+    for reflection in reflections:
+        if reflection.subject_id not in covered_map:
+            covered_map[reflection.subject_id] = reflection
+
+    is_admin = _has_tenant_admin(viewer)
+    subjects_data = []
+    for person in subject_persons:
+        reflection = covered_map.get(person.id)
+        covered_by_name = None
+        if reflection and reflection.author and is_admin:
+            covered_by_name = reflection.author.full_name
+        elif reflection and reflection.author:
+            covered_by_name = reflection.author.full_name
+        subjects_data.append({
+            "person_id": person.id,
+            "name": person.full_name,
+            "preferred_name": person.preferred_name or person.first_name,
+            "covered": bool(reflection),
+            "covered_by_me": bool(reflection and reflection.author_id == viewer.id),
+            "reflection_id": reflection.id if reflection else None,
+            "covered_by_name": covered_by_name,
+        })
+    return subjects_data
+
+
+def _subjects_by_group(group_ids: list[int]) -> dict[int, list[Person]]:
+    subject_agms = list(
+        AssignmentGroupMembership.objects.filter(
+            group_id__in=group_ids,
+            role_in_group="subject",
+            is_active=True,
+        ).select_related("person"),
+    )
+    subjects_by_group: dict[int, list[Person]] = {}
+    for sagm in subject_agms:
+        subjects_by_group.setdefault(sagm.group_id, []).append(sagm.person)
+    return subjects_by_group
+
+
+def _tasks_from_required_assignments(
+    *,
+    viewer: Person,
+    organization,
+    viewer_memberships: list[Membership],
+    author_agms: list[AssignmentGroupMembership],
+    today: date,
+) -> list[dict]:
+    """Build my-tasks rows from active TemplateAssignment audience matches."""
+    tasks: list[dict] = []
+    seen_keys: set[tuple] = set()
+
+    for membership in viewer_memberships:
+        program = membership.program
+        if program.organization_id != organization.id:
+            continue
+        for assignment in list_required_assignments_for(
+            viewer, organization, program, today,
+        ):
+            tpl = assignment.template
+            cadence = _assignment_cadence(assignment)
+            period_start, period_end = _current_period(today, cadence)
+            prog_slug = program.slug
+
+            if tpl.subject_mode == "self":
+                dedupe_key = (tpl.id, None, period_start, program.id)
+                if dedupe_key in seen_keys:
+                    continue
+                seen_keys.add(dedupe_key)
+
+                existing = (
+                    Reflection.all_objects.filter(
+                        author=viewer,
+                        subject=viewer,
+                        template=tpl,
+                        program=program,
+                        period_start=period_start,
+                        period_end=period_end,
+                    )
+                    .order_by("-submitted_at")
+                    .first()
+                )
+                tasks.append({
+                    "id": _task_id(tpl.id, None, period_start),
+                    "template": ReflectionTemplateSummarySerializer(tpl).data,
+                    "assignment_group": None,
+                    "subject_mode": "self",
+                    "period": {"start": period_start.isoformat(), "end": period_end.isoformat()},
+                    "program_slug": prog_slug,
+                    "subjects": [],
+                    "completion": {
+                        "covered": 1 if existing else 0,
+                        "total": 1,
+                        "my_count": 1 if existing else 0,
+                    },
+                    "self_status": {
+                        "submitted": bool(existing),
+                        "reflection_id": existing.id if existing else None,
+                        "submitted_at": existing.submitted_at.isoformat() if existing else None,
+                    },
+                })
+                continue
+
+            if tpl.subject_mode in ("single_subject", "multi_subject"):
+                groups = _eligible_groups_for_assignment(assignment, author_agms)
+                if not groups:
+                    continue
+                subjects_by_group = _subjects_by_group([g.id for g in groups])
+                for group in groups:
+                    subject_persons = subjects_by_group.get(group.id, [])
+                    if not subject_persons:
+                        continue
+                    dedupe_key = (tpl.id, group.id, period_start, program.id)
+                    if dedupe_key in seen_keys:
+                        continue
+                    seen_keys.add(dedupe_key)
+
+                    subjects_data = _roster_subjects_data(
+                        viewer=viewer,
+                        template=tpl,
+                        group=group,
+                        subject_persons=subject_persons,
+                        period_start=period_start,
+                        period_end=period_end,
+                    )
+                    covered_count = sum(1 for s in subjects_data if s["covered"])
+                    my_count = sum(1 for s in subjects_data if s["covered_by_me"])
+                    tasks.append({
+                        "id": _task_id(tpl.id, group.id, period_start),
+                        "template": ReflectionTemplateSummarySerializer(tpl).data,
+                        "assignment_group": {
+                            "id": group.id,
+                            "name": group.name,
+                            "group_type": group.group_type,
+                        },
+                        "subject_mode": tpl.subject_mode,
+                        "period": {"start": period_start.isoformat(), "end": period_end.isoformat()},
+                        "program_slug": prog_slug,
+                        "subjects": subjects_data,
+                        "completion": {
+                            "covered": covered_count,
+                            "total": len(subjects_data),
+                            "my_count": my_count,
+                        },
+                        "self_status": None,
+                    })
+                continue
+
+            if tpl.subject_mode == "group":
+                groups = _eligible_groups_for_assignment(assignment, author_agms)
+                for group in groups:
+                    dedupe_key = (tpl.id, group.id, period_start, program.id)
+                    if dedupe_key in seen_keys:
+                        continue
+                    seen_keys.add(dedupe_key)
+
+                    existing = (
+                        Reflection.all_objects.filter(
+                            author=viewer,
+                            template=tpl,
+                            program=program,
+                            subject_group=group,
+                            period_start=period_start,
+                            period_end=period_end,
+                        )
+                        .first()
+                    )
+                    tasks.append({
+                        "id": _task_id(tpl.id, group.id, period_start),
+                        "template": ReflectionTemplateSummarySerializer(tpl).data,
+                        "assignment_group": {
+                            "id": group.id,
+                            "name": group.name,
+                            "group_type": group.group_type,
+                        },
+                        "subject_mode": "group",
+                        "period": {"start": period_start.isoformat(), "end": period_end.isoformat()},
+                        "program_slug": prog_slug,
+                        "subjects": [],
+                        "completion": {
+                            "covered": 1 if existing else 0,
+                            "total": 1,
+                            "my_count": 1 if existing else 0,
+                        },
+                        "self_status": None,
+                    })
+
+    return tasks
 
 
 def _build_periods(today: date, cadence: str) -> list[tuple[date, date]]:
@@ -817,15 +1057,9 @@ class ReflectionViewSet(viewsets.ModelViewSet):
 
         today = date.today()
 
-        # Viewer's active memberships (needed for self-reflection eligibility + program_slug)
         viewer_memberships = list(
             Membership.objects.filter(person=viewer, is_active=True).select_related("program"),
         )
-        viewer_roles = {m.role for m in viewer_memberships}
-        # Use the most recent program as default for self-reflection submissions
-        default_program = viewer_memberships[0].program if viewer_memberships else None
-
-        # Viewer's assignment group author memberships
         author_agms = list(
             AssignmentGroupMembership.objects.filter(
                 person=viewer,
@@ -834,208 +1068,13 @@ class ReflectionViewSet(viewsets.ModelViewSet):
             ).select_related("group"),
         )
 
-        # Active templates for this org. Org-scoped rows shadow globals
-        # for the same (role, cadence, subject_mode) tuple so a tenant
-        # that has customised a template doesn't double-count the global
-        # fallback (Step 7_6 ships a global counselor self-reflection
-        # template that orgs may override).
-        templates_qs = (
-            ReflectionTemplate.objects.filter(
-                Q(organization=org) | Q(organization__isnull=True),
-                is_active=True,
-            )
-            .annotate(
-                _org_priority=Case(
-                    When(organization__isnull=True, then=1),
-                    default=0,
-                    output_field=IntegerField(),
-                ),
-            )
-            .order_by("_org_priority", "-version", "name")
+        tasks = _tasks_from_required_assignments(
+            viewer=viewer,
+            organization=org,
+            viewer_memberships=viewer_memberships,
+            author_agms=author_agms,
+            today=today,
         )
-        templates: list[ReflectionTemplate] = []
-        _seen_keys: set[tuple] = set()
-        for tpl in templates_qs:
-            shadow_key = (
-                tpl.subject_mode,
-                tpl.cadence,
-                tpl.role or "",
-                tuple(sorted(tpl.author_role_filter or [])),
-                tuple(sorted(tpl.assignment_group_types or [])),
-            )
-            if shadow_key in _seen_keys:
-                continue
-            _seen_keys.add(shadow_key)
-            templates.append(tpl)
-
-        tasks: list[dict] = []
-
-        for tpl in templates:
-            period_start, period_end = _current_period(today, tpl.cadence)
-            prog_slug = default_program.slug if default_program else ""
-
-            if tpl.subject_mode == "self":
-                eligible_roles = tpl.author_role_filter or []
-                if eligible_roles and not viewer_roles.intersection(set(eligible_roles)):
-                    continue
-                if not eligible_roles and not viewer_memberships:
-                    continue
-
-                existing = (
-                    Reflection.all_objects.filter(
-                        author=viewer,
-                        subject=viewer,
-                        template=tpl,
-                        period_start=period_start,
-                        period_end=period_end,
-                    )
-                    .order_by("-submitted_at")
-                    .first()
-                )
-                tasks.append({
-                    "id": _task_id(tpl.id, None, period_start),
-                    "template": ReflectionTemplateSummarySerializer(tpl).data,
-                    "assignment_group": None,
-                    "subject_mode": "self",
-                    "period": {"start": period_start.isoformat(), "end": period_end.isoformat()},
-                    "program_slug": prog_slug,
-                    "subjects": [],
-                    "completion": {
-                        "covered": 1 if existing else 0,
-                        "total": 1,
-                        "my_count": 1 if existing else 0,
-                    },
-                    "self_status": {
-                        "submitted": bool(existing),
-                        "reflection_id": existing.id if existing else None,
-                        "submitted_at": existing.submitted_at.isoformat() if existing else None,
-                    },
-                })
-
-            elif tpl.subject_mode in ("single_subject", "multi_subject"):
-                allowed_types = set(tpl.assignment_group_types or [])
-                eligible_agms = [
-                    agm for agm in author_agms
-                    if agm.group.is_active
-                    and (not allowed_types or agm.group.group_type in allowed_types)
-                ]
-                if not eligible_agms:
-                    continue
-
-                # Prefetch subject memberships for all eligible groups in one query
-                group_ids = [agm.group_id for agm in eligible_agms]
-                subject_agms = list(
-                    AssignmentGroupMembership.objects.filter(
-                        group_id__in=group_ids,
-                        role_in_group="subject",
-                        is_active=True,
-                    ).select_related("person"),
-                )
-                subjects_by_group: dict[int, list[Person]] = {}
-                for sagm in subject_agms:
-                    subjects_by_group.setdefault(sagm.group_id, []).append(sagm.person)
-
-                for agm in eligible_agms:
-                    group = agm.group
-                    subject_persons = subjects_by_group.get(group.id, [])
-                    if not subject_persons:
-                        continue
-
-                    person_ids = [p.id for p in subject_persons]
-                    reflections = list(
-                        Reflection.all_objects.filter(
-                            template=tpl,
-                            assignment_group=group,
-                            period_start=period_start,
-                            period_end=period_end,
-                            subject_id__in=person_ids,
-                        ).select_related("author"),
-                    )
-                    covered_map: dict[int, Reflection] = {}
-                    for r in reflections:
-                        if r.subject_id not in covered_map:
-                            covered_map[r.subject_id] = r
-
-                    is_admin = _has_tenant_admin(viewer)
-                    subjects_data = []
-                    for person in subject_persons:
-                        r = covered_map.get(person.id)
-                        covered_by_name = None
-                        if r and r.author and is_admin:
-                            covered_by_name = r.author.full_name
-                        elif r and r.author:
-                            # Authors in the same group can see who logged
-                            covered_by_name = r.author.full_name
-                        subjects_data.append({
-                            "person_id": person.id,
-                            "name": person.full_name,
-                            "preferred_name": person.preferred_name or person.first_name,
-                            "covered": bool(r),
-                            "covered_by_me": bool(r and r.author_id == viewer.id),
-                            "reflection_id": r.id if r else None,
-                            "covered_by_name": covered_by_name,
-                        })
-
-                    covered_count = sum(1 for s in subjects_data if s["covered"])
-                    my_count = sum(1 for s in subjects_data if s["covered_by_me"])
-                    tasks.append({
-                        "id": _task_id(tpl.id, group.id, period_start),
-                        "template": ReflectionTemplateSummarySerializer(tpl).data,
-                        "assignment_group": {
-                            "id": group.id,
-                            "name": group.name,
-                            "group_type": group.group_type,
-                        },
-                        "subject_mode": tpl.subject_mode,
-                        "period": {"start": period_start.isoformat(), "end": period_end.isoformat()},
-                        "program_slug": prog_slug,
-                        "subjects": subjects_data,
-                        "completion": {
-                            "covered": covered_count,
-                            "total": len(subjects_data),
-                            "my_count": my_count,
-                        },
-                        "self_status": None,
-                    })
-
-            elif tpl.subject_mode == "group":
-                allowed_types = set(tpl.assignment_group_types or [])
-                eligible_agms = [
-                    agm for agm in author_agms
-                    if agm.group.is_active
-                    and (not allowed_types or agm.group.group_type in allowed_types)
-                ]
-                for agm in eligible_agms:
-                    group = agm.group
-                    existing = (
-                        Reflection.all_objects.filter(
-                            author=viewer,
-                            template=tpl,
-                            subject_group=group,
-                            period_start=period_start,
-                            period_end=period_end,
-                        )
-                        .first()
-                    )
-                    tasks.append({
-                        "id": _task_id(tpl.id, group.id, period_start),
-                        "template": ReflectionTemplateSummarySerializer(tpl).data,
-                        "assignment_group": {
-                            "id": group.id,
-                            "name": group.name,
-                            "group_type": group.group_type,
-                        },
-                        "subject_mode": "group",
-                        "period": {"start": period_start.isoformat(), "end": period_end.isoformat()},
-                        "program_slug": prog_slug,
-                        "subjects": [],
-                        "completion": {
-                            "covered": 1 if existing else 0,
-                            "total": 1,
-                            "my_count": 1 if existing else 0,
-                        },
-                        "self_status": None,
-                    })
 
         cadence_order = {"daily": 0, "weekly": 1, "biweekly": 2, "monthly": 3, "on_demand": 4}
 

--- a/backend/bunk_logs/api/reflections.py
+++ b/backend/bunk_logs/api/reflections.py
@@ -233,14 +233,11 @@ def _roster_subjects_data(
         if reflection.subject_id not in covered_map:
             covered_map[reflection.subject_id] = reflection
 
-    is_admin = _has_tenant_admin(viewer)
     subjects_data = []
     for person in subject_persons:
         reflection = covered_map.get(person.id)
         covered_by_name = None
-        if reflection and reflection.author and is_admin:
-            covered_by_name = reflection.author.full_name
-        elif reflection and reflection.author:
+        if reflection and reflection.author:
             covered_by_name = reflection.author.full_name
         subjects_data.append({
             "person_id": person.id,

--- a/backend/bunk_logs/api/tests/test_dashboards_concerns.py
+++ b/backend/bunk_logs/api/tests/test_dashboards_concerns.py
@@ -242,6 +242,92 @@ def test_mark_read_blocked_for_invisible_reflection(
     assert ConcernReadState.objects.count() == 0
 
 
+def test_bulk_mark_read(api_client, org, program, setup):
+    bunk, camper, counselor_user, counselor = setup
+    tpl = _bunk_obs(org)
+    today = date.today()
+    ref_a = _make_reflection(
+        org, program, tpl, subject=camper, author=counselor, group=bunk,
+        day=today, answers={"overall": 4, "concerns": "worry a"},
+    )
+    ref_b = _make_reflection(
+        org, program, tpl, subject=camper, author=counselor, group=bunk,
+        day=today, answers={"overall": 1},
+    )
+    api_client.force_authenticate(user=counselor_user)
+    r = api_client.post(
+        "/api/v1/dashboards/concerns/bulk-read/",
+        {
+            "read": True,
+            "items": [
+                {"reflection_id": ref_a.id, "field_key": "concerns"},
+                {"reflection_id": ref_b.id, "field_key": "overall"},
+            ],
+        },
+        format="json",
+        **_hdr(org.slug),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["updated"] == 2
+    assert body["read"] is True
+    inbox = api_client.get("/api/v1/dashboards/concerns/", **_hdr(org.slug)).json()
+    assert inbox["items"] == []
+
+
+def test_bulk_mark_read_skips_invisible_reflections(api_client, org, program, setup):
+    bunk, camper, counselor_user, counselor = setup
+    tpl = _bunk_obs(org)
+    today = date.today()
+    ref = _make_reflection(
+        org, program, tpl, subject=camper, author=counselor, group=bunk,
+        day=today, answers={"overall": 4, "concerns": "hidden from other"},
+    )
+    other_user = _user("bulk-other@a.com")
+    other = _person(org, "Bu", "Lk", other_user)
+    Membership.all_objects.create(
+        program=program, person=other, role="counselor", is_active=True,
+    )
+    api_client.force_authenticate(user=other_user)
+    r = api_client.post(
+        "/api/v1/dashboards/concerns/bulk-read/",
+        {"items": [{"reflection_id": ref.id, "field_key": "concerns"}]},
+        format="json",
+        **_hdr(org.slug),
+    )
+    assert r.status_code == 200
+    assert r.json()["updated"] == 0
+    assert r.json()["skipped"] == 1
+    assert ConcernReadState.objects.count() == 0
+
+
+def test_bulk_mark_unread(api_client, org, program, setup):
+    bunk, camper, counselor_user, counselor = setup
+    tpl = _bunk_obs(org)
+    today = date.today()
+    ref = _make_reflection(
+        org, program, tpl, subject=camper, author=counselor, group=bunk,
+        day=today, answers={"overall": 4, "concerns": "restore me"},
+    )
+    api_client.force_authenticate(user=counselor_user)
+    api_client.post(
+        "/api/v1/dashboards/concerns/bulk-read/",
+        {"items": [{"reflection_id": ref.id, "field_key": "concerns"}]},
+        format="json",
+        **_hdr(org.slug),
+    )
+    r = api_client.post(
+        "/api/v1/dashboards/concerns/bulk-read/",
+        {"read": False, "items": [{"reflection_id": ref.id, "field_key": "concerns"}]},
+        format="json",
+        **_hdr(org.slug),
+    )
+    assert r.status_code == 200
+    assert r.json()["read"] is False
+    inbox = api_client.get("/api/v1/dashboards/concerns/", **_hdr(org.slug)).json()
+    assert any(i["reflection_id"] == ref.id for i in inbox["items"])
+
+
 def test_unmark_read_restores_item(api_client, org, program, setup):
     bunk, camper, counselor_user, counselor = setup
     tpl = _bunk_obs(org)

--- a/backend/bunk_logs/api/tests/test_leadership_team_templates.py
+++ b/backend/bunk_logs/api/tests/test_leadership_team_templates.py
@@ -599,7 +599,7 @@ def test_unpublish_with_responses_rejected(org, program, lt_membership, lt_user,
 
 
 # ---------------------------------------------------------------------------
-# DELETE endpoint (draft templates only)
+# DELETE endpoint (no responses — any status)
 # ---------------------------------------------------------------------------
 
 
@@ -621,13 +621,32 @@ def test_delete_draft_template_succeeds(org, lt_membership, lt_user):
 
 
 @pytest.mark.django_db
-def test_delete_published_template_rejected(org, lt_membership, lt_user, published_template):
-    """DELETE on a published template returns 400 — use archive instead."""
+def test_delete_published_template_succeeds_when_no_responses(
+    org, lt_membership, lt_user, published_template,
+):
+    """DELETE on a published template with no responses permanently removes it."""
     c = _client(lt_user, org)
     with organization_context(org):
         resp = c.delete(f"/api/v1/leadership-team/templates/{published_template.id}/")
-    assert resp.status_code == 400
-    assert "draft" in str(resp.data).lower() or "archive" in str(resp.data).lower()
+    assert resp.status_code == 204
+    assert not ReflectionTemplate.all_objects.filter(pk=published_template.id).exists()
+
+
+@pytest.mark.django_db
+def test_delete_archived_template_succeeds_when_no_responses(org, lt_membership, lt_user):
+    """DELETE on an archived template with no responses permanently removes it."""
+    tpl = ReflectionTemplate.all_objects.create(
+        organization=org, name="Archived Empty", slug="archived-empty",
+        cadence="daily",
+        schema={"fields": [{"key": "x", "type": "text", "prompts": {"en": "x?"}}]},
+        languages=["en"], subject_mode="self",
+        status=ReflectionTemplate.Status.ARCHIVED, is_active=False, version=1,
+    )
+    c = _client(lt_user, org)
+    with organization_context(org):
+        resp = c.delete(f"/api/v1/leadership-team/templates/{tpl.id}/")
+    assert resp.status_code == 204
+    assert not ReflectionTemplate.all_objects.filter(pk=tpl.id).exists()
 
 
 @pytest.mark.django_db

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -321,6 +321,11 @@ urlpatterns = [
         name="dashboard-concerns",
     ),
     path(
+        "dashboards/concerns/bulk-read/",
+        concerns_dashboard.ConcernBulkReadView.as_view(),
+        name="dashboard-concerns-bulk-read",
+    ),
+    path(
         "dashboards/concerns/<int:reflection_id>/<str:field_key>/read/",
         concerns_dashboard.ConcernMarkReadView.as_view(),
         name="dashboard-concerns-mark-read",

--- a/backend/bunk_logs/core/test_my_tasks_api.py
+++ b/backend/bunk_logs/core/test_my_tasks_api.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import date
+from datetime import timedelta
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -16,6 +17,7 @@ from bunk_logs.core.models import Person
 from bunk_logs.core.models import Program
 from bunk_logs.core.models import Reflection
 from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.models import TemplateAssignment
 
 User = get_user_model()
 
@@ -79,6 +81,59 @@ def counselor_membership(program, counselor_person):
         person=counselor_person,
         role="counselor",
         is_active=True,
+    )
+
+
+@pytest.fixture
+def lt_membership(program, org):
+    user = User.objects.create_user(email="lt_tasks@test.com", password="pw")
+    person = Person.all_objects.create(
+        organization=org,
+        first_name="LT",
+        last_name="Lead",
+        user=user,
+    )
+    return Membership.all_objects.create(
+        program=program,
+        person=person,
+        role="leadership_team",
+        is_active=True,
+    )
+
+
+def _role_assignment(*, organization, program, template, role, lt_membership, start=None):
+    return TemplateAssignment.all_objects.create(
+        organization=organization,
+        program=program,
+        template=template,
+        target_type=TemplateAssignment.TargetType.ROLE,
+        target_payload={"role": role},
+        start_date=start or (date.today() - timedelta(days=1)),
+        status=TemplateAssignment.Status.ACTIVE,
+        created_by=lt_membership,
+        is_required=True,
+    )
+
+
+@pytest.fixture
+def self_assignment(org, program, self_template, lt_membership, counselor_membership):
+    return _role_assignment(
+        organization=org,
+        program=program,
+        template=self_template,
+        role="counselor",
+        lt_membership=lt_membership,
+    )
+
+
+@pytest.fixture
+def roster_assignment(org, program, roster_template, lt_membership, counselor_membership):
+    return _role_assignment(
+        organization=org,
+        program=program,
+        template=roster_template,
+        role="counselor",
+        lt_membership=lt_membership,
     )
 
 
@@ -200,7 +255,13 @@ def _drop_seeded_counselor_self_template():
 
 @pytest.mark.django_db
 def test_my_tasks_self_reflection_appears(
-    org, program, counselor_user, counselor_person, counselor_membership, self_template,
+    org,
+    program,
+    counselor_user,
+    counselor_person,
+    counselor_membership,
+    self_template,
+    self_assignment,
 ):
     _drop_seeded_counselor_self_template()
     with organization_context(org):
@@ -220,7 +281,13 @@ def test_my_tasks_self_reflection_appears(
 
 @pytest.mark.django_db
 def test_my_tasks_self_reflection_shows_submitted(
-    org, program, counselor_user, counselor_person, counselor_membership, self_template,
+    org,
+    program,
+    counselor_user,
+    counselor_person,
+    counselor_membership,
+    self_template,
+    self_assignment,
 ):
     _drop_seeded_counselor_self_template()
     today = date.today()
@@ -256,6 +323,51 @@ def test_my_tasks_no_membership_no_tasks(org, counselor_user, counselor_person, 
     assert resp.data["tasks"] == []
 
 
+@pytest.mark.django_db
+def test_my_tasks_leadership_assignment_appears(org, program, lt_membership):
+    """LT-assigned self forms surface via TemplateAssignment, not template metadata alone."""
+    user = lt_membership.person.user
+    lt_template = ReflectionTemplate.all_objects.create(
+        organization=org,
+        name="Kitchen Sink",
+        slug="kitchen-sink-my-tasks",
+        cadence="daily",
+        schema=SIMPLE_SCHEMA,
+        languages=["en"],
+        subject_mode="self",
+        author_role_filter=["leadership_team"],
+        is_active=True,
+    )
+    _role_assignment(
+        organization=org,
+        program=program,
+        template=lt_template,
+        role="leadership_team",
+        lt_membership=lt_membership,
+    )
+    with organization_context(org):
+        client = _authed_client(user, org)
+        resp = client.get("/api/v1/reflections/my-tasks/")
+
+    assert resp.status_code == 200
+    slugs = {t["template"]["slug"] for t in resp.data["tasks"]}
+    assert "kitchen-sink-my-tasks" in slugs
+
+
+@pytest.mark.django_db
+def test_my_tasks_ignores_unassigned_templates(
+    org, program, counselor_user, counselor_membership, self_template,
+):
+    """Templates without an active assignment do not produce tasks."""
+    _drop_seeded_counselor_self_template()
+    with organization_context(org):
+        client = _authed_client(counselor_user, org)
+        resp = client.get("/api/v1/reflections/my-tasks/")
+
+    assert resp.status_code == 200
+    assert resp.data["tasks"] == []
+
+
 # ---------------------------------------------------------------------------
 # my-tasks: roster (single_subject) mode
 # ---------------------------------------------------------------------------
@@ -269,6 +381,7 @@ def test_my_tasks_roster_shows_subjects(
     counselor_person,
     counselor_membership,
     roster_template,
+    roster_assignment,
     bunk_group,
     counselor_as_author,
     camper_in_bunk,
@@ -302,6 +415,7 @@ def test_my_tasks_coverage_state_reflects_existing_reflections(
     counselor_person,
     counselor_membership,
     roster_template,
+    roster_assignment,
     bunk_group,
     counselor_as_author,
     camper_in_bunk,
@@ -348,6 +462,7 @@ def test_my_tasks_covered_by_me_flag_accurate(
     counselor_person,
     counselor_membership,
     roster_template,
+    roster_assignment,
     bunk_group,
     counselor_as_author,
     camper_in_bunk,
@@ -395,6 +510,7 @@ def test_my_tasks_multi_bunk_counselor_sees_both_bunks(
     counselor_person,
     counselor_membership,
     roster_template,
+    roster_assignment,
     bunk_group,
     counselor_as_author,
     camper_in_bunk,

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -3,13 +3,19 @@
 User-facing guides for BunkLogs product features. Each page explains what the
 feature does, who it is for, and how to use it in the app.
 
+These files are rendered in the in-app **Help** center (`/help`) for admins and
+program leads. Edit markdown here; rebuild the frontend to publish changes.
+
 For developer contracts (API shapes, `dashboard_role` wiring, widgets), see
 [`docs/dashboards.md`](../dashboards.md) and role flow docs under
 [`docs/role_flows/`](../role_flows/).
 
 ## Guides
 
-| Feature | Doc |
-|---------|-----|
-| Log Entries, Reflections, and Observations | [logs-reflections-observations.md](logs-reflections-observations.md) |
-| Concerns Inbox | [concern-inbox.md](concern-inbox.md) |
+| Feature | Doc | In-app slug |
+|---------|-----|-------------|
+| Log Entries, Reflections, and Observations | [logs-reflections-observations.md](logs-reflections-observations.md) | `logs-reflections-observations` |
+| Concerns Inbox | [concern-inbox.md](concern-inbox.md) | `concern-inbox` |
+| Form types (subject modes) | [form-types.md](form-types.md) | `form-types` |
+| Templates & assignments | [templates-and-assignments.md](templates-and-assignments.md) | `templates-and-assignments` |
+| Viewing form responses | [viewing-responses.md](viewing-responses.md) | `viewing-responses` |

--- a/docs/features/concern-inbox.md
+++ b/docs/features/concern-inbox.md
@@ -120,7 +120,15 @@ By default you only see items you have **not** marked read.
 2. Use **Open reflection** for full context (author, all answers, visibility).
 3. Click the subject name to open their **Subject** dashboard for trends and
    history.
-4. Click **Mark read** when you have handled it.
+4. Click **Mark read** when you have handled it—or select several rows with the
+   checkboxes and use **Mark N as read** to clear a batch at once.
+
+### Bulk mark read
+
+Each row has a checkbox. Use **Select all** to select every item in the current
+list, or pick individual rows. When at least one item is selected, a toolbar
+appears with **Mark N as read**. With **Show read items** enabled, you can also
+**Mark N as unread** on selected read rows.
 
 Read state is **personal**: marking read hides the item from *your* default view
 only. Other supervisors still see it until they mark it read themselves.

--- a/docs/features/form-types.md
+++ b/docs/features/form-types.md
@@ -1,0 +1,115 @@
+# Form types (subject modes)
+
+When you create a reflection template, **Subject mode** controls who each
+submission is about and where completed forms appear in the app. Pick the mode
+that matches how staff will fill out the form—not just what the form asks.
+
+---
+
+## Quick comparison
+
+| Subject mode | Who fills it out | Who it is about | Typical example |
+|--------------|------------------|-----------------|-----------------|
+| **Self-reflection** | The staff member | Themselves | Counselor end-of-day check-in |
+| **About one person** | Staff with a roster | One other person per submission | Daily camper log—one form per camper |
+| **About several people in one submission** | Staff with a roster | Multiple people named in a single form | "Which campers helped with cleanup?" |
+| **About a group** | Staff assigned to a group | The whole bunk/unit/class | "How did Bunk Maple do as a team today?" |
+
+---
+
+## Where each type appears
+
+| Subject mode | My Tasks | Bunk Logs dashboard | Reflections dashboard | Group dashboard |
+|--------------|----------|---------------------|----------------------|-----------------|
+| Self-reflection | Yes | No | Yes | No |
+| About one person | Yes | Yes | No | Yes |
+| About several people | Yes | Yes | No | Yes |
+| About a group | Yes | Yes | No | Yes |
+
+**Bunk Logs** (`/dashboards/logs`) lists forms about other people or groups.
+**Reflections** (`/dashboards/reflections`) lists self-reflection forms only.
+See [Log Entries, Reflections, and Observations](logs-reflections-observations.md)
+for the full distinction.
+
+---
+
+## Self-reflection
+
+The author writes about **themselves**. Author and subject are the same person.
+
+**Use for:** counselor daily self-reflection, kitchen staff check-in, leadership
+team reflection, unit head reflection.
+
+**Cadence:** one submission per author per period (daily, weekly, etc.).
+
+**Assignment:** target a **role** (all kitchen staff), **individuals**, or a
+**tag group**. Do not expect these on the Bunk Logs dashboard even if assigned
+in a group context—the dashboard routes by subject mode, not assignment target.
+
+---
+
+## About one person at a time
+
+The author files a **separate submission for each person** on their roster.
+
+**Use for:** daily bunk logs, per-camper ratings, faculty observations about
+individual madrichim. This is the **recommended default** for counselor camper
+logs.
+
+**How it works:** a counselor with eight campers files eight forms per day (one
+per camper). Each submission stores answers for that camper only. Coverage
+dashboards and My Tasks track completion per person.
+
+**Tip:** even if the counselor files all eight back-to-back, each camper still
+gets their own record.
+
+---
+
+## About several people in one submission
+
+The author names **multiple people in a single form** and the answers apply to
+that set together.
+
+**Use for:** rare cases where one question genuinely spans several people—e.g.
+"Rank your top three campers today" or "Which campers participated in cleanup?"
+
+**Important (current product behavior):** the batch UI for this mode is not
+built yet. In **My Tasks**, this mode currently looks the same as **About one
+person**: a roster of name pills, one person at a time. For standard daily bunk
+logs, choose **About one person** instead.
+
+---
+
+## About a group as a whole
+
+One submission per **group** (bunk, unit, classroom)—not tied to individual
+campers.
+
+**Use for:** a single daily note about how the bunk functioned as a team, without
+per-camper detail.
+
+**Difference from one-person mode:** you are not tracking coverage per camper;
+supervisors see one submission per group per period.
+
+---
+
+## Choosing the right mode
+
+```text
+Staff writes about themselves           →  Self-reflection
+One form per camper / madrich / peer    →  About one person
+One form naming several people at once  →  About several people (rare today)
+One note about the bunk as a whole      →  About a group
+```
+
+When in doubt for bunk logs, use **About one person**.
+
+---
+
+## Related guides
+
+- [Templates & assignments](templates-and-assignments.md) — publish, assign,
+  delete (unused forms), or archive (forms with responses)
+- [Viewing form responses](viewing-responses.md) — find submitted answers
+- [Log Entries, Reflections, and Observations](logs-reflections-observations.md)
+  — how the three capture types differ

--- a/docs/features/templates-and-assignments.md
+++ b/docs/features/templates-and-assignments.md
@@ -1,0 +1,205 @@
+# Templates & assignments
+
+Published forms reach staff through **templates** (the form definition) and
+**assignments** (who must or may fill them out, and when). Leadership Team and
+admins manage both surfaces.
+
+---
+
+## Templates
+
+A **template** defines:
+
+- Form fields (ratings, text areas, flags, etc.)
+- **Subject mode** — who each submission is about (see
+  [Form types](form-types.md))
+- **Cadence** — daily, weekly, biweekly, on demand, etc.
+- **Role metadata** — which staff role the form is designed for
+- **Group types** — which assignment groups apply (bunk, unit, classroom, …)
+
+Templates move through three statuses:
+
+| Status | Meaning |
+|--------|---------|
+| **Draft** | Editable; not visible to staff; not assignable |
+| **Published** | Active; can be assigned; staff may see it in My Tasks when an assignment is active |
+| **Archived** | Retired; no new assignments; existing responses remain readable |
+
+Whether you **delete** or **archive** depends on whether anyone has submitted the
+form yet—not on draft vs published status alone.
+
+---
+
+## Delete vs archive
+
+The app uses one simple rule:
+
+```text
+No submissions yet  →  Delete (permanent)
+Has submissions     →  Archive (retire, keep answers)
+```
+
+| Situation | What to do | What happens |
+|-----------|------------|--------------|
+| Draft you never published | **Delete** | Template row removed from the database |
+| Published but **nobody filed it yet** | **Delete** | Template and its assignments are removed |
+| Published or archived with **one or more submissions** | **Archive** (if not already) | Form hidden from new work; responses stay on dashboards and profiles |
+| Archived with **zero submissions** | **Delete** | Cleanup—same as deleting an unused draft |
+
+**Delete** is permanent. You cannot undo it. Associated **assignments** are removed
+with the template (CASCADE). Use Delete for experiments, duplicates, and mistaken
+publishes that never collected data.
+
+**Archive** is the safe off-ramp once staff have used the form. Archived templates
+no longer appear in My Tasks or assignment pickers, but supervisors can still
+browse historical answers. See [Viewing form responses](viewing-responses.md).
+
+### Where to delete or archive
+
+**Template library** (`/admin/templates`):
+
+- Each row shows action buttons based on status and whether responses exist.
+- **Delete** appears when the template has **no responses** (`reflection_count`
+  is zero). Click **Delete**, then confirm **Delete permanently?**
+- **Archive** appears on **published** templates (use when responses exist).
+- **Unpublish** appears on published templates **with no responses**—reverts to
+  draft without deleting. Optional if you prefer to edit before deleting.
+
+**Template builder** (`/admin/templates/:id`):
+
+- **Delete** — top action bar when the template has no responses. Confirm with
+  **Yes, delete**.
+- **Archive** — top action bar on published templates.
+- When responses exist, Delete is hidden and a hint explains: *Has responses —
+  use Archive to retire this form.*
+
+### Unpublish (published → draft)
+
+**Unpublish** is only available when the template is **published** and has **no
+responses**. It moves the template back to **draft** so you can keep editing or
+publish again later—without removing the row.
+
+If you unpublish a form that was already assigned, check **Admin → Assignments**
+and cancel or adjust any active assignments so staff are not pointed at a draft.
+
+### Step-by-step: remove a form nobody used
+
+1. Open **Admin → Templates**.
+2. Find the form (filter by status or role if needed).
+3. If status is **published** and you see **Delete**, click it and confirm.
+4. If you only see **Unpublish**, you can unpublish first, then delete from the
+   draft row—or delete directly when the Delete button is shown.
+
+### Step-by-step: retire a live form that has answers
+
+1. Open the template in the builder or library.
+2. Click **Archive** (not Delete).
+3. Cancel or end-date active **assignments** under **Admin → Assignments** if
+   staff should stop seeing the form immediately.
+4. Historical responses remain on Bunk Logs, Reflections, group dashboards, and
+   person profiles according to your access.
+
+---
+
+**Where to manage templates:**
+
+- **Admin** → **Templates** (`/admin/templates`) — full library, routing
+  settings, and WYSIWYG builder
+- Leadership Team members with program-lead access use the same admin templates
+  surface (legacy `/leadership-team/templates` URLs redirect here)
+
+---
+
+## Assignments
+
+An **assignment** binds a published template to an audience for a date window.
+
+| Field | What it controls |
+|-------|------------------|
+| **Target type** | Role, individuals, tag group, or assignment group |
+| **Start / end dates** | When the form appears in My Tasks and dashboards |
+| **Required** | Required forms count toward "all set"; optional forms land in a library |
+| **Title** | Display label (falls back to template name) |
+
+**Where to manage assignments:**
+
+- **Admin** → **Assignments** (`/admin/assignments`)
+
+Without an active assignment, staff will not see the form in **My Tasks**, and
+supervisor dashboards show a "no template" empty state for that role.
+
+---
+
+## End-to-end workflow
+
+1. **Create** a template (draft) in the template builder.
+2. Set **subject mode**, cadence, and fields. See
+   [Form types](form-types.md) if unsure which mode to pick.
+3. **Publish** the template.
+4. **Create an assignment** — pick the audience (e.g. all counselors), set
+   start date to today or the program start, mark required if appropriate.
+5. **Verify** as a test user: open **My Tasks** (`/tasks`) and confirm the form
+   appears.
+6. **Review responses** via Bunk Logs or Reflections depending on subject mode.
+   See [Viewing form responses](viewing-responses.md).
+
+---
+
+## Common pitfalls
+
+### Form does not appear in My Tasks
+
+Check:
+
+- Assignment **start date** is today or earlier (not tomorrow).
+- Template is **published** and assignment is active.
+- **Subject mode** matches how the user authors:
+  - Self-reflection → user needs a membership in the assigned role.
+  - Roster forms → user must be an **author** in an assignment group whose
+    `group_type` matches the template's allowed group types.
+- Assignment **target** includes that user (role, group, or individual).
+
+### Form appears in wrong dashboard
+
+- **Self** subject mode → **Reflections** dashboard (`/dashboards/reflections`)
+- **About one person / several people / group** → **Bunk Logs** dashboard
+  (`/dashboards/logs`)
+
+A leadership self-reflection assigned with `single_subject` will not behave as
+expected—use **Self-reflection** subject mode instead.
+
+### "Role" on the template vs assignment audience
+
+The template **role** field is metadata (which staff role the form is designed
+for). The assignment **target** decides who actually receives the form. They
+should align, but the assignment is what drives My Tasks.
+
+### I don't see a Delete button
+
+Delete only appears when **no one has submitted the form yet**. If counselors or
+other staff have already filed answers, use **Archive** instead. The builder
+shows *Has responses — use Archive to retire this form* in that case.
+
+### I published the wrong form type (e.g. single_subject instead of self)
+
+If nobody has submitted yet: **Delete** the template and create a new one with
+the correct [form type](form-types.md), then publish and assign again.
+
+If submissions already exist: **Archive** the old template, create and assign
+the corrected form, and leave historical responses on the old template for
+audit purposes.
+
+### Delete failed with an error about responses
+
+The API blocks delete once any Reflection row exists for that template, even if
+you cannot see those responses in the UI (permissions, date filters, or test
+data). Archive the template instead.
+
+---
+
+## Related guides
+
+- [Form types (subject modes)](form-types.md)
+- [Viewing form responses](viewing-responses.md)
+- [Log Entries, Reflections, and Observations](logs-reflections-observations.md)
+- [Concerns Inbox](concern-inbox.md) — triage worrying answers from completed forms

--- a/docs/features/viewing-responses.md
+++ b/docs/features/viewing-responses.md
@@ -1,0 +1,114 @@
+# Viewing form responses
+
+After staff submit forms, supervisors and admins review answers through several
+surfaces. The right entry point depends on the template's **subject mode**.
+
+---
+
+## Archived templates
+
+**Archive** retires a form but does **not** remove submitted answers. You can
+still review responses for archived templates from Bunk Logs, Reflections, or the
+template **Responses** link—as long as you have supervisor access and the
+assignment period you are viewing includes those submissions.
+
+To remove a form entirely, use **Delete** only when no submissions exist. See
+[Templates & assignments — Delete vs archive](templates-and-assignments.md#delete-vs-archive).
+
+---
+
+## Pick the right dashboard
+
+| Template subject mode | Start here |
+|-----------------------|------------|
+| Self-reflection | **Reflections** → `/dashboards/reflections` |
+| About one person, several people, or a group | **Bunk Logs** → `/dashboards/logs` |
+
+Both dashboards use the same pattern:
+
+1. Open the dashboard.
+2. Choose **Active** or **Ended** assignments.
+3. Filter by audience, program, or group if needed.
+4. Click a form tile to open the **responses** view for that assignment.
+
+See [Log Entries, Reflections, and Observations](logs-reflections-observations.md)
+for why these are separate.
+
+---
+
+## From the template library
+
+In **Admin → Templates** (`/admin/templates`):
+
+1. Find the published template.
+2. Use the **Responses** action (when available) to jump directly to submitted
+   answers for that template.
+
+This skips the assignment picker when you already know which form you need.
+
+---
+
+## Group dashboards
+
+Open a **group dashboard** (`/dashboards/group/<group-id>`) to see template
+response cards for log-style forms assigned to that bunk, unit, or classroom on
+the selected date.
+
+Use the date picker to change which day's submissions appear.
+
+---
+
+## Person profiles
+
+On a **subject profile** (`/profile/<person-id>`):
+
+- **Log-style** template responses appear in template response widgets (when you
+  have access).
+- **Self-reflections** appear in the self-reflection history section.
+- **Observations** (freeform notes) appear in a separate Observations stream—not
+  mixed with template responses.
+
+---
+
+## Concerns and triage
+
+For cross-template triage of worrying answers (open concern text, ratings ≤ 1),
+use the **Concerns Inbox** (`/dashboards/concerns`). That inbox mines completed
+reflections; it does not replace browsing a specific form on Bunk Logs or
+Reflections.
+
+See [Concerns Inbox](concern-inbox.md).
+
+---
+
+## Coverage and completion
+
+To see **who has not filed yet** (per bunk, per day):
+
+- **Coverage dashboard** → `/dashboards/coverage`
+- **Author attribution** → `/dashboards/authors`
+- **Group performance** → `/groups/performance`
+
+These complement the responses views—they show gaps, not full answer text.
+
+---
+
+## Quick URL reference
+
+| Goal | URL |
+|------|-----|
+| Browse log-style forms | `/dashboards/logs` |
+| Browse self-reflections | `/dashboards/reflections` |
+| Triage flagged answers | `/dashboards/concerns` |
+| Per-bunk daily cards | `/dashboards/group/<id>` |
+| Per-person history | `/profile/<id>` |
+| Manage templates | `/admin/templates` |
+| Manage assignments | `/admin/assignments` |
+
+---
+
+## Related guides
+
+- [Templates & assignments](templates-and-assignments.md)
+- [Form types (subject modes)](form-types.md)
+- [Log Entries, Reflections, and Observations](logs-reflections-observations.md)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,8 +33,10 @@
         "react-day-picker": "^9.5.1",
         "react-dom": "^19.1.0",
         "react-i18next": "^15.7.4",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^7.6.0",
         "react-transition-group": "^4.4.5",
+        "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.0.1"
       },
       "devDependencies": {
@@ -3545,18 +3547,59 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
@@ -3583,6 +3626,18 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.4.1",
@@ -3827,6 +3882,16 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3932,6 +3997,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
@@ -3980,6 +4055,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chart.js": {
@@ -4069,6 +4184,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/concat-map": {
@@ -4217,7 +4342,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4237,6 +4361,19 @@
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -4268,7 +4405,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4289,6 +4425,19 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -4629,6 +4778,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -4664,6 +4823,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4965,6 +5130,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -4985,6 +5190,16 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -5130,6 +5345,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5151,6 +5406,28 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -5605,6 +5882,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5663,6 +5950,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5671,6 +5968,851 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -5767,7 +6909,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5953,6 +7094,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -6150,6 +7316,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -6281,6 +7457,33 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -6427,6 +7630,72 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/requireindex": {
@@ -6593,6 +7862,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/spark-md5": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
@@ -6613,6 +7892,20 @@
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -6638,6 +7931,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/stylis": {
@@ -6826,6 +8137,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -6843,6 +8174,93 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -6927,6 +8345,34 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -8269,6 +9715,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,8 +41,10 @@
     "react-day-picker": "^9.5.1",
     "react-dom": "^19.1.0",
     "react-i18next": "^15.7.4",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.6.0",
     "react-transition-group": "^4.4.5",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.0.1"
   },
   "devDependencies": {

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -86,6 +86,9 @@ import LeadershipTeamSelfReflectionPage from './pages/leadership-team/SelfReflec
 import LeadershipTeamTemplateLibrary from './pages/leadership-team/TemplateLibrary';
 import LeadershipTeamTemplateBuilderPage from './pages/leadership-team/TemplateBuilder/TemplateBuilderPage';
 import LeadershipTeamResponses from './pages/leadership-team/Responses';
+import HelpIndexPage from './pages/help/HelpIndexPage';
+import HelpArticlePage from './pages/help/HelpArticlePage';
+import HelpRoute from './pages/help/HelpRoute';
 import SpecialistDashboard from './pages/specialist/Dashboard';
 import SpecialistCamperView from './pages/specialist/CamperView';
 import SpecialistSelfReflectionPage from './pages/specialist/SelfReflectionPage';
@@ -409,6 +412,22 @@ function Router() {
           <Route path="/reflect" element={<ReflectionFormPage />} />
           <Route path="/reflect/summary" element={<ReflectionSummaryPage />} />
           <Route path="/tasks" element={<TasksPage />} />
+          <Route
+            path="/help"
+            element={
+              <HelpRoute>
+                <HelpIndexPage />
+              </HelpRoute>
+            }
+          />
+          <Route
+            path="/help/:slug"
+            element={
+              <HelpRoute>
+                <HelpArticlePage />
+              </HelpRoute>
+            }
+          />
           <Route path="/notes" element={<Navigate to="/observations" replace />} />
           <Route path="/notes/*" element={<Navigate to="/observations" replace />} />
           <Route path="/subject-notes" element={<Navigate to="/observations" replace />} />

--- a/frontend/src/dashboards/concerns/ConcernsInbox.jsx
+++ b/frontend/src/dashboards/concerns/ConcernsInbox.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import api from '../../api';
 import PrivacyChip from '../../components/reflection/PrivacyChip';
@@ -8,6 +8,10 @@ function shortDate(iso) {
   const d = new Date(iso + 'T00:00:00');
   if (Number.isNaN(d.getTime())) return iso;
   return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function itemKey(it) {
+  return `${it.reflection_id}/${it.field_key}`;
 }
 
 function KindBadge({ kind }) {
@@ -24,12 +28,40 @@ function KindBadge({ kind }) {
 
 export default function ConcernsInbox({ payload, onChanged }) {
   const [busyId, setBusyId] = useState(null);
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const [selected, setSelected] = useState(() => new Set());
   const [error, setError] = useState(null);
   if (!payload) return null;
   const { items, period, include_read } = payload;
 
+  const selectedItems = useMemo(
+    () => items.filter((it) => selected.has(itemKey(it))),
+    [items, selected],
+  );
+  const unreadSelected = selectedItems.filter((it) => !it.read);
+  const readSelected = selectedItems.filter((it) => it.read);
+  const allSelected = items.length > 0 && selected.size === items.length;
+
+  const toggleOne = (it) => {
+    const key = itemKey(it);
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    if (allSelected) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(items.map(itemKey)));
+    }
+  };
+
   const markRead = async (item) => {
-    const key = `${item.reflection_id}/${item.field_key}`;
+    const key = itemKey(item);
     setBusyId(key);
     setError(null);
     try {
@@ -42,6 +74,11 @@ export default function ConcernsInbox({ payload, onChanged }) {
           `/api/v1/dashboards/concerns/${item.reflection_id}/${item.field_key}/read/`,
         );
       }
+      setSelected((prev) => {
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
       onChanged?.();
     } catch (e) {
       setError(e.response?.data?.detail || e.message || 'Failed to update read state');
@@ -50,9 +87,31 @@ export default function ConcernsInbox({ payload, onChanged }) {
     }
   };
 
+  const bulkUpdate = async (read) => {
+    const targets = read ? unreadSelected : readSelected;
+    if (targets.length === 0) return;
+    setBulkBusy(true);
+    setError(null);
+    try {
+      await api.post('/api/v1/dashboards/concerns/bulk-read/', {
+        read,
+        items: targets.map((it) => ({
+          reflection_id: it.reflection_id,
+          field_key: it.field_key,
+        })),
+      });
+      setSelected(new Set());
+      onChanged?.();
+    } catch (e) {
+      setError(e.response?.data?.detail || e.message || 'Failed to update selected items');
+    } finally {
+      setBulkBusy(false);
+    }
+  };
+
   return (
     <div>
-      <div className="mb-4 flex items-end justify-between">
+      <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
         <div>
           <p className="text-xs uppercase text-gray-500 dark:text-gray-400">
             {period.start} → {period.end}
@@ -60,8 +119,44 @@ export default function ConcernsInbox({ payload, onChanged }) {
           </p>
           <p className="text-sm text-gray-700 dark:text-gray-200">
             {items.length} item(s) in your inbox
+            {selected.size > 0 ? ` · ${selected.size} selected` : ''}
           </p>
         </div>
+        {items.length > 0 && selected.size > 0 && (
+          <div className="flex flex-wrap items-center gap-2">
+            {unreadSelected.length > 0 && (
+              <button
+                type="button"
+                onClick={() => bulkUpdate(true)}
+                disabled={bulkBusy}
+                className="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+                data-testid="concerns-bulk-mark-read"
+              >
+                Mark {unreadSelected.length} as read
+              </button>
+            )}
+            {include_read && readSelected.length > 0 && (
+              <button
+                type="button"
+                onClick={() => bulkUpdate(false)}
+                disabled={bulkBusy}
+                className="rounded-md border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50"
+                data-testid="concerns-bulk-mark-unread"
+              >
+                Mark {readSelected.length} as unread
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => setSelected(new Set())}
+              disabled={bulkBusy}
+              className="rounded-md px-2 py-1.5 text-xs text-gray-500 dark:text-gray-400 hover:underline disabled:opacity-50"
+              data-testid="concerns-clear-selection"
+            >
+              Clear selection
+            </button>
+          </div>
+        )}
       </div>
       {error && (
         <p className="mb-3 text-rose-600 dark:text-rose-400 text-sm">{error}</p>
@@ -72,85 +167,108 @@ export default function ConcernsInbox({ payload, onChanged }) {
         </p>
       ) : (
         <ul className="space-y-2">
-          {items.map((it) => (
-            <li
-              key={`${it.reflection_id}-${it.field_key}`}
-              className={`rounded-lg border ${
-                it.read
-                  ? 'border-gray-200 dark:border-gray-700 opacity-70'
-                  : 'border-amber-300 dark:border-amber-700'
-              } bg-white dark:bg-gray-900/40 p-3`}
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0 flex-1">
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mb-1 flex flex-wrap items-center gap-2">
-                    <KindBadge kind={it.kind} />
-                    <PrivacyChip teamVisibility={it.team_visibility} />
-                    <span>{shortDate(it.date)}</span>
-                    <span>·</span>
-                    <span>{it.template_name}</span>
-                    {it.assignment_group && (
-                      <>
-                        <span>·</span>
-                        <span>{it.assignment_group.name}</span>
-                      </>
-                    )}
-                    {it.author_name && (
-                      <>
-                        <span>·</span>
-                        <span>by {it.author_name}</span>
-                      </>
-                    )}
-                  </p>
-                  <p className="text-sm text-gray-900 dark:text-white">
-                    {it.subject_id ? (
-                      <Link
-                        to={`/profile/${it.subject_id}`}
-                        className="font-medium hover:underline"
-                      >
-                        {it.subject_name}
-                      </Link>
+          <li className="flex items-center gap-3 px-3 py-1 text-xs text-gray-500 dark:text-gray-400">
+            <input
+              type="checkbox"
+              checked={allSelected}
+              onChange={toggleAll}
+              aria-label="Select all concerns"
+              data-testid="concerns-select-all"
+              className="rounded border-gray-300 dark:border-gray-600"
+            />
+            <span>Select all</span>
+          </li>
+          {items.map((it) => {
+            const key = itemKey(it);
+            const isSelected = selected.has(key);
+            return (
+              <li
+                key={key}
+                className={`rounded-lg border ${
+                  it.read
+                    ? 'border-gray-200 dark:border-gray-700 opacity-70'
+                    : 'border-amber-300 dark:border-amber-700'
+                } ${isSelected ? 'ring-2 ring-indigo-400/60' : ''} bg-white dark:bg-gray-900/40 p-3`}
+              >
+                <div className="flex items-start gap-3">
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => toggleOne(it)}
+                    aria-label={`Select concern for ${it.subject_name ?? 'subject'}`}
+                    data-testid={`concerns-select-${it.reflection_id}-${it.field_key}`}
+                    className="mt-1 rounded border-gray-300 dark:border-gray-600 shrink-0"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mb-1 flex flex-wrap items-center gap-2">
+                      <KindBadge kind={it.kind} />
+                      <PrivacyChip teamVisibility={it.team_visibility} />
+                      <span>{shortDate(it.date)}</span>
+                      <span>·</span>
+                      <span>{it.template_name}</span>
+                      {it.assignment_group && (
+                        <>
+                          <span>·</span>
+                          <span>{it.assignment_group.name}</span>
+                        </>
+                      )}
+                      {it.author_name && (
+                        <>
+                          <span>·</span>
+                          <span>by {it.author_name}</span>
+                        </>
+                      )}
+                    </p>
+                    <p className="text-sm text-gray-900 dark:text-white">
+                      {it.subject_id ? (
+                        <Link
+                          to={`/profile/${it.subject_id}`}
+                          className="font-medium hover:underline"
+                        >
+                          {it.subject_name}
+                        </Link>
+                      ) : (
+                        <span className="font-medium">{it.subject_name ?? '—'}</span>
+                      )}
+                      <span className="mx-1.5 text-gray-400">·</span>
+                      <span className="text-gray-600 dark:text-gray-400">
+                        {it.field_label}
+                      </span>
+                    </p>
+                    {it.kind === 'open_concern' ? (
+                      <p className="mt-1 text-sm text-gray-800 dark:text-gray-100 whitespace-pre-wrap">
+                        {htmlToPlainText(it.value)}
+                      </p>
                     ) : (
-                      <span className="font-medium">{it.subject_name ?? '—'}</span>
+                      <p className="mt-1 text-sm font-mono text-rose-700 dark:text-rose-300">
+                        Rating: {it.value}
+                      </p>
                     )}
-                    <span className="mx-1.5 text-gray-400">·</span>
-                    <span className="text-gray-600 dark:text-gray-400">
-                      {it.field_label}
-                    </span>
-                  </p>
-                  {it.kind === 'open_concern' ? (
-                    <p className="mt-1 text-sm text-gray-800 dark:text-gray-100 whitespace-pre-wrap">
-                      {htmlToPlainText(it.value)}
+                    <p className="mt-2 text-xs">
+                      <Link
+                        to={`/reflections/${it.reflection_id}?returnTo=/dashboards/concerns`}
+                        className="text-indigo-700 dark:text-indigo-300 hover:underline"
+                      >
+                        Open reflection
+                      </Link>
                     </p>
-                  ) : (
-                    <p className="mt-1 text-sm font-mono text-rose-700 dark:text-rose-300">
-                      Rating: {it.value}
-                    </p>
-                  )}
-                  <p className="mt-2 text-xs">
-                    <Link
-                      to={`/reflections/${it.reflection_id}?returnTo=/dashboards/concerns`}
-                      className="text-indigo-700 dark:text-indigo-300 hover:underline"
-                    >
-                      Open reflection
-                    </Link>
-                  </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => markRead(it)}
+                    disabled={busyId === key || bulkBusy}
+                    className={`shrink-0 rounded-md px-2 py-1 text-xs font-medium ${
+                      it.read
+                        ? 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600'
+                        : 'bg-indigo-600 text-white hover:bg-indigo-500'
+                    }`}
+                  >
+                    {it.read ? 'Mark unread' : 'Mark read'}
+                  </button>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => markRead(it)}
-                  disabled={busyId === `${it.reflection_id}/${it.field_key}`}
-                  className={`shrink-0 rounded-md px-2 py-1 text-xs font-medium ${
-                    it.read
-                      ? 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600'
-                      : 'bg-indigo-600 text-white hover:bg-indigo-500'
-                  }`}
-                >
-                  {it.read ? 'Mark unread' : 'Mark read'}
-                </button>
-              </div>
-            </li>
-          ))}
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/frontend/src/dashboards/concerns/__tests__/ConcernsInbox.test.jsx
+++ b/frontend/src/dashboards/concerns/__tests__/ConcernsInbox.test.jsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import ConcernsInbox from '../ConcernsInbox';
+
+const postMock = vi.fn();
+const deleteMock = vi.fn();
+
+vi.mock('../../../api', () => ({
+  default: {
+    post: (...args) => postMock(...args),
+    delete: (...args) => deleteMock(...args),
+  },
+}));
+
+const payload = {
+  period: { start: '2026-06-01', end: '2026-06-14' },
+  include_read: false,
+  items: [
+    {
+      reflection_id: 1,
+      field_key: 'concerns',
+      kind: 'open_concern',
+      read: false,
+      date: '2026-06-10',
+      subject_id: 5,
+      subject_name: 'Alex Kim',
+      author_name: 'Sam Lee',
+      template_name: 'Daily log',
+      team_visibility: 'team',
+      field_label: 'Concerns?',
+      value: 'Homesick today',
+    },
+    {
+      reflection_id: 2,
+      field_key: 'overall',
+      kind: 'low_rating',
+      read: false,
+      date: '2026-06-11',
+      subject_id: 6,
+      subject_name: 'Jordan Park',
+      author_name: 'Sam Lee',
+      template_name: 'Daily log',
+      team_visibility: 'team',
+      field_label: 'Overall',
+      value: 1,
+    },
+  ],
+};
+
+beforeEach(() => {
+  postMock.mockReset();
+  deleteMock.mockReset();
+  postMock.mockResolvedValue({ data: { updated: 2, read: true } });
+});
+
+describe('ConcernsInbox bulk actions', () => {
+  it('selects all and bulk marks unread items as read', async () => {
+    const user = userEvent.setup();
+    const onChanged = vi.fn();
+    render(
+      <MemoryRouter>
+        <ConcernsInbox payload={payload} onChanged={onChanged} />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByTestId('concerns-select-all'));
+    expect(screen.getByTestId('concerns-bulk-mark-read')).toHaveTextContent('Mark 2 as read');
+
+    await user.click(screen.getByTestId('concerns-bulk-mark-read'));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalledWith(
+      '/api/v1/dashboards/concerns/bulk-read/',
+      {
+        read: true,
+        items: [
+          { reflection_id: 1, field_key: 'concerns' },
+          { reflection_id: 2, field_key: 'overall' },
+        ],
+      },
+    ));
+    expect(onChanged).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/help/HelpMarkdown.jsx
+++ b/frontend/src/help/HelpMarkdown.jsx
@@ -1,0 +1,63 @@
+import { Link } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+/**
+ * Rewrite intra-guide links like [Title](other-guide.md) to /help/other-guide.
+ */
+function rewriteHref(href) {
+  if (!href || typeof href !== 'string') return href;
+  if (href.startsWith('http://') || href.startsWith('https://') || href.startsWith('/')) {
+    return href;
+  }
+  const mdMatch = href.match(/^([^#?]+\.md)(.*)$/);
+  if (mdMatch) {
+    const slug = mdMatch[1].replace(/\.md$/, '');
+    return `/help/${slug}${mdMatch[2] || ''}`;
+  }
+  return href;
+}
+
+const proseClass =
+  'help-prose max-w-none text-gray-700 dark:text-gray-300 ' +
+  '[&_h1]:text-2xl [&_h1]:font-bold [&_h1]:text-gray-900 [&_h1]:dark:text-white [&_h1]:mb-4 ' +
+  '[&_h2]:text-lg [&_h2]:font-semibold [&_h2]:text-gray-900 [&_h2]:dark:text-white [&_h2]:mt-8 [&_h2]:mb-3 ' +
+  '[&_h3]:text-base [&_h3]:font-semibold [&_h3]:text-gray-800 [&_h3]:dark:text-gray-100 [&_h3]:mt-6 [&_h3]:mb-2 ' +
+  '[&_p]:mb-4 [&_p]:leading-relaxed ' +
+  '[&_ul]:list-disc [&_ul]:pl-6 [&_ul]:mb-4 [&_ol]:list-decimal [&_ol]:pl-6 [&_ol]:mb-4 ' +
+  '[&_li]:mb-1 ' +
+  '[&_a]:text-indigo-600 [&_a]:dark:text-indigo-400 [&_a]:underline hover:[&_a]:text-indigo-800 ' +
+  '[&_code]:text-sm [&_code]:bg-gray-100 [&_code]:dark:bg-gray-800 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded ' +
+  '[&_pre]:bg-gray-100 [&_pre]:dark:bg-gray-900 [&_pre]:p-4 [&_pre]:rounded-lg [&_pre]:overflow-x-auto [&_pre]:mb-4 ' +
+  '[&_table]:w-full [&_table]:text-sm [&_table]:mb-6 [&_th]:text-left [&_th]:font-semibold [&_th]:border-b [&_th]:border-gray-200 [&_th]:dark:border-gray-700 [&_th]:py-2 [&_th]:pr-3 ' +
+  '[&_td]:py-2 [&_td]:pr-3 [&_td]:border-b [&_td]:border-gray-100 [&_td]:dark:border-gray-800 ' +
+  '[&_hr]:my-8 [&_hr]:border-gray-200 [&_hr]:dark:border-gray-700';
+
+export default function HelpMarkdown({ content }) {
+  return (
+    <div className={proseClass}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          a({ href, children, ...props }) {
+            const resolved = rewriteHref(href);
+            if (resolved?.startsWith('/')) {
+              return (
+                <Link to={resolved} {...props}>
+                  {children}
+                </Link>
+              );
+            }
+            return (
+              <a href={resolved} target="_blank" rel="noopener noreferrer" {...props}>
+                {children}
+              </a>
+            );
+          },
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/frontend/src/help/helpManifest.js
+++ b/frontend/src/help/helpManifest.js
@@ -1,0 +1,81 @@
+/**
+ * Help center manifest. Article bodies live in docs/features/*.md;
+ * metadata here drives the index, search, and sort order.
+ */
+
+const articleModules = import.meta.glob('../../../docs/features/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+});
+
+/** @type {import('./helpTypes').HelpArticleMeta[]} */
+export const HELP_ARTICLE_META = [
+  {
+    slug: 'logs-reflections-observations',
+    title: 'Log Entries, Reflections, and Observations',
+    summary:
+      'Three ways staff capture input about people and groups—and where each one appears in the app.',
+    tags: ['getting-started', 'dashboards'],
+    sortOrder: 10,
+  },
+  {
+    slug: 'form-types',
+    title: 'Form types (subject modes)',
+    summary:
+      'Self-reflection vs one person vs several people vs group—and which dashboard each uses.',
+    tags: ['templates', 'getting-started'],
+    sortOrder: 20,
+  },
+  {
+    slug: 'templates-and-assignments',
+    title: 'Templates & assignments',
+    summary:
+      'Create, publish, and assign forms; delete unused templates or archive forms that have responses.',
+    tags: ['templates', 'assignments'],
+    sortOrder: 30,
+  },
+  {
+    slug: 'viewing-responses',
+    title: 'Viewing form responses',
+    summary:
+      'Find submitted answers via Bunk Logs, Reflections, group dashboards, and person profiles.',
+    tags: ['dashboards', 'templates'],
+    sortOrder: 40,
+  },
+  {
+    slug: 'concern-inbox',
+    title: 'Concerns Inbox',
+    summary:
+      'Triage open-concern text and low ratings from completed reflection forms.',
+    tags: ['dashboards', 'supervise'],
+    sortOrder: 50,
+  },
+];
+
+const contentBySlug = Object.fromEntries(
+  Object.entries(articleModules).map(([path, raw]) => {
+    const match = path.match(/\/([^/]+)\.md$/);
+    const fileSlug = match?.[1];
+    return fileSlug && fileSlug !== 'README' ? [fileSlug, raw] : null;
+  }).filter(Boolean),
+);
+
+/** @returns {import('./helpTypes').HelpArticle[]} */
+export function listHelpArticles() {
+  return HELP_ARTICLE_META
+    .filter((meta) => contentBySlug[meta.slug])
+    .map((meta) => ({
+      ...meta,
+      content: contentBySlug[meta.slug],
+    }))
+    .sort((a, b) => a.sortOrder - b.sortOrder);
+}
+
+/** @param {string} slug */
+export function getHelpArticle(slug) {
+  const meta = HELP_ARTICLE_META.find((a) => a.slug === slug);
+  const content = contentBySlug[slug];
+  if (!meta || !content) return null;
+  return { ...meta, content };
+}

--- a/frontend/src/pages/admin/templates/TemplateRoutingPanel.jsx
+++ b/frontend/src/pages/admin/templates/TemplateRoutingPanel.jsx
@@ -156,6 +156,9 @@ export default function TemplateRoutingPanel({ value, onChange, defaultOpen = fa
                 {SUBJECT_MODE_OPTIONS.find((m) => m.value === subjectMode)?.description}
               </p>
               <p className="mt-1 text-[11px] text-gray-400 dark:text-gray-500">
+                Appears on: {SUBJECT_MODE_OPTIONS.find((m) => m.value === subjectMode)?.appearsOn}
+              </p>
+              <p className="mt-1 text-[11px] text-gray-400 dark:text-gray-500">
                 Assignment scope: <code>{assignmentScopeFor(subjectMode)}</code>
                 <span className="opacity-70"> (auto-set)</span>
               </p>

--- a/frontend/src/pages/admin/templates/templateRouting.js
+++ b/frontend/src/pages/admin/templates/templateRouting.js
@@ -26,21 +26,25 @@ export const SUBJECT_MODE_OPTIONS = [
     value: 'self',
     label: 'Self-reflection',
     description: 'The author reflects about themselves. One submission per author per period.',
+    appearsOn: 'My Tasks, Reflections dashboard',
   },
   {
     value: 'single_subject',
     label: 'About one person at a time',
-    description: 'Author files one submission per subject (e.g. one form per camper, per day).',
+    description: 'Author files one submission per subject (e.g. one form per camper, per day). Recommended for bunk logs.',
+    appearsOn: 'My Tasks, Bunk Logs dashboard, group dashboard',
   },
   {
     value: 'multi_subject',
     label: 'About several people in one submission',
-    description: 'Author covers multiple subjects in a single form (rare).',
+    description: 'One form names multiple people with shared answers (rare). Today My Tasks still works one person at a time—use single-subject for standard bunk logs.',
+    appearsOn: 'My Tasks, Bunk Logs dashboard, group dashboard',
   },
   {
     value: 'group',
     label: 'About a group as a whole',
     description: 'One submission per group (e.g. one daily bunk note, no per-camper detail).',
+    appearsOn: 'My Tasks, Bunk Logs dashboard, group dashboard',
   },
 ];
 

--- a/frontend/src/pages/help/HelpArticlePage.jsx
+++ b/frontend/src/pages/help/HelpArticlePage.jsx
@@ -1,0 +1,43 @@
+import { Link, useParams } from 'react-router-dom';
+import { ArrowLeft } from 'lucide-react';
+import HelpMarkdown from '../../help/HelpMarkdown';
+import { getHelpArticle } from '../../help/helpManifest';
+
+export default function HelpArticlePage() {
+  const { slug } = useParams();
+  const article = getHelpArticle(slug);
+
+  if (!article) {
+    return (
+      <main className="grow px-4 sm:px-6 lg:px-8 py-8 w-full max-w-3xl mx-auto">
+        <Link
+          to="/help"
+          className="inline-flex items-center gap-1 text-sm text-indigo-600 dark:text-indigo-400 hover:underline mb-6"
+        >
+          <ArrowLeft size={14} aria-hidden="true" />
+          Back to Help
+        </Link>
+        <h1 className="text-xl font-bold text-gray-900 dark:text-white">Guide not found</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
+          That article does not exist or has been removed.
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="grow px-4 sm:px-6 lg:px-8 py-8 w-full max-w-3xl mx-auto">
+      <Link
+        to="/help"
+        data-testid="help-back-link"
+        className="inline-flex items-center gap-1 text-sm text-indigo-600 dark:text-indigo-400 hover:underline mb-6"
+      >
+        <ArrowLeft size={14} aria-hidden="true" />
+        Back to Help
+      </Link>
+      <article data-testid={`help-article-${article.slug}`}>
+        <HelpMarkdown content={article.content} />
+      </article>
+    </main>
+  );
+}

--- a/frontend/src/pages/help/HelpIndexPage.jsx
+++ b/frontend/src/pages/help/HelpIndexPage.jsx
@@ -1,0 +1,97 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { BookOpen, Search } from 'lucide-react';
+import { listHelpArticles } from '../../help/helpManifest';
+
+function ArticleCard({ article }) {
+  return (
+    <Link
+      to={`/help/${article.slug}`}
+      data-testid={`help-card-${article.slug}`}
+      className="group flex flex-col rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-5 shadow-sm hover:shadow-md hover:border-indigo-300 dark:hover:border-indigo-700 transition-all"
+    >
+      <div className="flex items-start gap-3 mb-2">
+        <span className="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300 shrink-0">
+          <BookOpen size={18} aria-hidden="true" />
+        </span>
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white group-hover:text-indigo-700 dark:group-hover:text-indigo-300">
+          {article.title}
+        </h2>
+      </div>
+      <p className="text-sm text-gray-600 dark:text-gray-400 flex-1">
+        {article.summary}
+      </p>
+      {article.tags?.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mt-3">
+          {article.tags.map((tag) => (
+            <span
+              key={tag}
+              className="text-[11px] font-medium px-2 py-0.5 rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+    </Link>
+  );
+}
+
+export default function HelpIndexPage() {
+  const articles = useMemo(() => listHelpArticles(), []);
+  const [query, setQuery] = useState('');
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return articles;
+    return articles.filter(
+      (a) =>
+        a.title.toLowerCase().includes(q) ||
+        a.summary.toLowerCase().includes(q) ||
+        (a.tags || []).some((t) => t.toLowerCase().includes(q)),
+    );
+  }, [articles, query]);
+
+  return (
+    <main className="grow px-4 sm:px-6 lg:px-8 py-8 w-full max-w-5xl mx-auto">
+      <header className="mb-8 border-b-2 border-indigo-500/70 dark:border-indigo-400/60 pb-4">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Help</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+          Guides for admins and program leads—templates, dashboards, assignments, and more.
+        </p>
+      </header>
+
+      <div className="relative mb-6">
+        <label htmlFor="help-search" className="sr-only">
+          Search guides
+        </label>
+        <Search
+          size={16}
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+          aria-hidden="true"
+        />
+        <input
+          id="help-search"
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search guides…"
+          data-testid="help-search"
+          className="w-full pl-9 pr-3 py-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        />
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400" data-testid="help-empty">
+          No guides match your search.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4" data-testid="help-article-grid">
+          {filtered.map((article) => (
+            <ArticleCard key={article.slug} article={article} />
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/pages/help/HelpRoute.jsx
+++ b/frontend/src/pages/help/HelpRoute.jsx
@@ -1,0 +1,31 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../../auth/AuthContext';
+import { hasCapability } from '../../utils/auth/capability';
+
+/**
+ * Help is for program leads and admins (inclusive of super-admins).
+ */
+export default function HelpRoute({ children }) {
+  const { isAuthenticated, loading, user } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (!isAuthenticated) {
+    const next = `${location.pathname}${location.search}${location.hash}`;
+    return (
+      <Navigate
+        to={`/signin?next=${encodeURIComponent(next)}`}
+        replace
+      />
+    );
+  }
+
+  if (!hasCapability(user, 'program_lead')) {
+    return <Navigate to="/" replace state={{ toast: 'Help is available to program leads and admins' }} />;
+  }
+
+  return children;
+}

--- a/frontend/src/pages/help/__tests__/HelpArticlePage.test.jsx
+++ b/frontend/src/pages/help/__tests__/HelpArticlePage.test.jsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import HelpArticlePage from '../HelpArticlePage';
+
+function renderAt(slug) {
+  return render(
+    <MemoryRouter initialEntries={[`/help/${slug}`]}>
+      <Routes>
+        <Route path="/help/:slug" element={<HelpArticlePage />} />
+        <Route path="/help" element={<div>Help home</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('HelpArticlePage', () => {
+  it('renders a known guide heading', () => {
+    renderAt('form-types');
+    expect(screen.getByTestId('help-article-form-types')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /form types/i })).toBeInTheDocument();
+  });
+
+  it('shows not found for unknown slug', () => {
+    renderAt('does-not-exist');
+    expect(screen.getByText(/guide not found/i)).toBeInTheDocument();
+  });
+
+  it('links internal markdown guides to /help routes', () => {
+    renderAt('form-types');
+    const related = screen.getByRole('link', { name: /templates & assignments/i });
+    expect(related).toHaveAttribute('href', '/help/templates-and-assignments');
+  });
+});

--- a/frontend/src/pages/help/__tests__/HelpIndexPage.test.jsx
+++ b/frontend/src/pages/help/__tests__/HelpIndexPage.test.jsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import HelpIndexPage from '../HelpIndexPage';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <HelpIndexPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('HelpIndexPage', () => {
+  it('lists all help guides', () => {
+    renderPage();
+    expect(screen.getByTestId('help-card-logs-reflections-observations')).toBeInTheDocument();
+    expect(screen.getByTestId('help-card-form-types')).toBeInTheDocument();
+    expect(screen.getByTestId('help-card-templates-and-assignments')).toBeInTheDocument();
+    expect(screen.getByTestId('help-card-viewing-responses')).toBeInTheDocument();
+    expect(screen.getByTestId('help-card-concern-inbox')).toBeInTheDocument();
+  });
+
+  it('filters guides by search query', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.type(screen.getByTestId('help-search'), 'subject mode');
+    expect(screen.getByTestId('help-card-form-types')).toBeInTheDocument();
+    expect(screen.queryByTestId('help-card-concern-inbox')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/help/__tests__/HelpRoute.test.jsx
+++ b/frontend/src/pages/help/__tests__/HelpRoute.test.jsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import HelpRoute from '../HelpRoute';
+
+const mockUseAuth = vi.fn();
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+function renderAt(path, user) {
+  mockUseAuth.mockReturnValue({ user, isAuthenticated: !!user, loading: false });
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="/help"
+          element={
+            <HelpRoute>
+              <div data-testid="help-content">Help</div>
+            </HelpRoute>
+          }
+        />
+        <Route path="/" element={<div data-testid="home">Home</div>} />
+        <Route path="/signin" element={<div data-testid="signin">Signin</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockUseAuth.mockReset();
+});
+
+describe('HelpRoute', () => {
+  it('allows program leads', () => {
+    renderAt('/help', { role: 'Leadership' });
+    expect(screen.getByTestId('help-content')).toBeInTheDocument();
+  });
+
+  it('allows admins', () => {
+    renderAt('/help', { role: 'Admin' });
+    expect(screen.getByTestId('help-content')).toBeInTheDocument();
+  });
+
+  it('redirects counselors', () => {
+    renderAt('/help', { role: 'Counselor' });
+    expect(screen.getByTestId('home')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/leadership-team/TemplateBuilder/TemplateBuilderPage.jsx
+++ b/frontend/src/pages/leadership-team/TemplateBuilder/TemplateBuilderPage.jsx
@@ -20,6 +20,7 @@ import {
   archiveTemplate,
   cloneTemplate,
   createTemplate,
+  deleteTemplate,
   getTemplate,
   patchTemplate,
   publishTemplate,
@@ -27,6 +28,7 @@ import {
 import { useAuth } from '../../../auth/AuthContext';
 import AssignmentList from '../AssignmentList';
 import AssignFormDialog from '../AssignFormDialog';
+import { SUBJECT_MODE_OPTIONS } from '../../admin/templates/templateRouting';
 
 const TIER_1_TYPES = [
   { value: 'text', label: 'Short text' },
@@ -52,13 +54,6 @@ const DASHBOARD_ROLES_BY_TYPE = {
 };
 
 const SUPPORTED_LANGUAGES = ['en', 'es', 'he'];
-
-const SUBJECT_MODES = [
-  { value: 'self', label: 'Self-reflection (author == subject)' },
-  { value: 'single_subject', label: 'About one other person' },
-  { value: 'multi_subject', label: 'About multiple people in one submission' },
-  { value: 'group', label: 'About a group / unit (no individual subject)' },
-];
 
 // assignment_scope is derived from subject_mode via the backend coherence rule.
 // Showing it read-only so the user sees what will be saved without being able
@@ -437,6 +432,7 @@ export default function TemplateBuilderPage() {
   const [showForceVersion, setShowForceVersion] = useState(false);
   const [showAssignDialog, setShowAssignDialog] = useState(false);
   const [assignRefreshKey, setAssignRefreshKey] = useState(0);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const dirtyRef = useRef(false);
   dirtyRef.current = dirty;
 
@@ -460,6 +456,7 @@ export default function TemplateBuilderPage() {
         is_active: data.is_active,
         version: data.version ?? 1,
         slug: data.slug,
+        reflection_count: data.reflection_count ?? 0,
       });
       setFields(addLocalIds(data.schema?.fields ?? []));
       setPreviewLanguage(data.languages?.[0] ?? 'en');
@@ -620,6 +617,25 @@ export default function TemplateBuilderPage() {
     }
   };
 
+  const doDelete = async () => {
+    setSaving(true);
+    setError('');
+    try {
+      await deleteTemplate(orgSlug, id);
+      navigate('/admin/templates');
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      setError(
+        typeof detail === 'string'
+          ? detail
+          : 'Cannot delete this form. Archive it instead if responses exist.',
+      );
+      setConfirmDelete(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const doClone = async () => {
     setSaving(true);
     try {
@@ -643,6 +659,7 @@ export default function TemplateBuilderPage() {
   const status = template.status ?? 'draft';
   const isPublished = status === 'published';
   const isArchived = status === 'archived';
+  const canDelete = isEdit && (template.reflection_count ?? 0) === 0;
 
   return (
     <div>
@@ -723,6 +740,48 @@ export default function TemplateBuilderPage() {
                 Assign form
               </button>
             )}
+            {canDelete && !confirmDelete && (
+              <button
+                type="button"
+                onClick={() => setConfirmDelete(true)}
+                disabled={saving}
+                className="text-sm rounded-lg border border-red-300 dark:border-red-700 text-red-600 dark:text-red-400 px-3 py-1.5 hover:bg-red-50 dark:hover:bg-red-900/30"
+                data-testid="lt-builder-delete"
+              >
+                Delete
+              </button>
+            )}
+            {canDelete && confirmDelete && (
+              <span className="flex items-center gap-2">
+                <span className="text-xs text-red-600 dark:text-red-400">Delete permanently?</span>
+                <button
+                  type="button"
+                  onClick={doDelete}
+                  disabled={saving}
+                  className="text-sm rounded-lg bg-red-600 hover:bg-red-700 text-white px-3 py-1.5"
+                  data-testid="lt-builder-delete-confirm"
+                >
+                  Yes, delete
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirmDelete(false)}
+                  disabled={saving}
+                  className="text-sm rounded-lg border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 px-3 py-1.5"
+                  data-testid="lt-builder-delete-cancel"
+                >
+                  Cancel
+                </button>
+              </span>
+            )}
+            {isEdit && (template.reflection_count ?? 0) > 0 && (
+              <p
+                className="text-xs text-gray-500 dark:text-gray-400 self-center"
+                data-testid="lt-builder-delete-blocked-hint"
+              >
+                Has responses — use Archive to retire this form.
+              </p>
+            )}
             {isEdit && (
               <button
                 type="button"
@@ -773,20 +832,39 @@ export default function TemplateBuilderPage() {
             </select>
           </label>
 
-          <label className="block text-sm text-gray-700 dark:text-gray-300">
-            Subject mode
+          <div className="text-sm text-gray-700 dark:text-gray-300">
+            <label htmlFor="lt-builder-subject-mode" className="block">
+              Who is each submission about?
+            </label>
             <select
+              id="lt-builder-subject-mode"
               value={template.subject_mode ?? 'self'}
               onChange={(e) => updateSubjectMode(e.target.value)}
               disabled={isArchived}
               className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-sm"
               data-testid="lt-builder-subject-mode"
             >
-              {SUBJECT_MODES.map((m) => (
+              {SUBJECT_MODE_OPTIONS.map((m) => (
                 <option key={m.value} value={m.value}>{m.label}</option>
               ))}
             </select>
-          </label>
+            <p
+              className="mt-1 text-xs text-gray-500 dark:text-gray-400"
+              data-testid="lt-builder-subject-mode-description"
+            >
+              {SUBJECT_MODE_OPTIONS.find((m) => m.value === (template.subject_mode ?? 'self'))?.description}
+            </p>
+            <p className="mt-1 text-[11px] text-gray-400 dark:text-gray-500">
+              Appears on:{' '}
+              {SUBJECT_MODE_OPTIONS.find((m) => m.value === (template.subject_mode ?? 'self'))?.appearsOn}
+            </p>
+            <Link
+              to="/help/form-types"
+              className="mt-1 inline-block text-xs text-indigo-600 dark:text-indigo-400 hover:underline"
+            >
+              Learn about form types
+            </Link>
+          </div>
 
           <div className="text-sm text-gray-700 dark:text-gray-300">
             <p className="mb-1">

--- a/frontend/src/pages/leadership-team/TemplateLibrary.jsx
+++ b/frontend/src/pages/leadership-team/TemplateLibrary.jsx
@@ -35,6 +35,36 @@ const ROLE_OPTIONS = [
   'madrich', 'faculty',
 ];
 
+/** Permanent delete is allowed only when no one has submitted answers yet. */
+function canDeleteTemplate(tpl) {
+  return (tpl.reflection_count ?? 0) === 0;
+}
+
+function DeleteConfirmButtons({ tplId, actionPending, onConfirm, onCancel }) {
+  return (
+    <span className="flex items-center gap-1">
+      <span className="text-xs text-red-600 dark:text-red-400">Delete permanently?</span>
+      <button
+        type="button"
+        onClick={onConfirm}
+        disabled={actionPending === tplId}
+        className="text-xs rounded-md bg-red-600 hover:bg-red-700 text-white px-2 py-1"
+        data-testid={`lt-tpl-delete-confirm-${tplId}`}
+      >
+        Yes
+      </button>
+      <button
+        type="button"
+        onClick={onCancel}
+        className="text-xs rounded-md border border-gray-300 dark:border-gray-600 px-2 py-1 text-gray-600 dark:text-gray-400"
+        data-testid={`lt-tpl-delete-cancel-${tplId}`}
+      >
+        No
+      </button>
+    </span>
+  );
+}
+
 function statusBadge(status) {
   const map = {
     draft: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200',
@@ -246,49 +276,35 @@ export default function LeadershipTeamTemplateLibrary() {
                       Edit
                     </Link>
                     {tpl.status === 'draft' && (
-                      <>
+                      <button
+                        type="button"
+                        onClick={() => doAction(tpl.id, 'publish')}
+                        disabled={actionPending === tpl.id}
+                        className="text-xs rounded-md bg-indigo-600 hover:bg-indigo-700 text-white px-2 py-1"
+                        data-testid={`lt-tpl-publish-${tpl.id}`}
+                      >
+                        Publish
+                      </button>
+                    )}
+                    {canDeleteTemplate(tpl) && (
+                      confirmDeleteId === tpl.id ? (
+                        <DeleteConfirmButtons
+                          tplId={tpl.id}
+                          actionPending={actionPending}
+                          onConfirm={() => doAction(tpl.id, 'delete')}
+                          onCancel={() => setConfirmDeleteId(null)}
+                        />
+                      ) : (
                         <button
                           type="button"
-                          onClick={() => doAction(tpl.id, 'publish')}
+                          onClick={() => setConfirmDeleteId(tpl.id)}
                           disabled={actionPending === tpl.id}
-                          className="text-xs rounded-md bg-indigo-600 hover:bg-indigo-700 text-white px-2 py-1"
-                          data-testid={`lt-tpl-publish-${tpl.id}`}
+                          className="text-xs rounded-md border border-red-300 dark:border-red-700 px-2 py-1 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30"
+                          data-testid={`lt-tpl-delete-${tpl.id}`}
                         >
-                          Publish
+                          Delete
                         </button>
-                        {confirmDeleteId === tpl.id ? (
-                          <span className="flex items-center gap-1">
-                            <span className="text-xs text-red-600 dark:text-red-400">Delete?</span>
-                            <button
-                              type="button"
-                              onClick={() => doAction(tpl.id, 'delete')}
-                              disabled={actionPending === tpl.id}
-                              className="text-xs rounded-md bg-red-600 hover:bg-red-700 text-white px-2 py-1"
-                              data-testid={`lt-tpl-delete-confirm-${tpl.id}`}
-                            >
-                              Yes
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => setConfirmDeleteId(null)}
-                              className="text-xs rounded-md border border-gray-300 dark:border-gray-600 px-2 py-1 text-gray-600 dark:text-gray-400"
-                              data-testid={`lt-tpl-delete-cancel-${tpl.id}`}
-                            >
-                              No
-                            </button>
-                          </span>
-                        ) : (
-                          <button
-                            type="button"
-                            onClick={() => setConfirmDeleteId(tpl.id)}
-                            disabled={actionPending === tpl.id}
-                            className="text-xs rounded-md border border-red-300 dark:border-red-700 px-2 py-1 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30"
-                            data-testid={`lt-tpl-delete-${tpl.id}`}
-                          >
-                            Delete
-                          </button>
-                        )}
-                      </>
+                      )
                     )}
                     {tpl.status === 'published' && (
                       <>

--- a/frontend/src/pages/leadership-team/__tests__/TemplateBuilder.test.jsx
+++ b/frontend/src/pages/leadership-team/__tests__/TemplateBuilder.test.jsx
@@ -6,12 +6,14 @@ import TemplateBuilderPage from '../TemplateBuilder/TemplateBuilderPage';
 const getMock = vi.fn();
 const postMock = vi.fn();
 const patchMock = vi.fn();
+const deleteMock = vi.fn();
 
 vi.mock('../../../api', () => ({
   default: {
     get: (...args) => getMock(...args),
     post: (...args) => postMock(...args),
     patch: (...args) => patchMock(...args),
+    delete: (...args) => deleteMock(...args),
   },
 }));
 
@@ -29,6 +31,7 @@ beforeEach(() => {
   getMock.mockReset();
   postMock.mockReset();
   patchMock.mockReset();
+  deleteMock.mockReset();
 });
 
 function renderNew() {
@@ -193,6 +196,58 @@ describe('TemplateBuilderPage', () => {
     await waitFor(() =>
       expect(screen.getByTestId('assign-form-dialog')).toBeInTheDocument(),
     );
+  });
+
+  it('shows Delete on a draft with no responses and calls the delete API', async () => {
+    const draftTemplate = {
+      id: 25,
+      name: 'Deletable Draft',
+      slug: 'deletable-draft',
+      role: 'counselor',
+      languages: ['en'],
+      cadence: 'daily',
+      subject_mode: 'self',
+      assignment_scope: 'none',
+      assignment_group_types: [],
+      status: 'draft',
+      is_active: false,
+      version: 1,
+      reflection_count: 0,
+      schema: { fields: [] },
+    };
+    deleteMock.mockResolvedValue({});
+    renderEdit(draftTemplate);
+
+    await waitFor(() => expect(screen.getByTestId('lt-builder-delete')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('lt-builder-delete'));
+    expect(screen.getByTestId('lt-builder-delete-confirm')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('lt-builder-delete-confirm'));
+    await waitFor(() => expect(deleteMock).toHaveBeenCalled());
+  });
+
+  it('hides Delete and shows archive hint when responses exist', async () => {
+    const usedTemplate = {
+      id: 26,
+      name: 'Used Template',
+      slug: 'used-template',
+      role: 'counselor',
+      languages: ['en'],
+      cadence: 'daily',
+      subject_mode: 'self',
+      assignment_scope: 'none',
+      assignment_group_types: [],
+      status: 'published',
+      is_active: true,
+      version: 1,
+      reflection_count: 2,
+      schema: { fields: [] },
+    };
+    renderEdit(usedTemplate);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('lt-builder-delete-blocked-hint')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('lt-builder-delete')).not.toBeInTheDocument();
   });
 
   it('shows the "Form assignments" section on a published template', async () => {

--- a/frontend/src/pages/leadership-team/__tests__/TemplateLibrary.test.jsx
+++ b/frontend/src/pages/leadership-team/__tests__/TemplateLibrary.test.jsx
@@ -105,7 +105,10 @@ describe('LeadershipTeamTemplateLibrary', () => {
       .mockResolvedValueOnce({
         data: {
           templates: [
-            { id: 40, name: 'Live Template', status: 'published', version: 1, languages: ['en'], cadence: 'daily' },
+            {
+              id: 40, name: 'Live Template', status: 'published', version: 1,
+              languages: ['en'], cadence: 'daily', reflection_count: 2,
+            },
           ],
         },
       })
@@ -116,7 +119,7 @@ describe('LeadershipTeamTemplateLibrary', () => {
     renderLib();
     await waitFor(() => expect(screen.getByTestId('lt-tpl-unpublish-40')).toBeInTheDocument());
 
-    // Unpublish should not appear on draft rows
+    // Delete hidden once responses exist
     expect(screen.queryByTestId('lt-tpl-delete-40')).not.toBeInTheDocument();
 
     await user.click(screen.getByTestId('lt-tpl-unpublish-40'));
@@ -164,13 +167,23 @@ describe('LeadershipTeamTemplateLibrary', () => {
     expect(screen.getByTestId('lt-tpl-edit-12')).toBeInTheDocument();
   });
 
-  it('shows a Delete button only for draft templates and requires confirmation', async () => {
+  it('shows Delete when a template has no responses and requires confirmation', async () => {
     getMock
       .mockResolvedValueOnce({
         data: {
           templates: [
-            { id: 20, name: 'Draft Template', status: 'draft', version: 1, languages: ['en'], cadence: 'daily' },
-            { id: 21, name: 'Published Template', status: 'published', version: 1, languages: ['en'], cadence: 'daily' },
+            {
+              id: 20, name: 'Draft Template', status: 'draft', version: 1,
+              languages: ['en'], cadence: 'daily', reflection_count: 0,
+            },
+            {
+              id: 21, name: 'Published Template', status: 'published', version: 1,
+              languages: ['en'], cadence: 'daily', reflection_count: 0,
+            },
+            {
+              id: 22, name: 'Used Template', status: 'published', version: 1,
+              languages: ['en'], cadence: 'daily', reflection_count: 3,
+            },
           ],
         },
       })
@@ -181,9 +194,9 @@ describe('LeadershipTeamTemplateLibrary', () => {
     renderLib();
     await waitFor(() => expect(screen.getByTestId('lt-tpl-row-20')).toBeInTheDocument());
 
-    // Delete button only for drafts
     expect(screen.getByTestId('lt-tpl-delete-20')).toBeInTheDocument();
-    expect(screen.queryByTestId('lt-tpl-delete-21')).not.toBeInTheDocument();
+    expect(screen.getByTestId('lt-tpl-delete-21')).toBeInTheDocument();
+    expect(screen.queryByTestId('lt-tpl-delete-22')).not.toBeInTheDocument();
 
     // Click Delete shows confirmation
     await user.click(screen.getByTestId('lt-tpl-delete-20'));

--- a/frontend/src/partials/Sidebar.jsx
+++ b/frontend/src/partials/Sidebar.jsx
@@ -53,6 +53,7 @@ const PROGRAM_LEAD_PLUS = ['program_lead'];
  * Admin IA (admin + super_admin) — Phase 1 of the role-based nav refactor:
  *
  *   HOME (top)           /admin/home
+ *   HELP (top)           /help
  *
  *   MY WORK
  *     Performance Dashboard /groups/performance
@@ -84,8 +85,8 @@ const PROGRAM_LEAD_PLUS = ['program_lead'];
  *
  * Default nav (non-admin): My work (Home/tasks/reflections/
  * observations/maintenance), Supervise (supervisor+; program_lead+ also
- * gets performance / log entries / reflections / authors there). Leadership
- * Team (program_lead+). Camper Care omits My tasks / File a reflection /
+ * gets performance / log entries / reflections / authors there). Help
+ * (program_lead+). Leadership Team (program_lead+). Camper Care omits My tasks / File a reflection /
  * My reflections / Bunk Logs — those live on the Camper Care home dashboard.
  * Gates use
  * hasCapability(user, [...]) || isSuperAdmin(user); direct `user.role`
@@ -164,6 +165,7 @@ function Sidebar({
   const canSupervise = hasCapability(user, SUPERVISOR_PLUS) || isSuperAdmin(user);
   const canSeeDashboards = hasCapability(user, PROGRAM_LEAD_PLUS) || isSuperAdmin(user);
   const canSeeLeadershipTeam = hasCapability(user, PROGRAM_LEAD_PLUS) || isSuperAdmin(user);
+  const canSeeHelp = canSeeLeadershipTeam;
   const canAdmin = hasCapability(user, 'admin') || isSuperAdmin(user);
   const canFileReflection = REFLECTION_FORM_ROLES.includes(user.role);
   const isCounselor = user.role === 'Counselor';
@@ -234,6 +236,9 @@ function Sidebar({
           <div>
             <ul>
               <NavItem to="/admin/home" label="Home" icon={IconHome} end />
+              {canSeeHelp && (
+                <NavItem to="/help" label="Help" icon={IconHelp} />
+              )}
             </ul>
           </div>
 
@@ -311,6 +316,9 @@ function Sidebar({
           <>
           <Section heading="My work">
             <NavItem to={homePathFor(user.role)} label="Home" icon={IconHome} end />
+            {canSeeHelp && (
+              <NavItem to="/help" label="Help" icon={IconHelp} />
+            )}
             {!isCamperCare && (
               <NavItem to="/tasks" label="My tasks" icon={IconTasks} />
             )}
@@ -662,6 +670,13 @@ function IconWrench() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
       <path strokeLinecap="round" strokeLinejoin="round" d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z" />
+    </svg>
+  );
+}
+function IconHelp() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
     </svg>
   );
 }

--- a/frontend/src/partials/__tests__/Sidebar.test.jsx
+++ b/frontend/src/partials/__tests__/Sidebar.test.jsx
@@ -48,9 +48,10 @@ beforeEach(() => {
 });
 
 describe('Sidebar — section gating (3.32)', () => {
-  it('participant (counselor) sees My work but no Supervise / Dashboards / Admin / Legacy', () => {
+  it('participant (counselor) sees My work but no Help / Supervise / Admin', () => {
     renderWith({ role: 'Counselor' });
 
+    expect(screen.queryByRole('link', { name: 'Help' })).not.toBeInTheDocument();
     // Multiple "My work" headings can render (mobile + desktop variants);
     // use getAllByText so it doesn't throw on duplicates.
     expect(screen.getAllByText('My work').length).toBeGreaterThan(0);
@@ -117,9 +118,10 @@ describe('Sidebar — section gating (3.32)', () => {
     expect(links).not.toContain('/my-reflections');
   });
 
-  it('program_lead (leadership) sees Supervise dashboard links but not Admin or Dashboards menu', () => {
+  it('program_lead (leadership) sees Help and Supervise dashboard links but not Admin', () => {
     renderWith({ role: 'Leadership' });
 
+    expect(screen.getByRole('link', { name: 'Help' })).toHaveAttribute('href', '/help');
     expect(screen.queryByText('Dashboards')).not.toBeInTheDocument();
     expect(screen.getAllByText('Supervise').length).toBeGreaterThan(0);
     expect(screen.queryByText('Admin')).not.toBeInTheDocument();
@@ -138,6 +140,7 @@ describe('Sidebar — section gating (3.32)', () => {
     renderWith({ role: 'Admin' }, { path: '/admin/home' });
 
     expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/admin/home');
+    expect(screen.getByRole('link', { name: 'Help' })).toHaveAttribute('href', '/help');
     expect(screen.getByRole('link', { name: 'Bunk Logs' })).toHaveAttribute(
       'href',
       '/dashboards/logs',
@@ -153,6 +156,7 @@ describe('Sidebar — section gating (3.32)', () => {
 
     const links = hrefs();
     expect(links).toContain('/admin/home');
+    expect(links).toContain('/help');
     expect(links).toContain('/admin/dashboard');
     expect(links).toContain('/dashboards/logs');
     expect(links).toContain('/dashboards/reflections');

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -11,6 +11,10 @@ export default defineConfig({
   server: {
     port: 5173,
     host: true, // Allow access from other devices on network
+    fs: {
+      // Help center imports markdown from docs/features at build time.
+      allow: ['..'],
+    },
     proxy: {
       // Proxy all requests starting with /_allauth to your Django backend
       '/_allauth': {


### PR DESCRIPTION
## Summary
- Add in-app **Help** (`/help`) for admins and program leads, rendering `docs/features/` guides with subject-mode helper text in the template builder.
- Allow **permanent delete** of templates with zero responses from the library and builder; archive remains when responses exist.
- **Concerns inbox** bulk actions: row checkboxes, select all, and bulk mark read/unread via new API endpoint.
- **My Tasks** now resolves required work from `TemplateAssignment` instead of scanning all published templates.

## Test plan
- [ ] Log in as program lead → sidebar shows **Help** → browse articles and open `/help/form-types`
- [ ] Template library/builder: delete a draft template with `reflection_count === 0`; confirm archive still required when responses exist
- [ ] Concerns inbox: select multiple rows → bulk mark read/unread → verify state persists on refresh
- [ ] Assign a form to a user → **My Tasks** shows only assigned required forms
- [ ] CI: backend pytest + ruff, frontend vitest + build


Made with [Cursor](https://cursor.com)