### PR TITLE
feat: add All tab on Observations inbox for org admins

### DIFF
--- a/backend/bunk_logs/api/observations/views.py
+++ b/backend/bunk_logs/api/observations/views.py
@@ -3,6 +3,7 @@
 Endpoints (all under /api/v1/observations/):
   GET  inbox/                      — received + authored-with-reply (mirrors Notes inbox)
   GET  sent/                       — authored observations without an inbound reply yet
+  GET  all/                        — every observation the org admin may read (admin only)
   GET  unread-count/               — {count} for the nav badge
   GET  <id>/                       — thread view; updates the read receipt
   POST /                           — create (subjects + recipients + sensitivity gate)
@@ -31,12 +32,15 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from bunk_logs.api.observations.common import ViewerContext
 from bunk_logs.api.observations.common import viewer_or_403
 from bunk_logs.core import audit as audit_trail
 from bunk_logs.core.models import Person
 from bunk_logs.core.permissions.observation_authoring import observation_authorable_subject_queryset
 from bunk_logs.core.permissions.observation_authoring import recipients_clearing_sensitivity
 from bunk_logs.core.permissions.observation_read import filter_observations_readable
+from bunk_logs.core.permissions.subject_dashboard import _has_legacy_user_role_admin
+from bunk_logs.core.permissions.subject_dashboard import _has_org_admin_membership
 from bunk_logs.core.permissions.super_admin import is_super_admin
 from bunk_logs.core.person_search import filter_persons_by_name_query
 from bunk_logs.notes.models import Observation
@@ -98,6 +102,24 @@ def has_unread_activity(obs: Observation, person: Person, *, is_author: bool) ->
     return bool(not is_author and obs.created_at > latest)
 
 
+def _is_observation_org_admin(request, ctx: ViewerContext) -> bool:
+    """True when the viewer may browse every observation in the org (admin role)."""
+    if is_super_admin(request.user):
+        return True
+    if _has_org_admin_membership(ctx.person, ctx.organization):
+        return True
+    return _has_legacy_user_role_admin(request.user, ctx.person, ctx.organization)
+
+
+def _paginated_observation_list(request, qs, *, person: Person):
+    """Serialize a paginated observation queryset for inbox/sent/all list views."""
+    request._notes_person = person
+    paginator = ObservationsPagination()
+    page = paginator.paginate_queryset(qs, request)
+    serializer = ObservationListSerializer(page, many=True, context={"request": request})
+    return paginator.get_paginated_response(serializer.data)
+
+
 def _readable_observation(ctx, obs_id: int) -> Observation | None:
     """Load an observation in the viewer's org that they are allowed to read."""
     base = Observation.all_objects.filter(organization=ctx.organization, pk=obs_id)
@@ -130,10 +152,7 @@ class ObservationsInboxView(APIView):
             .prefetch_related("subject_links__subject", "replies", "read_receipts")
             .order_by("-observed_at")
         )
-        paginator = ObservationsPagination()
-        page = paginator.paginate_queryset(qs, request)
-        serializer = ObservationListSerializer(page, many=True, context={"request": request})
-        return paginator.get_paginated_response(serializer.data)
+        return _paginated_observation_list(request, qs, person=ctx.person)
 
 
 class ObservationsSentView(APIView):
@@ -155,10 +174,27 @@ class ObservationsSentView(APIView):
             .prefetch_related("subject_links__subject", "replies", "read_receipts")
             .order_by("-observed_at")
         )
-        paginator = ObservationsPagination()
-        page = paginator.paginate_queryset(qs, request)
-        serializer = ObservationListSerializer(page, many=True, context={"request": request})
-        return paginator.get_paginated_response(serializer.data)
+        return _paginated_observation_list(request, qs, person=ctx.person)
+
+
+class ObservationsAllView(APIView):
+    """GET all/ — every observation in the org the admin may read."""
+
+    def get(self, request):
+        ctx = viewer_or_403(request)
+        if not _is_observation_org_admin(request, ctx):
+            return Response(
+                {"detail": "Only org admins may view all observations."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        base = Observation.all_objects.filter(organization=ctx.organization)
+        qs = (
+            filter_observations_readable(base, ctx.person, ctx.organization, request.user)
+            .select_related("author")
+            .prefetch_related("subject_links__subject", "replies", "read_receipts")
+            .order_by("-observed_at")
+        )
+        return _paginated_observation_list(request, qs, person=ctx.person)
 
 
 class ObservationsUnreadCountView(APIView):

--- a/backend/bunk_logs/api/urls.py
+++ b/backend/bunk_logs/api/urls.py
@@ -645,6 +645,11 @@ urlpatterns = [
         name="observations-sent",
     ),
     path(
+        "observations/all/",
+        observations_views.ObservationsAllView.as_view(),
+        name="observations-all",
+    ),
+    path(
         "observations/unread-count/",
         observations_views.ObservationsUnreadCountView.as_view(),
         name="observations-unread-count",

--- a/backend/bunk_logs/notes/tests/test_observations_api.py
+++ b/backend/bunk_logs/notes/tests/test_observations_api.py
@@ -205,6 +205,39 @@ class TestInboxAndThread:
         inbox_ids = [o["id"] for o in inbox.json().get("results", inbox.json())]
         assert obs.id not in inbox_ids
 
+    def test_all_lists_every_observation_for_org_admin(
+        self, org, program, counselor_person, counselor_membership, camper,
+    ):
+        from bunk_logs.users.models import User
+
+        admin_user = User.objects.create_user(
+            email="all-tab-admin@t.test", password="pw", role=User.ADMIN,
+        )
+        admin_person = Person.all_objects.create(
+            organization=org, first_name="All", last_name="Admin", user=admin_user,
+        )
+        Membership.all_objects.create(
+            program=program, person=admin_person, role="admin", is_active=True,
+        )
+        obs_a = _make_observation(org, program, counselor_person, subjects=[camper])
+        other_author = Person.all_objects.create(organization=org, first_name="Other", last_name="Staff")
+        obs_b = _make_observation(org, program, other_author, subjects=[camper], sensitivity="confidential")
+
+        client = _auth_client(admin_user, org)
+        resp = client.get("/api/v1/observations/all/")
+        assert resp.status_code == 200
+        ids = [o["id"] for o in resp.json().get("results", resp.json())]
+        assert obs_a.id in ids
+        assert obs_b.id in ids
+
+    def test_all_rejects_non_admin(
+        self, org, program, counselor_user, counselor_membership, counselor_person, camper,
+    ):
+        _make_observation(org, program, counselor_person, subjects=[camper])
+        client = _auth_client(counselor_user, org)
+        resp = client.get("/api/v1/observations/all/")
+        assert resp.status_code == 403
+
     def test_thread_updates_read_receipt(
         self, org, program, counselor_person, counselor_membership, uh_user, uh_membership, uh_person, camper,
     ):

--- a/frontend/src/api/observations.js
+++ b/frontend/src/api/observations.js
@@ -75,6 +75,12 @@ export async function fetchObservationSent() {
   return r.data;
 }
 
+/** All observations in the org (admin only). */
+export async function fetchObservationAll() {
+  const r = await api.get('/api/v1/observations/all/');
+  return r.data;
+}
+
 export async function fetchObservationThread(id) {
   const r = await api.get(`/api/v1/observations/${id}/`);
   return r.data;

--- a/frontend/src/pages/observations/Observations.test.jsx
+++ b/frontend/src/pages/observations/Observations.test.jsx
@@ -22,6 +22,11 @@ vi.mock('../../api', () => ({
 vi.mock('../../partials/Header', () => ({ default: () => <div data-testid="header" /> }));
 vi.mock('../../partials/Sidebar', () => ({ default: () => <div data-testid="sidebar" /> }));
 
+const authState = { user: { role: 'Counselor' } };
+vi.mock('../../auth/AuthContext', () => ({
+  useAuth: () => authState,
+}));
+
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal();
@@ -66,6 +71,7 @@ describe('ObservationsInbox', () => {
   beforeEach(() => {
     getMock.mockReset();
     postMock.mockReset();
+    authState.user = { role: 'Counselor' };
   });
 
   it('renders inbox items with subject summary', async () => {
@@ -95,6 +101,7 @@ describe('ObservationsInbox', () => {
 
   it('shows message counts next to the Inbox and Sent tabs', async () => {
     getMock.mockImplementation((url) => {
+      if (url.includes('/all/')) return Promise.resolve({ data: { count: 0, results: [] } });
       if (url.includes('/sent/')) {
         return Promise.resolve({ data: { count: 4, results: [] } });
       }
@@ -111,8 +118,62 @@ describe('ObservationsInbox', () => {
     });
   });
 
+  it('shows an All tab for admins with every observation', async () => {
+    authState.user = { role: 'Admin' };
+    getMock.mockImplementation((url) => {
+      if (url.includes('/all/')) {
+        return Promise.resolve({
+          data: {
+            count: 2,
+            results: [
+              { id: 10, author: { full_name: 'Bob UH' }, sensitivity: 'normal', subjects_summary: 'Cam Per', last_activity_at: new Date().toISOString(), unread: false, viewer_is_author: false },
+              { id: 11, author: { full_name: 'Org Admin' }, sensitivity: 'sensitive', subjects_summary: 'Sam Smith', last_activity_at: new Date().toISOString(), unread: false, viewer_is_author: true },
+            ],
+          },
+        });
+      }
+      if (url.includes('/sent/')) return Promise.resolve({ data: { count: 0, results: [] } });
+      return Promise.resolve({ data: { count: 0, results: [] } });
+    });
+    render(
+      <MemoryRouter>
+        <ObservationsInbox />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /All/i })).toBeDefined();
+      expect(screen.getByTestId('observations-tab-count-all')).toHaveTextContent('2');
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /All/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Cam Per')).toBeDefined();
+      expect(screen.getByText('Sam Smith')).toBeDefined();
+      expect(screen.getByText(/From Bob UH/)).toBeDefined();
+      expect(screen.getByText('You wrote this')).toBeDefined();
+    });
+  });
+
+  it('does not show the All tab for counselors', async () => {
+    getMock.mockImplementation((url) => {
+      if (url.includes('/sent/')) return Promise.resolve({ data: { count: 0, results: [] } });
+      return Promise.resolve({ data: { count: 0, results: [] } });
+    });
+    render(
+      <MemoryRouter>
+        <ObservationsInbox />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Inbox/i })).toBeDefined();
+    });
+    expect(screen.queryByRole('button', { name: /^All/i })).toBeNull();
+    expect(getMock.mock.calls.some(([url]) => url.includes('/all/'))).toBe(false);
+  });
+
   it('filters the list by search query and shows a no-match state', async () => {
     getMock.mockImplementation((url) => {
+      if (url.includes('/all/')) return Promise.resolve({ data: { count: 0, results: [] } });
       if (url.includes('/sent/')) return Promise.resolve({ data: { count: 0, results: [] } });
       return Promise.resolve({
         data: {
@@ -148,6 +209,7 @@ describe('ObservationsInbox', () => {
     const older = new Date(Date.now() - 7200000).toISOString();
     const newer = new Date(Date.now() - 600000).toISOString();
     getMock.mockImplementation((url) => {
+      if (url.includes('/all/')) return Promise.resolve({ data: { count: 0, results: [] } });
       if (url.includes('/sent/')) return Promise.resolve({ data: { count: 0, results: [] } });
       return Promise.resolve({
         data: {

--- a/frontend/src/pages/observations/ObservationsInbox.jsx
+++ b/frontend/src/pages/observations/ObservationsInbox.jsx
@@ -4,14 +4,18 @@
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../auth/AuthContext';
 import ObservationComposer from '../../components/observations/ObservationComposer';
 import {
+  fetchObservationAll,
   fetchObservationInbox,
   fetchObservationSent,
   sensitivityAudience,
 } from '../../api/observations';
+import { hasCapability } from '../../utils/auth/capability';
+import isSuperAdmin from '../../utils/auth/isSuperAdmin';
 
-const TABS = [
+const BASE_TABS = [
   { key: 'inbox', label: 'Inbox' },
   { key: 'sent', label: 'Sent' },
 ];
@@ -35,9 +39,15 @@ function timeAgo(iso) {
 
 export default function ObservationsInbox() {
   const navigate = useNavigate();
+  const { user } = useAuth();
+  const canViewAll = hasCapability(user, 'admin') || isSuperAdmin(user);
+  const tabs = useMemo(
+    () => (canViewAll ? [...BASE_TABS, { key: 'all', label: 'All' }] : BASE_TABS),
+    [canViewAll],
+  );
   const [activeTab, setActiveTab] = useState('inbox');
-  const [itemsByTab, setItemsByTab] = useState({ inbox: [], sent: [] });
-  const [counts, setCounts] = useState({ inbox: null, sent: null });
+  const [itemsByTab, setItemsByTab] = useState({ inbox: [], sent: [], all: [] });
+  const [counts, setCounts] = useState({ inbox: null, sent: null, all: null });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [composing, setComposing] = useState(false);
@@ -48,27 +58,36 @@ export default function ObservationsInbox() {
     setLoading(true);
     setError(null);
     try {
-      const [inbox, sent] = await Promise.all([
-        fetchObservationInbox(),
-        fetchObservationSent(),
-      ]);
+      const requests = [fetchObservationInbox(), fetchObservationSent()];
+      if (canViewAll) {
+        requests.push(fetchObservationAll());
+      }
+      const [inbox, sent, all] = await Promise.all(requests);
       const inboxItems = inbox.results ?? inbox ?? [];
       const sentItems = sent.results ?? sent ?? [];
-      setItemsByTab({ inbox: inboxItems, sent: sentItems });
+      const allItems = all ? (all.results ?? all ?? []) : [];
+      setItemsByTab({ inbox: inboxItems, sent: sentItems, all: allItems });
       setCounts({
         inbox: inbox.count ?? inboxItems.length,
         sent: sent.count ?? sentItems.length,
+        all: all ? (all.count ?? allItems.length) : null,
       });
     } catch {
       setError('Failed to load observations.');
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [canViewAll]);
 
   useEffect(() => {
     load();
   }, [load]);
+
+  useEffect(() => {
+    if (!canViewAll && activeTab === 'all') {
+      setActiveTab('inbox');
+    }
+  }, [canViewAll, activeTab]);
 
   function handleSent(data) {
     if (data?.id) {
@@ -123,7 +142,7 @@ export default function ObservationsInbox() {
         </div>
 
         <div className="flex flex-wrap gap-2 mb-5">
-          {TABS.map((tab) => {
+          {tabs.map((tab) => {
             const isActive = activeTab === tab.key;
             const count = counts[tab.key];
             return (
@@ -207,6 +226,7 @@ export default function ObservationsInbox() {
           <div className="rounded-xl border border-dashed border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 py-12 text-center text-gray-500 dark:text-gray-400">
             {activeTab === 'inbox' && 'Your observations inbox is empty.'}
             {activeTab === 'sent' && "You haven't sent any observations yet."}
+            {activeTab === 'all' && 'No observations in this organization yet.'}
           </div>
         )}
         {!loading && !error && items.length > 0 && visibleItems.length === 0 && (
@@ -250,7 +270,7 @@ export default function ObservationsInbox() {
                   <span className="text-xs text-gray-500 dark:text-gray-400">
                     {o.viewer_is_author || activeTab === 'sent'
                       ? 'You wrote this'
-                      : `From ${o.author?.full_name}`}
+                      : `From ${o.author?.full_name || 'Unknown'}`}
                   </span>
                   <span className="text-xs rounded-full bg-amber-50 dark:bg-amber-900/20 px-2 py-0.5 text-amber-800 dark:text-amber-200">
                     {sensitivityAudience(o.sensitivity)}


### PR DESCRIPTION
## Summary
- Adds a third **All** tab on `/observations` for users with admin capability, showing every observation in the org they can read.
- Introduces `GET /api/v1/observations/all/` (admin-gated, paginated) and wires the frontend inbox to load it alongside Inbox/Sent.
- Fixes list serialization so `viewer_is_author` is populated correctly across inbox list views.

## Test plan
- [x] Backend: `pytest bunk_logs/notes/tests/test_observations_api.py` (admin sees all, counselor gets 403)
- [x] Frontend: `npm test -- --run src/pages/observations/Observations.test.jsx`
- [ ] Manual: log in as Admin → Observations → confirm **All** tab appears with org-wide observations
- [ ] Manual: log in as Counselor → confirm **All** tab is hidden


Made with [Cursor](https://cursor.com)