### PR TITLE
fix: org context for JWT-only mobile clients

### DIFF
--- a/backend/bunk_logs/core/middleware.py
+++ b/backend/bunk_logs/core/middleware.py
@@ -38,14 +38,54 @@ def _dev_org_routing_overrides_enabled() -> bool:
     )
 
 
-def _dev_org_slug_override(request: HttpRequest) -> str | None:
+def _org_slug_from_header(request: HttpRequest) -> str | None:
+    """Tenant slug from X-Organization-Slug (SPA → admin API calls)."""
+    header = (request.META.get("HTTP_X_ORGANIZATION_SLUG") or "").strip()
+    return header or None
+
+
+def _org_slug_from_query_dev_only(request: HttpRequest) -> str | None:
     if not _dev_org_routing_overrides_enabled():
         return None
-    header = (request.META.get("HTTP_X_ORGANIZATION_SLUG") or "").strip()
-    if header:
-        return header
     q = (request.GET.get("org") or "").strip()
     return q or None
+
+
+def _org_slug_override(request: HttpRequest) -> str | None:
+    return _org_slug_from_header(request) or _org_slug_from_query_dev_only(request)
+
+
+def _user_from_bearer_jwt(request: HttpRequest):
+    """Resolve user from Authorization: Bearer for org fallback before DRF runs."""
+    auth = (request.META.get("HTTP_AUTHORIZATION") or "").strip()
+    if not auth.lower().startswith("bearer "):
+        return None
+    from rest_framework_simplejwt.authentication import JWTAuthentication
+
+    try:
+        result = JWTAuthentication().authenticate(request)
+    except Exception:
+        return None
+    if result is None:
+        return None
+    user, _token = result
+    if user is None or not getattr(user, "is_authenticated", False):
+        return None
+    return user
+
+
+def _org_from_linked_person(user) -> Organization | None:
+    from bunk_logs.core.models import Person
+
+    person = (
+        Person.all_objects.select_related("organization")
+        .filter(user=user)
+        .first()
+    )
+    if person is None:
+        return None
+    org = person.organization
+    return org if org.is_active else None
 
 
 def _host_subdomain_label(host: str) -> str | None:
@@ -68,7 +108,6 @@ class OrganizationMiddleware:
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         from bunk_logs.core.models import Organization
-        from bunk_logs.core.models import Person
 
         org: Organization | None = None
         try:
@@ -80,7 +119,7 @@ class OrganizationMiddleware:
                     org = None
 
             if org is None:
-                slug = _dev_org_slug_override(request)
+                slug = _org_slug_override(request)
                 if slug:
                     try:
                         org = Organization.objects.get(slug=slug, is_active=True)
@@ -88,14 +127,13 @@ class OrganizationMiddleware:
                         org = None
 
             user = getattr(request, "user", None)
-            if org is None and user is not None and user.is_authenticated:
-                person = (
-                    Person.all_objects.select_related("organization")
-                    .filter(user=user)
-                    .first()
-                )
-                if person is not None:
-                    org = person.organization if person.organization.is_active else None
+            if user is not None and user.is_authenticated:
+                effective_user = user
+            else:
+                effective_user = _user_from_bearer_jwt(request)
+
+            if org is None and effective_user is not None:
+                org = _org_from_linked_person(effective_user)
 
             request.organization = org
             set_current_organization(org)

--- a/backend/bunk_logs/core/test_multitenancy.py
+++ b/backend/bunk_logs/core/test_multitenancy.py
@@ -251,7 +251,7 @@ def test_dev_query_param_resolves_organization(org_alpha, settings):
 
 
 @pytest.mark.django_db
-def test_dev_override_disabled_ignores_header(org_alpha, settings):
+def test_header_resolves_organization_without_dev_overrides(org_alpha, settings):
     settings.DEBUG = False
     settings.ORGANIZATION_ROUTING_DEV_OVERRIDES = False
 
@@ -259,11 +259,55 @@ def test_dev_override_disabled_ignores_header(org_alpha, settings):
         return HttpResponse("ok")
 
     rf = RequestFactory()
-    request = rf.get("/", HTTP_HOST="localhost", HTTP_X_ORGANIZATION_SLUG="alpha-mt")
+    request = rf.get("/", HTTP_HOST="admin.bunklogs.net", HTTP_X_ORGANIZATION_SLUG="alpha-mt")
+    request.user = AnonymousUser()
+    OrganizationMiddleware(get_response)(request)
+
+    assert request.organization == org_alpha
+
+
+@pytest.mark.django_db
+def test_dev_override_disabled_ignores_query_param(org_alpha, settings):
+    settings.DEBUG = False
+    settings.ORGANIZATION_ROUTING_DEV_OVERRIDES = False
+
+    def get_response(request):
+        return HttpResponse("ok")
+
+    rf = RequestFactory()
+    request = rf.get("/?org=alpha-mt", HTTP_HOST="localhost")
     request.user = AnonymousUser()
     OrganizationMiddleware(get_response)(request)
 
     assert request.organization is None
+
+
+@pytest.mark.django_db
+def test_jwt_bearer_resolves_org_from_person_on_admin_host(org_alpha):
+    from rest_framework_simplejwt.tokens import RefreshToken
+
+    user = User.objects.create_user(email="jwt-org@example.com", password="pw")
+    Person.all_objects.create(
+        organization=org_alpha,
+        first_name="J",
+        last_name="WT",
+        user=user,
+    )
+    access = str(RefreshToken.for_user(user).access_token)
+
+    def get_response(request):
+        return HttpResponse("ok")
+
+    rf = RequestFactory()
+    request = rf.get(
+        "/",
+        HTTP_HOST="admin.bunklogs.net",
+        HTTP_AUTHORIZATION=f"Bearer {access}",
+    )
+    request.user = AnonymousUser()
+    OrganizationMiddleware(get_response)(request)
+
+    assert request.organization == org_alpha
 
 
 @pytest.mark.django_db

--- a/backend/config/views.py
+++ b/backend/config/views.py
@@ -543,6 +543,10 @@ def google_callback(request):
                     extra_data=userinfo,
                 )
 
+        # Session cookie lets OrganizationMiddleware resolve tenant on later API
+        # calls (JWT alone is applied later in DRF, after middleware runs).
+        login(request, user, backend="django.contrib.auth.backends.ModelBackend")
+
         # Generate JWT token
         refresh = RefreshToken.for_user(user)
         access_token = str(refresh.access_token)

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { getCSRFToken } from './django';
 import isSuperAdmin from './utils/auth/isSuperAdmin';
+import { resolveOrganizationSlug } from './utils/orgSlug';
 
 // Get and clean the API URL
 const getApiUrl = () => {
@@ -33,10 +34,6 @@ const getServerCSRFToken = async () => {
   }
 };
 
-// Attach the dev org slug header when running locally so the multi-tenant
-// middleware can resolve the org without a subdomain.
-const DEV_ORG_SLUG = import.meta.env.VITE_DEV_ORGANIZATION_SLUG;
-
 // Add request interceptor to attach token and CSRF token
 api.interceptors.request.use(
   async (config) => {
@@ -45,8 +42,11 @@ api.interceptors.request.use(
       config.headers.Authorization = `Bearer ${token}`;
     }
 
-    if (DEV_ORG_SLUG) {
-      config.headers['X-Organization-Slug'] = DEV_ORG_SLUG;
+    // API host is admin.bunklogs.net (no tenant subdomain). Send the tenant
+    // slug from the SPA hostname (clc.bunklogs.net) or local dev env var.
+    const orgSlug = resolveOrganizationSlug();
+    if (orgSlug) {
+      config.headers['X-Organization-Slug'] = orgSlug;
     }
     
     // Add CSRF token for non-GET requests (except user creation)

--- a/frontend/src/utils/__tests__/orgSlug.test.js
+++ b/frontend/src/utils/__tests__/orgSlug.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { orgSlugFromHost, resolveOrganizationSlug } from '../orgSlug';
+
+describe('orgSlugFromHost', () => {
+  it('returns tenant slug from production subdomain', () => {
+    expect(orgSlugFromHost('clc.bunklogs.net')).toBe('clc');
+    expect(orgSlugFromHost('tbe.bunklogs.net')).toBe('tbe');
+  });
+
+  it('returns null for reserved or non-tenant hosts', () => {
+    expect(orgSlugFromHost('admin.bunklogs.net')).toBeNull();
+    expect(orgSlugFromHost('www.bunklogs.net')).toBeNull();
+    expect(orgSlugFromHost('localhost')).toBeNull();
+    expect(orgSlugFromHost('127.0.0.1')).toBeNull();
+  });
+});
+
+describe('resolveOrganizationSlug', () => {
+  it('prefers VITE_DEV_ORGANIZATION_SLUG when set', () => {
+    const prev = import.meta.env.VITE_DEV_ORGANIZATION_SLUG;
+    import.meta.env.VITE_DEV_ORGANIZATION_SLUG = 'dev-clc';
+    expect(resolveOrganizationSlug()).toBe('dev-clc');
+    import.meta.env.VITE_DEV_ORGANIZATION_SLUG = prev;
+  });
+});

--- a/frontend/src/utils/orgSlug.js
+++ b/frontend/src/utils/orgSlug.js
@@ -1,0 +1,28 @@
+/** Reserved first labels on *.bunklogs.net — must match backend middleware. */
+const SUBDOMAIN_SKIP = new Set(['', 'www', 'admin', 'api', 'localhost']);
+
+/**
+ * Tenant slug from the SPA hostname (e.g. clc.bunklogs.net → "clc").
+ * Returns null on localhost, admin host, or non-bunklogs hosts.
+ */
+export function orgSlugFromHost(hostname) {
+  const host = String(hostname || '').toLowerCase().replace(/\.$/, '');
+  const parts = host.split('.');
+  if (parts.length < 3 || parts.slice(-2).join('.') !== 'bunklogs.net') {
+    return null;
+  }
+  const label = parts[0];
+  return SUBDOMAIN_SKIP.has(label) ? null : label;
+}
+
+/** Dev env override, else tenant subdomain on production hosts. */
+export function resolveOrganizationSlug() {
+  const devSlug = import.meta.env.VITE_DEV_ORGANIZATION_SLUG;
+  if (devSlug) {
+    return String(devSlug).trim() || null;
+  }
+  if (typeof window !== 'undefined' && window.location?.hostname) {
+    return orgSlugFromHost(window.location.hostname);
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- Frontend sends `X-Organization-Slug` derived from SPA hostname (`clc.bunklogs.net` → `clc`)
- Backend honors org header in production and resolves tenant from JWT + linked Person when no session cookie exists
- Google OAuth callback establishes a shared `.bunklogs.net` session cookie

Fixes Performance Dashboard (and other org-scoped APIs) returning 403 on phone when logged in with JWT only.

## Test plan
- [x] `orgSlug` unit tests pass
- [x] Multitenancy middleware tests updated (header in prod, JWT bearer fallback)
- [ ] After deploy: sign in on phone at clc.bunklogs.net → Group Performance loads


Made with [Cursor](https://cursor.com)