### PR TITLE
fix: group dashboard future-date clamp and performance date default

### DIFF
--- a/backend/bunk_logs/api/dashboards/group_dashboard.py
+++ b/backend/bunk_logs/api/dashboards/group_dashboard.py
@@ -58,9 +58,10 @@ class GroupDashboardView(APIView):
         target_date = _parse_date_param(
             request.query_params.get("date"), default=ctx.today,
         )
+        # Clamp browser-local "today" links (e.g. from Group Performance)
+        # to the org rollover-aware cap so the dashboard still loads.
         if target_date > ctx.today:
-            msg = "Future dates are not selectable."
-            raise ValidationError(msg)
+            target_date = ctx.today
 
         builder = _PAYLOAD_BY_GROUP_TYPE.get(ctx.group.group_type)
         if builder is None:

--- a/backend/bunk_logs/api/dashboards/group_dashboard.py
+++ b/backend/bunk_logs/api/dashboards/group_dashboard.py
@@ -60,8 +60,7 @@ class GroupDashboardView(APIView):
         )
         # Clamp browser-local "today" links (e.g. from Group Performance)
         # to the org rollover-aware cap so the dashboard still loads.
-        if target_date > ctx.today:
-            target_date = ctx.today
+        target_date = min(target_date, ctx.today)
 
         builder = _PAYLOAD_BY_GROUP_TYPE.get(ctx.group.group_type)
         if builder is None:

--- a/backend/bunk_logs/api/tests/test_dashboards_group.py
+++ b/backend/bunk_logs/api/tests/test_dashboards_group.py
@@ -952,7 +952,7 @@ class TestAssignedTemplateCards:
 
 
 class TestDateHandling:
-    def test_future_date_rejected(self, api, org, program, bunk, url):
+    def test_future_date_clamped_to_today(self, api, org, program, bunk, url):
         person, user = _make_person(
             org, first="LT", last="Future", email="ltf@dash.test",
         )
@@ -963,7 +963,9 @@ class TestDateHandling:
         api.force_authenticate(user=user)
         with organization_context(org):
             resp = api.get(f"{url}?date={future}", **_hdr(org.slug))
-        assert resp.status_code == 400
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["header"]["date"] == body["header"]["today"]
 
     def test_invalid_date_format_rejected(self, api, org, program, bunk, url):
         person, user = _make_person(

--- a/frontend/src/dashboards/performance/PerformanceDashboard.jsx
+++ b/frontend/src/dashboards/performance/PerformanceDashboard.jsx
@@ -79,7 +79,9 @@ export default function PerformanceDashboard() {
   const programParam = searchParams.get('program') || '';
 
   const tab = tabParam === 'past' ? 'past' : 'current';
-  const selectedDate = dateParam || todayIso();
+  // Omit date on the initial API call so the backend picks org-local
+  // "today" (rollover-aware). Browser ``todayIso()`` can be ahead of
+  // that before the 04:00 camp rollover and breaks group-dashboard links.
   const groupType = groupTypeParam;
   const program = programParam;
 
@@ -119,7 +121,7 @@ export default function PerformanceDashboard() {
         params: {
           group_type: groupType || undefined,
           program: program || undefined,
-          date: selectedDate,
+          date: dateParam || undefined,
         },
       });
       setPayload(data);
@@ -132,7 +134,7 @@ export default function PerformanceDashboard() {
     } finally {
       setLoading(false);
     }
-  }, [groupType, program, selectedDate, shouldFetchGroups, programOptions.length]);
+  }, [groupType, program, dateParam, shouldFetchGroups, programOptions.length]);
 
   useEffect(() => {
     load();
@@ -146,6 +148,7 @@ export default function PerformanceDashboard() {
   }, [payload, tab, program, syncParams]);
 
   const orgToday = payload?.today ?? null;
+  const effectiveDate = dateParam || payload?.date || orgToday || '';
 
   const selectedProgramMeta = useMemo(() => {
     if (program) {
@@ -220,7 +223,7 @@ export default function PerformanceDashboard() {
             )}
             {showGroups && (
               <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
-                {formatDisplayDate(payload?.date || selectedDate)}
+                {formatDisplayDate(effectiveDate)}
               </p>
             )}
           </div>
@@ -243,7 +246,7 @@ export default function PerformanceDashboard() {
                 <span>Date</span>
                 <input
                   type="date"
-                  value={selectedDate}
+                  value={effectiveDate}
                   onChange={(e) => syncParams({ date: e.target.value })}
                   data-testid="performance-date-picker"
                   className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-sm"
@@ -395,7 +398,7 @@ export default function PerformanceDashboard() {
                 <GroupPerformanceCard
                   key={group.id}
                   group={group}
-                  date={payload?.date || selectedDate}
+                  date={payload?.date || effectiveDate}
                   program={program}
                   tab={tab}
                 />


### PR DESCRIPTION
## Summary
- Clamp `?date=` on the group dashboard to org-local today instead of returning 400 when the browser calendar day is ahead of camp rollover (before 04:00 ET).
- Group Performance no longer defaults API calls to `todayIso()`; it lets the backend pick rollover-aware today and uses that for bunk links.

## Test plan
- [x] `npm run test -- --run src/dashboards/performance/__tests__/PerformanceDashboard.test.jsx`
- [ ] CI backend + frontend green
- [ ] After deploy: open a bunk from Group Performance before 04:00 ET and confirm the dashboard loads

## Production data note
Also extend the NCO program `end_date` to `2026-06-14` in Django admin if it was created as `2026-06-07`, so it stays "current" through orientation week.


Made with [Cursor](https://cursor.com)