### PR TITLE
feat: LT nav, team groups, observation labels, and counselor UX polish

### DIFF
--- a/backend/bunk_logs/api/admin_flow/assignments.py
+++ b/backend/bunk_logs/api/admin_flow/assignments.py
@@ -11,6 +11,8 @@ relationship types via a ``sub_tab`` query / body parameter:
                          ``target_type=ROLE_IN_PROGRAM``
 * ``counselor_bunk``  -- :class:`AssignmentGroupMembership` (Counselor
                          membership added to a Bunk as ``role_in_group='author'``)
+* ``staff_team``      -- :class:`AssignmentGroupMembership` (staff member
+                         added to a Team group as ``role_in_group='author'``)
 * ``camper_bunk``     -- :class:`AssignmentGroupMembership` (Camper /
                          Student membership added as ``role_in_group='subject'``)
 
@@ -52,7 +54,7 @@ SUPERVISION_SUB_TABS = {
     "cc_caseload": Supervision.TargetType.BUNK,
     "lt_team": Supervision.TargetType.ROLE_IN_PROGRAM,
 }
-GROUP_SUB_TABS = {"counselor_bunk", "camper_bunk"}
+GROUP_SUB_TABS = {"counselor_bunk", "staff_team", "camper_bunk"}
 VALID_SUB_TABS = set(SUPERVISION_SUB_TABS) | GROUP_SUB_TABS
 
 
@@ -89,11 +91,19 @@ def _sub_tab_for_supervision(s: Supervision) -> str:
     return "unknown"
 
 
+def _sub_tab_for_group_membership(g: AssignmentGroupMembership) -> str:
+    if g.role_in_group == "subject":
+        return "camper_bunk"
+    if g.group_id and g.group.group_type == "team":
+        return "staff_team"
+    return "counselor_bunk"
+
+
 def _serialize_group_membership(g: AssignmentGroupMembership) -> dict:
     return {
         "id": g.id,
         "kind": "group_membership",
-        "sub_tab": "camper_bunk" if g.role_in_group == "subject" else "counselor_bunk",
+        "sub_tab": _sub_tab_for_group_membership(g),
         "group_id": g.group_id,
         "group_name": g.group.name if g.group_id else None,
         "person_id": g.person_id,
@@ -139,6 +149,8 @@ class AdminAssignmentsListCreateView(APIView):
             qs = AssignmentGroupMembership.objects.select_related("group", "person")
             if sub_tab == "counselor_bunk":
                 qs = qs.filter(role_in_group="author", group__group_type="bunk")
+            elif sub_tab == "staff_team":
+                qs = qs.filter(role_in_group="author", group__group_type="team")
             elif sub_tab == "camper_bunk":
                 qs = qs.filter(role_in_group="subject", group__group_type__in=("bunk", "classroom"))
             results.extend(
@@ -299,7 +311,14 @@ def _create_group_membership(ctx, request, sub_tab: str) -> Response:
             {"detail": "Valid person_id is required."},
             status=status.HTTP_400_BAD_REQUEST,
         )
-    role_in_group = "author" if sub_tab == "counselor_bunk" else "subject"
+    if sub_tab == "camper_bunk":
+        role_in_group = "subject"
+    else:
+        role_in_group = "author"
+
+    mismatch = _group_sub_tab_mismatch(group, sub_tab)
+    if mismatch:
+        return Response({"detail": mismatch}, status=status.HTTP_400_BAD_REQUEST)
 
     requested_start = _coerce_date(request.data.get("start_date"), ctx.today)
     effective_start = requested_start
@@ -450,6 +469,17 @@ class AdminAssignmentDetailView(APIView):
                 content_type="assignment_group_membership",
             )
         return Response(_serialize_group_membership(g))
+
+
+def _group_sub_tab_mismatch(group: AssignmentGroup, sub_tab: str) -> str | None:
+    """Return an error message when ``group`` does not match ``sub_tab``."""
+    if sub_tab == "counselor_bunk" and group.group_type != "bunk":
+        return "counselor_bunk assignments require a bunk group."
+    if sub_tab == "staff_team" and group.group_type != "team":
+        return "staff_team assignments require a team group."
+    if sub_tab == "camper_bunk" and group.group_type not in ("bunk", "classroom"):
+        return "camper_bunk assignments require a bunk or classroom group."
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/bunk_logs/api/tests/test_admin_flow_pr2.py
+++ b/backend/bunk_logs/api/tests/test_admin_flow_pr2.py
@@ -307,6 +307,62 @@ class TestAdminAssignments:
         assert r1.status_code == 201
         assert r2.status_code == 409
 
+    def test_staff_team_membership_create_and_list(
+        self, api, org, program, admin_user,
+    ):
+        with organization_context(org):
+            team = AssignmentGroup.all_objects.create(
+                organization=org, program=program, name="Kitchen Staff",
+                slug="kitchen-staff", group_type="team",
+            )
+            person = Person.all_objects.create(
+                organization=org, first_name="Kit", last_name="Chen",
+            )
+        api.force_authenticate(user=admin_user)
+        payload = {
+            "sub_tab": "staff_team",
+            "group_id": team.id,
+            "person_id": person.id,
+        }
+        with organization_context(org):
+            r = api.post(self.URL, payload, format="json", **_hdr(org.slug))
+            assert r.status_code == 201, r.content
+            assert r.json()["assignment_group_membership"]["sub_tab"] == "staff_team"
+            listed = api.get(
+                self.URL, {"sub_tab": "staff_team"}, **_hdr(org.slug),
+            )
+        assert listed.status_code == 200
+        rows = listed.json()["results"]
+        assert len(rows) == 1
+        assert rows[0]["sub_tab"] == "staff_team"
+        assert rows[0]["group_id"] == team.id
+
+    def test_staff_team_rejects_non_team_group(
+        self, api, org, program, admin_user,
+    ):
+        with organization_context(org):
+            bunk = AssignmentGroup.all_objects.create(
+                organization=org, program=program, name="Bunk 2",
+                slug="bunk-2", group_type="bunk",
+            )
+            person = Person.all_objects.create(
+                organization=org, first_name="No", last_name="Match",
+            )
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            r = api.post(
+                self.URL,
+                {
+                    "sub_tab": "staff_team",
+                    "group_id": bunk.id,
+                    "person_id": person.id,
+                },
+                format="json",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 400
+        assert "team group" in r.json()["detail"].lower()
+
 
 # ---------------------------------------------------------------------------
 # Programs + End Program

--- a/backend/bunk_logs/api/tests/test_assignment_groups_write_api.py
+++ b/backend/bunk_logs/api/tests/test_assignment_groups_write_api.py
@@ -121,6 +121,23 @@ class TestCreateGroup:
         assert r.status_code == 201
         assert AssignmentGroup.all_objects.filter(slug="bunk-bravo-write").exists()
 
+    def test_admin_can_create_team_group(self, client, org, program, admin_user):
+        user, _ = admin_user
+        client.force_authenticate(user=user)
+        r = client.post(
+            "/api/v1/assignment-groups/",
+            {
+                "name": "Kitchen Staff",
+                "group_type": "team",
+                "program": program.pk,
+                "slug": "kitchen-staff-team",
+            },
+            **_hdr(org.slug),
+        )
+        assert r.status_code == 201, r.content
+        created = AssignmentGroup.all_objects.get(slug="kitchen-staff-team")
+        assert created.group_type == "team"
+
     def test_regular_user_denied(self, client, org, program, regular_user):
         user, _ = regular_user
         client.force_authenticate(user=user)

--- a/backend/bunk_logs/api/tests/test_user_membership_roles.py
+++ b/backend/bunk_logs/api/tests/test_user_membership_roles.py
@@ -54,6 +54,14 @@ def test_membership_roles_in_profile(org, program):
     assert "maintenance" in r.json()["membership_roles"]
 
 
+def test_membership_roles_in_token_login(org, program):
+    user = _make_member(org, program, "maint-token@mr.com", "maintenance")
+    api = APIClient()
+    r = api.post("/api/auth/token/", {"email": user.email, "password": "pw"}, format="json")
+    assert r.status_code == 200, r.content
+    assert "maintenance" in r.json()["user"]["membership_roles"]
+
+
 def test_no_memberships_returns_empty_list(org):
     user = User.objects.create_user(email="no-member@mr.com", password="pw")
     api = APIClient()

--- a/backend/bunk_logs/core/migrations/0048_assignmentgroup_add_team_group_type.py
+++ b/backend/bunk_logs/core/migrations/0048_assignmentgroup_add_team_group_type.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0047_alter_membership_role"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="assignmentgroup",
+            name="group_type",
+            field=models.CharField(
+                choices=[
+                    ("bunk", "Bunk"),
+                    ("classroom", "Classroom"),
+                    ("caseload", "Caseload"),
+                    ("unit", "Unit"),
+                    ("division", "Division"),
+                    ("cohort", "Cohort"),
+                    ("team", "Team"),
+                    ("specialty", "Specialty/Activity Group"),
+                    ("custom", "Custom Group"),
+                ],
+                max_length=32,
+            ),
+        ),
+    ]

--- a/backend/bunk_logs/core/models.py
+++ b/backend/bunk_logs/core/models.py
@@ -415,6 +415,7 @@ class AssignmentGroup(models.Model):
         ("unit", "Unit"),
         ("division", "Division"),
         ("cohort", "Cohort"),
+        ("team", "Team"),
         ("specialty", "Specialty/Activity Group"),
         ("custom", "Custom Group"),
     ]

--- a/backend/bunk_logs/core/permissions/observation_read.py
+++ b/backend/bunk_logs/core/permissions/observation_read.py
@@ -24,12 +24,20 @@ from bunk_logs.core.permissions.super_admin import is_super_admin
 # Sensitivity tiers, ordered low -> high.
 SENSITIVITY_TIERS = ["normal", "sensitive", "domain", "confidential"]
 
+# User-facing audience copy for each tier (composer labels, API disclosures).
+SENSITIVITY_AUDIENCE_LABELS: dict[str, str] = {
+    "normal": "Everyone",
+    "sensitive": "Unit Heads and above",
+    "domain": "Leadership Team and above",
+    "confidential": "Pro Team only",
+}
+
 # Code default mirrors NOTE_VIS_BY_CAP with sensitivity tier names. Orgs may
 # override per capability via Organization.settings["observations"]["view_by_capability"].
 DEFAULT_VIEW_BY_CAPABILITY: dict[str, set[str]] = {
     "admin": {"normal", "sensitive", "domain", "confidential"},
     "program_lead": {"normal", "sensitive", "domain"},
-    "domain_specialist": {"normal", "sensitive", "domain"},
+    "domain_specialist": {"normal", "sensitive"},
     "supervisor": {"normal", "sensitive"},
     "participant": set(),
 }
@@ -98,6 +106,7 @@ def filter_observations_readable(qs, viewer_person, org, user):
 
 __all__ = [
     "DEFAULT_VIEW_BY_CAPABILITY",
+    "SENSITIVITY_AUDIENCE_LABELS",
     "SENSITIVITY_TIERS",
     "capability_clears",
     "filter_observations_readable",

--- a/backend/bunk_logs/core/permissions/test_observation_read.py
+++ b/backend/bunk_logs/core/permissions/test_observation_read.py
@@ -115,6 +115,38 @@ def test_recipient_reads_even_confidential(org, program):
     assert obs.id in _readable_ids(counselor, org)
 
 
+def test_program_lead_covers_subject_reads_domain_not_confidential(org, program):
+    lt = _person(org, "LT")
+    _member(program, lt, "leadership_team")  # capability=program_lead
+    author = _person(org, "Author")
+    _member(program, author, "counselor")
+    camper = _person(org, "Camper")
+    bunk = _bunk(org, program)
+    _author_in(bunk, lt)
+    _subject_in(bunk, camper)
+    domain = _obs(org, program, author, S.DOMAIN, [camper])
+    confidential = _obs(org, program, author, S.CONFIDENTIAL, [camper])
+    readable = _readable_ids(lt, org)
+    assert domain.id in readable
+    assert confidential.id not in readable
+
+
+def test_domain_specialist_covers_subject_reads_sensitive_not_domain(org, program):
+    cc = _person(org, "CC")
+    _member(program, cc, "camper_care")  # capability=domain_specialist
+    author = _person(org, "Author")
+    _member(program, author, "counselor")
+    camper = _person(org, "Camper")
+    bunk = _bunk(org, program)
+    _author_in(bunk, cc)
+    _subject_in(bunk, camper)
+    sensitive = _obs(org, program, author, S.SENSITIVE, [camper])
+    domain = _obs(org, program, author, S.DOMAIN, [camper])
+    readable = _readable_ids(cc, org)
+    assert sensitive.id in readable
+    assert domain.id not in readable
+
+
 def test_supervisor_covers_subject_reads_sensitive_not_confidential(org, program):
     uh = _person(org, "UH")
     _member(program, uh, "unit_head")  # capability=supervisor
@@ -186,6 +218,9 @@ def test_cross_org_isolation(org, other_org, program):
 # ---------------------------------------------------------------------------
 def test_capability_clears_defaults(org):
     assert capability_clears("supervisor", "sensitive", org) is True
+    assert capability_clears("supervisor", "domain", org) is False
+    assert capability_clears("domain_specialist", "domain", org) is False
+    assert capability_clears("program_lead", "domain", org) is True
     assert capability_clears("supervisor", "confidential", org) is False
     assert capability_clears("admin", "confidential", org) is True
     assert capability_clears("participant", "normal", org) is False

--- a/backend/bunk_logs/core/test_assignment_group.py
+++ b/backend/bunk_logs/core/test_assignment_group.py
@@ -281,6 +281,17 @@ class TestAssignmentGroup:
         assert group.group_type == "bunk"
         assert group.is_active is True
 
+    def test_create_team_group(self, org, program):
+        team = AssignmentGroup.all_objects.create(
+            organization=org,
+            program=program,
+            name="Kitchen Staff",
+            slug="kitchen-staff",
+            group_type="team",
+        )
+        assert team.group_type == "team"
+        assert "Team" in str(team)
+
     def test_unique_slug_per_program(self, org, program, group):
         with pytest.raises(IntegrityError):
             AssignmentGroup.all_objects.create(

--- a/backend/config/auth_api.py
+++ b/backend/config/auth_api.py
@@ -7,6 +7,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from rest_framework_simplejwt.views import TokenObtainPairView
 
+from bunk_logs.api.views import _active_membership_roles
 from bunk_logs.bunks.models import CounselorBunkAssignment
 from bunk_logs.bunks.models import UnitStaffAssignment
 
@@ -34,7 +35,7 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
         data["access"] = str(refresh.access_token)
         data["refresh"] = str(refresh)
 
-        # Add basic user details
+        # Add basic user details (membership_roles gates maintenance-only nav/home).
         data["user"] = {
             "id": str(self.user.id),
             "email": self.user.email,
@@ -43,6 +44,7 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
             "role": getattr(self.user, "role", "User"),
             "is_staff": self.user.is_staff,
             "is_superuser": self.user.is_superuser,
+            "membership_roles": _active_membership_roles(self.user),
         }
 
         return data

--- a/docs/features/logs-reflections-observations.md
+++ b/docs/features/logs-reflections-observations.md
@@ -197,10 +197,10 @@ Open a row to read the full thread, reply, or archive it for yourself.
    the event was earlier. Future dates are not allowed.
 5. **Context tag** — optional short label (for example `swim_instruction`).
 6. **Sensitivity** — controls who can be notified and who can read via hierarchy:
-   - **Normal** — readable by the hierarchy
-   - **Sensitive** — supervisors and above
-   - **Domain** — domain specialists and above
-   - **Confidential** — admin only
+   - **Normal** — Everyone
+   - **Sensitive** — Unit Heads and above
+   - **Domain** — Leadership Team and above
+   - **Confidential** — Pro Team only
 7. **Notify** — optional checkboxes; only people who clear the selected
    sensitivity tier appear.
 8. **Make visible to the subject on their Profile** — optional; lets the

--- a/frontend/e2e/rbac-sidebar.spec.ts
+++ b/frontend/e2e/rbac-sidebar.spec.ts
@@ -24,6 +24,11 @@ const HREFS = {
   counselorHome: '/counselor',
   unitHeadHome: '/unit-head',
   camperCareHome: '/camper-care',
+  leadershipTeamHome: '/leadership-team',
+  camperCareOrders: '/camper-care/orders',
+  observations: '/observations',
+  maintenance: '/maintenance',
+  help: '/help',
   orders: '/orders',
   // Supervise
   groupsPerformance: '/groups/performance',
@@ -116,20 +121,37 @@ test.describe('Sidebar RBAC — capability tiers (3.32)', () => {
     expect(await hasLink(page, HREFS.legacyBunkLogs)).toBe(false);
   });
 
-  test('leadership (program_lead): Supervise dashboard links but no Admin or Dashboards menu', async ({
+  test('leadership (program_lead): Admin-style nav with Templates-only Admin submenu', async ({
     page,
   }) => {
     await loginAs(page, 'leadership');
     await readSidebarText(page);
 
+    expect(await hasLink(page, HREFS.leadershipTeamHome)).toBe(true);
+    expect(await hasLink(page, HREFS.help)).toBe(true);
     expect(await hasLink(page, HREFS.groupsPerformance)).toBe(true);
     expect(await hasLink(page, HREFS.dashboardsLogs)).toBe(true);
     expect(await hasLink(page, HREFS.dashboardsReflections)).toBe(true);
+    expect(await hasLink(page, HREFS.dashboardsCoverage)).toBe(true);
     expect(await hasLink(page, HREFS.dashboardsAuthors)).toBe(true);
+    expect(await hasLink(page, HREFS.concernsInbox)).toBe(true);
+    expect(await hasLink(page, HREFS.observations)).toBe(true);
+    expect(await hasLink(page, HREFS.maintenance)).toBe(true);
+    expect(await hasLink(page, HREFS.camperCareOrders)).toBe(true);
+    expect(await hasLink(page, HREFS.adminTemplates)).toBe(true);
+    expect(await countLinks(page, HREFS.dashboardsLogs)).toBe(1);
+    expect(await countLinks(page, HREFS.dashboardsReflections)).toBe(1);
+
+    expect(await hasLink(page, HREFS.adminHome)).toBe(false);
+    expect(await hasLink(page, HREFS.adminDashboard)).toBe(false);
+    expect(await hasLink(page, HREFS.adminMemberships)).toBe(false);
+    expect(await hasLink(page, HREFS.adminGroups)).toBe(false);
+    expect(await hasLink(page, HREFS.adminFieldKeys)).toBe(false);
     expect(await hasLink(page, HREFS.dashboardsHome)).toBe(false);
     expect(await hasLink(page, HREFS.dashboardsWellness)).toBe(false);
-
-    expect(await hasLink(page, HREFS.adminMemberships)).toBe(false);
+    expect(await hasLink(page, HREFS.tasks)).toBe(false);
+    expect(await hasLink(page, HREFS.reflect)).toBe(false);
+    expect(await hasLink(page, HREFS.myReflections)).toBe(false);
     expect(await hasLink(page, HREFS.legacyBunkLogs)).toBe(false);
   });
 

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -10,7 +10,7 @@ import {
 import { useAuth } from './auth/AuthContext';
 import { useEffect } from 'react';
 import isSuperAdmin from './utils/auth/isSuperAdmin';
-import { hasCapability } from './utils/auth/capability';
+import { hasCapability, homePathForUser } from './utils/auth/capability';
 import Signin from './pages/Signin';
 import Signup from './pages/Signup';
 import Dashboard from './pages/Dashboard';
@@ -103,6 +103,12 @@ import CamperCareRequestFormPage from './pages/counselor/CamperCareRequestFormPa
 import MaintenanceTicketFormPage from './pages/counselor/MaintenanceTicketFormPage';
 import { useBunk } from './contexts/BunkContext';
 
+function HomeRedirect() {
+  const { user, loading } = useAuth();
+  if (loading) return <div>Loading...</div>;
+  return <Navigate to={homePathForUser(user)} replace />;
+}
+
 // Protected route component
 function ProtectedRoute({ children }) {
   const { isAuthenticated, loading } = useAuth();
@@ -150,6 +156,31 @@ function AdminRoute({ children }) {
 
   const isAdmin = isSuperAdmin(user) || user?.role?.toLowerCase() === 'admin';
   if (!isAdmin) {
+    return <Navigate to="/" replace state={{ toast: 'Admin access required' }} />;
+  }
+
+  return children;
+}
+
+// Template library routes: admin or program_lead (Leadership Team).
+function LeadershipTemplatesRoute({ children }) {
+  const { isAuthenticated, loading, user } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (!isAuthenticated) {
+    const next = `${location.pathname}${location.search}${location.hash}`;
+    return <Navigate to={`/signin?next=${encodeURIComponent(next)}`} replace />;
+  }
+
+  const canAccess =
+    isSuperAdmin(user)
+    || user?.role?.toLowerCase() === 'admin'
+    || hasCapability(user, 'program_lead');
+  if (!canAccess) {
     return <Navigate to="/" replace state={{ toast: 'Admin access required' }} />;
   }
 
@@ -818,13 +849,13 @@ function Router() {
               </AdminRoute>
             }
           />
-          {/* Template library + builder (LT UI, admin-only via AdminRoute). */}
+          {/* Template library + builder (LT UI; admin or program_lead). */}
           <Route
             path="templates"
             element={
-              <AdminRoute>
+              <LeadershipTemplatesRoute>
                 <LeadershipTeamTemplateLibrary />
-              </AdminRoute>
+              </LeadershipTemplatesRoute>
             }
           />
           <Route
@@ -834,25 +865,25 @@ function Router() {
           <Route
             path="templates/new"
             element={
-              <AdminRoute>
+              <LeadershipTemplatesRoute>
                 <LeadershipTeamTemplateBuilderPage />
-              </AdminRoute>
+              </LeadershipTemplatesRoute>
             }
           />
           <Route
             path="templates/:id/responses"
             element={
-              <AdminRoute>
+              <LeadershipTemplatesRoute>
                 <LeadershipTeamResponses />
-              </AdminRoute>
+              </LeadershipTemplatesRoute>
             }
           />
           <Route
             path="templates/:id"
             element={
-              <AdminRoute>
+              <LeadershipTemplatesRoute>
                 <LeadershipTeamTemplateBuilderPage />
-              </AdminRoute>
+              </LeadershipTemplatesRoute>
             }
           />
           <Route
@@ -891,8 +922,8 @@ function Router() {
         />
 
         {/* Default redirect */}
-        <Route path="/" element={<Navigate to="/dashboard" />} />
-        <Route path="*" element={<Navigate to="/dashboard" />} />
+        <Route path="/" element={<HomeRedirect />} />
+        <Route path="*" element={<HomeRedirect />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/api/observations.js
+++ b/frontend/src/api/observations.js
@@ -7,12 +7,24 @@
 
 import api from '../api';
 
+export const SENSITIVITY_AUDIENCE = Object.freeze({
+  normal: 'Everyone',
+  sensitive: 'Unit Heads and above',
+  domain: 'Leadership Team and above',
+  confidential: 'Pro Team only',
+});
+
 export const SENSITIVITY_OPTIONS = Object.freeze([
-  { value: 'normal', label: 'Normal — readable by the hierarchy' },
-  { value: 'sensitive', label: 'Sensitive — supervisors and above' },
-  { value: 'domain', label: 'Domain — specialists and above' },
-  { value: 'confidential', label: 'Confidential — admin only' },
+  { value: 'normal', label: `Normal — ${SENSITIVITY_AUDIENCE.normal}` },
+  { value: 'sensitive', label: `Sensitive — ${SENSITIVITY_AUDIENCE.sensitive}` },
+  { value: 'domain', label: `Domain — ${SENSITIVITY_AUDIENCE.domain}` },
+  { value: 'confidential', label: `Confidential — ${SENSITIVITY_AUDIENCE.confidential}` },
 ]);
+
+/** Audience label for a sensitivity tier (badges, inbox rows, etc.). */
+export function sensitivityAudience(value) {
+  return SENSITIVITY_AUDIENCE[value] ?? value;
+}
 
 /** Search subjects the viewer may write observations about. */
 export async function searchObservationSubjects(q) {

--- a/frontend/src/auth/AuthContext.jsx
+++ b/frontend/src/auth/AuthContext.jsx
@@ -104,10 +104,18 @@ export function AuthProvider({ children }) {
       // If we have a user object directly from the API response (username/password login)
       if (tokens.user) {
         console.log('Setting user from API response:', tokens.user);
-        setUser(tokens.user);
-        // Also store in localStorage
-        localStorage.setItem('user_profile', JSON.stringify(tokens.user));
-        return tokens.user;
+        let profile = tokens.user;
+        if (!Array.isArray(profile.membership_roles) && profile.email) {
+          try {
+            const response = await api.get(`/api/v1/users/email/${profile.email}/`);
+            profile = response.data;
+          } catch (e) {
+            console.warn('Could not enrich login profile with membership_roles:', e);
+          }
+        }
+        setUser(profile);
+        localStorage.setItem('user_profile', JSON.stringify(profile));
+        return profile;
       }
       
       // If we have a full user profile passed directly (social login), use that

--- a/frontend/src/components/BunkDashboard.jsx
+++ b/frontend/src/components/BunkDashboard.jsx
@@ -18,6 +18,7 @@
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { groupDashboardLink, observationThreadLink, profileLink } from '../utils/dashboardLinks';
+import { sensitivityAudience } from '../api/observations';
 import ScoreGrid from './ScoreGrid';
 
 // Field types kept as grid columns. Triage single_choice/yes-no fields
@@ -201,13 +202,6 @@ function OrdersSection({ orders }) {
   );
 }
 
-const SENSITIVITY_LABEL = {
-  normal: 'Normal',
-  sensitive: 'Sensitive',
-  domain: 'Domain',
-  confidential: 'Confidential',
-};
-
 const SOURCE_TAG = {
   bunk_concern: {
     label: 'Bunk concern',
@@ -302,7 +296,7 @@ function NoteStreamMeta({ item }) {
           key="sensitivity"
           className="text-xs rounded-full bg-amber-50 dark:bg-amber-900/20 px-2 py-0.5 text-amber-800 dark:text-amber-200"
         >
-          {SENSITIVITY_LABEL[item.sensitivity] ?? item.sensitivity}
+          {sensitivityAudience(item.sensitivity)}
         </span>,
       );
     }

--- a/frontend/src/components/__tests__/BunkDashboard.test.jsx
+++ b/frontend/src/components/__tests__/BunkDashboard.test.jsx
@@ -156,7 +156,7 @@ describe('BunkDashboard', () => {
       'href',
       '/observations/7',
     );
-    expect(screen.getByTestId('bunk-observation-7')).toHaveTextContent('Sensitive');
+    expect(screen.getByTestId('bunk-observation-7')).toHaveTextContent('Unit Heads and above');
     expect(screen.getByTestId('bunk-observation-7')).toHaveTextContent('mealtime');
     expect(screen.getByTestId('bunk-concern-42')).toHaveTextContent('Worried about cabin dynamics');
     expect(screen.getByTestId('bunk-concern-42')).toHaveTextContent('Bunk concern');

--- a/frontend/src/dashboards/coverage/CoverageDashboard.jsx
+++ b/frontend/src/dashboards/coverage/CoverageDashboard.jsx
@@ -10,6 +10,7 @@ const GROUP_TYPES = [
   { value: 'classroom',  label: 'Classrooms' },
   { value: 'caseload',   label: 'Caseloads' },
   { value: 'cohort',     label: 'Cohorts' },
+  { value: 'team',       label: 'Teams' },
   { value: 'specialty',  label: 'Specialties' },
   { value: 'custom',     label: 'Custom' },
 ];

--- a/frontend/src/dashboards/performance/PerformanceDashboard.jsx
+++ b/frontend/src/dashboards/performance/PerformanceDashboard.jsx
@@ -11,6 +11,7 @@ const GROUP_TYPES = [
   { value: 'classroom', label: 'Classrooms' },
   { value: 'caseload', label: 'Caseloads' },
   { value: 'cohort', label: 'Cohorts' },
+  { value: 'team', label: 'Teams' },
   { value: 'specialty', label: 'Specialties' },
   { value: 'custom', label: 'Custom' },
 ];

--- a/frontend/src/dashboards/subject/SubjectDetail.jsx
+++ b/frontend/src/dashboards/subject/SubjectDetail.jsx
@@ -22,6 +22,7 @@ import {
   profileBackLabel,
   resolveProfileBackGroup,
 } from '../../utils/dashboardLinks';
+import { sensitivityAudience } from '../../api/observations';
 import ObservationComposer, { dateOnlyToLocalDatetime } from '../../components/observations/ObservationComposer';
 import PrivacyChip from '../../components/reflection/PrivacyChip';
 import {
@@ -313,13 +314,6 @@ function RecentTexts({ texts }) {
 // Root
 // ---------------------------------------------------------------------------
 
-const SENSITIVITY_LABEL = {
-  normal: 'Normal',
-  sensitive: 'Sensitive',
-  domain: 'Domain',
-  confidential: 'Confidential',
-};
-
 function formatObservationWhen(iso) {
   if (!iso) return '';
   const d = new Date(iso);
@@ -397,7 +391,7 @@ function ObservationsPanel({ observations = [], onCompose, profileReturnTo = nul
                     >
                       <div className="flex items-center gap-2 mb-1 flex-wrap">
                         <span className="text-xs rounded-full bg-amber-50 dark:bg-amber-900/20 px-2 py-0.5 text-amber-800 dark:text-amber-200">
-                          {SENSITIVITY_LABEL[o.sensitivity] ?? o.sensitivity}
+                          {sensitivityAudience(o.sensitivity)}
                         </span>
                         {o.context && (
                           <span className="text-xs text-gray-400">{o.context}</span>

--- a/frontend/src/dashboards/subject/__tests__/SubjectDetail.test.jsx
+++ b/frontend/src/dashboards/subject/__tests__/SubjectDetail.test.jsx
@@ -7,6 +7,7 @@ vi.mock('../../../api/observations', () => ({
   fetchRecipientCandidates: vi.fn(() => Promise.resolve([])),
   searchObservationSubjects: vi.fn(() => Promise.resolve([])),
   createObservation: vi.fn(),
+  sensitivityAudience: (value) => value,
   SENSITIVITY_OPTIONS: [
     { value: 'normal', label: 'Normal' },
   ],

--- a/frontend/src/pages/AuthCallback.jsx
+++ b/frontend/src/pages/AuthCallback.jsx
@@ -2,6 +2,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../auth/AuthContext';
+import { homePathForUser } from '../utils/auth/capability';
 
 function AuthCallback() {
   const navigate = useNavigate();
@@ -122,14 +123,15 @@ function AuthCallback() {
               });
             };
             
-            await waitForUserProfile();
+            const profile = await waitForUserProfile();
             
             setStatus('success');
             
             // Additional delay to ensure all auth state is propagated to React components
             setTimeout(() => {
-              console.log('🎯 Redirecting to dashboard with fully loaded profile...');
-              navigate('/dashboard', { replace: true });
+              const destination = homePathForUser(profile);
+              console.log('🎯 Redirecting after auth callback:', destination);
+              navigate(destination, { replace: true });
             }, 1000); // Reduced delay since we already waited for profile
             
           } catch (loginError) {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '../auth/AuthContext';
 import { useNavigate } from 'react-router-dom';
-import isSuperAdmin from '../utils/auth/isSuperAdmin';
+import { homePathForUser } from '../utils/auth/capability';
 
 import Sidebar from '../partials/Sidebar';
 import Header from '../partials/Header';
@@ -20,19 +20,6 @@ import UserProfile from '../partials/dashboard/UserProfile';
  * is also kept as the fallback for Admins / Super-Admins browsing the legacy UI.
  */
 
-const ROLE_DESTINATIONS = {
-  'Admin':          '/admin/home',
-  'Counselor':      '/counselor',
-  'Unit Head':      '/unit-head',
-  'Camper Care':    '/camper-care',
-  'Leadership':     '/leadership-team',
-  'Leadership Team': '/leadership-team',
-  'Kitchen Staff':  '/kitchen-staff',
-  'Specialist':     '/specialist',
-  'Madrich':        '/madrich',
-  'Maintenance':    '/maintenance',
-};
-
 function Dashboard() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const { userProfile, isAuthenticated, user, loading: authLoading, isAuthenticating } = useAuth();
@@ -41,10 +28,8 @@ function Dashboard() {
   useEffect(() => {
     if (authLoading || isAuthenticating) return;
 
-    const destination = user?.role
-      ? ROLE_DESTINATIONS[user.role]
-      : (isSuperAdmin(user) ? '/admin/home' : null);
-    if (destination) {
+    const destination = homePathForUser(user);
+    if (destination !== '/dashboard') {
       navigate(destination, { replace: true });
     }
   }, [user, navigate, authLoading, isAuthenticating]);

--- a/frontend/src/pages/Signin.jsx
+++ b/frontend/src/pages/Signin.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Link, useNavigate, useLocation, NavLink } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
+import { homePathForUser } from "../utils/auth/capability";
 import ProviderList from '../socialaccount/ProviderList';
 import CampLogo from "../../src/images/clc-logo.jpeg";
 import SocialLoginButton from "../components/SocialLoginButton";
@@ -78,11 +79,8 @@ function Signin() {
         user: response.data.user // Include user data from response
       };
       
-      // Call the login function from AuthContext
-      login(tokens);
-      
-      // Redirect to dashboard
-      navigate("/dashboard");
+      const profile = await login(tokens);
+      navigate(homePathForUser(profile));
     } catch (error) {
       console.error("Login error:", error);
       

--- a/frontend/src/pages/admin/Assignments.jsx
+++ b/frontend/src/pages/admin/Assignments.jsx
@@ -13,7 +13,8 @@ import {
  *   - uh_counselor   (Supervision target_type=MEMBERSHIP)
  *   - cc_caseload    (Supervision target_type=BUNK)
  *   - lt_team        (Supervision target_type=ROLE_IN_PROGRAM)
- *   - counselor_bunk (AssignmentGroupMembership role=author)
+ *   - counselor_bunk (AssignmentGroupMembership role=author on a Bunk)
+ *   - staff_team     (AssignmentGroupMembership role=author on a Team)
  *   - camper_bunk    (AssignmentGroupMembership role=subject)
  *
  * Reflects the server-side backdated-clamp invariant: if the user
@@ -23,6 +24,7 @@ import {
 
 const SUB_TABS = [
   { key: 'counselor_bunk', label: 'Counselor → Bunk' },
+  { key: 'staff_team', label: 'Staff → Team' },
   { key: 'uh_counselor', label: 'Unit Head → Counselor' },
   { key: 'cc_caseload', label: 'Camper Care → Caseload' },
   { key: 'lt_team', label: 'Leadership → Team' },
@@ -181,9 +183,13 @@ function CreateForm({ subTab, onCreated }) {
           <TextField label="Target role" value={draft.target_role || ''} onChange={(v) => setDraft({ ...draft, target_role: v })} />
         </>
       )}
-      {(subTab === 'counselor_bunk' || subTab === 'camper_bunk') && (
+      {(subTab === 'counselor_bunk' || subTab === 'staff_team' || subTab === 'camper_bunk') && (
         <>
-          <NumberField label="Group (Bunk) ID" value={draft.group_id || ''} onChange={(v) => setDraft({ ...draft, group_id: v })} />
+          <NumberField
+            label={subTab === 'staff_team' ? 'Group (Team) ID' : 'Group (Bunk) ID'}
+            value={draft.group_id || ''}
+            onChange={(v) => setDraft({ ...draft, group_id: v })}
+          />
           <NumberField label="Person ID" value={draft.person_id || ''} onChange={(v) => setDraft({ ...draft, person_id: v })} />
         </>
       )}

--- a/frontend/src/pages/admin/__tests__/Assignments.test.jsx
+++ b/frontend/src/pages/admin/__tests__/Assignments.test.jsx
@@ -19,9 +19,10 @@ beforeEach(() => {
 });
 
 describe('AdminAssignments (7_13 PR2)', () => {
-  it('renders all five sub-tabs and switches between them', async () => {
+  it('renders all six sub-tabs and switches between them', async () => {
     render(<AdminAssignments />);
     expect(await screen.findByTestId('assignment-sub-tab-counselor_bunk')).toBeInTheDocument();
+    expect(screen.getByTestId('assignment-sub-tab-staff_team')).toBeInTheDocument();
     expect(screen.getByTestId('assignment-sub-tab-uh_counselor')).toBeInTheDocument();
     expect(screen.getByTestId('assignment-sub-tab-cc_caseload')).toBeInTheDocument();
     expect(screen.getByTestId('assignment-sub-tab-lt_team')).toBeInTheDocument();

--- a/frontend/src/pages/admin/groups/GroupListPage.jsx
+++ b/frontend/src/pages/admin/groups/GroupListPage.jsx
@@ -15,11 +15,12 @@ const GROUP_TYPE_LABELS = {
   unit: 'Unit',
   division: 'Division',
   cohort: 'Cohort',
+  team: 'Team',
   specialty: 'Specialty / Activity',
   custom: 'Custom',
 };
 
-const GROUP_TYPE_ORDER = ['division', 'unit', 'bunk', 'classroom', 'caseload', 'cohort', 'specialty', 'custom'];
+const GROUP_TYPE_ORDER = ['division', 'unit', 'bunk', 'classroom', 'caseload', 'cohort', 'team', 'specialty', 'custom'];
 
 function groupByType(groups) {
   const map = {};
@@ -119,7 +120,7 @@ export default function GroupListPage() {
           <div>
             <h1 className="text-xl font-bold text-gray-900 dark:text-white">Groups</h1>
             <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-              Manage bunks, classrooms, caseloads, and other assignment groups
+              Manage bunks, teams, classrooms, caseloads, and other assignment groups
             </p>
           </div>
           <Button onClick={() => setCreating(true)}>

--- a/frontend/src/pages/admin/templates/__tests__/AdminRoute.test.jsx
+++ b/frontend/src/pages/admin/templates/__tests__/AdminRoute.test.jsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Routes, Route, Navigate } from 'react-router-dom';
 import isSuperAdmin from '../../../../utils/auth/isSuperAdmin';
+import { hasCapability } from '../../../../utils/auth/capability';
 
 // Minimal re-implementation of AdminRoute that matches the production check in
 // frontend/src/Router.jsx -- both share the canonical isSuperAdmin helper.
@@ -10,6 +11,18 @@ function AdminRoute({ user, loading, isAuthenticated, children }) {
   if (!isAuthenticated) return <Navigate to="/signin" replace />;
   const isAdmin = isSuperAdmin(user) || user?.role === 'admin';
   if (!isAdmin) return <Navigate to="/" replace state={{ toast: 'Admin access required' }} />;
+  return children;
+}
+
+// Mirrors LeadershipTemplatesRoute in Router.jsx.
+function LeadershipTemplatesRoute({ user, loading, isAuthenticated, children }) {
+  if (loading) return <div>Loading...</div>;
+  if (!isAuthenticated) return <Navigate to="/signin" replace />;
+  const canAccess =
+    isSuperAdmin(user)
+    || user?.role?.toLowerCase() === 'admin'
+    || hasCapability(user, 'program_lead');
+  if (!canAccess) return <Navigate to="/" replace state={{ toast: 'Admin access required' }} />;
   return children;
 }
 
@@ -58,5 +71,53 @@ describe('AdminRoute permission gate', () => {
     renderWithRoute(null, false);
     expect(screen.getByTestId('signin')).toBeInTheDocument();
     expect(screen.queryByTestId('admin-content')).not.toBeInTheDocument();
+  });
+});
+
+function renderTemplatesRoute(user, authenticated = true) {
+  return render(
+    <MemoryRouter initialEntries={['/admin/templates']}>
+      <Routes>
+        <Route
+          path="/admin/templates"
+          element={
+            <LeadershipTemplatesRoute user={user} loading={false} isAuthenticated={authenticated}>
+              <div data-testid="templates-content">Templates area</div>
+            </LeadershipTemplatesRoute>
+          }
+        />
+        <Route path="/" element={<div data-testid="home">Home</div>} />
+        <Route path="/signin" element={<div data-testid="signin">Signin</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('LeadershipTemplatesRoute permission gate', () => {
+  it('renders children for role=Leadership (program_lead)', () => {
+    renderTemplatesRoute({ role: 'Leadership' });
+    expect(screen.getByTestId('templates-content')).toBeInTheDocument();
+  });
+
+  it('renders children for role=admin user', () => {
+    renderTemplatesRoute({ role: 'admin' });
+    expect(screen.getByTestId('templates-content')).toBeInTheDocument();
+  });
+
+  it('renders children for is_staff user', () => {
+    renderTemplatesRoute({ is_staff: true });
+    expect(screen.getByTestId('templates-content')).toBeInTheDocument();
+  });
+
+  it('redirects to / for non-admin, non-leadership authenticated user', () => {
+    renderTemplatesRoute({ role: 'Counselor' });
+    expect(screen.getByTestId('home')).toBeInTheDocument();
+    expect(screen.queryByTestId('templates-content')).not.toBeInTheDocument();
+  });
+
+  it('redirects to /signin for unauthenticated user', () => {
+    renderTemplatesRoute(null, false);
+    expect(screen.getByTestId('signin')).toBeInTheDocument();
+    expect(screen.queryByTestId('templates-content')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/admin/templates/templateRouting.js
+++ b/frontend/src/pages/admin/templates/templateRouting.js
@@ -55,6 +55,7 @@ export const GROUP_TYPE_OPTIONS = [
   { value: 'unit', label: 'Unit' },
   { value: 'division', label: 'Division' },
   { value: 'cohort', label: 'Cohort' },
+  { value: 'team', label: 'Team' },
   { value: 'specialty', label: 'Specialty / Activity' },
   { value: 'custom', label: 'Custom' },
 ];

--- a/frontend/src/pages/counselor/CounselorMobileDashboard.jsx
+++ b/frontend/src/pages/counselor/CounselorMobileDashboard.jsx
@@ -3,8 +3,8 @@
  *
  * Renders viewer context, a date picker (defaults to org "today"), bunk
  * tiles for groups the counselor authors (with form-assignment progress),
- * self-reflection status, quick actions (requests + observations), and
- * the all-set banner when camper + self work is complete.
+ * quick actions (requests + observations) at the top, bunk tiles,
+ * self-reflection status, and the all-set banner when work is complete.
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -418,6 +418,43 @@ export default function CounselorMobileDashboard() {
         </label>
       </header>
 
+      <section data-testid="counselor-quick-actions">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
+          Requests & observations
+        </h2>
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
+          <QuickActionButton
+            to="/counselor/requests/camper-care/new"
+            icon={HeartHandshake}
+            label="Camper care"
+            sublabel="Submit a request"
+            testid="counselor-action-camper-care"
+          />
+          <QuickActionButton
+            to="/counselor/requests/maintenance/new"
+            icon={Wrench}
+            label="Maintenance"
+            sublabel="Report an issue"
+            testid="counselor-action-maintenance"
+          />
+          <QuickActionButton
+            to="/counselor/requests"
+            icon={ClipboardList}
+            label="My requests"
+            sublabel={openCount ? `${openCount} open` : 'View progress'}
+            testid="counselor-action-requests"
+            badge={openCount > 0 ? openCount : null}
+          />
+          <QuickActionButton
+            to="/observations"
+            icon={MessageSquarePlus}
+            label="Observation"
+            sublabel="Note about a camper"
+            testid="counselor-action-observation"
+          />
+        </div>
+      </section>
+
       {allSet && isToday ? (
         <div
           className="flex items-start gap-3 rounded-xl border border-green-200 bg-green-50 dark:bg-green-950/40 dark:border-green-800 px-4 py-3"
@@ -489,43 +526,6 @@ export default function CounselorMobileDashboard() {
             <p className="text-sm text-gray-600 dark:text-gray-300">History and streaks</p>
           </div>
         </Link>
-      </section>
-
-      <section data-testid="counselor-quick-actions">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
-          Requests & observations
-        </h2>
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
-          <QuickActionButton
-            to="/counselor/requests/camper-care/new"
-            icon={HeartHandshake}
-            label="Camper care"
-            sublabel="Submit a request"
-            testid="counselor-action-camper-care"
-          />
-          <QuickActionButton
-            to="/counselor/requests/maintenance/new"
-            icon={Wrench}
-            label="Maintenance"
-            sublabel="Report an issue"
-            testid="counselor-action-maintenance"
-          />
-          <QuickActionButton
-            to="/counselor/requests"
-            icon={ClipboardList}
-            label="My requests"
-            sublabel={openCount ? `${openCount} open` : 'View progress'}
-            testid="counselor-action-requests"
-            badge={openCount > 0 ? openCount : null}
-          />
-          <QuickActionButton
-            to="/observations"
-            icon={MessageSquarePlus}
-            label="Observation"
-            sublabel="Note about a camper"
-            testid="counselor-action-observation"
-          />
-        </div>
       </section>
     </div>
   );

--- a/frontend/src/pages/leadership-team/AssignFormDialog.jsx
+++ b/frontend/src/pages/leadership-team/AssignFormDialog.jsx
@@ -46,7 +46,7 @@ const CONFLICT_CHOICES = [
 
 const GROUP_TYPE_LABELS = {
   bunk: 'Bunk', unit: 'Unit', division: 'Division', cohort: 'Cohort',
-  classroom: 'Classroom', caseload: 'Caseload', specialty: 'Specialty', custom: 'Custom',
+  classroom: 'Classroom', caseload: 'Caseload', team: 'Team', specialty: 'Specialty', custom: 'Custom',
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/frontend/src/pages/leadership-team/AssignmentDialog.jsx
+++ b/frontend/src/pages/leadership-team/AssignmentDialog.jsx
@@ -58,7 +58,7 @@ const SCOPE_LABELS = {
 // Human labels for group types shown as compact pills in the template header.
 const GROUP_TYPE_SHORT = {
   bunk: 'Bunk', unit: 'Unit', division: 'Division', cohort: 'Cohort',
-  classroom: 'Classroom', caseload: 'Caseload', specialty: 'Specialty', custom: 'Custom',
+  classroom: 'Classroom', caseload: 'Caseload', team: 'Team', specialty: 'Specialty', custom: 'Custom',
 };
 
 const CONFLICT_CHOICES = [
@@ -70,7 +70,7 @@ const CONFLICT_CHOICES = [
 // Display order for group_type sections; anything unrecognised falls under
 // "Other". Matches the order in core.models.AssignmentGroup.GROUP_TYPES.
 const GROUP_TYPE_ORDER = [
-  'bunk', 'unit', 'division', 'cohort', 'classroom', 'caseload', 'specialty', 'custom',
+  'bunk', 'unit', 'division', 'cohort', 'classroom', 'caseload', 'team', 'specialty', 'custom',
 ];
 
 const GROUP_TYPE_LABEL = {
@@ -80,6 +80,7 @@ const GROUP_TYPE_LABEL = {
   cohort: 'Cohorts',
   classroom: 'Classrooms',
   caseload: 'Caseloads',
+  team: 'Teams',
   specialty: 'Specialty / Activity groups',
   custom: 'Custom groups',
 };

--- a/frontend/src/pages/leadership-team/TemplateBuilder/TemplateBuilderPage.jsx
+++ b/frontend/src/pages/leadership-team/TemplateBuilder/TemplateBuilderPage.jsx
@@ -78,6 +78,7 @@ const ASSIGNMENT_GROUP_TYPES = [
   { value: 'cohort', label: 'Cohort' },
   { value: 'classroom', label: 'Classroom' },
   { value: 'caseload', label: 'Caseload' },
+  { value: 'team', label: 'Team' },
   { value: 'specialty', label: 'Specialty / Activity group' },
   { value: 'custom', label: 'Custom group' },
 ];

--- a/frontend/src/pages/observations/ObservationThread.jsx
+++ b/frontend/src/pages/observations/ObservationThread.jsx
@@ -14,6 +14,7 @@ import {
   archiveObservation,
   fetchObservationThread,
   replyToObservation,
+  sensitivityAudience,
 } from '../../api/observations';
 
 function timeAgo(iso) {
@@ -28,13 +29,6 @@ function timeAgo(iso) {
   if (days === 1) return 'yesterday';
   return `${days}d ago`;
 }
-
-const SENSITIVITY_LABEL = {
-  normal: 'Normal',
-  sensitive: 'Sensitive',
-  domain: 'Domain',
-  confidential: 'Confidential',
-};
 
 export default function ObservationThread() {
   const { observationId } = useParams();
@@ -163,7 +157,7 @@ export default function ObservationThread() {
                     );
                   })}
                   <span className="inline-flex rounded-full bg-amber-50 dark:bg-amber-900/20 px-2.5 py-0.5 text-xs font-medium text-amber-800 dark:text-amber-200">
-                    {SENSITIVITY_LABEL[obs.sensitivity] ?? obs.sensitivity}
+                    {sensitivityAudience(obs.sensitivity)}
                   </span>
                 </div>
                 <div className="flex items-center gap-3 mt-2 flex-wrap">

--- a/frontend/src/pages/observations/ObservationsInbox.jsx
+++ b/frontend/src/pages/observations/ObservationsInbox.jsx
@@ -5,7 +5,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ObservationComposer from '../../components/observations/ObservationComposer';
-import { fetchObservationInbox, fetchObservationSent } from '../../api/observations';
+import {
+  fetchObservationInbox,
+  fetchObservationSent,
+  sensitivityAudience,
+} from '../../api/observations';
 
 const TABS = [
   { key: 'inbox', label: 'Inbox' },
@@ -17,13 +21,6 @@ const SORT_OPTIONS = [
   { value: 'oldest', label: 'Oldest first' },
   { value: 'unread', label: 'Unread first' },
 ];
-
-const SENSITIVITY_LABEL = {
-  normal: 'Normal',
-  sensitive: 'Sensitive',
-  domain: 'Domain',
-  confidential: 'Confidential',
-};
 
 function timeAgo(iso) {
   if (!iso) return '';
@@ -256,7 +253,7 @@ export default function ObservationsInbox() {
                       : `From ${o.author?.full_name}`}
                   </span>
                   <span className="text-xs rounded-full bg-amber-50 dark:bg-amber-900/20 px-2 py-0.5 text-amber-800 dark:text-amber-200">
-                    {SENSITIVITY_LABEL[o.sensitivity] ?? o.sensitivity}
+                    {sensitivityAudience(o.sensitivity)}
                   </span>
                 </div>
               </button>

--- a/frontend/src/partials/Sidebar.jsx
+++ b/frontend/src/partials/Sidebar.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 import isSuperAdmin from "../utils/auth/isSuperAdmin";
-import { hasCapability } from "../utils/auth/capability";
+import { hasCapability, homePathForUser, isMaintenanceOnlyMember } from "../utils/auth/capability";
 import api from "../api";
 
 import SidebarLinkGroup from "./SidebarLinkGroup";
@@ -44,11 +44,13 @@ const PROGRAM_LEAD_PLUS = ['program_lead'];
 /**
  * Navigation IA.
  *
- * The nav is role-dependent. There are three render paths:
+ * The nav is role-dependent. There are four render paths:
  *
- *   1. maintenance-only members  — stripped nav (Maintenance + Observations)
+ *   1. maintenance-only members  — Maintenance Queue only
  *   2. admins / super-admins     — curated Admin IA (see below)
- *   3. everyone else             — the shared default nav
+ *   3. program_lead (LT)         — same Admin IA structure; Home →
+ *      /leadership-team; Admin submenu is Templates only
+ *   4. everyone else             — the shared default nav
  *
  * Admin IA (admin + super_admin) — Phase 1 of the role-based nav refactor:
  *
@@ -78,15 +80,14 @@ const PROGRAM_LEAD_PLUS = ['program_lead'];
  *     Field keys          /admin/field-keys
  *     Settings            /admin/settings
  *
- * Admins land on /admin (see pages/Dashboard.jsx). My tasks / File a
- * reflection / My reflections are folded into the Admin dashboard
- * rather than the global nav. The Leadership Team group is intentionally
- * absent from the Admin IA (it's the Leadership Team's own home).
+ * Admins land on /admin (see pages/Dashboard.jsx). Leadership Team lands
+ * on /leadership-team with the same My work / Supervise sections but
+ * only Templates under Admin. My tasks / File a reflection / My
+ * reflections are folded into those home dashboards, not the global nav.
  *
- * Default nav (non-admin): My work (Home/tasks/reflections/
- * observations/maintenance), Supervise (supervisor+; program_lead+ also
- * gets performance / log entries / reflections / authors there). Help
- * (program_lead+). Leadership Team (program_lead+). Camper Care omits My tasks / File a reflection /
+ * Default nav (non-admin, non-LT): My work (Home/tasks/reflections/
+ * observations/maintenance), Supervise (supervisor+). Help
+ * (program_lead+). Camper Care omits My tasks / File a reflection /
  * My reflections / Bunk Logs — those live on the Camper Care home dashboard.
  * Gates use
  * hasCapability(user, [...]) || isSuperAdmin(user); direct `user.role`
@@ -167,6 +168,9 @@ function Sidebar({
   const canSeeLeadershipTeam = hasCapability(user, PROGRAM_LEAD_PLUS) || isSuperAdmin(user);
   const canSeeHelp = canSeeLeadershipTeam;
   const canAdmin = hasCapability(user, 'admin') || isSuperAdmin(user);
+  const useLeadershipAdminNav = canSeeDashboards && !canAdmin;
+  const useAdminStyleNav = canAdmin || useLeadershipAdminNav;
+  const adminStyleHomePath = canAdmin ? '/admin/home' : '/leadership-team';
   const canFileReflection = REFLECTION_FORM_ROLES.includes(user.role);
   const isCounselor = user.role === 'Counselor';
   const isCamperCare = user.role === 'Camper Care';
@@ -174,14 +178,11 @@ function Sidebar({
   const canSeeLogs = canSupervise || canAdmin;
   // Counselors see assigned/submitted work via My tasks + My reflections, not the org-wide dashboard.
   const canSeeReflectionsDashboard = (canSeeLogs || canFileReflection) && !isCounselor;
-  // Maintenance staff get a stripped-down nav: just the queue + notes. The
-  // canonical role lives on Membership (legacy User.role has no maintenance
-  // value), surfaced via `membership_roles` on the profile payload.
-  const membershipRoles = Array.isArray(user.membership_roles) ? user.membership_roles : [];
-  const isMaintenanceOnly =
-    membershipRoles.includes('maintenance') &&
-    !membershipRoles.includes('admin') &&
-    !canAdmin;
+  // Maintenance staff get a stripped-down nav: just the queue. The canonical
+  // role lives on Membership (legacy User.role has no maintenance value),
+  // surfaced via `membership_roles` on the profile payload.
+  const isMaintenanceOnly = isMaintenanceOnlyMember(user);
+  const homePath = homePathForUser(user);
   // Poll unread Observations count every 60 seconds (Step 7_23 nav badge).
   const [observationsUnread, setObservationsUnread] = useState(0);
   useEffect(() => {
@@ -214,6 +215,7 @@ function Sidebar({
           trigger={trigger}
           sidebarOpen={sidebarOpen}
           setSidebarOpen={setSidebarOpen}
+          homePath={homePath}
         />
 
         <div className="space-y-6">
@@ -224,18 +226,12 @@ function Sidebar({
                 label="Maintenance Queue"
                 icon={IconWrench}
               />
-              <NavItem
-                to="/observations"
-                label="Observations"
-                icon={IconChat}
-                badge={observationsUnread > 0 ? observationsUnread : null}
-              />
             </Section>
-          ) : canAdmin ? (
+          ) : useAdminStyleNav ? (
           <>
           <div>
             <ul>
-              <NavItem to="/admin/home" label="Home" icon={IconHome} end />
+              <NavItem to={adminStyleHomePath} label="Home" icon={IconHome} end />
               {canSeeHelp && (
                 <NavItem to="/help" label="Help" icon={IconHelp} />
               )}
@@ -302,14 +298,21 @@ function Sidebar({
             icon={IconGear}
             setSidebarExpanded={setSidebarExpanded}
           >
-            <SubItem to="/admin/dashboard" label="Admin Dashboard" />
-            <SubItem to="/admin/templates" label="Templates" />
-            <SubItem to="/admin/people" label="People" />
-            <SubItem to="/admin/assignments" label="Assignments" />
-            <SubItem to="/admin/memberships" label="Memberships" />
-            <SubItem to="/admin/groups" label="Assignment groups" />
-            <SubItem to="/admin/field-keys" label="Field keys" />
-            <SubItem to="/admin/settings" label="Settings" />
+            {canAdmin && (
+              <>
+                <SubItem to="/admin/dashboard" label="Admin Dashboard" />
+                <SubItem to="/admin/templates" label="Templates" />
+                <SubItem to="/admin/people" label="People" />
+                <SubItem to="/admin/assignments" label="Assignments" />
+                <SubItem to="/admin/memberships" label="Memberships" />
+                <SubItem to="/admin/groups" label="Assignment groups" />
+                <SubItem to="/admin/field-keys" label="Field keys" />
+                <SubItem to="/admin/settings" label="Settings" />
+              </>
+            )}
+            {!canAdmin && (
+              <SubItem to="/admin/templates" label="Templates" />
+            )}
           </CollapsibleSection>
           </>
           ) : (
@@ -439,7 +442,7 @@ function Sidebar({
   );
 }
 
-function SidebarHeader({ trigger, sidebarOpen, setSidebarOpen }) {
+function SidebarHeader({ trigger, sidebarOpen, setSidebarOpen, homePath = '/' }) {
   return (
     <div className="flex justify-between mb-10 pr-3 sm:px-2">
       <button
@@ -454,7 +457,7 @@ function SidebarHeader({ trigger, sidebarOpen, setSidebarOpen }) {
           <path d="M10.7 18.7l1.4-1.4L7.8 13H20v-2H7.8l4.3-4.3-1.4-1.4L4 12z" />
         </svg>
       </button>
-      <NavLink end to="/" className="block">
+      <NavLink end to={homePath} className="block">
         <img className="shrink-0 mr-2 sm:mr-3" width="70" height="35" viewBox="0 0 36 36" src={CampLogo} />
       </NavLink>
     </div>

--- a/frontend/src/partials/__tests__/Sidebar.test.jsx
+++ b/frontend/src/partials/__tests__/Sidebar.test.jsx
@@ -62,7 +62,7 @@ describe('Sidebar — section gating (3.32)', () => {
 
     const links = hrefs();
     expect(links).toContain('/counselor');
-    expect(links.filter((h) => h === '/counselor')).toHaveLength(1);
+    expect(links.filter((h) => h === '/counselor')).toHaveLength(2);
     expect(links).not.toContain('/dashboard');
     expect(links).toContain('/tasks');
     expect(links).not.toContain('/reflect');
@@ -95,7 +95,7 @@ describe('Sidebar — section gating (3.32)', () => {
 
     const links = hrefs();
     expect(links).toContain('/unit-head');
-    expect(links.filter((h) => h === '/unit-head')).toHaveLength(1);
+    expect(links.filter((h) => h === '/unit-head')).toHaveLength(2);
     expect(links).not.toContain('/dashboard');
     expect(links).toContain('/groups/performance');
     expect(links).toContain('/dashboards/concerns');
@@ -108,7 +108,7 @@ describe('Sidebar — section gating (3.32)', () => {
     expect(screen.getAllByText('Supervise').length).toBeGreaterThan(0);
     const links = hrefs();
     expect(links).toContain('/camper-care');
-    expect(links.filter((h) => h === '/camper-care')).toHaveLength(1);
+    expect(links.filter((h) => h === '/camper-care')).toHaveLength(2);
     expect(links).not.toContain('/dashboard');
     expect(links).toContain('/groups/performance');
     expect(links).toContain('/dashboards/concerns');
@@ -118,22 +118,46 @@ describe('Sidebar — section gating (3.32)', () => {
     expect(links).not.toContain('/my-reflections');
   });
 
-  it('program_lead (leadership) sees Help and Supervise dashboard links but not Admin', () => {
-    renderWith({ role: 'Leadership' });
+  it('program_lead (leadership) sees Admin-style nav with Templates-only Admin submenu', () => {
+    renderWith({ role: 'Leadership' }, { path: '/leadership-team' });
 
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/leadership-team');
     expect(screen.getByRole('link', { name: 'Help' })).toHaveAttribute('href', '/help');
-    expect(screen.queryByText('Dashboards')).not.toBeInTheDocument();
+    expect(screen.getAllByText('My work').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Supervise').length).toBeGreaterThan(0);
-    expect(screen.queryByText('Admin')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Admin').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Templates').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Dashboards')).not.toBeInTheDocument();
+    expect(screen.queryByText('Leadership Team')).not.toBeInTheDocument();
     expect(screen.queryByText('Crane Lake legacy')).not.toBeInTheDocument();
-    expect(hrefs()).not.toContain('/leadership-team/templates');
+
     const links = hrefs();
+    expect(links).toContain('/leadership-team');
+    expect(links).toContain('/help');
     expect(links).toContain('/groups/performance');
     expect(links).toContain('/dashboards/logs');
     expect(links).toContain('/dashboards/reflections');
+    expect(links).toContain('/observations');
+    expect(links).toContain('/maintenance');
+    expect(links).toContain('/camper-care/orders');
+    expect(links).toContain('/dashboards/coverage');
+    expect(links).toContain('/dashboards/concerns');
     expect(links).toContain('/dashboards/authors');
+    expect(links).toContain('/admin/templates');
+    expect(links).not.toContain('/admin/home');
+    expect(links).not.toContain('/admin/dashboard');
+    expect(links).not.toContain('/admin/people');
+    expect(links).not.toContain('/admin/memberships');
+    expect(links).not.toContain('/admin/groups');
+    expect(links).not.toContain('/admin/field-keys');
+    expect(links).not.toContain('/admin/settings');
+    expect(links).not.toContain('/tasks');
+    expect(links).not.toContain('/reflect');
+    expect(links).not.toContain('/my-reflections');
     expect(links).not.toContain('/dashboards');
     expect(links).not.toContain('/dashboards/wellness');
+    expect(links.filter((h) => h === '/dashboards/logs')).toHaveLength(1);
+    expect(links.filter((h) => h === '/dashboards/reflections')).toHaveLength(1);
   });
 
   it('admin sees the curated Admin IA, not the default My work nav', () => {
@@ -192,27 +216,22 @@ describe('Sidebar — section gating (3.32)', () => {
 });
 
 describe('Sidebar — maintenance-only nav', () => {
-  it('shows only Maintenance Queue + Observations for a maintenance member', () => {
+  it('shows only Maintenance Queue for a maintenance member', () => {
     renderWith({ role: 'Counselor', membership_roles: ['maintenance'] });
 
     const links = hrefs();
     expect(links).toContain('/maintenance');
-    expect(links).toContain('/observations');
+    expect(links.filter((h) => h === '/maintenance')).toHaveLength(2);
+    expect(links).not.toContain('/');
     // Everything else is hidden.
     expect(links).not.toContain('/dashboard');
     expect(links).not.toContain('/tasks');
     expect(links).not.toContain('/counselor');
     expect(links).not.toContain('/reflect');
     expect(links).not.toContain('/orders');
+    expect(links).not.toContain('/observations');
     expect(links).not.toContain('/subject-notes');
     expect(screen.queryByText('Supervise')).not.toBeInTheDocument();
-  });
-
-  it('orders Maintenance Queue before Observations', () => {
-    renderWith({ role: 'Counselor', membership_roles: ['maintenance'] });
-    const appLinks = hrefs().filter((h) => h === '/maintenance' || h === '/observations');
-    expect(appLinks[0]).toBe('/maintenance');
-    expect(appLinks[1]).toBe('/observations');
   });
 
   it('keeps the full Admin nav when the user also holds an admin membership', () => {

--- a/frontend/src/utils/auth/__tests__/capability.test.js
+++ b/frontend/src/utils/auth/__tests__/capability.test.js
@@ -4,6 +4,7 @@ import {
   CAPABILITIES,
   userCapability,
   hasCapability,
+  homePathForUser,
   _LEGACY_USER_ROLE_TO_CAPABILITY,
 } from '../capability';
 
@@ -149,5 +150,18 @@ describe('hasCapability — list-of-capabilities checks', () => {
   it('handles a single-element list the same as a bare string', () => {
     const u = { role: 'Camper Care' };
     expect(hasCapability(u, ['supervisor'])).toBe(hasCapability(u, 'supervisor'));
+  });
+});
+
+describe('homePathForUser', () => {
+  it('sends maintenance-only members to the queue', () => {
+    expect(homePathForUser({
+      role: 'Counselor',
+      membership_roles: ['maintenance'],
+    })).toBe('/maintenance');
+  });
+
+  it('keeps counselor home for non-maintenance counselors', () => {
+    expect(homePathForUser({ role: 'Counselor', membership_roles: [] })).toBe('/counselor');
   });
 });

--- a/frontend/src/utils/auth/capability.js
+++ b/frontend/src/utils/auth/capability.js
@@ -127,6 +127,40 @@ export function hasCapability(user, capOrList) {
  *   const cap = useCapability();
  *   if (cap === 'admin') ...
  */
+/** Maintenance membership with no admin role — stripped nav + /maintenance home. */
+export function isMaintenanceOnlyMember(user) {
+  if (!user) return false;
+  const roles = Array.isArray(user.membership_roles) ? user.membership_roles : [];
+  return (
+    roles.includes('maintenance')
+    && !roles.includes('admin')
+    && !hasCapability(user, 'admin')
+    && !isSuperAdmin(user)
+  );
+}
+
+const ROLE_HOME_PATHS = Object.freeze({
+  Admin: '/admin/home',
+  Counselor: '/counselor',
+  'Unit Head': '/unit-head',
+  'Camper Care': '/camper-care',
+  Leadership: '/leadership-team',
+  'Leadership Team': '/leadership-team',
+  'Kitchen Staff': '/kitchen-staff',
+  Specialist: '/specialist',
+  Madrich: '/madrich',
+  Maintenance: '/maintenance',
+});
+
+/** Post-login and logo home target for the signed-in user. */
+export function homePathForUser(user) {
+  if (!user) return '/dashboard';
+  if (isMaintenanceOnlyMember(user)) return '/maintenance';
+  if (isSuperAdmin(user)) return '/admin/home';
+  const rolePath = user.role && ROLE_HOME_PATHS[user.role];
+  return rolePath || '/dashboard';
+}
+
 export function useCapability() {
   const { user } = useAuth();
   return userCapability(user);


### PR DESCRIPTION
## Summary
- Give Leadership Team the admin-style sidebar (Home → `/leadership-team`) with Templates as the only Admin submenu item, plus route gates for `/admin/templates*`.
- Add **Team** assignment group type with admin `staff_team` assignment support, labels across group/template UIs, and migration `0048`.
- Update observation sensitivity audience copy (Everyone / Unit Heads and above / Leadership Team and above / Pro Team only) and restrict domain-tier reads to program_lead+.
- Strip maintenance-only nav to Maintenance Queue only; route login, `/`, and logo home to `/maintenance` (JWT login now includes `membership_roles`).
- Move counselor dashboard **Requests & observations** quick actions to the top, below the header.

## Test plan
- [ ] LT user sees admin IA with Templates-only Admin submenu; can open `/admin/templates`
- [ ] Admin can create Team groups and assign staff via Staff → Team tab
- [ ] Observation composer/badges show new audience labels; domain specialists cannot read domain-tier notes
- [ ] Maintenance-only member lands on `/maintenance` with queue-only sidebar
- [ ] Counselor home shows requests/observations bar above bunks
- [ ] CI: backend pytest + ruff, frontend vitest + build


Made with [Cursor](https://cursor.com)