### PR TITLE
feat: admin People dedupe UI and paginated roster browse

### DIFF
--- a/backend/bunk_logs/api/admin_flow/people.py
+++ b/backend/bunk_logs/api/admin_flow/people.py
@@ -26,10 +26,9 @@ Design notes:
 
 from __future__ import annotations
 
+import re
 from datetime import timedelta
 from typing import Any
-
-import re
 
 from django.db import transaction
 from django.db.models.functions import Trim

--- a/backend/bunk_logs/api/admin_flow/people.py
+++ b/backend/bunk_logs/api/admin_flow/people.py
@@ -29,7 +29,10 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any
 
+import re
+
 from django.db import transaction
+from django.db.models.functions import Trim
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.response import Response
@@ -179,6 +182,14 @@ class AdminPeopleListCreateView(APIView):
         tag = (request.query_params.get("tag") or "").strip().lower()
         if tag:
             qs = qs.filter(memberships__tags__contains=[tag]).distinct()
+
+        last_name_initial = (request.query_params.get("last_name_initial") or "").strip()
+        if last_name_initial:
+            letter = last_name_initial[0].upper()
+            if letter.isalpha():
+                qs = qs.annotate(_last_name_trim=Trim("last_name")).filter(
+                    _last_name_trim__iregex=rf"^\s*{re.escape(letter)}",
+                )
 
         status_filter = (request.query_params.get("status") or "").strip().lower()
         if status_filter == "active":

--- a/backend/bunk_logs/api/admin_flow/people_dedupe.py
+++ b/backend/bunk_logs/api/admin_flow/people_dedupe.py
@@ -1,0 +1,185 @@
+"""Admin People dedupe — preview and apply Person merges from the UI."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.db import transaction
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.models import Person
+from bunk_logs.core.permissions import IsOrgAdminOrSuperuser
+from bunk_logs.core.person_merge import LoserSpec
+from bunk_logs.core.person_merge import dedupe_persons
+from bunk_logs.core.person_merge import plan_dedupe
+
+from .common import viewer_or_403
+from .people import _get_person_or_404
+from .people import _not_found
+from .people import _person_snapshot
+from .people import _serialize_person
+
+
+def _parse_loser_specs(raw: Any) -> tuple[list[LoserSpec] | None, str | None]:
+    if not isinstance(raw, list) or not raw:
+        return None, "losers must be a non-empty list"
+
+    specs: list[LoserSpec] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            return None, "each loser entry must be an object"
+        person_id = item.get("person_id")
+        strategy = (item.get("strategy") or "repoint").strip().lower()
+        if not isinstance(person_id, int):
+            return None, "each loser must include integer person_id"
+        if strategy not in {"repoint", "discard"}:
+            return None, f"invalid strategy {strategy!r}; use repoint or discard"
+        specs.append(LoserSpec(
+            person_id=person_id,
+            strategy=strategy,  # type: ignore[arg-type]
+            force_user=bool(item.get("force_user")),
+        ))
+    return specs, None
+
+
+def _parse_payload(data: dict) -> tuple[int | None, list[LoserSpec] | None, bool, str | None, str | None]:
+    winner_id = data.get("winner_id")
+    if not isinstance(winner_id, int):
+        return None, None, False, None, "winner_id is required"
+
+    loser_specs, loser_err = _parse_loser_specs(data.get("losers"))
+    if loser_err:
+        return None, None, False, None, loser_err
+
+    reason = (data.get("reason") or "").strip()
+    confirm_destructive = bool(data.get("confirm_destructive"))
+    return winner_id, loser_specs, confirm_destructive, reason, None
+
+
+def _build_response(*, ctx, winner: Person, loser_specs: list[LoserSpec], plan, ok: bool) -> dict:
+    loser_ids = [spec.person_id for spec in loser_specs]
+    persons = {
+        p.id: _serialize_person(p, include_memberships=True)
+        for p in Person.all_objects.filter(
+            pk__in=[winner.pk, *loser_ids],
+            organization=ctx.organization,
+        )
+    }
+    return {
+        "ok": ok,
+        "winner_id": winner.pk,
+        "winner": persons.get(winner.pk),
+        "losers": [persons.get(spec.person_id) for spec in loser_specs if persons.get(spec.person_id)],
+        "plans": plan.losers,
+    }
+
+
+class AdminPeopleDedupePreviewView(APIView):
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def post(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        data = request.data or {}
+        winner_id, loser_specs, confirm_destructive, _, err = _parse_payload(data)
+        if err:
+            return Response({"detail": err}, status=status.HTTP_400_BAD_REQUEST)
+
+        winner = _get_person_or_404(ctx, winner_id)
+        if winner is None:
+            return _not_found("Person")
+
+        plan = plan_dedupe(
+            winner=winner,
+            loser_specs=loser_specs,
+            confirm_destructive=confirm_destructive,
+        )
+        payload = _build_response(
+            ctx=ctx,
+            winner=winner,
+            loser_specs=loser_specs,
+            plan=plan,
+            ok=plan.ok,
+        )
+        if not plan.ok:
+            return Response(payload, status=status.HTTP_409_CONFLICT)
+        return Response(payload)
+
+
+class AdminPeopleDedupeApplyView(APIView):
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def post(self, request, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        data = request.data or {}
+        winner_id, loser_specs, confirm_destructive, reason, err = _parse_payload(data)
+        if err:
+            return Response({"detail": err}, status=status.HTTP_400_BAD_REQUEST)
+        if not reason:
+            return Response({"detail": "reason is required."}, status=status.HTTP_400_BAD_REQUEST)
+
+        winner = _get_person_or_404(ctx, winner_id)
+        if winner is None:
+            return _not_found("Person")
+
+        preview = plan_dedupe(
+            winner=winner,
+            loser_specs=loser_specs,
+            confirm_destructive=confirm_destructive,
+        )
+        if not preview.ok:
+            payload = _build_response(
+                ctx=ctx,
+                winner=winner,
+                loser_specs=loser_specs,
+                plan=preview,
+                ok=False,
+            )
+            return Response(payload, status=status.HTTP_409_CONFLICT)
+
+        before = _person_snapshot(winner)
+        actor = ctx.membership or request.user
+
+        try:
+            with transaction.atomic():
+                applied = dedupe_persons(
+                    winner=winner,
+                    loser_specs=loser_specs,
+                    confirm_destructive=confirm_destructive,
+                )
+                winner.refresh_from_db()
+                audit_module.override_edit(
+                    actor,
+                    winner,
+                    before,
+                    _person_snapshot(winner),
+                    reason=reason,
+                    content_type="person_dedupe",
+                    metadata={
+                        "winner_id": winner.pk,
+                        "loser_specs": [
+                            {
+                                "person_id": spec.person_id,
+                                "strategy": spec.strategy,
+                                "force_user": spec.force_user,
+                            }
+                            for spec in loser_specs
+                        ],
+                        "plans": applied.losers,
+                    },
+                )
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_409_CONFLICT)
+
+        winner = _get_person_or_404(ctx, winner_id)
+        payload = _build_response(
+            ctx=ctx,
+            winner=winner,
+            loser_specs=loser_specs,
+            plan=applied,
+            ok=True,
+        )
+        payload["winner"] = _serialize_person(winner, include_memberships=True)
+        return Response(payload)

--- a/backend/bunk_logs/api/admin_flow/urls.py
+++ b/backend/bunk_logs/api/admin_flow/urls.py
@@ -22,6 +22,8 @@ from .people import AdminPeopleDetailView
 from .people import AdminPeopleListCreateView
 from .people import AdminPersonInviteView
 from .people import AdminPersonMembershipsView
+from .people_dedupe import AdminPeopleDedupeApplyView
+from .people_dedupe import AdminPeopleDedupePreviewView
 from .programs import AdminProgramDetailView
 from .programs import AdminProgramEndView
 from .programs import AdminProgramsListCreateView
@@ -60,6 +62,16 @@ urlpatterns = [
         "people/<int:person_id>/invite/",
         AdminPersonInviteView.as_view(),
         name="admin-person-invite",
+    ),
+    path(
+        "people/dedupe/preview/",
+        AdminPeopleDedupePreviewView.as_view(),
+        name="admin-people-dedupe-preview",
+    ),
+    path(
+        "people/dedupe/",
+        AdminPeopleDedupeApplyView.as_view(),
+        name="admin-people-dedupe",
     ),
     path(
         "memberships/<int:membership_id>/",

--- a/backend/bunk_logs/api/tests/test_admin_flow_pr2.py
+++ b/backend/bunk_logs/api/tests/test_admin_flow_pr2.py
@@ -150,6 +150,55 @@ class TestAdminPeople:
         body = r.json()
         assert body["existing_person"]["id"] == existing_person.id
 
+    def test_list_pagination_and_last_name_initial(
+        self, api, org, program, admin_user,
+    ):
+        with organization_context(org):
+            for last_name, first_name in [
+                ("Adams", "Amy"),
+                ("Brown", "Ben"),
+                ("Adams", "Zoe"),
+            ]:
+                person = Person.all_objects.create(
+                    organization=org,
+                    first_name=first_name,
+                    last_name=last_name,
+                )
+                Membership.all_objects.create(
+                    program=program, person=person, role="counselor", is_active=True,
+                )
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            page1 = api.get(
+                self.URL,
+                {"offset": 0, "page_size": 2},
+                **_hdr(org.slug),
+            )
+            assert page1.status_code == 200
+            body1 = page1.json()
+            assert body1["count"] == 4  # admin + 3 created
+            assert body1["page_size"] == 2
+            assert len(body1["results"]) == 2
+            assert body1["results"][0]["last_name"] == "Adams"
+            assert body1["results"][1]["last_name"] == "Adams"
+
+            page2 = api.get(
+                self.URL,
+                {"offset": 2, "page_size": 2},
+                **_hdr(org.slug),
+            )
+            assert page2.status_code == 200
+            assert len(page2.json()["results"]) == 2
+
+            filtered = api.get(
+                self.URL,
+                {"last_name_initial": "b", "status": "active"},
+                **_hdr(org.slug),
+            )
+        assert filtered.status_code == 200
+        names = [row["full_name"] for row in filtered.json()["results"]]
+        assert names == ["Ben Brown"]
+
     def test_membership_role_is_immutable(
         self, api, org, program, admin_user, existing_person,
     ):

--- a/backend/bunk_logs/api/tests/test_admin_people_dedupe.py
+++ b/backend/bunk_logs/api/tests/test_admin_people_dedupe.py
@@ -1,0 +1,188 @@
+"""API tests for Admin People dedupe."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import AuditEvent
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def _hdr(slug: str) -> dict:
+    return {"HTTP_X_ORGANIZATION_SLUG": slug}
+
+
+@pytest.fixture
+def api() -> APIClient:
+    return APIClient()
+
+
+@pytest.fixture
+def org():
+    return Organization.objects.create(name="Dedupe Org", slug="dedupe-org")
+
+
+@pytest.fixture
+def program(org):
+    return Program.all_objects.create(
+        organization=org,
+        name="Dedupe Org Summer",
+        slug="summer",
+        program_type="summer_camp",
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def admin_user(org, program):
+    user = User.objects.create_user(email="admin-dedupe@example.com", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="Ad", last_name="Min", user=user,
+    )
+    Membership.all_objects.create(program=program, person=person, role="admin", is_active=True)
+    return user
+
+
+@pytest.fixture
+def non_admin_user(org, program):
+    user = User.objects.create_user(email="other-dedupe@example.com", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="Co", last_name="Un", user=user,
+    )
+    Membership.all_objects.create(program=program, person=person, role="counselor", is_active=True)
+    return user
+
+
+class TestAdminPeopleDedupe:
+    PREVIEW_URL = "/api/v1/admin/people/dedupe/preview/"
+    APPLY_URL = "/api/v1/admin/people/dedupe/"
+
+    def test_non_admin_blocked(self, api, org, non_admin_user):
+        api.force_authenticate(user=non_admin_user)
+        with organization_context(org):
+            response = api.post(
+                self.PREVIEW_URL,
+                {"winner_id": 1, "losers": [{"person_id": 2, "strategy": "repoint"}]},
+                format="json",
+                **_hdr(org.slug),
+            )
+        assert response.status_code == 403
+
+    def test_preview_and_apply_repoint_merge(self, api, org, program, admin_user):
+        winner = Person.all_objects.create(
+            organization=org,
+            first_name="Win",
+            last_name="Ner",
+            external_ids={"campminder_id": "123"},
+        )
+        loser = Person.all_objects.create(
+            organization=org,
+            first_name="Los",
+            last_name="Er",
+        )
+        Membership.all_objects.create(program=program, person=loser, role="counselor")
+
+        api.force_authenticate(user=admin_user)
+        payload = {
+            "winner_id": winner.id,
+            "losers": [{"person_id": loser.id, "strategy": "repoint"}],
+        }
+        with organization_context(org):
+            preview = api.post(self.PREVIEW_URL, payload, format="json", **_hdr(org.slug))
+        assert preview.status_code == 200, preview.content
+        assert preview.json()["ok"] is True
+        assert preview.json()["plans"][0]["strategy"] == "repoint"
+
+        apply_payload = {**payload, "reason": "Duplicate legacy import"}
+        with organization_context(org):
+            applied = api.post(self.APPLY_URL, apply_payload, format="json", **_hdr(org.slug))
+        assert applied.status_code == 200, applied.content
+        assert not Person.all_objects.filter(pk=loser.id).exists()
+        assert Membership.all_objects.filter(person=winner, role="counselor").exists()
+        assert AuditEvent.all_objects.filter(content_type="person_dedupe").exists()
+
+    def test_apply_requires_force_user_when_users_conflict(self, api, org, admin_user):
+        winner_user = User.objects.create_user(email="winner@example.com", password="pw")
+        loser_user = User.objects.create_user(email="loser@example.com", password="pw")
+        winner = Person.all_objects.create(
+            organization=org, first_name="Win", last_name="Ner", user=winner_user,
+        )
+        loser = Person.all_objects.create(
+            organization=org, first_name="Los", last_name="Er", user=loser_user,
+        )
+
+        api.force_authenticate(user=admin_user)
+        payload = {
+            "winner_id": winner.id,
+            "losers": [{"person_id": loser.id, "strategy": "repoint"}],
+            "reason": "Duplicate login",
+        }
+        with organization_context(org):
+            blocked = api.post(self.APPLY_URL, payload, format="json", **_hdr(org.slug))
+        assert blocked.status_code == 409
+
+        payload["losers"][0]["force_user"] = True
+        with organization_context(org):
+            applied = api.post(self.APPLY_URL, payload, format="json", **_hdr(org.slug))
+        assert applied.status_code == 200, applied.content
+        winner.refresh_from_db()
+        assert winner.user_id == winner_user.id
+        assert not Person.all_objects.filter(pk=loser.id).exists()
+
+    def test_discard_blocked_without_confirm_destructive(self, api, org, program, admin_user):
+        person = Person.all_objects.create(
+            organization=org, first_name="Cam", last_name="Per",
+        )
+        author = Person.all_objects.create(
+            organization=org, first_name="Auth", last_name="Or",
+        )
+        winner = Person.all_objects.create(
+            organization=org, first_name="Keep", last_name="Er",
+        )
+        template = ReflectionTemplate.all_objects.create(
+            organization=org,
+            name="Dedupe Org Daily",
+            slug="daily",
+            cadence="daily",
+            schema={"fields": []},
+        )
+        Reflection.all_objects.create(
+            organization=org,
+            program=program,
+            subject=person,
+            author=author,
+            template=template,
+            period_start=date(2026, 7, 1),
+            period_end=date(2026, 7, 7),
+            answers={},
+        )
+
+        api.force_authenticate(user=admin_user)
+        payload = {
+            "winner_id": winner.id,
+            "losers": [{"person_id": person.id, "strategy": "discard"}],
+            "reason": "Remove duplicate",
+        }
+        with organization_context(org):
+            blocked = api.post(self.APPLY_URL, payload, format="json", **_hdr(org.slug))
+        assert blocked.status_code == 409
+
+        payload["confirm_destructive"] = True
+        with organization_context(org):
+            applied = api.post(self.APPLY_URL, payload, format="json", **_hdr(org.slug))
+        assert applied.status_code == 200, applied.content
+        assert not Person.all_objects.filter(pk=person.id).exists()

--- a/backend/bunk_logs/core/management/commands/merge_persons.py
+++ b/backend/bunk_logs/core/management/commands/merge_persons.py
@@ -60,13 +60,7 @@ class Command(BaseCommand):
             msg = f"Person not found in org {org_slug!r}: {exc}"
             raise CommandError(msg) from exc
 
-        plan = plan_person_merge(winner=winner, loser=loser)
-        user_blocker = (
-            winner.user_id
-            and loser.user_id
-            and winner.user_id != loser.user_id
-            and not force_user
-        )
+        plan = plan_person_merge(winner=winner, loser=loser, force_user=force_user)
 
         self.stdout.write(
             f"Merge plan: keep Person #{winner.id} ({winner.full_name}), "
@@ -78,10 +72,6 @@ class Command(BaseCommand):
         for action in plan.actions:
             suffix = f" (x{action.count})" if action.count > 1 else ""
             self.stdout.write(f"  [{action.model}] {action.description}{suffix}")
-
-        if user_blocker:
-            msg = "Merge blocked: both Persons link to different Users. Use --force-user."
-            raise CommandError(msg)
 
         if plan.blockers:
             msg = "Merge blocked; resolve blockers before applying."

--- a/backend/bunk_logs/core/person_merge.py
+++ b/backend/bunk_logs/core/person_merge.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
+from typing import Literal
 
 from django.db import transaction
+from django.utils import timezone
 
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import CamperDayState
@@ -163,6 +165,242 @@ def plan_person_merge(*, winner: Person, loser: Person, force_user: bool = False
 
     plan.actions.append(MergeAction("Person", f"delete Person {loser.pk}"))
     return plan
+
+
+@dataclass
+class DiscardPlan:
+    person_id: int
+    actions: list[MergeAction] = field(default_factory=list)
+    blockers: list[str] = field(default_factory=list)
+    impact_counts: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return not self.blockers
+
+
+@dataclass
+class LoserSpec:
+    person_id: int
+    strategy: Literal["repoint", "discard"]
+    force_user: bool = False
+
+
+@dataclass
+class DedupePlan:
+    winner_id: int
+    losers: list[dict] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return all(entry.get("ok") for entry in self.losers)
+
+
+def serialize_merge_plan(plan: MergePlan) -> dict:
+    return {
+        "ok": plan.ok,
+        "winner_id": plan.winner_id,
+        "loser_id": plan.loser_id,
+        "actions": [
+            {"model": action.model, "description": action.description, "count": action.count}
+            for action in plan.actions
+        ],
+        "blockers": list(plan.blockers),
+    }
+
+
+def serialize_discard_plan(plan: DiscardPlan) -> dict:
+    return {
+        "ok": plan.ok,
+        "person_id": plan.person_id,
+        "actions": [
+            {"model": action.model, "description": action.description, "count": action.count}
+            for action in plan.actions
+        ],
+        "blockers": list(plan.blockers),
+        "impact_counts": dict(plan.impact_counts),
+    }
+
+
+def person_impact_counts(person: Person) -> dict[str, int]:
+    return {
+        "reflections_as_subject": _count(Reflection.all_objects.filter(subject=person)),
+        "reflections_as_author": _count(Reflection.all_objects.filter(author=person)),
+        "observations_as_author": _count(Observation.all_objects.filter(author=person)),
+        "observation_replies_as_author": _count(ObservationReply.objects.filter(author=person)),
+        "memberships_active": _count(Membership.all_objects.filter(person=person, is_active=True)),
+        "group_memberships_active": _count(
+            AssignmentGroupMembership.all_objects.filter(person=person, is_active=True),
+        ),
+        "orders_as_subject": _count(Order.all_objects.filter(subject=person)),
+        "flags_as_camper": _count(Flag.all_objects.filter(subject_camper=person)),
+    }
+
+
+def plan_discard_person(*, person: Person, confirm_destructive: bool = False) -> DiscardPlan:
+    """Dry-run plan for discarding a duplicate Person without repointing to a winner."""
+    plan = DiscardPlan(person_id=person.pk)
+    plan.impact_counts = person_impact_counts(person)
+
+    if plan.impact_counts["reflections_as_subject"] > 0 and not confirm_destructive:
+        plan.blockers.append(
+            f"Person is subject of {plan.impact_counts['reflections_as_subject']} reflection(s); "
+            "confirm_destructive required to delete",
+        )
+
+    n_memberships = _count(Membership.all_objects.filter(person=person, is_active=True))
+    if n_memberships:
+        plan.actions.append(MergeAction(
+            "Membership",
+            f"deactivate {n_memberships} active membership(s)",
+            count=n_memberships,
+        ))
+
+    n_group = _count(AssignmentGroupMembership.all_objects.filter(person=person, is_active=True))
+    if n_group:
+        plan.actions.append(MergeAction(
+            "AssignmentGroupMembership",
+            f"deactivate {n_group} active group membership(s)",
+            count=n_group,
+        ))
+
+    if person.user_id:
+        plan.actions.append(MergeAction("Person.user", f"unlink User {person.user_id}"))
+
+    for label, key in (
+        ("Reflection.subject", "reflections_as_subject"),
+        ("Reflection.author", "reflections_as_author"),
+        ("Observation.author", "observations_as_author"),
+        ("ObservationReply.author", "observation_replies_as_author"),
+    ):
+        count = plan.impact_counts[key]
+        if count:
+            plan.actions.append(MergeAction(label, f"affected on delete ({count} row(s))", count=count))
+
+    plan.actions.append(MergeAction("Person", f"delete Person {person.pk}"))
+    return plan
+
+
+def _soft_deactivate_memberships(*, person: Person, today) -> None:
+    for membership in Membership.all_objects.filter(person=person, is_active=True):
+        membership.is_active = False
+        if not membership.end_date:
+            membership.end_date = today
+        membership.save(update_fields=["is_active", "end_date"])
+
+    for agm in AssignmentGroupMembership.all_objects.filter(person=person, is_active=True):
+        agm.is_active = False
+        if not agm.end_date:
+            agm.end_date = today
+        agm.save(update_fields=["is_active", "end_date"])
+
+
+def discard_person(*, person: Person, confirm_destructive: bool = False) -> DiscardPlan:
+    """Discard a Person without merging content to a winner."""
+    plan = plan_discard_person(person=person, confirm_destructive=confirm_destructive)
+    if plan.blockers:
+        raise ValueError("; ".join(plan.blockers))
+
+    today = timezone.localdate()
+    _soft_deactivate_memberships(person=person, today=today)
+    if person.user_id:
+        person.user = None
+        person.save(update_fields=["user"])
+    person.delete()
+    return plan
+
+
+def plan_dedupe(
+    *,
+    winner: Person,
+    loser_specs: list[LoserSpec],
+    confirm_destructive: bool = False,
+) -> DedupePlan:
+    """Dry-run plan for deduping multiple losers into one winner."""
+    dedupe = DedupePlan(winner_id=winner.pk)
+    for spec in loser_specs:
+        if spec.person_id == winner.pk:
+            dedupe.losers.append({
+                "person_id": spec.person_id,
+                "strategy": spec.strategy,
+                "ok": False,
+                "actions": [],
+                "blockers": ["winner cannot also be a loser"],
+                "impact_counts": {},
+            })
+            continue
+
+        try:
+            loser = Person.all_objects.get(pk=spec.person_id, organization=winner.organization)
+        except Person.DoesNotExist:
+            dedupe.losers.append({
+                "person_id": spec.person_id,
+                "strategy": spec.strategy,
+                "ok": False,
+                "actions": [],
+                "blockers": [f"Person {spec.person_id} not found in org"],
+                "impact_counts": {},
+            })
+            continue
+
+        if spec.strategy == "discard":
+            discard_plan = plan_discard_person(
+                person=loser,
+                confirm_destructive=confirm_destructive,
+            )
+            dedupe.losers.append({
+                "person_id": spec.person_id,
+                "strategy": spec.strategy,
+                **serialize_discard_plan(discard_plan),
+            })
+        else:
+            merge_plan = plan_person_merge(
+                winner=winner,
+                loser=loser,
+                force_user=spec.force_user,
+            )
+            entry = serialize_merge_plan(merge_plan)
+            entry["person_id"] = spec.person_id
+            entry["strategy"] = spec.strategy
+            entry["impact_counts"] = person_impact_counts(loser)
+            dedupe.losers.append(entry)
+
+    return dedupe
+
+
+@transaction.atomic
+def dedupe_persons(
+    *,
+    winner: Person,
+    loser_specs: list[LoserSpec],
+    confirm_destructive: bool = False,
+) -> DedupePlan:
+    """Apply dedupe for all losers into winner."""
+    plan = plan_dedupe(
+        winner=winner,
+        loser_specs=loser_specs,
+        confirm_destructive=confirm_destructive,
+    )
+    if not plan.ok:
+        blockers = [
+            blocker
+            for entry in plan.losers
+            for blocker in entry.get("blockers", [])
+        ]
+        raise ValueError("; ".join(blockers) if blockers else "dedupe blocked")
+
+    preview = plan
+    for spec in loser_specs:
+        if spec.person_id == winner.pk:
+            continue
+        loser = Person.all_objects.get(pk=spec.person_id, organization=winner.organization)
+        if spec.strategy == "discard":
+            discard_person(person=loser, confirm_destructive=confirm_destructive)
+        else:
+            merge_persons(winner=winner, loser=loser, force_user=spec.force_user)
+            winner.refresh_from_db()
+
+    return preview
 
 
 def _merge_memberships(*, winner: Person, loser: Person) -> int:

--- a/backend/bunk_logs/core/person_merge.py
+++ b/backend/bunk_logs/core/person_merge.py
@@ -45,7 +45,7 @@ def _count(qs) -> int:
     return qs.count()
 
 
-def plan_person_merge(*, winner: Person, loser: Person) -> MergePlan:
+def plan_person_merge(*, winner: Person, loser: Person, force_user: bool = False) -> MergePlan:
     """Dry-run plan for merging ``loser`` into ``winner``."""
     plan = MergePlan(winner_id=winner.pk, loser_id=loser.pk)
 
@@ -69,10 +69,16 @@ def plan_person_merge(*, winner: Person, loser: Person) -> MergePlan:
         )
 
     if winner.user_id and loser.user_id and winner.user_id != loser.user_id:
-        plan.blockers.append(
-            f"Both persons are linked to different Users "
-            f"({winner.user_id} vs {loser.user_id}); unlink loser or pass --force-user",
-        )
+        if force_user:
+            plan.actions.append(MergeAction(
+                "Person.user",
+                f"unlink User {loser.user_id} from loser (keep winner's User {winner.user_id})",
+            ))
+        else:
+            plan.blockers.append(
+                f"Both persons are linked to different Users "
+                f"({winner.user_id} vs {loser.user_id}); unlink loser or pass --force-user",
+            )
 
     for membership in Membership.all_objects.filter(person=loser):
         conflict = Membership.all_objects.filter(
@@ -242,16 +248,13 @@ def merge_persons(
     force_user: bool = False,
 ) -> MergePlan:
     """Merge ``loser`` into ``winner``. Raises ValueError when blocked."""
-    plan = plan_person_merge(winner=winner, loser=loser)
-    if winner.user_id and loser.user_id and winner.user_id != loser.user_id:
-        if not force_user:
-            msg = plan.blockers[0] if plan.blockers else "user conflict"
-            raise ValueError(msg)
-        loser.user = None
-        loser.save(update_fields=["user"])
-
+    plan = plan_person_merge(winner=winner, loser=loser, force_user=force_user)
     if plan.blockers:
         raise ValueError("; ".join(plan.blockers))
+
+    if force_user and winner.user_id and loser.user_id and winner.user_id != loser.user_id:
+        loser.user = None
+        loser.save(update_fields=["user"])
 
     _merge_memberships(winner=winner, loser=loser)
     _merge_assignment_group_memberships(winner=winner, loser=loser)

--- a/backend/bunk_logs/core/test_person_merge.py
+++ b/backend/bunk_logs/core/test_person_merge.py
@@ -131,6 +131,66 @@ class TestMergePersons:
         assert not plan.ok
         assert "campminder_id" in plan.blockers[0]
 
+    def test_merge_force_user_unlinks_loser_and_keeps_winner_user(self, org, program):
+        winner_user = User.objects.create_user(email="winner@example.com", password="pass")
+        loser_user = User.objects.create_user(email="loser@example.com", password="pass")
+        winner = Person.all_objects.create(
+            organization=org,
+            first_name="Charlie",
+            last_name="Capewell",
+            email="winner@example.com",
+            user=winner_user,
+            external_ids={"campminder_id": "18045818"},
+        )
+        loser = Person.all_objects.create(
+            organization=org,
+            first_name="Charles",
+            last_name="Capewell",
+            email="loser@example.com",
+            user=loser_user,
+        )
+        Membership.all_objects.create(program=program, person=loser, role="counselor")
+
+        plan = plan_person_merge(winner=winner, loser=loser, force_user=True)
+        assert plan.ok
+        assert any(action.model == "Person.user" for action in plan.actions)
+
+        merge_persons(winner=winner, loser=loser, force_user=True)
+
+        winner.refresh_from_db()
+        assert winner.user_id == winner_user.id
+        assert not Person.all_objects.filter(pk=loser.pk).exists()
+        assert Membership.all_objects.filter(person=winner, role="counselor").exists()
+        assert Person.all_objects.filter(user=loser_user).count() == 0
+
+    def test_merge_command_force_user_dry_run_succeeds(self, org):
+        winner_user = User.objects.create_user(email="winner@example.com", password="pass")
+        loser_user = User.objects.create_user(email="loser@example.com", password="pass")
+        winner = Person.all_objects.create(
+            organization=org,
+            first_name="Charlie",
+            last_name="Capewell",
+            user=winner_user,
+        )
+        loser = Person.all_objects.create(
+            organization=org,
+            first_name="Charles",
+            last_name="Capewell",
+            user=loser_user,
+        )
+
+        out = StringIO()
+        call_command(
+            "merge_persons",
+            org_slug="clc",
+            winner=winner.pk,
+            loser=loser.pk,
+            force_user=True,
+            stdout=out,
+        )
+        assert "BLOCKER" not in out.getvalue()
+        assert "Dry-run only" in out.getvalue()
+
     def test_merge_repoints_group_membership(self, org, program):
         winner = Person.all_objects.create(
             organization=org, first_name="Sam", last_name="Lee",

--- a/backend/bunk_logs/core/test_person_merge.py
+++ b/backend/bunk_logs/core/test_person_merge.py
@@ -1,5 +1,6 @@
 """Tests for duplicate identity audit and Person merge tooling."""
 
+from datetime import date
 from io import StringIO
 
 import pytest
@@ -11,7 +12,13 @@ from bunk_logs.core.models import Membership
 from bunk_logs.core.models import Organization
 from bunk_logs.core.models import Person
 from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+from bunk_logs.core.person_merge import LoserSpec
+from bunk_logs.core.person_merge import dedupe_persons
+from bunk_logs.core.person_merge import discard_person
 from bunk_logs.core.person_merge import merge_persons
+from bunk_logs.core.person_merge import plan_discard_person
 from bunk_logs.core.person_merge import plan_person_merge
 from bunk_logs.users.models import User
 
@@ -216,3 +223,84 @@ class TestMergePersons:
 
         agm.refresh_from_db()
         assert agm.person_id == winner.id
+
+
+@pytest.mark.django_db
+class TestDiscardPerson:
+    def test_discard_deactivates_memberships_and_deletes_person(self, org, program):
+        person = Person.all_objects.create(
+            organization=org,
+            first_name="Dup",
+            last_name="Licate",
+            email="dup@example.com",
+        )
+        Membership.all_objects.create(program=program, person=person, role="counselor", is_active=True)
+
+        plan = plan_discard_person(person=person)
+        assert plan.ok
+
+        discard_person(person=person)
+
+        assert not Person.all_objects.filter(pk=person.pk).exists()
+        assert not Membership.all_objects.filter(person_id=person.pk, is_active=True).exists()
+
+    def test_discard_blocks_when_subject_reflections_without_confirm(self, org, program):
+        person = Person.all_objects.create(
+            organization=org, first_name="Cam", last_name="Per",
+        )
+        author = Person.all_objects.create(
+            organization=org, first_name="Auth", last_name="Or",
+        )
+        template = ReflectionTemplate.all_objects.create(
+            organization=org,
+            name="Dedupe Org Daily",
+            slug="daily",
+            cadence="daily",
+            schema={"fields": []},
+        )
+        Reflection.all_objects.create(
+            organization=org,
+            program=program,
+            subject=person,
+            author=author,
+            template=template,
+            period_start=date(2026, 7, 1),
+            period_end=date(2026, 7, 7),
+            answers={},
+        )
+
+        plan = plan_discard_person(person=person)
+        assert not plan.ok
+        assert "confirm_destructive" in plan.blockers[0]
+
+        discard_person(person=person, confirm_destructive=True)
+        assert not Person.all_objects.filter(pk=person.pk).exists()
+
+
+@pytest.mark.django_db
+class TestDedupePersons:
+    def test_dedupe_repoints_multiple_losers(self, org, program):
+        winner = Person.all_objects.create(
+            organization=org, first_name="Win", last_name="Ner",
+            external_ids={"campminder_id": "111"},
+        )
+        loser_one = Person.all_objects.create(
+            organization=org, first_name="Los", last_name="One",
+        )
+        loser_two = Person.all_objects.create(
+            organization=org, first_name="Los", last_name="Two",
+        )
+        Membership.all_objects.create(program=program, person=loser_one, role="counselor")
+        Membership.all_objects.create(program=program, person=loser_two, role="kitchen_staff")
+
+        dedupe_persons(
+            winner=winner,
+            loser_specs=[
+                LoserSpec(person_id=loser_one.pk, strategy="repoint"),
+                LoserSpec(person_id=loser_two.pk, strategy="repoint"),
+            ],
+        )
+
+        assert not Person.all_objects.filter(pk__in=[loser_one.pk, loser_two.pk]).exists()
+        assert Membership.all_objects.filter(person=winner, role="counselor").exists()
+        assert Membership.all_objects.filter(person=winner, role="kitchen_staff").exists()

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -33,9 +33,27 @@ export async function postAdminOverrideEdit({
 // People (Story 55)
 // ---------------------------------------------------------------------------
 
-export async function listAdminPeople(params = {}) {
-  const resp = await api.get(`${ADMIN_BASE}/people/`, { params });
+export async function listAdminPeople(params = {}, config = {}) {
+  const resp = await api.get(`${ADMIN_BASE}/people/`, { params, ...config });
   return resp?.data ?? { results: [] };
+}
+
+/** Build query params for GET /admin/people/ — omits empty filters. */
+export function buildAdminPeopleListParams({
+  search = '',
+  role = '',
+  status = '',
+  last_name_initial = '',
+  offset = 0,
+  page_size = 50,
+} = {}) {
+  const params = { offset, page_size };
+  const trimmedSearch = search.trim();
+  if (trimmedSearch) params.search = trimmedSearch;
+  if (role) params.role = role;
+  if (status) params.status = status;
+  if (last_name_initial) params.last_name_initial = last_name_initial;
+  return params;
 }
 
 export async function getAdminPerson(personId) {
@@ -70,6 +88,16 @@ export async function deactivateAdminMembership(membershipId, reason) {
 
 export async function inviteAdminPerson(personId, payload = {}) {
   const resp = await api.post(`${ADMIN_BASE}/people/${personId}/invite/`, payload);
+  return resp?.data ?? null;
+}
+
+export async function previewAdminPeopleDedupe(payload) {
+  const resp = await api.post(`${ADMIN_BASE}/people/dedupe/preview/`, payload);
+  return resp?.data ?? null;
+}
+
+export async function commitAdminPeopleDedupe(payload) {
+  const resp = await api.post(`${ADMIN_BASE}/people/dedupe/`, payload);
   return resp?.data ?? null;
 }
 

--- a/frontend/src/components/admin/DedupePeopleModal.jsx
+++ b/frontend/src/components/admin/DedupePeopleModal.jsx
@@ -1,0 +1,314 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  previewAdminPeopleDedupe,
+  commitAdminPeopleDedupe,
+} from '../../api/admin';
+
+function classNames(...args) {
+  return args.filter(Boolean).join(' ');
+}
+
+function campminderId(person) {
+  return person?.external_ids?.campminder_id || '';
+}
+
+/**
+ * Modal for merging duplicate Person records selected on the Admin People page.
+ */
+export default function DedupePeopleModal({
+  selectedPeople,
+  onClose,
+  onCompleted,
+}) {
+  const people = useMemo(
+    () => Array.from(selectedPeople.values()).filter(Boolean),
+    [selectedPeople],
+  );
+  const [winnerId, setWinnerId] = useState(people[0]?.id ?? null);
+  const [loserStrategies, setLoserStrategies] = useState({});
+  const [forceUser, setForceUser] = useState(false);
+  const [confirmDestructive, setConfirmDestructive] = useState(false);
+  const [reason, setReason] = useState('');
+  const [preview, setPreview] = useState(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState('');
+
+  useEffect(() => {
+    const defaults = {};
+    for (const person of people) {
+      if (person.id !== winnerId) {
+        defaults[person.id] = 'repoint';
+      }
+    }
+    setLoserStrategies(defaults);
+    setPreview(null);
+    setPreviewError('');
+    setSubmitError('');
+  }, [winnerId, people]);
+
+  const losers = people.filter((person) => person.id !== winnerId);
+
+  const buildPayload = () => ({
+    winner_id: winnerId,
+    losers: losers.map((person) => ({
+      person_id: person.id,
+      strategy: loserStrategies[person.id] || 'repoint',
+      force_user: forceUser,
+    })),
+    confirm_destructive: confirmDestructive,
+    reason: reason.trim(),
+  });
+
+  const handlePreview = async () => {
+    if (!winnerId || losers.length === 0) return;
+    setPreviewLoading(true);
+    setPreviewError('');
+    setPreview(null);
+    try {
+      const data = await previewAdminPeopleDedupe({
+        winner_id: winnerId,
+        losers: losers.map((person) => ({
+          person_id: person.id,
+          strategy: loserStrategies[person.id] || 'repoint',
+          force_user: forceUser,
+        })),
+        confirm_destructive: confirmDestructive,
+      });
+      setPreview(data);
+      if (!data.ok) {
+        setPreviewError('Resolve the blockers below before deduping.');
+      }
+    } catch (err) {
+      const data = err?.response?.data;
+      if (data?.plans) {
+        setPreview(data);
+      }
+      setPreviewError(data?.detail || 'Preview failed.');
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
+
+  const handleApply = async () => {
+    if (!reason.trim()) {
+      setSubmitError('A reason is required.');
+      return;
+    }
+    setSubmitting(true);
+    setSubmitError('');
+    try {
+      const result = await commitAdminPeopleDedupe(buildPayload());
+      onCompleted(result);
+    } catch (err) {
+      const data = err?.response?.data;
+      if (data?.plans) {
+        setPreview(data);
+      }
+      setSubmitError(data?.detail || 'Dedupe failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const needsForceUser = preview?.plans?.some(
+    (plan) => plan.blockers?.some((blocker) => blocker.includes('different Users')),
+  );
+  const needsDestructiveConfirm = preview?.plans?.some(
+    (plan) => plan.blockers?.some((blocker) => blocker.includes('confirm_destructive')),
+  );
+
+  return (
+    <div
+      role="dialog"
+      data-testid="dedupe-people-modal"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => { if (e.target === e.currentTarget && !submitting) onClose(); }}
+    >
+      <div className="w-full max-w-3xl max-h-[90vh] overflow-y-auto rounded-xl bg-white p-5 shadow-lg dark:bg-gray-900 space-y-4">
+        <header>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Dedupe people</h2>
+          <p className="text-sm text-gray-500 mt-1">
+            Choose the canonical Person to keep, then decide how to handle each duplicate.
+          </p>
+        </header>
+
+        <section>
+          <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-2">Keep this person</h3>
+          <div className="space-y-2">
+            {people.map((person) => (
+              <label
+                key={person.id}
+                className={classNames(
+                  'flex items-start gap-3 rounded-md border p-3 cursor-pointer',
+                  winnerId === person.id
+                    ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20'
+                    : 'border-gray-200 dark:border-gray-700',
+                )}
+              >
+                <input
+                  type="radio"
+                  name="dedupe-winner"
+                  data-testid={`dedupe-winner-${person.id}`}
+                  checked={winnerId === person.id}
+                  onChange={() => setWinnerId(person.id)}
+                  className="mt-1"
+                />
+                <div className="min-w-0">
+                  <p className="font-medium text-sm">{person.full_name}</p>
+                  <p className="text-xs text-gray-500">{person.email || 'no email'}</p>
+                  <p className="text-xs text-gray-500">
+                    User: {person.has_user ? 'linked' : 'none'}
+                    {campminderId(person) ? ` · Campminder ${campminderId(person)}` : ''}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    Memberships: {(person.memberships || []).length}
+                  </p>
+                </div>
+              </label>
+            ))}
+          </div>
+        </section>
+
+        {losers.length > 0 && (
+          <section>
+            <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-2">
+              Handle duplicates
+            </h3>
+            <div className="space-y-2">
+              {losers.map((person) => (
+                <div
+                  key={person.id}
+                  data-testid={`dedupe-loser-${person.id}`}
+                  className="rounded-md border border-gray-200 dark:border-gray-700 p-3"
+                >
+                  <p className="font-medium text-sm">{person.full_name}</p>
+                  <p className="text-xs text-gray-500 mb-2">{person.email || 'no email'}</p>
+                  <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+                    Strategy
+                    <select
+                      value={loserStrategies[person.id] || 'repoint'}
+                      onChange={(e) => setLoserStrategies({
+                        ...loserStrategies,
+                        [person.id]: e.target.value,
+                      })}
+                      className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 p-2 text-sm"
+                    >
+                      <option value="repoint">Roll into winner</option>
+                      <option value="discard">Discard duplicate</option>
+                    </select>
+                  </label>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <div className="flex flex-wrap items-center gap-4">
+          {needsForceUser && (
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={forceUser}
+                onChange={(e) => setForceUser(e.target.checked)}
+                data-testid="dedupe-force-user"
+              />
+              Keep winner&apos;s login (unlink duplicate users)
+            </label>
+          )}
+          {needsDestructiveConfirm && (
+            <label className="flex items-center gap-2 text-sm text-amber-800">
+              <input
+                type="checkbox"
+                checked={confirmDestructive}
+                onChange={(e) => setConfirmDestructive(e.target.checked)}
+                data-testid="dedupe-confirm-destructive"
+              />
+              Confirm destructive delete of reflection subjects
+            </label>
+          )}
+        </div>
+
+        <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+          Reason (required)
+          <input
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            data-testid="dedupe-reason"
+            className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 p-2 text-sm"
+            placeholder="Why are these records being merged?"
+          />
+        </label>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            data-testid="dedupe-preview"
+            disabled={previewLoading || !winnerId || losers.length === 0}
+            onClick={handlePreview}
+            className="px-3 py-1.5 rounded-md text-sm border border-indigo-300 text-indigo-700 hover:bg-indigo-50 disabled:opacity-50"
+          >
+            {previewLoading ? 'Previewing…' : 'Preview changes'}
+          </button>
+        </div>
+
+        {previewError && <p className="text-sm text-red-700">{previewError}</p>}
+        {submitError && <p className="text-sm text-red-700">{submitError}</p>}
+
+        {preview?.plans?.length > 0 && (
+          <section
+            data-testid="dedupe-preview-results"
+            className="rounded-md border border-gray-200 dark:border-gray-700 p-3 space-y-3"
+          >
+            <p className="text-sm font-medium">
+              Preview {preview.ok ? 'ready' : 'blocked'}
+            </p>
+            {preview.plans.map((plan) => (
+              <div key={plan.person_id || plan.loser_id} className="text-sm space-y-1">
+                <p className="font-medium">
+                  Person #{plan.person_id || plan.loser_id}
+                  {' '}
+                  ({plan.strategy || 'repoint'})
+                </p>
+                {(plan.blockers || []).map((blocker) => (
+                  <p key={blocker} className="text-xs text-red-700">{blocker}</p>
+                ))}
+                {(plan.actions || []).map((action) => (
+                  <p key={`${action.model}-${action.description}`} className="text-xs text-gray-600">
+                    [{action.model}] {action.description}
+                  </p>
+                ))}
+              </div>
+            ))}
+          </section>
+        )}
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="text-sm text-gray-600 hover:underline disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            data-testid="dedupe-apply"
+            disabled={
+              submitting
+              || !preview?.ok
+              || !reason.trim()
+              || losers.length === 0
+            }
+            onClick={handleApply}
+            className="px-3 py-1.5 rounded-md text-sm bg-red-600 text-white disabled:opacity-50"
+          >
+            {submitting ? 'Deduping…' : 'Confirm dedupe'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/People.jsx
+++ b/frontend/src/pages/admin/People.jsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   listAdminPeople,
+  buildAdminPeopleListParams,
   getAdminPerson,
   createAdminPerson,
   patchAdminPerson,
@@ -12,6 +13,7 @@ import {
   listAdminPrograms,
 } from '../../api/admin';
 import BulkImportModal from '../../components/admin/BulkImportModal';
+import DedupePeopleModal from '../../components/admin/DedupePeopleModal';
 import { profileLink } from '../../utils/dashboardLinks';
 
 /**
@@ -30,6 +32,9 @@ const ROLE_OPTIONS = [
   'medical', 'special_diets',
   'madrich', 'faculty', 'camper',
 ];
+
+const PAGE_SIZE_OPTIONS = [25, 50, 100];
+const LAST_NAME_INITIALS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
 function classNames(...args) {
   return args.filter(Boolean).join(' ');
@@ -467,55 +472,224 @@ function AddPersonModal({ programs, onClose, onCreated }) {
   );
 }
 
+function PeopleListPagination({
+  offset,
+  resultCount,
+  totalCount,
+  loading,
+  onPrevious,
+  onNext,
+}) {
+  if (totalCount === 0) return null;
+  const start = offset + 1;
+  const end = Math.min(offset + resultCount, totalCount);
+  const hasPrevious = offset > 0;
+  const hasNext = offset + Math.max(resultCount, 1) < totalCount;
+  return (
+    <div
+      data-testid="people-list-pagination"
+      className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between text-sm text-gray-500"
+    >
+      <p>
+        Showing <span className="font-medium text-gray-700 dark:text-gray-300">{start}</span>
+        {' '}to{' '}
+        <span className="font-medium text-gray-700 dark:text-gray-300">{end}</span>
+        {' '}of{' '}
+        <span className="font-medium text-gray-700 dark:text-gray-300">{totalCount}</span>
+        {' '}· sorted A–Z by last name
+      </p>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          data-testid="people-page-previous"
+          disabled={!hasPrevious || loading}
+          onClick={onPrevious}
+          className="px-3 py-1 rounded-md border border-gray-300 bg-white text-gray-700 disabled:opacity-40 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200"
+        >
+          Previous
+        </button>
+        <button
+          type="button"
+          data-testid="people-page-next"
+          disabled={!hasNext || loading}
+          onClick={onNext}
+          className="px-3 py-1 rounded-md border border-gray-300 bg-white text-gray-700 disabled:opacity-40 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function PersonProfilePanel({
+  person,
+  programs,
+  invitedStatus,
+  onInvite,
+  onPersonChanged,
+  onDismiss,
+}) {
+  return (
+    <div
+      className="rounded-md border border-gray-200 dark:border-gray-700 p-3 bg-gray-50/50 dark:bg-gray-900/40"
+      data-testid={`person-profile-panel-${person.id}`}
+    >
+      <header className="flex items-start justify-between gap-2 mb-3">
+        <div>
+          <h2 className="text-base font-semibold">
+            <Link
+              to={profileLink(person.id)}
+              className="text-indigo-700 dark:text-indigo-300 hover:underline"
+            >
+              {person.full_name}
+            </Link>
+          </h2>
+          <p className="text-xs text-gray-500">{person.email || 'no email'}</p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <button
+            type="button"
+            data-testid={`invite-person-${person.id}`}
+            onClick={() => onInvite(person.id)}
+            disabled={!person.email || invitedStatus[person.id] === 'pending'}
+            className="text-xs px-2 py-1 rounded-md border border-indigo-300 text-indigo-700 hover:bg-indigo-50 disabled:opacity-50"
+          >
+            {invitedStatus[person.id] === 'sent' ? 'Invitation sent' : 'Send invitation'}
+          </button>
+          {onDismiss && (
+            <button
+              type="button"
+              aria-label={`Remove ${person.full_name} from selection`}
+              data-testid={`dismiss-person-${person.id}`}
+              onClick={() => onDismiss(person.id)}
+              className="text-xs px-2 py-1 rounded-md border border-gray-300 text-gray-600 hover:bg-gray-100"
+            >
+              ×
+            </button>
+          )}
+        </div>
+      </header>
+      <ProfileTabs
+        person={person}
+        programs={programs}
+        onPersonChanged={onPersonChanged}
+      />
+    </div>
+  );
+}
+
 export default function AdminPeople() {
   const [people, setPeople] = useState([]);
   const [programs, setPrograms] = useState([]);
   const [search, setSearch] = useState('');
   const [roleFilter, setRoleFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState('active');
+  const [lastNameInitial, setLastNameInitial] = useState('');
+  const [offset, setOffset] = useState(0);
+  const [pageSize, setPageSize] = useState(50);
+  const [totalCount, setTotalCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [selectedId, setSelectedId] = useState(null);
-  const [selectedPerson, setSelectedPerson] = useState(null);
+  const [selectedIds, setSelectedIds] = useState(() => new Set());
+  const [selectedPeople, setSelectedPeople] = useState(() => new Map());
   const [adding, setAdding] = useState(false);
   const [importing, setImporting] = useState(false);
+  const [deduping, setDeduping] = useState(false);
   const [invitedStatus, setInvitedStatus] = useState({});
+  const [reloadToken, setReloadToken] = useState(0);
+  const reloadPeople = () => setReloadToken((token) => token + 1);
 
-  const load = useCallback(async () => {
-    setError(null);
-    setLoading(true);
-    try {
-      const [list, progList] = await Promise.all([
-        listAdminPeople({
+  useEffect(() => {
+    const controller = new AbortController();
+    let cancelled = false;
+
+    const fetchPeople = async () => {
+      setError(null);
+      setLoading(true);
+      try {
+        const params = buildAdminPeopleListParams({
           search,
           role: roleFilter,
           status: statusFilter,
-          page_size: 100,
-        }),
-        listAdminPrograms('active'),
-      ]);
-      setPeople(list.results || []);
-      setPrograms(progList.results || []);
-    } catch (err) {
-      setError(err);
-    } finally {
-      setLoading(false);
-    }
-  }, [search, roleFilter, statusFilter]);
+          last_name_initial: lastNameInitial,
+          offset,
+          page_size: pageSize,
+        });
+        const [list, progList] = await Promise.all([
+          listAdminPeople(params, { signal: controller.signal }),
+          listAdminPrograms('active'),
+        ]);
+        if (cancelled) return;
+        setPeople(list.results || []);
+        setTotalCount(list.count ?? 0);
+        setPrograms(progList.results || []);
+      } catch (err) {
+        if (cancelled || err?.code === 'ERR_CANCELED' || err?.name === 'CanceledError') return;
+        setError(err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
 
-  useEffect(() => { load(); }, [load]);
+    fetchPeople();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [search, roleFilter, statusFilter, lastNameInitial, offset, pageSize, reloadToken]);
+
+  const resetPage = () => setOffset(0);
+  const updateSearch = (value) => {
+    setSearch(value);
+    resetPage();
+  };
 
   useEffect(() => {
-    if (selectedId == null) {
-      setSelectedPerson(null);
-      return;
+    let cancelled = false;
+    const ids = Array.from(selectedIds);
+    if (ids.length === 0) {
+      setSelectedPeople(new Map());
+      return undefined;
     }
-    getAdminPerson(selectedId).then(setSelectedPerson).catch(() => setSelectedPerson(null));
-  }, [selectedId]);
+    Promise.all(
+      ids.map(async (id) => {
+        try {
+          const person = await getAdminPerson(id);
+          return [id, person];
+        } catch {
+          return [id, null];
+        }
+      }),
+    ).then((entries) => {
+      if (cancelled) return;
+      setSelectedPeople(new Map(entries.filter(([, person]) => person)));
+    });
+    return () => { cancelled = true; };
+  }, [selectedIds]);
 
-  const refreshSelected = () => {
-    if (selectedId == null) return;
-    getAdminPerson(selectedId).then(setSelectedPerson);
+  const togglePersonSelection = (personId) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(personId)) next.delete(personId);
+      else next.add(personId);
+      return next;
+    });
+  };
+
+  const clearSelection = () => {
+    setSelectedIds(new Set());
+    setSelectedPeople(new Map());
+  };
+
+  const refreshPerson = (personId) => {
+    getAdminPerson(personId).then((person) => {
+      setSelectedPeople((prev) => {
+        const next = new Map(prev);
+        next.set(personId, person);
+        return next;
+      });
+    });
   };
 
   const handleInvite = async (personId) => {
@@ -527,6 +701,12 @@ export default function AdminPeople() {
       setInvitedStatus({ ...invitedStatus, [personId]: 'error' });
     }
   };
+
+  const selectedCount = selectedIds.size;
+  const multiSelected = selectedCount > 1;
+  const selectedProfiles = Array.from(selectedIds)
+    .map((id) => selectedPeople.get(id))
+    .filter(Boolean);
 
   return (
     <main className="grow px-4 sm:px-6 lg:px-8 py-6 w-full max-w-6xl mx-auto" data-testid="admin-people">
@@ -551,12 +731,12 @@ export default function AdminPeople() {
           </button>
         </div>
       </header>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-2 mb-4">
-        <FieldInput label="Search name or email" value={search} onChange={setSearch} />
+      <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-2 mb-4">
+        <FieldInput label="Search name or email" value={search} onChange={updateSearch} />
         <label className="block text-xs font-medium">Role
           <select
             value={roleFilter}
-            onChange={(e) => setRoleFilter(e.target.value)}
+            onChange={(e) => { setRoleFilter(e.target.value); resetPage(); }}
             className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm"
           >
             <option value="">Any</option>
@@ -566,7 +746,7 @@ export default function AdminPeople() {
         <label className="block text-xs font-medium">Status
           <select
             value={statusFilter}
-            onChange={(e) => setStatusFilter(e.target.value)}
+            onChange={(e) => { setStatusFilter(e.target.value); resetPage(); }}
             className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm"
           >
             <option value="active">Active</option>
@@ -574,9 +754,59 @@ export default function AdminPeople() {
             <option value="">All</option>
           </select>
         </label>
+        <label className="block text-xs font-medium">Last name starts with
+          <select
+            value={lastNameInitial}
+            onChange={(e) => { setLastNameInitial(e.target.value); resetPage(); }}
+            data-testid="last-name-initial-filter"
+            className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm"
+          >
+            <option value="">Any letter</option>
+            {LAST_NAME_INITIALS.map((letter) => (
+              <option key={letter} value={letter}>{letter}</option>
+            ))}
+          </select>
+        </label>
+        <label className="block text-xs font-medium">Per page
+          <select
+            value={pageSize}
+            onChange={(e) => { setPageSize(Number(e.target.value)); resetPage(); }}
+            data-testid="people-page-size"
+            className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm"
+          >
+            {PAGE_SIZE_OPTIONS.map((size) => (
+              <option key={size} value={size}>{size}</option>
+            ))}
+          </select>
+        </label>
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <section data-testid="people-list" className="space-y-2">
+      {selectedCount > 0 && (
+        <div
+          data-testid="people-selection-toolbar"
+          className="mb-4 flex flex-wrap items-center gap-3 rounded-md border border-indigo-200 bg-indigo-50 px-3 py-2 text-sm dark:border-indigo-800 dark:bg-indigo-900/20"
+        >
+          <span>{selectedCount} selected</span>
+          <button
+            type="button"
+            data-testid="open-dedupe"
+            disabled={selectedCount < 2}
+            onClick={() => setDeduping(true)}
+            className="px-3 py-1 rounded-md bg-red-600 text-white disabled:opacity-50"
+          >
+            Dedupe
+          </button>
+          <button
+            type="button"
+            data-testid="clear-people-selection"
+            onClick={clearSelection}
+            className="text-indigo-700 hover:underline dark:text-indigo-300"
+          >
+            Clear
+          </button>
+        </div>
+      )}
+      <div className={classNames('grid grid-cols-1 gap-4', multiSelected ? 'md:grid-cols-5' : 'md:grid-cols-2')}>
+        <section data-testid="people-list" className={classNames('space-y-2', multiSelected && 'md:col-span-2')}>
           {loading ? (
             <p className="text-sm text-gray-500">Loading…</p>
           ) : error ? (
@@ -591,54 +821,68 @@ export default function AdminPeople() {
                   key={p.id}
                   data-testid={`person-row-${p.id}`}
                   className={classNames(
-                    'p-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800',
-                    selectedId === p.id && 'bg-indigo-50 dark:bg-indigo-900/20',
+                    'p-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 flex items-start gap-3',
+                    selectedIds.has(p.id) && 'bg-indigo-50 dark:bg-indigo-900/20',
                   )}
-                  onClick={() => setSelectedId(p.id)}
+                  onClick={() => togglePersonSelection(p.id)}
                 >
-                  <Link
-                    to={profileLink(p.id)}
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.has(p.id)}
+                    onChange={() => togglePersonSelection(p.id)}
                     onClick={(e) => e.stopPropagation()}
-                    className="font-medium text-sm text-indigo-700 dark:text-indigo-300 hover:underline"
-                  >
-                    {p.full_name}
-                  </Link>
-                  <p className="text-xs text-gray-500">{p.email || 'no email'}</p>
+                    data-testid={`person-select-${p.id}`}
+                    className="mt-1"
+                    aria-label={`Select ${p.full_name}`}
+                  />
+                  <div className="min-w-0">
+                    <Link
+                      to={profileLink(p.id)}
+                      onClick={(e) => e.stopPropagation()}
+                      className="font-medium text-sm text-indigo-700 dark:text-indigo-300 hover:underline"
+                    >
+                      {p.full_name}
+                    </Link>
+                    <p className="text-xs text-gray-500">{p.email || 'no email'}</p>
+                  </div>
                 </li>
               ))}
             </ul>
           )}
+          {!loading && !error && (
+            <PeopleListPagination
+              offset={offset}
+              resultCount={people.length}
+              totalCount={totalCount}
+              loading={loading}
+              onPrevious={() => setOffset((prev) => Math.max(0, prev - pageSize))}
+              onNext={() => setOffset((prev) => prev + pageSize)}
+            />
+          )}
         </section>
-        <aside data-testid="person-drawer" className="rounded-md border bg-white dark:bg-gray-900 p-4">
-          {!selectedPerson ? (
+        <aside
+          data-testid="person-drawer"
+          className={classNames(
+            'rounded-md border bg-white dark:bg-gray-900 p-4',
+            multiSelected && 'md:col-span-3',
+          )}
+        >
+          {selectedCount === 0 ? (
             <p className="text-sm italic text-gray-500">Select a Person to view their profile.</p>
           ) : (
-            <>
-              <header className="flex items-center justify-between mb-3">
-                <h2 className="text-lg font-semibold">
-                  <Link
-                    to={profileLink(selectedPerson.id)}
-                    className="text-indigo-700 dark:text-indigo-300 hover:underline"
-                  >
-                    {selectedPerson.full_name}
-                  </Link>
-                </h2>
-                <button
-                  type="button"
-                  data-testid="invite-person"
-                  onClick={() => handleInvite(selectedPerson.id)}
-                  disabled={!selectedPerson.email || invitedStatus[selectedPerson.id] === 'pending'}
-                  className="text-xs px-2 py-1 rounded-md border border-indigo-300 text-indigo-700 hover:bg-indigo-50 disabled:opacity-50"
-                >
-                  {invitedStatus[selectedPerson.id] === 'sent' ? 'Invitation sent' : 'Send invitation'}
-                </button>
-              </header>
-              <ProfileTabs
-                person={selectedPerson}
-                programs={programs}
-                onPersonChanged={refreshSelected}
-              />
-            </>
+            <div className="max-h-[70vh] overflow-y-auto space-y-4">
+              {selectedProfiles.map((person) => (
+                <PersonProfilePanel
+                  key={person.id}
+                  person={person}
+                  programs={programs}
+                  invitedStatus={invitedStatus}
+                  onInvite={handleInvite}
+                  onPersonChanged={() => refreshPerson(person.id)}
+                  onDismiss={multiSelected ? (personId) => togglePersonSelection(personId) : null}
+                />
+              ))}
+            </div>
           )}
         </aside>
       </div>
@@ -648,15 +892,30 @@ export default function AdminPeople() {
           onClose={() => setAdding(false)}
           onCreated={(person) => {
             setAdding(false);
-            load();
-            if (person?.id) setSelectedId(person.id);
+            reloadPeople();
+            if (person?.id) setSelectedIds(new Set([person.id]));
+          }}
+        />
+      )}
+      {deduping && (
+        <DedupePeopleModal
+          selectedPeople={selectedPeople}
+          onClose={() => setDeduping(false)}
+          onCompleted={(result) => {
+            setDeduping(false);
+            reloadPeople();
+            if (result?.winner_id) {
+              setSelectedIds(new Set([result.winner_id]));
+            } else {
+              clearSelection();
+            }
           }}
         />
       )}
       {importing && (
         <BulkImportModal
           programs={programs}
-          onClose={() => { setImporting(false); load(); }}
+          onClose={() => { setImporting(false); reloadPeople(); }}
         />
       )}
     </main>

--- a/frontend/src/pages/admin/__tests__/Assignments.test.jsx
+++ b/frontend/src/pages/admin/__tests__/Assignments.test.jsx
@@ -82,7 +82,7 @@ describe('AdminAssignments', () => {
 
   it('passes filter params when listing assignments', async () => {
     render(<AdminAssignments />);
-    await screen.findByTestId('assignment-filter-bar');
+    await screen.findByTestId('assignment-program-chip-1');
 
     fireEvent.click(screen.getByTestId('assignment-program-chip-1'));
 

--- a/frontend/src/pages/admin/__tests__/People.test.jsx
+++ b/frontend/src/pages/admin/__tests__/People.test.jsx
@@ -2,16 +2,37 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
-vi.mock('../../../api/admin', () => ({
-  listAdminPeople: vi.fn(),
-  getAdminPerson: vi.fn(),
-  createAdminPerson: vi.fn(),
-  patchAdminPerson: vi.fn(),
-  addAdminMembership: vi.fn(),
-  patchAdminMembership: vi.fn(),
-  deactivateAdminMembership: vi.fn(),
-  inviteAdminPerson: vi.fn(),
-  listAdminPrograms: vi.fn(),
+vi.mock('../../../api/admin', async () => {
+  const actual = await vi.importActual('../../../api/admin');
+  return {
+    ...actual,
+    listAdminPeople: vi.fn(),
+    getAdminPerson: vi.fn(),
+    createAdminPerson: vi.fn(),
+    patchAdminPerson: vi.fn(),
+    addAdminMembership: vi.fn(),
+    patchAdminMembership: vi.fn(),
+    deactivateAdminMembership: vi.fn(),
+    inviteAdminPerson: vi.fn(),
+    listAdminPrograms: vi.fn(),
+    previewAdminPeopleDedupe: vi.fn(),
+    commitAdminPeopleDedupe: vi.fn(),
+  };
+});
+
+vi.mock('../../../components/admin/DedupePeopleModal', () => ({
+  default: ({ onClose, onCompleted }) => (
+    <div data-testid="dedupe-people-modal">
+      <button type="button" data-testid="dedupe-modal-close" onClick={onClose}>Close</button>
+      <button
+        type="button"
+        data-testid="dedupe-modal-complete"
+        onClick={() => onCompleted({ winner_id: 1 })}
+      >
+        Complete
+      </button>
+    </div>
+  ),
 }));
 
 import {
@@ -19,6 +40,7 @@ import {
   getAdminPerson,
   createAdminPerson,
   listAdminPrograms,
+  previewAdminPeopleDedupe,
 } from '../../../api/admin';
 import AdminPeople from '../People';
 
@@ -39,17 +61,36 @@ const ALICE_DETAIL = {
   last_name: 'Admin',
   preferred_name: '',
   preferred_language: 'en',
+  has_user: true,
+  external_ids: { campminder_id: '111' },
   memberships: [
     { id: 100, role: 'counselor', program_name: 'Summer 2026', tags: ['veteran'], is_active: true },
   ],
   recent_activity: [],
 };
 
+const BOB_DETAIL = {
+  id: 2,
+  full_name: 'Bob Counselor',
+  email: 'b@example.com',
+  first_name: 'Bob',
+  last_name: 'Counselor',
+  preferred_name: '',
+  preferred_language: 'en',
+  has_user: false,
+  external_ids: {},
+  memberships: [],
+  recent_activity: [],
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
-  listAdminPeople.mockResolvedValue({ results: PEOPLE });
+  listAdminPeople.mockResolvedValue({ results: PEOPLE, count: 2, offset: 0, page_size: 50 });
   listAdminPrograms.mockResolvedValue({ results: PROGRAMS });
-  getAdminPerson.mockResolvedValue(ALICE_DETAIL);
+  getAdminPerson.mockImplementation(async (id) => (
+    id === 1 ? ALICE_DETAIL : BOB_DETAIL
+  ));
+  previewAdminPeopleDedupe.mockResolvedValue({ ok: true, plans: [] });
 });
 
 function renderPeople() {
@@ -76,6 +117,31 @@ describe('AdminPeople (7_13 PR2)', () => {
     expect(screen.getByTestId('identity-tab')).toBeInTheDocument();
   });
 
+  it('stacks multiple selected profiles in the drawer', async () => {
+    renderPeople();
+    await screen.findByTestId('person-row-1');
+
+    fireEvent.click(screen.getByTestId('person-select-1'));
+    fireEvent.click(screen.getByTestId('person-select-2'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('person-profile-panel-1')).toBeInTheDocument();
+      expect(screen.getByTestId('person-profile-panel-2')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('people-selection-toolbar')).toHaveTextContent('2 selected');
+  });
+
+  it('opens the dedupe modal when Dedupe is clicked', async () => {
+    renderPeople();
+    await screen.findByTestId('person-row-1');
+    fireEvent.click(screen.getByTestId('person-select-1'));
+    fireEvent.click(screen.getByTestId('person-select-2'));
+    await screen.findByTestId('people-selection-toolbar');
+
+    fireEvent.click(screen.getByTestId('open-dedupe'));
+    expect(await screen.findByTestId('dedupe-people-modal')).toBeInTheDocument();
+  });
+
   it('surfaces the email-conflict response from POST /admin/people/', async () => {
     createAdminPerson.mockRejectedValueOnce({
       response: {
@@ -94,5 +160,64 @@ describe('AdminPeople (7_13 PR2)', () => {
     fireEvent.click(screen.getByTestId('add-person-save'));
 
     expect(await screen.findByTestId('add-person-conflict')).toBeInTheDocument();
+  });
+
+  it('paginates the people list and passes filter params to the API', async () => {
+    listAdminPeople.mockImplementation(async (params = {}) => {
+      if (params.last_name_initial === 'B') {
+        return {
+          results: [PEOPLE[1]],
+          count: 1,
+          offset: 0,
+          page_size: params.page_size ?? 50,
+        };
+      }
+      if ((params.offset ?? 0) >= 50) {
+        return {
+          results: [PEOPLE[1]],
+          count: 75,
+          offset: params.offset,
+          page_size: params.page_size ?? 50,
+        };
+      }
+      return {
+        results: [PEOPLE[0]],
+        count: 75,
+        offset: params.offset ?? 0,
+        page_size: params.page_size ?? 50,
+      };
+    });
+
+    renderPeople();
+    await screen.findByTestId('people-list-pagination');
+    expect(screen.getByTestId('people-list-pagination')).toHaveTextContent('Showing 1 to 1 of 75');
+    expect(screen.getByTestId('people-page-next')).not.toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('last-name-initial-filter'), { target: { value: 'B' } });
+    await waitFor(() => {
+      expect(listAdminPeople).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          last_name_initial: 'B',
+          offset: 0,
+        }),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+    expect(await screen.findByTestId('people-list-pagination')).toHaveTextContent('Showing 1 to 1 of 1');
+
+    fireEvent.change(screen.getByTestId('last-name-initial-filter'), { target: { value: '' } });
+    await screen.findByTestId('people-page-next');
+    fireEvent.click(screen.getByTestId('people-page-next'));
+    await waitFor(() => {
+      expect(listAdminPeople).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          offset: 50,
+          page_size: 50,
+        }),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+    expect(await screen.findByTestId('person-row-2')).toBeInTheDocument();
+    expect(screen.getByTestId('people-list-pagination')).toHaveTextContent('Showing 51 to 51 of 75');
   });
 });


### PR DESCRIPTION
## Summary
- Add admin People dedupe flow: multi-select compare, preview/apply API endpoints, and a modal to pick a winner with per-loser repoint/discard strategies (audited).
- Paginate the People list (25/50/100 per page) with Previous/Next controls and a last-name letter filter; abort in-flight fetches so stale pages do not overwrite filtered results.
- Include the pending `merge_persons --force-user` dry-run/apply fix and a flaky Assignments filter test stabilization from the same branch.

## Test plan
- [ ] Admin People: paginate through a large roster; confirm count and range text update
- [ ] Admin People: filter by last-name letter; confirm total drops and all visible rows match
- [ ] Admin People: select 2+ duplicates, open Dedupe, preview, apply with reason; winner remains selected
- [ ] `make test-backend` — dedupe API + person_merge tests pass
- [ ] `make test-frontend` — People.test.jsx passes


Made with [Cursor](https://cursor.com)