### PR TITLE
feat: add NCO roster CSV and date-aware Campminder import

### DIFF
--- a/backend/bunk_logs/core/campminder_csv.py
+++ b/backend/bunk_logs/core/campminder_csv.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import io
+from datetime import date
 from pathlib import Path
 
 from bunk_logs.core.models import Membership
@@ -87,7 +88,20 @@ _HEADER_ALIASES: dict[str, tuple[str, ...]] = {
     ),
     "language_preference": ("language preference", "language", "language_preference"),
     "tags": ("tags",),
+    "start_date": ("start date", "start_date", "start"),
+    "end_date": ("end date", "end_date", "end"),
 }
+
+
+def parse_optional_iso_date(raw: str) -> date | None:
+    """Parse YYYY-MM-DD from a CSV date cell; return None when blank or invalid."""
+    value = (raw or "").strip()
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError:
+        return None
 
 
 def _field_value(indexed: dict[str, str], field: str) -> str:
@@ -245,6 +259,8 @@ def normalize_campminder_row(row: dict) -> dict:
         "caseload_owner_campminder_id": _field_value(indexed, "caseload_owner_campminder_id"),
         "language_preference": _field_value(indexed, "language_preference"),
         "tags": _field_value(indexed, "tags"),
+        "start_date": _field_value(indexed, "start_date"),
+        "end_date": _field_value(indexed, "end_date"),
     }
 
 

--- a/backend/bunk_logs/core/management/commands/import_campminder_roster.py
+++ b/backend/bunk_logs/core/management/commands/import_campminder_roster.py
@@ -10,6 +10,7 @@ AssignmentGroups are keyed by (program, group_type, slugified-name).
 from __future__ import annotations
 
 import logging
+from datetime import date
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +21,7 @@ from django.utils.text import slugify
 
 from bunk_logs.core.campminder_csv import format_csv_headers
 from bunk_logs.core.campminder_csv import normalize_campminder_row
+from bunk_logs.core.campminder_csv import parse_optional_iso_date
 from bunk_logs.core.campminder_csv import read_campminder_csv_rows
 from bunk_logs.core.campminder_person_match import MatchStrategy
 from bunk_logs.core.campminder_person_match import match_campminder_person
@@ -80,17 +82,33 @@ def _ensure_membership(
     group: AssignmentGroup,
     person: Person,
     role_in_group: str,
-) -> AssignmentGroupMembership:
-    membership, _ = AssignmentGroupMembership.all_objects.get_or_create(
+    *,
+    start_date: date | None = None,
+    end_date: date | None = None,
+) -> tuple[AssignmentGroupMembership, bool]:
+    membership, created = AssignmentGroupMembership.all_objects.get_or_create(
         group=group,
         person=person,
         role_in_group=role_in_group,
-        defaults={"is_active": True},
+        defaults={
+            "is_active": True,
+            "start_date": start_date,
+            "end_date": end_date,
+        },
     )
+    changed: list[str] = []
     if not membership.is_active:
         membership.is_active = True
-        membership.save(update_fields=["is_active"])
-    return membership
+        changed.append("is_active")
+    if start_date is not None and membership.start_date != start_date:
+        membership.start_date = start_date
+        changed.append("start_date")
+    if end_date is not None and membership.end_date != end_date:
+        membership.end_date = end_date
+        changed.append("end_date")
+    if changed:
+        membership.save(update_fields=changed)
+    return membership, created
 
 
 def _duplicate_message(
@@ -299,12 +317,15 @@ class Command(BaseCommand):
             position_type = row.get("position_type") or ""
             position = row.get("position") or ""
             tags = _normalize_tags(row["tags"])
+            start_date = parse_optional_iso_date(row.get("start_date") or "")
+            end_date = parse_optional_iso_date(row.get("end_date") or "")
 
             if dry_run:
                 self.stdout.write(
                     f"[dry-run] Row {i}: campminder_id={campminder_id} role={role} "
                     f"bunk={bunk_name or '—'} unit={unit_name or '—'} "
-                    f"division={division_name or '—'} caseload={caseload_name or '—'}",
+                    f"division={division_name or '—'} caseload={caseload_name or '—'} "
+                    f"dates={start_date or '—'}→{end_date or '—'}",
                 )
                 continue
 
@@ -379,7 +400,14 @@ class Command(BaseCommand):
                     meta["campminder_position"] = position
                 membership.metadata = meta
                 membership.tags = tags
-                membership.save(update_fields=["tags", "metadata"])
+                membership_fields = ["tags", "metadata"]
+                if start_date is not None:
+                    membership.start_date = start_date
+                    membership_fields.append("start_date")
+                if end_date is not None:
+                    membership.end_date = end_date
+                    membership_fields.append("end_date")
+                membership.save(update_fields=membership_fields)
 
                 user_link = ensure_user_for_imported_person(person, membership_role=role)
                 if user_link.action == UserLinkAction.CREATED:
@@ -416,11 +444,12 @@ class Command(BaseCommand):
                     bunk_group = _get_or_create_group(program, "bunk", bunk_name, parent=unit_group)
 
                     role_in_group = "subject" if role == "camper" else "author"
-                    _, bunk_mem_created = AssignmentGroupMembership.all_objects.get_or_create(
-                        group=bunk_group,
-                        person=person,
-                        role_in_group=role_in_group,
-                        defaults={"is_active": True},
+                    _, bunk_mem_created = _ensure_membership(
+                        bunk_group,
+                        person,
+                        role_in_group,
+                        start_date=start_date,
+                        end_date=end_date,
                     )
                     key = (bunk_group.pk, role_in_group)
                     seen_group_members.setdefault(key, set()).add(person.pk)
@@ -443,17 +472,19 @@ class Command(BaseCommand):
                             )
                         else:
                             caseload_group = _get_or_create_group(program, "caseload", caseload_name)
-                            AssignmentGroupMembership.all_objects.get_or_create(
-                                group=caseload_group,
-                                person=owner,
-                                role_in_group="author",
-                                defaults={"is_active": True},
+                            _ensure_membership(
+                                caseload_group,
+                                owner,
+                                "author",
+                                start_date=start_date,
+                                end_date=end_date,
                             )
-                            _, case_mem_created = AssignmentGroupMembership.all_objects.get_or_create(
-                                group=caseload_group,
-                                person=person,
-                                role_in_group="subject",
-                                defaults={"is_active": True},
+                            _, case_mem_created = _ensure_membership(
+                                caseload_group,
+                                person,
+                                "subject",
+                                start_date=start_date,
+                                end_date=end_date,
                             )
                             key = (caseload_group.pk, "subject")
                             seen_group_members.setdefault(key, set()).add(person.pk)

--- a/backend/bunk_logs/core/management/commands/import_campminder_roster.py
+++ b/backend/bunk_logs/core/management/commands/import_campminder_roster.py
@@ -10,9 +10,12 @@ AssignmentGroups are keyed by (program, group_type, slugified-name).
 from __future__ import annotations
 
 import logging
-from datetime import date
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Any
+
+if TYPE_CHECKING:
+    from datetime import date
 
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError

--- a/backend/data/nco_2026_campers.csv
+++ b/backend/data/nco_2026_campers.csv
@@ -1,0 +1,61 @@
+campminder_id,first_name,last_name,role,bunk_name,tags,start_date,end_date
+nco-2026-001,Aria,Seltzer,camper,Bunk 1,K'tanim 1 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-002,Sophia,Hinckley,camper,Bunk 1,K'tanim 1 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-003,Massimo,Dorn,camper,Bunk 1,K'tanim 1 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-004,Nathan,Shah,camper,Bunk 1,K'tanim 1 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-005,Mateo,Goldsmith,camper,Bunk 1,K'tanim 1 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-006,Kira,Golub,camper,Bunk 1,K'tanim 1 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-007,Isabel,Forman,camper,Bunk 1,Lower Nitzanim Full Summer,2026-06-06,2026-06-14
+nco-2026-008,Mabel,Fox,camper,Bunk 3,K'tanim 1 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-009,Ada,Beck,camper,Bunk 3,K'tanim 1 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-010,Joshua,Prager,camper,Bunk 3,K'tanim 1 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-011,Jackson,Golub,camper,Bunk 3,K'tanim 1 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-012,Jonah,Cohlan,camper,Bunk 3,Lower Nitzanim Full Summer,2026-06-06,2026-06-14
+nco-2026-013,Ryder,Weil,camper,Bunk 3,Lower Nitzanim Session 1,2026-06-06,2026-06-14
+nco-2026-014,Caleb,Weil,camper,Bunk 3,Lower Nitzanim Session 1,2026-06-06,2026-06-14
+nco-2026-015,Ezra,Schwartz,camper,Bunk 3,Lower Nitzanim Session 1,2026-06-06,2026-06-14
+nco-2026-016,Rose,Rothenberg,camper,Bunk 2,K'tanim 2 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-017,Esther,Sawyer,camper,Bunk 2,K'tanim 2 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-018,Samuel,Ahlfors,camper,Bunk 2,Lower Nitzanim Session 2,2026-06-06,2026-06-14
+nco-2026-019,Reva,Weber,camper,Bunk 2,K'tanim 2 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-020,Hannah,Weber,camper,Bunk 2,K'tanim 2 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-021,Anya,Wolfe,camper,Bunk 2,K'tanim 2 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-022,Oliver,Povill,camper,Bunk 2,K'tanim 2 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-023,Talia,Allen,camper,Bunk 2,K'tanim 2 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-024,Noah,Lerner,camper,Bunk 2,K'tanim 2 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-025,Nate,Danford,camper,Bunk 2,K'tanim 2 (Grades 2-4),2026-06-06,2026-06-14
+nco-2026-026,Eliza,Schak,camper,Bunk 2,Lower Nitzanim Session 2,2026-06-06,2026-06-14
+nco-2026-027,Lulu,Rolf,camper,Bunk 2,Lower Nitzanim Session 2,2026-06-06,2026-06-14
+nco-2026-028,Ruben,DeLano,camper,Bunk 2,Lower Nitzanim Session 2,2026-06-06,2026-06-14
+nco-2026-029,Azi,Sherman,camper,Bunk 4,Upper Nitzanim Session 1,2026-06-06,2026-06-14
+nco-2026-030,Sara,Kleinhandler-Dahan,camper,Bunk 4,Upper Nitzanim Session 1,2026-06-06,2026-06-14
+nco-2026-031,Teo,Chiang,camper,Bunk 4,Upper Nitzanim Session 1,2026-06-06,2026-06-14
+nco-2026-032,Kirsten,Samuels,camper,Bunk 4,Upper Nitzanim Session 1,2026-06-06,2026-06-14
+nco-2026-033,Noah,Lathroum,camper,Bunk 4,Upper Nitzanim Session 2,2026-06-06,2026-06-14
+nco-2026-034,Asher,Leventhal,camper,Bunk 4,Upper Nitzanim Session 2,2026-06-06,2026-06-14
+nco-2026-035,Ezra,Berger,camper,Bunk 4,Upper Nitzanim Session 2,2026-06-06,2026-06-14
+nco-2026-036,Doron,Yoffe,camper,Bunk 4,Upper Nitzanim Session 2,2026-06-06,2026-06-14
+nco-2026-037,Zoe,Reiner,camper,Bunk 4,Upper Nitzanim Session 2,2026-06-06,2026-06-14
+nco-2026-038,Asher,Young,camper,Bunk 4,Upper Nitzanim Session 2,2026-06-06,2026-06-14
+nco-2026-039,Yossi,Ramadge,camper,Bunk 4,Upper Nitzanim Session 2,2026-06-06,2026-06-14
+nco-2026-040,Aya,Hartwich,camper,Bunk 5,Lower Bonim Session 1,2026-06-06,2026-06-14
+nco-2026-041,Arielle,Brown,camper,Bunk 5,Lower Bonim Session 1,2026-06-06,2026-06-14
+nco-2026-042,Gabrielle,Cohan,camper,Bunk 5,Lower Bonim Session 2,2026-06-06,2026-06-14
+nco-2026-043,Lena,Hadad,camper,Bunk 5,Lower Bonim Session 2,2026-06-06,2026-06-14
+nco-2026-044,Jonah,Steffen,camper,Bunk 5,Lower Bonim Session 2,2026-06-06,2026-06-14
+nco-2026-045,Emilia,Brody,camper,Bunk 5,Upper Bonim Session 1,2026-06-06,2026-06-14
+nco-2026-046,Charlie,Levy,camper,Bunk 5,Upper Bonim Session 1,2026-06-06,2026-06-14
+nco-2026-047,Evelyn,Reimer,camper,Bunk 5,Upper Bonim Session 1,2026-06-06,2026-06-14
+nco-2026-048,Samuel,Scheer,camper,Bunk 6,Lower Chaverim Session 2,2026-06-06,2026-06-14
+nco-2026-049,Inbar,Montias,camper,Bunk 6,Upper Chaverim Session 1,2026-06-06,2026-06-14
+nco-jc-001,Maya,Fox,junior_counselor,Bunk 1,,2026-06-06,2026-06-14
+nco-jc-002,Noa,Epstein,junior_counselor,Bunk 1,,2026-06-06,2026-06-14
+nco-jc-003,Judah,Eglash,junior_counselor,Bunk 2,,2026-06-06,2026-06-14
+nco-jc-004,Sofia,Wolfe,junior_counselor,Bunk 2,,2026-06-06,2026-06-14
+nco-jc-005,Evyn,Cohen,junior_counselor,Bunk 3,,2026-06-06,2026-06-14
+nco-jc-006,Jonah,Bryfman,junior_counselor,Bunk 4,,2026-06-06,2026-06-14
+nco-jc-007,Ella,Kroloff,junior_counselor,Bunk 4,,2026-06-06,2026-06-14
+nco-jc-008,Hailey,Kraut,junior_counselor,Bunk 4,,2026-06-06,2026-06-14
+nco-jc-009,Sammy,Johnson,junior_counselor,Bunk 4,,2026-06-06,2026-06-14
+nco-jc-010,Pearl,Brackup,junior_counselor,Bunk 5,,2026-06-06,2026-06-14
+nco-jc-011,Jane,O'Neill,junior_counselor,Bunk 5,,2026-06-06,2026-06-14


### PR DESCRIPTION
## Summary
- Add `backend/data/nco_2026_campers.csv` with 49 campers and 11 JCs across Bunk 1–6 for New Camper Orientation (`new-camper-orientation-2026`).
- Extend Campminder roster import to read optional `start_date` / `end_date` columns and apply them to program Membership and bunk AssignmentGroupMembership records.

## Test plan
- [x] Dry-run `import_campminder_roster` locally against `nco_2026_campers.csv` (60 rows, dates parsed)
- [ ] CI: backend pytest + ruff, frontend vitest + build
- [ ] After merge/deploy, run production import:
  ```bash
  python manage.py import_campminder_roster \
    --csv-path backend/data/nco_2026_campers.csv \
    --org-slug clc \
    --program-slug new-camper-orientation-2026
  ```


Made with [Cursor](https://cursor.com)