### PR TITLE
feat: duplicate identity audit/merge tools and OAuth email fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ help:
 	@echo "  make setup-crane-lake  New tenant models: ensure CLC org + Summer 2026 program"
 	@echo "  make onboard-clc       Full CLC Summer 2026 onboarding (org+templates; pass CSV_PATH=... for staff)"
 	@echo "  make seed-clc-assignments  Seed 12 TemplateAssignment rows for CLC Summer 2026 (pass DRY_RUN=1 to preview)"
+	@echo "  make audit-duplicates  Audit duplicate Person/User identity issues (ORG_SLUG=clc)"
+	@echo "  make merge-persons     Merge duplicate Persons (ORG_SLUG=clc WINNER=1 LOSER=2 APPLY=1)"
 	@echo "  make shell           Open Django shell (shell_plus if available)"
 	@echo ""
 	@echo "Frontend:"
@@ -90,6 +92,16 @@ seed-clc-assignments:
 	  --org-slug clc --program-slug summer-2026 \
 	  $(if $(ACTOR_USERNAME),--actor-username $(ACTOR_USERNAME),) \
 	  $(if $(DRY_RUN),--dry-run,)
+
+audit-duplicates:
+	$(DJANGO_EXEC) python manage.py audit_duplicate_identities \
+	  $(if $(ORG_SLUG),--org-slug $(ORG_SLUG),) \
+	  $(if $(JSON_OUT),--json-out $(JSON_OUT),)
+
+merge-persons:
+	$(DJANGO_EXEC) python manage.py merge_persons \
+	  --org-slug $(ORG_SLUG) --winner $(WINNER) --loser $(LOSER) \
+	  $(if $(APPLY),--apply,) $(if $(FORCE_USER),--force-user,)
 
 shell:
 	$(DJANGO_EXEC) python manage.py shell_plus 2>/dev/null || $(DJANGO_EXEC) python manage.py shell

--- a/backend/bunk_logs/core/management/commands/audit_duplicate_identities.py
+++ b/backend/bunk_logs/core/management/commands/audit_duplicate_identities.py
@@ -1,0 +1,204 @@
+"""Read-only audit of duplicate Person/User identity issues within an org.
+
+Safe to run against production. Performs zero writes.
+
+Usage
+-----
+    python manage.py audit_duplicate_identities --org-slug clc
+    python manage.py audit_duplicate_identities --org-slug clc --json-out /tmp/dup-audit.json
+"""
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+from django.db.models import Count
+from django.db.models.functions import Lower
+
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+
+User = get_user_model()
+
+
+def _person_campminder_id(person: Person) -> str:
+    return str(person.external_ids.get("campminder_id") or "").strip()
+
+
+class Command(BaseCommand):
+    help = "Read-only audit of duplicate Person/User identity issues."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--org-slug",
+            default="clc",
+            help="Organization slug to scope Person checks (default: clc).",
+        )
+        parser.add_argument(
+            "--json-out",
+            default=None,
+            help="Optional path for machine-readable JSON output.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        org_slug: str = options["org_slug"]
+        json_out: str | None = options["json_out"]
+
+        try:
+            org = Organization.objects.get(slug=org_slug)
+        except Organization.DoesNotExist as exc:
+            msg = f"Organization not found: {org_slug!r}"
+            raise CommandError(msg) from exc
+
+        report: dict[str, Any] = {"org_slug": org_slug, "org_id": org.id}
+
+        self.stdout.write(self.style.MIGRATE_HEADING(f"Duplicate identity audit — org {org_slug!r}"))
+
+        # ── 1A. Duplicate Person emails (case-insensitive) ─────────────────
+        email_groups: dict[str, list[dict]] = defaultdict(list)
+        for person in Person.all_objects.filter(organization=org).exclude(email=""):
+            key = person.email.strip().lower()
+            email_groups[key].append({
+                "id": person.id,
+                "email": person.email,
+                "name": person.full_name,
+                "campminder_id": _person_campminder_id(person),
+                "user_id": person.user_id,
+                "legacy_user_id": person.external_ids.get("legacy_user_id"),
+            })
+        dup_emails = {email: rows for email, rows in email_groups.items() if len(rows) > 1}
+        report["duplicate_person_emails"] = dup_emails
+        self._section(f"Duplicate Person emails ({len(dup_emails)} groups)")
+        for email, rows in sorted(dup_emails.items()):
+            ids = ", ".join(f"#{r['id']}" for r in rows)
+            self.stdout.write(f"  {email}: {ids}")
+
+        # ── Legacy staff without Campminder ID ─────────────────────────────
+        legacy_qs = Person.all_objects.filter(
+            organization=org,
+            external_ids__campminder_id__isnull=True,
+        ).exclude(user__isnull=True)
+        legacy_without_cm = [
+            {
+                "id": p.id,
+                "name": p.full_name,
+                "email": p.email,
+                "user_id": p.user_id,
+                "legacy_user_id": p.external_ids.get("legacy_user_id"),
+            }
+            for p in legacy_qs.order_by("last_name", "first_name")
+        ]
+        report["legacy_staff_without_campminder_id"] = legacy_without_cm
+        self._section(f"Legacy staff linked to User but missing Campminder ID ({len(legacy_without_cm)})")
+        for row in legacy_without_cm[:20]:
+            self.stdout.write(f"  Person #{row['id']} {row['name']} user={row['user_id']}")
+        if len(legacy_without_cm) > 20:
+            self.stdout.write(f"  … and {len(legacy_without_cm) - 20} more")
+
+        # ── Persons with email but no login User ───────────────────────────
+        no_user = list(
+            Person.all_objects.filter(organization=org, user__isnull=True)
+            .exclude(email="")
+            .order_by("last_name", "first_name")
+            .values("id", "email", "first_name", "last_name"),
+        )
+        report["persons_with_email_no_user"] = no_user
+        self._section(f"Persons with email but no linked User ({len(no_user)})")
+
+        # ── Duplicate campminder_id on multiple Persons ────────────────────
+        cm_dupes: dict[str, list[int]] = defaultdict(list)
+        for person in Person.all_objects.filter(organization=org):
+            cm_id = _person_campminder_id(person)
+            if cm_id:
+                cm_dupes[cm_id].append(person.id)
+        cm_dupes = {k: v for k, v in cm_dupes.items() if len(v) > 1}
+        report["duplicate_campminder_ids"] = cm_dupes
+        self._section(f"Duplicate campminder_id values ({len(cm_dupes)} groups)")
+        for cm_id, ids in sorted(cm_dupes.items()):
+            self.stdout.write(f"  {cm_id}: Person ids {ids}")
+
+        # ── 1C. User linked to multiple Persons in org ─────────────────────
+        user_multi = list(
+            Person.all_objects.filter(organization=org, user__isnull=False)
+            .values("user_id")
+            .annotate(n=Count("id"))
+            .filter(n__gt=1),
+        )
+        user_multi_detail = []
+        for row in user_multi:
+            persons = list(
+                Person.all_objects.filter(organization=org, user_id=row["user_id"]).values(
+                    "id", "email", "first_name", "last_name",
+                ),
+            )
+            user_multi_detail.append({"user_id": row["user_id"], "persons": persons})
+        report["users_linked_to_multiple_persons"] = user_multi_detail
+        self._section(f"Users linked to multiple Persons in org ({len(user_multi_detail)})")
+        for item in user_multi_detail:
+            ids = ", ".join(f"#{p['id']}" for p in item["persons"])
+            self.stdout.write(f"  User {item['user_id']}: {ids}")
+
+        # ── Ambiguous name matches (multiple Persons, no campminder_id) ────
+        name_groups: dict[tuple[str, str], list[int]] = defaultdict(list)
+        for person in Person.all_objects.filter(organization=org):
+            if _person_campminder_id(person):
+                continue
+            key = (person.first_name.strip().lower(), person.last_name.strip().lower())
+            name_groups[key].append(person.id)
+        ambiguous_names = {
+            f"{first} {last}": ids
+            for (first, last), ids in name_groups.items()
+            if len(ids) > 1
+        }
+        report["ambiguous_names_without_campminder_id"] = ambiguous_names
+        self._section(f"Ambiguous names without Campminder ID ({len(ambiguous_names)} groups)")
+
+        # ── 1B. Duplicate auth Users (case-insensitive email) ──────────────
+        user_email_dupes = list(
+            User.objects.values(lower=Lower("email"))
+            .annotate(n=Count("id"))
+            .filter(n__gt=1),
+        )
+        user_dup_detail = []
+        for row in user_email_dupes:
+            users = list(
+                User.objects.annotate(email_lower=Lower("email"))
+                .filter(email_lower=row["lower"])
+                .values("id", "email", "is_active"),
+            )
+            user_dup_detail.append({"email_lower": row["lower"], "users": users})
+        report["duplicate_auth_users"] = user_dup_detail
+        self._section(f"Duplicate auth Users by email (case-insensitive) ({len(user_dup_detail)})")
+        for item in user_dup_detail:
+            ids = ", ".join(f"#{u['id']} ({u['email']})" for u in item["users"])
+            self.stdout.write(f"  {item['email_lower']}: {ids}")
+
+        # ── Summary ──────────────────────────────────────────────────────
+        summary = {
+            "duplicate_person_email_groups": len(dup_emails),
+            "legacy_staff_without_campminder_id": len(legacy_without_cm),
+            "persons_with_email_no_user": len(no_user),
+            "duplicate_campminder_id_groups": len(cm_dupes),
+            "users_linked_to_multiple_persons": len(user_multi_detail),
+            "ambiguous_name_groups": len(ambiguous_names),
+            "duplicate_auth_user_groups": len(user_dup_detail),
+        }
+        report["summary"] = summary
+        self.stdout.write("")
+        self.stdout.write(self.style.SUCCESS("Summary"))
+        for key, value in summary.items():
+            self.stdout.write(f"  {key}: {value}")
+
+        if json_out:
+            path = json_out
+            with open(path, "w", encoding="utf-8") as handle:
+                json.dump(report, handle, indent=2, default=str)
+            self.stdout.write(self.style.NOTICE(f"Wrote JSON report to {path}"))
+
+    def _section(self, title: str) -> None:
+        self.stdout.write("")
+        self.stdout.write(self.style.MIGRATE_LABEL(title))

--- a/backend/bunk_logs/core/management/commands/merge_persons.py
+++ b/backend/bunk_logs/core/management/commands/merge_persons.py
@@ -1,0 +1,99 @@
+"""Merge duplicate Person records (loser into winner).
+
+Dry-run by default. Re-points Memberships, group memberships, Reflections,
+Observations, and related FKs before deleting the loser.
+
+Usage
+-----
+    python manage.py merge_persons --org-slug clc --winner 42 --loser 99
+    python manage.py merge_persons --org-slug clc --winner 42 --loser 99 --apply
+    python manage.py merge_persons --org-slug clc --winner 42 --loser 99 --apply --force-user
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.person_merge import merge_persons
+from bunk_logs.core.person_merge import plan_person_merge
+
+
+class Command(BaseCommand):
+    help = "Merge duplicate Person records by re-pointing FKs from loser to winner."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument("--org-slug", default="clc", help="Organization slug.")
+        parser.add_argument("--winner", type=int, required=True, help="Canonical Person pk to keep.")
+        parser.add_argument("--loser", type=int, required=True, help="Duplicate Person pk to merge away.")
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Perform the merge. Default is dry-run plan only.",
+        )
+        parser.add_argument(
+            "--force-user",
+            action="store_true",
+            help="When both Persons link to different Users, keep winner's User and unlink loser's.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        org_slug: str = options["org_slug"]
+        winner_id: int = options["winner"]
+        loser_id: int = options["loser"]
+        apply: bool = options["apply"]
+        force_user: bool = options["force_user"]
+
+        try:
+            org = Organization.objects.get(slug=org_slug)
+        except Organization.DoesNotExist as exc:
+            msg = f"Organization not found: {org_slug!r}"
+            raise CommandError(msg) from exc
+
+        try:
+            winner = Person.all_objects.get(pk=winner_id, organization=org)
+            loser = Person.all_objects.get(pk=loser_id, organization=org)
+        except Person.DoesNotExist as exc:
+            msg = f"Person not found in org {org_slug!r}: {exc}"
+            raise CommandError(msg) from exc
+
+        plan = plan_person_merge(winner=winner, loser=loser)
+        user_blocker = (
+            winner.user_id
+            and loser.user_id
+            and winner.user_id != loser.user_id
+            and not force_user
+        )
+
+        self.stdout.write(
+            f"Merge plan: keep Person #{winner.id} ({winner.full_name}), "
+            f"remove Person #{loser.id} ({loser.full_name})",
+        )
+        if plan.blockers:
+            for blocker in plan.blockers:
+                self.stdout.write(self.style.ERROR(f"  BLOCKER: {blocker}"))
+        for action in plan.actions:
+            suffix = f" (x{action.count})" if action.count > 1 else ""
+            self.stdout.write(f"  [{action.model}] {action.description}{suffix}")
+
+        if user_blocker:
+            msg = "Merge blocked: both Persons link to different Users. Use --force-user."
+            raise CommandError(msg)
+
+        if plan.blockers:
+            msg = "Merge blocked; resolve blockers before applying."
+            raise CommandError(msg)
+
+        if not apply:
+            self.stdout.write(self.style.WARNING("Dry-run only — pass --apply to execute."))
+            return
+
+        try:
+            merge_persons(winner=winner, loser=loser, force_user=force_user)
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
+
+        self.stdout.write(self.style.SUCCESS(f"Merged Person #{loser_id} into #{winner_id}."))

--- a/backend/bunk_logs/core/person_merge.py
+++ b/backend/bunk_logs/core/person_merge.py
@@ -1,0 +1,284 @@
+"""Merge duplicate Person records by re-pointing FKs from loser to winner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+
+from django.db import transaction
+
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import CamperDayState
+from bunk_logs.core.models import Flag
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Order
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Reflection
+from bunk_logs.notes.models import Observation
+from bunk_logs.notes.models import ObservationArchive
+from bunk_logs.notes.models import ObservationReadReceipt
+from bunk_logs.notes.models import ObservationRecipient
+from bunk_logs.notes.models import ObservationReply
+from bunk_logs.notes.models import ObservationSubject
+
+
+@dataclass
+class MergeAction:
+    model: str
+    description: str
+    count: int = 1
+
+
+@dataclass
+class MergePlan:
+    winner_id: int
+    loser_id: int
+    actions: list[MergeAction] = field(default_factory=list)
+    blockers: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.blockers
+
+
+def _count(qs) -> int:
+    return qs.count()
+
+
+def plan_person_merge(*, winner: Person, loser: Person) -> MergePlan:
+    """Dry-run plan for merging ``loser`` into ``winner``."""
+    plan = MergePlan(winner_id=winner.pk, loser_id=loser.pk)
+
+    if winner.organization_id != loser.organization_id:
+        plan.blockers.append(
+            f"Organization mismatch: winner org={winner.organization_id}, "
+            f"loser org={loser.organization_id}",
+        )
+        return plan
+
+    if winner.pk == loser.pk:
+        plan.blockers.append("winner and loser must be different Person records")
+        return plan
+
+    winner_cm = str(winner.external_ids.get("campminder_id") or "").strip()
+    loser_cm = str(loser.external_ids.get("campminder_id") or "").strip()
+    if winner_cm and loser_cm and winner_cm != loser_cm:
+        plan.blockers.append(
+            f"Both persons have different campminder_id values "
+            f"({winner_cm!r} vs {loser_cm!r}); resolve manually first",
+        )
+
+    if winner.user_id and loser.user_id and winner.user_id != loser.user_id:
+        plan.blockers.append(
+            f"Both persons are linked to different Users "
+            f"({winner.user_id} vs {loser.user_id}); unlink loser or pass --force-user",
+        )
+
+    for membership in Membership.all_objects.filter(person=loser):
+        conflict = Membership.all_objects.filter(
+            program=membership.program,
+            person=winner,
+            role=membership.role,
+        ).exists()
+        if conflict:
+            plan.actions.append(MergeAction(
+                "Membership",
+                f"deactivate duplicate {membership.role} on program {membership.program_id}",
+            ))
+        else:
+            plan.actions.append(MergeAction(
+                "Membership",
+                f"re-point {membership.role} on program {membership.program_id}",
+            ))
+
+    for agm in AssignmentGroupMembership.all_objects.filter(person=loser):
+        conflict = AssignmentGroupMembership.all_objects.filter(
+            group=agm.group,
+            person=winner,
+            role_in_group=agm.role_in_group,
+        ).exists()
+        if conflict:
+            plan.actions.append(MergeAction(
+                "AssignmentGroupMembership",
+                f"deactivate duplicate {agm.role_in_group} in group {agm.group_id}",
+            ))
+        else:
+            plan.actions.append(MergeAction(
+                "AssignmentGroupMembership",
+                f"re-point {agm.role_in_group} in group {agm.group_id}",
+            ))
+
+    for label, qs in (
+        ("Reflection.subject", Reflection.all_objects.filter(subject=loser)),
+        ("Reflection.author", Reflection.all_objects.filter(author=loser)),
+    ):
+        n = _count(qs)
+        if n:
+            plan.actions.append(MergeAction(label, f"re-point {n} row(s)", count=n))
+
+    for label, qs in (
+        ("Observation.author", Observation.all_objects.filter(author=loser)),
+        ("ObservationReply.author", ObservationReply.objects.filter(author=loser)),
+    ):
+        n = _count(qs)
+        if n:
+            plan.actions.append(MergeAction(label, f"re-point {n} row(s)", count=n))
+
+    for label, model, fk in (
+        ("ObservationSubject", ObservationSubject, "subject"),
+        ("ObservationRecipient", ObservationRecipient, "person"),
+        ("ObservationReadReceipt", ObservationReadReceipt, "person"),
+        ("ObservationArchive", ObservationArchive, "person"),
+    ):
+        n = _count(model.objects.filter(**{fk: loser}))
+        if n:
+            plan.actions.append(MergeAction(label, f"re-point or dedupe {n} row(s)", count=n))
+
+    n = _count(CamperDayState.all_objects.filter(camper=loser))
+    if n:
+        plan.actions.append(MergeAction("CamperDayState", f"re-point or drop {n} row(s)", count=n))
+
+    n = _count(Order.all_objects.filter(subject=loser))
+    if n:
+        plan.actions.append(MergeAction("Order.subject", f"re-point {n} row(s)", count=n))
+
+    n = _count(Flag.all_objects.filter(subject_camper=loser))
+    if n:
+        plan.actions.append(MergeAction("Flag", f"re-point {n} row(s)", count=n))
+
+    if not winner.user_id and loser.user_id:
+        plan.actions.append(MergeAction("Person.user", f"link User {loser.user_id} to winner"))
+
+    if loser_cm and not winner_cm:
+        plan.actions.append(MergeAction(
+            "Person.external_ids",
+            f"copy campminder_id={loser_cm!r} onto winner",
+        ))
+
+    plan.actions.append(MergeAction("Person", f"delete Person {loser.pk}"))
+    return plan
+
+
+def _merge_memberships(*, winner: Person, loser: Person) -> int:
+    moved = 0
+    for membership in list(Membership.all_objects.filter(person=loser)):
+        conflict = Membership.all_objects.filter(
+            program=membership.program,
+            person=winner,
+            role=membership.role,
+        ).first()
+        if conflict:
+            if membership.is_active and not conflict.is_active:
+                conflict.is_active = True
+                conflict.save(update_fields=["is_active"])
+            membership.is_active = False
+            membership.save(update_fields=["is_active"])
+        else:
+            membership.person = winner
+            membership.save(update_fields=["person"])
+            moved += 1
+    return moved
+
+
+def _merge_assignment_group_memberships(*, winner: Person, loser: Person) -> int:
+    moved = 0
+    for agm in list(AssignmentGroupMembership.all_objects.filter(person=loser)):
+        conflict = AssignmentGroupMembership.all_objects.filter(
+            group=agm.group,
+            person=winner,
+            role_in_group=agm.role_in_group,
+        ).first()
+        if conflict:
+            if agm.is_active and not conflict.is_active:
+                conflict.is_active = True
+                conflict.save(update_fields=["is_active"])
+            agm.is_active = False
+            agm.save(update_fields=["is_active"])
+        else:
+            agm.person = winner
+            agm.save(update_fields=["person"])
+            moved += 1
+    return moved
+
+
+def _repoint_fk(model, *, field: str, winner: Person, loser: Person) -> int:
+    return model.objects.filter(**{field: loser}).update(**{field: winner})
+
+
+def _merge_observation_m2m(*, model, fk: str, winner: Person, loser: Person) -> int:
+    moved = 0
+    for row in list(model.objects.filter(**{fk: loser})):
+        observation_id = row.observation_id
+        if model.objects.filter(observation_id=observation_id, **{fk: winner}).exists():
+            row.delete()
+        else:
+            setattr(row, fk, winner)
+            row.save(update_fields=[fk])
+            moved += 1
+    return moved
+
+
+def _merge_camper_day_states(*, winner: Person, loser: Person) -> int:
+    moved = 0
+    for state in list(CamperDayState.all_objects.filter(camper=loser)):
+        if CamperDayState.all_objects.filter(
+            organization=state.organization,
+            camper=winner,
+            date=state.date,
+        ).exists():
+            state.delete()
+        else:
+            state.camper = winner
+            state.save(update_fields=["camper"])
+            moved += 1
+    return moved
+
+
+@transaction.atomic
+def merge_persons(
+    *,
+    winner: Person,
+    loser: Person,
+    force_user: bool = False,
+) -> MergePlan:
+    """Merge ``loser`` into ``winner``. Raises ValueError when blocked."""
+    plan = plan_person_merge(winner=winner, loser=loser)
+    if winner.user_id and loser.user_id and winner.user_id != loser.user_id:
+        if not force_user:
+            msg = plan.blockers[0] if plan.blockers else "user conflict"
+            raise ValueError(msg)
+        loser.user = None
+        loser.save(update_fields=["user"])
+
+    if plan.blockers:
+        raise ValueError("; ".join(plan.blockers))
+
+    _merge_memberships(winner=winner, loser=loser)
+    _merge_assignment_group_memberships(winner=winner, loser=loser)
+    Reflection.all_objects.filter(subject=loser).update(subject=winner)
+    Reflection.all_objects.filter(author=loser).update(author=winner)
+    Observation.all_objects.filter(author=loser).update(author=winner)
+    ObservationReply.objects.filter(author=loser).update(author=winner)
+    _merge_observation_m2m(model=ObservationSubject, fk="subject", winner=winner, loser=loser)
+    _merge_observation_m2m(model=ObservationRecipient, fk="person", winner=winner, loser=loser)
+    _merge_observation_m2m(model=ObservationReadReceipt, fk="person", winner=winner, loser=loser)
+    _merge_observation_m2m(model=ObservationArchive, fk="person", winner=winner, loser=loser)
+    _merge_camper_day_states(winner=winner, loser=loser)
+    Order.all_objects.filter(subject=loser).update(subject=winner)
+    Flag.all_objects.filter(subject_camper=loser).update(subject_camper=winner)
+
+    if not winner.user_id and loser.user_id:
+        winner.user = loser.user
+        loser.user = None
+        loser.save(update_fields=["user"])
+
+    merged_ids = {**loser.external_ids, **winner.external_ids}
+    if merged_ids != winner.external_ids:
+        winner.external_ids = merged_ids
+    for attr in ("email", "preferred_name", "date_of_birth"):
+        if not getattr(winner, attr) and getattr(loser, attr):
+            setattr(winner, attr, getattr(loser, attr))
+
+    winner.save()
+    loser.delete()
+    return plan

--- a/backend/bunk_logs/core/test_person_merge.py
+++ b/backend/bunk_logs/core/test_person_merge.py
@@ -1,0 +1,159 @@
+"""Tests for duplicate identity audit and Person merge tooling."""
+
+import pytest
+
+from django.core.management import call_command
+
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.person_merge import merge_persons
+from bunk_logs.core.person_merge import plan_person_merge
+from bunk_logs.users.models import User
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="Crane Lake", slug="clc")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="Crane Lake Summer 2026",
+        slug="summer-2026",
+        program_type="summer_camp",
+        start_date="2026-06-01",
+        end_date="2026-08-15",
+    )
+
+
+@pytest.mark.django_db
+class TestAuditDuplicateIdentities:
+    def test_finds_duplicate_person_emails(self, org, program):
+        user = User.objects.create_user(email="staff@example.com", password="pass")
+        Person.all_objects.create(
+            organization=org,
+            first_name="Legacy",
+            last_name="Staff",
+            email="staff@example.com",
+            user=user,
+            external_ids={"legacy_user_id": user.id},
+        )
+        Person.all_objects.create(
+            organization=org,
+            first_name="Legacy",
+            last_name="Staff",
+            email="Staff@example.com",
+            external_ids={"campminder_id": "12345"},
+        )
+
+        from io import StringIO
+
+        out = StringIO()
+        call_command("audit_duplicate_identities", org_slug="clc", stdout=out)
+        output = out.getvalue()
+        assert "Duplicate Person emails (1 groups)" in output
+        assert "staff@example.com" in output
+
+
+@pytest.mark.django_db
+class TestMergePersons:
+    def test_merge_repoints_membership_and_deletes_loser(self, org, program):
+        user = User.objects.create_user(email="counselor@example.com", password="pass")
+        winner = Person.all_objects.create(
+            organization=org,
+            first_name="Chris",
+            last_name="Allen",
+            email="drchrisa@gmail.com",
+            user=user,
+            external_ids={"legacy_user_id": user.id},
+        )
+        loser = Person.all_objects.create(
+            organization=org,
+            first_name="Christopher",
+            last_name="Allen",
+            email="drchrisa@gmail.com",
+            external_ids={"campminder_id": "5927217"},
+        )
+        Membership.all_objects.create(program=program, person=loser, role="counselor")
+
+        plan = plan_person_merge(winner=winner, loser=loser)
+        assert plan.ok
+
+        merge_persons(winner=winner, loser=loser)
+
+        winner.refresh_from_db()
+        assert not Person.all_objects.filter(pk=loser.pk).exists()
+        assert Membership.all_objects.filter(person=winner, role="counselor").exists()
+        assert winner.external_ids.get("campminder_id") == "5927217"
+        assert winner.user_id == user.id
+
+    def test_merge_keeps_winner_membership_when_roles_conflict(self, org, program):
+        winner = Person.all_objects.create(
+            organization=org, first_name="A", last_name="B", email="a@example.com",
+        )
+        loser = Person.all_objects.create(
+            organization=org, first_name="A", last_name="B", email="a@example.com",
+            external_ids={"campminder_id": "999"},
+        )
+        Membership.all_objects.create(program=program, person=winner, role="counselor", is_active=True)
+        Membership.all_objects.create(
+            program=program, person=loser, role="counselor", is_active=True,
+        )
+
+        merge_persons(winner=winner, loser=loser)
+        loser_id = loser.pk
+
+        assert not Person.all_objects.filter(pk=loser_id).exists()
+        assert Membership.all_objects.filter(
+            person=winner, role="counselor", is_active=True,
+        ).exists()
+        assert not Membership.all_objects.filter(person_id=loser_id).exists()
+
+    def test_merge_blocks_different_campminder_ids(self, org):
+        winner = Person.all_objects.create(
+            organization=org,
+            first_name="A",
+            last_name="B",
+            external_ids={"campminder_id": "111"},
+        )
+        loser = Person.all_objects.create(
+            organization=org,
+            first_name="A",
+            last_name="B",
+            external_ids={"campminder_id": "222"},
+        )
+        plan = plan_person_merge(winner=winner, loser=loser)
+        assert not plan.ok
+        assert "campminder_id" in plan.blockers[0]
+
+    def test_merge_repoints_group_membership(self, org, program):
+        winner = Person.all_objects.create(
+            organization=org, first_name="Sam", last_name="Lee",
+        )
+        loser = Person.all_objects.create(
+            organization=org,
+            first_name="Sam",
+            last_name="Lee",
+            external_ids={"campminder_id": "555"},
+        )
+        group = AssignmentGroup.all_objects.create(
+            organization=org,
+            program=program,
+            name="Bunk 1",
+            slug="bunk-1",
+            group_type="bunk",
+        )
+        agm = AssignmentGroupMembership.all_objects.create(
+            group=group, person=loser, role_in_group="author",
+        )
+
+        merge_persons(winner=winner, loser=loser)
+
+        agm.refresh_from_db()
+        assert agm.person_id == winner.id

--- a/backend/bunk_logs/core/test_person_merge.py
+++ b/backend/bunk_logs/core/test_person_merge.py
@@ -1,7 +1,8 @@
 """Tests for duplicate identity audit and Person merge tooling."""
 
-import pytest
+from io import StringIO
 
+import pytest
 from django.core.management import call_command
 
 from bunk_logs.core.models import AssignmentGroup
@@ -51,8 +52,6 @@ class TestAuditDuplicateIdentities:
             email="Staff@example.com",
             external_ids={"campminder_id": "12345"},
         )
-
-        from io import StringIO
 
         out = StringIO()
         call_command("audit_duplicate_identities", org_slug="clc", stdout=out)

--- a/backend/bunk_logs/users/adapters.py
+++ b/backend/bunk_logs/users/adapters.py
@@ -54,12 +54,12 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
             return None
 
         # Check if we have a user with the same email
-        email = sociallogin.account.extra_data.get("email")
+        email = (sociallogin.account.extra_data.get("email") or "").strip()
         if email:
             User = sociallogin.user.__class__
             try:
-                # Try to find an existing user with this email
-                user = User.objects.get(email=email)
+                # Case-insensitive match — Campminder linking uses email__iexact too.
+                user = User.objects.get(email__iexact=email)
                 # Connect the social account to this user and login
                 sociallogin.connect(request, user)
                 # Skip the rest of the social login flow and redirect using dynamic URL

--- a/backend/bunk_logs/users/managers.py
+++ b/backend/bunk_logs/users/managers.py
@@ -17,7 +17,7 @@ class UserManager(DjangoUserManager["User"]):
         if not email:
             msg = "The given email must be set"
             raise ValueError(msg)
-        email = self.normalize_email(email)
+        email = self.normalize_email(email).strip().lower()
         user = self.model(email=email, **extra_fields)
         user.password = make_password(password)
         user.save(using=self._db)

--- a/backend/bunk_logs/users/tests/test_social_adapter.py
+++ b/backend/bunk_logs/users/tests/test_social_adapter.py
@@ -1,0 +1,28 @@
+"""Tests for OAuth email case-insensitive linking."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from bunk_logs.users.adapters import SocialAccountAdapter
+from bunk_logs.users.models import User
+
+
+@pytest.mark.django_db
+class TestSocialAccountAdapter:
+    def test_pre_social_login_links_existing_user_case_insensitive(self, rf):
+        user = User(email="Staff@Example.com")
+        user.set_unusable_password()
+        user.save()
+
+        sociallogin = MagicMock()
+        sociallogin.is_existing = False
+        sociallogin.account.extra_data = {"email": "staff@example.com"}
+        sociallogin.user.__class__ = User
+
+        adapter = SocialAccountAdapter()
+        request = rf.get("/")
+        with patch.object(sociallogin, "connect") as mock_connect:
+            adapter.pre_social_login(request, sociallogin)
+            mock_connect.assert_called_once_with(request, user)

--- a/backend/bunk_logs/utils/management/commands/scrub_pii.py
+++ b/backend/bunk_logs/utils/management/commands/scrub_pii.py
@@ -34,9 +34,19 @@ from bunk_logs.bunklogs.models import BunkLog
 from bunk_logs.bunklogs.models import StaffLog
 from bunk_logs.bunks.models import Cabin
 from bunk_logs.campers.models import Camper
+from bunk_logs.core.models import AuditEvent
+from bunk_logs.core.models import CamperDayState
+from bunk_logs.core.models import MaintenanceTicket
+from bunk_logs.core.models import Order as CamperCareOrder
+from bunk_logs.core.models import OrderActivityEvent
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import TranslationRecord
 from bunk_logs.messaging.models import EmailLog
 from bunk_logs.messaging.models import EmailRecipient
-from bunk_logs.orders.models import Order
+from bunk_logs.notes.models import Observation
+from bunk_logs.notes.models import ObservationReply
+from bunk_logs.orders.models import Order as LegacyOrder
 from bunk_logs.users.models import User
 
 LOCAL_DB_HOST_ALLOWLIST = {
@@ -49,6 +59,17 @@ LOCAL_DB_HOST_ALLOWLIST = {
 
 DEV_PASSWORD = "devpass123"
 SCRUB_PLACEHOLDER = "[scrubbed]"
+
+
+def scrub_json_strings(value: object) -> object:
+    """Replace string leaves in JSON-ish structures with the scrub placeholder."""
+    if isinstance(value, str):
+        return SCRUB_PLACEHOLDER if value else value
+    if isinstance(value, list):
+        return [scrub_json_strings(item) for item in value]
+    if isinstance(value, dict):
+        return {key: scrub_json_strings(item) for key, item in value.items()}
+    return value
 
 
 class Command(BaseCommand):
@@ -97,11 +118,21 @@ class Command(BaseCommand):
 
         with transaction.atomic():
             counts["users"] = self._scrub_users(fake, keep_superuser_emails=keep_superuser_emails)
+            counts["persons"] = self._scrub_persons(fake)
             counts["campers"] = self._scrub_campers(fake)
             counts["cabins"] = self._scrub_cabins(fake)
             counts["bunk_logs"] = self._scrub_bunk_logs()
             counts["staff_logs"] = self._scrub_staff_logs()
-            counts["orders"] = self._scrub_orders()
+            counts["legacy_orders"] = self._scrub_legacy_orders()
+            counts["observations"] = self._scrub_observations()
+            counts["observation_replies"] = self._scrub_observation_replies()
+            counts["reflections"] = self._scrub_reflections()
+            counts["camper_care_orders"] = self._scrub_camper_care_orders()
+            counts["maintenance_tickets"] = self._scrub_maintenance_tickets()
+            counts["camper_day_states"] = self._scrub_camper_day_states()
+            counts["order_activity_events"] = self._scrub_order_activity_events()
+            counts["audit_events"] = self._scrub_audit_events()
+            counts["translation_records"] = self._scrub_translation_records()
             counts["email_recipients"] = self._scrub_email_recipients(fake)
             counts["email_logs_truncated"] = self._truncate_email_logs()
             counts["sessions_truncated"] = self._truncate_table("django_session")
@@ -179,6 +210,35 @@ class Command(BaseCommand):
             count += 1
         return count
 
+    # --------------------------------------------------------------- persons
+
+    def _scrub_persons(self, fake: Faker) -> int:
+        count = 0
+        for person in Person.all_objects.all().iterator(chunk_size=500):
+            person.first_name = fake.first_name()
+            person.last_name = fake.last_name()
+            if person.preferred_name:
+                person.preferred_name = fake.first_name()
+            person.date_of_birth = self._jitter_dob(person.date_of_birth)
+            person.notes = SCRUB_PLACEHOLDER
+            if person.email:
+                if person.user_id:
+                    person.email = f"user{person.user_id}@example.test"
+                else:
+                    person.email = f"person{person.pk}@example.test"
+            person.save(
+                update_fields=[
+                    "first_name",
+                    "last_name",
+                    "preferred_name",
+                    "date_of_birth",
+                    "email",
+                    "notes",
+                ],
+            )
+            count += 1
+        return count
+
     # --------------------------------------------------------------- campers
 
     def _scrub_campers(self, fake: Faker) -> int:
@@ -240,10 +300,84 @@ class Command(BaseCommand):
 
     # --------------------------------------------------------------- orders
 
-    def _scrub_orders(self) -> int:
-        return Order.objects.update(
+    def _scrub_legacy_orders(self) -> int:
+        return LegacyOrder.objects.update(
             additional_notes=SCRUB_PLACEHOLDER,
             narrative_description=SCRUB_PLACEHOLDER,
+        )
+
+    # ----------------------------------------------------- observations / reflections
+
+    def _scrub_observations(self) -> int:
+        return Observation.all_objects.exclude(body="").update(body=SCRUB_PLACEHOLDER)
+
+    def _scrub_observation_replies(self) -> int:
+        return ObservationReply.objects.exclude(body="").update(body=SCRUB_PLACEHOLDER)
+
+    def _scrub_reflections(self) -> int:
+        count = 0
+        for reflection in Reflection.all_objects.all().iterator(chunk_size=200):
+            scrubbed = scrub_json_strings(reflection.answers)
+            if scrubbed != reflection.answers:
+                reflection.answers = scrubbed
+                reflection.save(update_fields=["answers"])
+                count += 1
+        return count
+
+    def _scrub_camper_care_orders(self) -> int:
+        return CamperCareOrder.all_objects.update(
+            item_note=SCRUB_PLACEHOLDER,
+            description=SCRUB_PLACEHOLDER,
+        )
+
+    def _scrub_maintenance_tickets(self) -> int:
+        return MaintenanceTicket.all_objects.update(
+            description=SCRUB_PLACEHOLDER,
+            urgent_reason=SCRUB_PLACEHOLDER,
+        )
+
+    def _scrub_camper_day_states(self) -> int:
+        return CamperDayState.all_objects.exclude(reason="").update(reason=SCRUB_PLACEHOLDER)
+
+    def _scrub_order_activity_events(self) -> int:
+        return OrderActivityEvent.all_objects.update(
+            note=SCRUB_PLACEHOLDER,
+            reason=SCRUB_PLACEHOLDER,
+        )
+
+    def _scrub_audit_events(self) -> int:
+        """Scrub audit rows via raw SQL — AuditEvent.save() blocks updates."""
+        table = AuditEvent._meta.db_table
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT to_regclass(%s)", [f"public.{table}"])
+            row = cursor.fetchone()
+            if not row or row[0] is None:
+                return -1
+
+            cursor.execute(f'SELECT COUNT(*) FROM "{table}"')  # noqa: S608
+            total = cursor.fetchone()[0]
+            if total == 0:
+                return 0
+
+            cursor.execute(
+                f"""
+                UPDATE "{table}"
+                SET reason_note = CASE
+                        WHEN reason_note <> '' THEN %s
+                        ELSE reason_note
+                    END,
+                    before_state = %s::jsonb,
+                    after_state = %s::jsonb,
+                    metadata = %s::jsonb
+                """,  # noqa: S608
+                [SCRUB_PLACEHOLDER, "{}", "{}", "{}"],
+            )
+            return cursor.rowcount
+
+    def _scrub_translation_records(self) -> int:
+        return TranslationRecord.all_objects.update(
+            translated_text=SCRUB_PLACEHOLDER,
+            last_error=SCRUB_PLACEHOLDER,
         )
 
     # ------------------------------------------------------------ messaging

--- a/backend/bunk_logs/utils/tests/test_scrub_pii.py
+++ b/backend/bunk_logs/utils/tests/test_scrub_pii.py
@@ -1,0 +1,94 @@
+"""Tests for scrub_pii multi-tenant model coverage."""
+
+import pytest
+from django.core.management import call_command
+from django.test import override_settings
+
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.notes.models import Observation
+from bunk_logs.users.models import User
+from bunk_logs.utils.management.commands.scrub_pii import SCRUB_PLACEHOLDER
+from bunk_logs.utils.management.commands.scrub_pii import scrub_json_strings
+
+
+@pytest.mark.django_db
+class TestScrubJsonStrings:
+    def test_scrubs_nested_strings(self):
+        payload = {
+            "notes": "real camper name here",
+            "scores": [1, 2],
+            "nested": {"comment": "private"},
+        }
+        scrubbed = scrub_json_strings(payload)
+        assert scrubbed["notes"] == SCRUB_PLACEHOLDER
+        assert scrubbed["scores"] == [1, 2]
+        assert scrubbed["nested"]["comment"] == SCRUB_PLACEHOLDER
+
+
+@pytest.mark.django_db
+class TestScrubPiiCommand:
+    @pytest.fixture
+    def org(self):
+        return Organization.objects.create(name="Crane Lake", slug="clc")
+
+    @pytest.fixture
+    def program(self, org):
+        return Program.all_objects.create(
+            organization=org,
+            name="Crane Lake Summer 2026",
+            slug="summer-2026",
+            program_type="summer_camp",
+            start_date="2026-06-01",
+            end_date="2026-08-15",
+        )
+
+    @override_settings(DEBUG=True)
+    def test_scrubs_person_observation_and_reflection(self, org, program):
+        user = User.objects.create_user(email="staff@example.com", password="pass")
+        person = Person.all_objects.create(
+            organization=org,
+            first_name="Real",
+            last_name="Name",
+            email="real.name@camp.example",
+            notes="private staff note",
+            user=user,
+        )
+        Observation.all_objects.create(
+            organization=org,
+            program=program,
+            author=person,
+            body="sensitive observation about camper",
+        )
+        template = ReflectionTemplate.all_objects.create(
+            organization=org,
+            name="Daily",
+            slug="daily",
+            cadence="daily",
+            schema={"fields": []},
+        )
+        Reflection.all_objects.create(
+            organization=org,
+            program=program,
+            author=person,
+            subject=person,
+            template=template,
+            period_start="2026-06-01",
+            period_end="2026-06-01",
+            answers={"comment": "private reflection text"},
+        )
+
+        call_command("scrub_pii", "--confirm")
+
+        person.refresh_from_db()
+        obs = Observation.all_objects.get()
+        reflection = Reflection.all_objects.get()
+
+        assert person.email == f"user{user.id}@example.test"
+        assert person.first_name != "Real"
+        assert person.notes == SCRUB_PLACEHOLDER
+        assert obs.body == SCRUB_PLACEHOLDER
+        assert reflection.answers["comment"] == SCRUB_PLACEHOLDER

--- a/docs/dev-data.md
+++ b/docs/dev-data.md
@@ -143,11 +143,21 @@ for the source.
 | Model / table                     | Action                                                                 |
 | --------------------------------- | ---------------------------------------------------------------------- |
 | `users.User`                      | `email` → `user{pk}@example.test`, names → Faker, password → `devpass123`, `last_login` → null |
+| `core.Person`                     | names → Faker, DOB → same year/month + random day, `email` → `user{user_id}@example.test` or `person{pk}@example.test`, `notes` → `[scrubbed]` |
 | `campers.Camper`                  | names → Faker, DOB → same year/month, random day; emergency contact → Faker; all `*_notes` / `status_note` → `[scrubbed]` |
 | `bunks.Cabin`                     | `location`, `notes` → blank / `[scrubbed]` (capacity preserved)         |
 | `bunklogs.BunkLog`                | `description` → `[scrubbed]` (scores preserved so the UI looks real)   |
 | `bunklogs.StaffLog`               | `elaboration`, `values_reflection` → `[scrubbed]` (scores preserved for all staff roles) |
-| `orders.Order`                    | `additional_notes`, `narrative_description` → `[scrubbed]`             |
+| `orders.Order` (legacy)           | `additional_notes`, `narrative_description` → `[scrubbed]`             |
+| `notes.Observation`               | `body` → `[scrubbed]`                                                  |
+| `notes.ObservationReply`          | `body` → `[scrubbed]`                                                  |
+| `core.Reflection`                 | string values inside `answers` JSON → `[scrubbed]` (structure preserved) |
+| `core.Order` (camper care)        | `item_note`, `description` → `[scrubbed]`                              |
+| `core.MaintenanceTicket`          | `description`, `urgent_reason` → `[scrubbed]`                          |
+| `core.CamperDayState`             | `reason` → `[scrubbed]`                                                |
+| `core.OrderActivityEvent`         | `note`, `reason` → `[scrubbed]`                                        |
+| `core.AuditEvent`                 | `reason_note` → `[scrubbed]`; `before_state` / `after_state` / `metadata` cleared via raw SQL (append-only model) |
+| `core.TranslationRecord`          | `translated_text`, `last_error` → `[scrubbed]`                         |
 | `messaging.EmailRecipient`        | `email`, `name` → Faker                                                 |
 | `messaging.EmailLog`              | TRUNCATE                                                                |
 | `django_session`                  | TRUNCATE                                                                |
@@ -207,7 +217,12 @@ upstream:
 - **`scrub_pii` aborts with "DB host not in local allowlist"** -- you
   ran the command outside the podman django container, or `DATABASE_URL`
   in your `.django` env points somewhere unexpected. Always invoke via
-  `./backend/dev.sh sync-prod` or `./backend/dev.sh scrub-pii`.
+  `make sync-prod-db` or `./scripts/sync-prod-db.sh`.
+- **Observations / reflections missing after sync** -- the dump is full-database;
+  if counts are zero, production likely has no rows yet. After a successful
+  sync, the script prints post-scrub counts for `persons`, `observations`,
+  and `reflections`. Re-grant `SELECT` on new tables to `bunklogs_readonly` if
+  `pg_dump` fails after a schema migration (see [One-time setup](#one-time-setup)).
 - **Local sign-in fails after scrub** -- you're a superuser? rerun with
   `--keep-superuser-emails`. You're not? Use `user{your_pk}@example.test`
   / `devpass123`. Find your pk in Django admin or via shell.

--- a/scripts/sync-prod-db.sh
+++ b/scripts/sync-prod-db.sh
@@ -192,6 +192,15 @@ info "running 'manage.py scrub_pii --confirm'..."
 $CMP -f "$COMPOSE_FILE" exec -T django \
     python manage.py scrub_pii --confirm "${SCRUB_EXTRA_ARGS[@]+"${SCRUB_EXTRA_ARGS[@]}"}"
 
+info "post-sync row counts (scrubbed):"
+$CMP -f "$COMPOSE_FILE" exec -T django python manage.py shell -c "
+from bunk_logs.core.models import Person, Reflection
+from bunk_logs.notes.models import Observation
+print(f'  persons={Person.all_objects.count()}')
+print(f'  observations={Observation.all_objects.count()}')
+print(f'  reflections={Reflection.all_objects.count()}')
+"
+
 # --- cleanup ---------------------------------------------------------------
 
 if [[ "$KEEP_DUMP" -eq 1 ]]; then


### PR DESCRIPTION
## Summary

- Adds **`audit_duplicate_identities`** — read-only production audit for duplicate emails, legacy staff without Campminder IDs, ambiguous name groups, and User↔Person conflicts.
- Adds **`merge_persons`** — dry-run by default; re-points Memberships, group memberships, Reflections, Observations, orders, and flags before deleting the loser Person. Supports `--force-user` for user-link conflicts.
- Fixes **Google OAuth** to match existing Users with `email__iexact` and lowercases email on User creation to prevent new case-variant duplicates.
- Extends **`scrub_pii`** for local prod sync: Person, Observation, Reflection answers, camper-care orders, audit events, etc. `sync-prod-db.sh` prints post-scrub row counts.

## Production workflow (after merge)

1. Render shell on `bunklogs-backend`:
   ```bash
   python manage.py audit_duplicate_identities --org-slug clc
   ```
2. Auto-fix legacy staff via Admin → People → Bulk import (Campminder CSV preview + commit).
3. Manual conflicts:
   ```bash
   python manage.py merge_persons --org-slug clc --winner <ID> --loser <ID>        # dry-run
   python manage.py merge_persons --org-slug clc --winner <ID> --loser <ID> --apply
   ```

Local equivalents: `make audit-duplicates`, `make merge-persons ORG_SLUG=clc WINNER=… LOSER=… APPLY=1`.

## Test plan

- [x] `make test-backend` — 1413 passed (1 pre-existing unrelated failure in `test_translation.py`)
- [ ] CI green on PR
- [ ] After deploy: run `audit_duplicate_identities` on Render shell
- [ ] Spot-check one dry-run + apply merge on a known duplicate pair in prod


Made with [Cursor](https://cursor.com)