### PR TITLE
feat: link admin People list to subject profiles

### DIFF
--- a/frontend/src/pages/admin/People.jsx
+++ b/frontend/src/pages/admin/People.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import {
   listAdminPeople,
   getAdminPerson,
@@ -11,6 +12,7 @@ import {
   listAdminPrograms,
 } from '../../api/admin';
 import BulkImportModal from '../../components/admin/BulkImportModal';
+import { profileLink } from '../../utils/dashboardLinks';
 
 /**
  * Step 7_13 PR2 — People + Memberships management (Story 55).
@@ -594,7 +596,13 @@ export default function AdminPeople() {
                   )}
                   onClick={() => setSelectedId(p.id)}
                 >
-                  <p className="font-medium text-sm">{p.full_name}</p>
+                  <Link
+                    to={profileLink(p.id)}
+                    onClick={(e) => e.stopPropagation()}
+                    className="font-medium text-sm text-indigo-700 dark:text-indigo-300 hover:underline"
+                  >
+                    {p.full_name}
+                  </Link>
                   <p className="text-xs text-gray-500">{p.email || 'no email'}</p>
                 </li>
               ))}
@@ -607,7 +615,14 @@ export default function AdminPeople() {
           ) : (
             <>
               <header className="flex items-center justify-between mb-3">
-                <h2 className="text-lg font-semibold">{selectedPerson.full_name}</h2>
+                <h2 className="text-lg font-semibold">
+                  <Link
+                    to={profileLink(selectedPerson.id)}
+                    className="text-indigo-700 dark:text-indigo-300 hover:underline"
+                  >
+                    {selectedPerson.full_name}
+                  </Link>
+                </h2>
                 <button
                   type="button"
                   data-testid="invite-person"

--- a/frontend/src/pages/admin/__tests__/People.test.jsx
+++ b/frontend/src/pages/admin/__tests__/People.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 vi.mock('../../../api/admin', () => ({
   listAdminPeople: vi.fn(),
@@ -51,15 +52,27 @@ beforeEach(() => {
   getAdminPerson.mockResolvedValue(ALICE_DETAIL);
 });
 
+function renderPeople() {
+  return render(
+    <MemoryRouter>
+      <AdminPeople />
+    </MemoryRouter>,
+  );
+}
+
 describe('AdminPeople (7_13 PR2)', () => {
   it('renders the list and opens the profile drawer for the selected Person', async () => {
-    render(<AdminPeople />);
+    renderPeople();
     expect(await screen.findByTestId('person-row-1')).toBeInTheDocument();
     expect(screen.getByTestId('person-row-2')).toBeInTheDocument();
 
+    expect(screen.getByRole('link', { name: 'Alice Admin' })).toHaveAttribute('href', '/profile/1');
+    expect(screen.getByRole('link', { name: 'Bob Counselor' })).toHaveAttribute('href', '/profile/2');
+
     fireEvent.click(screen.getByTestId('person-row-1'));
     await waitFor(() => expect(getAdminPerson).toHaveBeenCalledWith(1));
-    expect(await screen.findByText('Alice Admin', { selector: 'h2' })).toBeInTheDocument();
+    const drawer = await screen.findByTestId('person-drawer');
+    expect(drawer.querySelector('h2 a')).toHaveAttribute('href', '/profile/1');
     expect(screen.getByTestId('identity-tab')).toBeInTheDocument();
   });
 
@@ -73,7 +86,7 @@ describe('AdminPeople (7_13 PR2)', () => {
         },
       },
     });
-    render(<AdminPeople />);
+    renderPeople();
     await screen.findByTestId('person-row-1');
     fireEvent.click(screen.getByTestId('open-add-person'));
     expect(await screen.findByTestId('add-person-modal')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Add profile links (`/profile/:id`) to every person name in the admin People list and drawer header.

## Test plan
- [x] `npm run test -- --run src/pages/admin/__tests__/People.test.jsx`
- [ ] CI backend + frontend green
- [ ] On `/admin/people`, click a person name and confirm it opens their subject profile


Made with [Cursor](https://cursor.com)