### PR TITLE
fix: honor --force-user in merge_persons

### DIFF
--- a/backend/bunk_logs/core/management/commands/merge_persons.py
+++ b/backend/bunk_logs/core/management/commands/merge_persons.py
@@ -60,13 +60,7 @@ class Command(BaseCommand):
             msg = f"Person not found in org {org_slug!r}: {exc}"
             raise CommandError(msg) from exc
 
-        plan = plan_person_merge(winner=winner, loser=loser)
-        user_blocker = (
-            winner.user_id
-            and loser.user_id
-            and winner.user_id != loser.user_id
-            and not force_user
-        )
+        plan = plan_person_merge(winner=winner, loser=loser, force_user=force_user)
 
         self.stdout.write(
             f"Merge plan: keep Person #{winner.id} ({winner.full_name}), "
@@ -78,10 +72,6 @@ class Command(BaseCommand):
         for action in plan.actions:
             suffix = f" (x{action.count})" if action.count > 1 else ""
             self.stdout.write(f"  [{action.model}] {action.description}{suffix}")
-
-        if user_blocker:
-            msg = "Merge blocked: both Persons link to different Users. Use --force-user."
-            raise CommandError(msg)
 
         if plan.blockers:
             msg = "Merge blocked; resolve blockers before applying."

--- a/backend/bunk_logs/core/person_merge.py
+++ b/backend/bunk_logs/core/person_merge.py
@@ -45,7 +45,7 @@ def _count(qs) -> int:
     return qs.count()
 
 
-def plan_person_merge(*, winner: Person, loser: Person) -> MergePlan:
+def plan_person_merge(*, winner: Person, loser: Person, force_user: bool = False) -> MergePlan:
     """Dry-run plan for merging ``loser`` into ``winner``."""
     plan = MergePlan(winner_id=winner.pk, loser_id=loser.pk)
 
@@ -69,10 +69,16 @@ def plan_person_merge(*, winner: Person, loser: Person) -> MergePlan:
         )
 
     if winner.user_id and loser.user_id and winner.user_id != loser.user_id:
-        plan.blockers.append(
-            f"Both persons are linked to different Users "
-            f"({winner.user_id} vs {loser.user_id}); unlink loser or pass --force-user",
-        )
+        if force_user:
+            plan.actions.append(MergeAction(
+                "Person.user",
+                f"unlink User {loser.user_id} from loser (keep winner's User {winner.user_id})",
+            ))
+        else:
+            plan.blockers.append(
+                f"Both persons are linked to different Users "
+                f"({winner.user_id} vs {loser.user_id}); unlink loser or pass --force-user",
+            )
 
     for membership in Membership.all_objects.filter(person=loser):
         conflict = Membership.all_objects.filter(
@@ -242,16 +248,13 @@ def merge_persons(
     force_user: bool = False,
 ) -> MergePlan:
     """Merge ``loser`` into ``winner``. Raises ValueError when blocked."""
-    plan = plan_person_merge(winner=winner, loser=loser)
-    if winner.user_id and loser.user_id and winner.user_id != loser.user_id:
-        if not force_user:
-            msg = plan.blockers[0] if plan.blockers else "user conflict"
-            raise ValueError(msg)
-        loser.user = None
-        loser.save(update_fields=["user"])
-
+    plan = plan_person_merge(winner=winner, loser=loser, force_user=force_user)
     if plan.blockers:
         raise ValueError("; ".join(plan.blockers))
+
+    if force_user and winner.user_id and loser.user_id and winner.user_id != loser.user_id:
+        loser.user = None
+        loser.save(update_fields=["user"])
 
     _merge_memberships(winner=winner, loser=loser)
     _merge_assignment_group_memberships(winner=winner, loser=loser)

--- a/backend/bunk_logs/core/test_person_merge.py
+++ b/backend/bunk_logs/core/test_person_merge.py
@@ -131,6 +131,66 @@ class TestMergePersons:
         assert not plan.ok
         assert "campminder_id" in plan.blockers[0]
 
+    def test_merge_force_user_unlinks_loser_and_keeps_winner_user(self, org, program):
+        winner_user = User.objects.create_user(email="winner@example.com", password="pass")
+        loser_user = User.objects.create_user(email="loser@example.com", password="pass")
+        winner = Person.all_objects.create(
+            organization=org,
+            first_name="Charlie",
+            last_name="Capewell",
+            email="winner@example.com",
+            user=winner_user,
+            external_ids={"campminder_id": "18045818"},
+        )
+        loser = Person.all_objects.create(
+            organization=org,
+            first_name="Charles",
+            last_name="Capewell",
+            email="loser@example.com",
+            user=loser_user,
+        )
+        Membership.all_objects.create(program=program, person=loser, role="counselor")
+
+        plan = plan_person_merge(winner=winner, loser=loser, force_user=True)
+        assert plan.ok
+        assert any(action.model == "Person.user" for action in plan.actions)
+
+        merge_persons(winner=winner, loser=loser, force_user=True)
+
+        winner.refresh_from_db()
+        assert winner.user_id == winner_user.id
+        assert not Person.all_objects.filter(pk=loser.pk).exists()
+        assert Membership.all_objects.filter(person=winner, role="counselor").exists()
+        assert Person.all_objects.filter(user=loser_user).count() == 0
+
+    def test_merge_command_force_user_dry_run_succeeds(self, org):
+        winner_user = User.objects.create_user(email="winner@example.com", password="pass")
+        loser_user = User.objects.create_user(email="loser@example.com", password="pass")
+        winner = Person.all_objects.create(
+            organization=org,
+            first_name="Charlie",
+            last_name="Capewell",
+            user=winner_user,
+        )
+        loser = Person.all_objects.create(
+            organization=org,
+            first_name="Charles",
+            last_name="Capewell",
+            user=loser_user,
+        )
+
+        out = StringIO()
+        call_command(
+            "merge_persons",
+            org_slug="clc",
+            winner=winner.pk,
+            loser=loser.pk,
+            force_user=True,
+            stdout=out,
+        )
+        assert "BLOCKER" not in out.getvalue()
+        assert "Dry-run only" in out.getvalue()
+
     def test_merge_repoints_group_membership(self, org, program):
         winner = Person.all_objects.create(
             organization=org, first_name="Sam", last_name="Lee",

--- a/frontend/src/pages/admin/__tests__/Assignments.test.jsx
+++ b/frontend/src/pages/admin/__tests__/Assignments.test.jsx
@@ -82,7 +82,7 @@ describe('AdminAssignments', () => {
 
   it('passes filter params when listing assignments', async () => {
     render(<AdminAssignments />);
-    await screen.findByTestId('assignment-filter-bar');
+    await screen.findByTestId('assignment-program-chip-1');
 
     fireEvent.click(screen.getByTestId('assignment-program-chip-1'));
 


### PR DESCRIPTION
## Summary

- Fixes a bug where `merge_persons --force-user` still failed because the user-link conflict remained in `plan.blockers` after the separate `user_blocker` check was skipped.
- With `--force-user`, the plan now records an unlink action instead of a blocker; dry-run and `--apply` both proceed.

## Test plan

- [x] Added tests for `force_user` plan/merge and command dry-run
- [ ] CI green
- [ ] After deploy, on Render shell:
  ```bash
  python manage.py merge_persons --org-slug clc --winner 731 --loser 622 --force-user
  python manage.py merge_persons --org-slug clc --winner 731 --loser 622 --force-user --apply
  ```


Made with [Cursor](https://cursor.com)