### PR TITLE
feat: admin Person delete and dedupe login conflict UX

### DIFF
--- a/backend/bunk_logs/api/admin_flow/people.py
+++ b/backend/bunk_logs/api/admin_flow/people.py
@@ -86,6 +86,7 @@ def _serialize_person(person: Person, *, include_memberships: bool = False) -> d
         "translation_preference": person.translation_preference,
         "external_ids": person.external_ids or {},
         "has_user": person.user_id is not None,
+        "user_id": person.user_id,
         "created_at": person.created_at.isoformat() if person.created_at else None,
     }
     if include_memberships:

--- a/backend/bunk_logs/api/admin_flow/people_delete.py
+++ b/backend/bunk_logs/api/admin_flow/people_delete.py
@@ -1,0 +1,90 @@
+"""Admin Person delete — preview and apply discard without merging to a winner."""
+
+from __future__ import annotations
+
+from django.db import transaction
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bunk_logs.core import audit as audit_module
+from bunk_logs.core.permissions import IsOrgAdminOrSuperuser
+from bunk_logs.core.person_merge import discard_person
+from bunk_logs.core.person_merge import plan_discard_person
+from bunk_logs.core.person_merge import serialize_discard_plan
+
+from .common import viewer_or_403
+from .people import _get_person_or_404
+from .people import _not_found
+from .people import _person_snapshot
+from .people import _serialize_person
+
+
+def _build_delete_response(*, person, plan) -> dict:
+    payload = serialize_discard_plan(plan)
+    payload["person_id"] = person.pk
+    payload["person"] = _serialize_person(person, include_memberships=True)
+    return payload
+
+
+class AdminPersonDeletePreviewView(APIView):
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def post(self, request, person_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        person = _get_person_or_404(ctx, person_id)
+        if person is None:
+            return _not_found("Person")
+
+        confirm_destructive = bool((request.data or {}).get("confirm_destructive"))
+        plan = plan_discard_person(person=person, confirm_destructive=confirm_destructive)
+        payload = _build_delete_response(person=person, plan=plan)
+        if not plan.ok:
+            return Response(payload, status=status.HTTP_409_CONFLICT)
+        return Response(payload)
+
+
+class AdminPersonDeleteApplyView(APIView):
+    permission_classes = [IsOrgAdminOrSuperuser]
+
+    def post(self, request, person_id, *args, **kwargs):
+        ctx = viewer_or_403(request)
+        person = _get_person_or_404(ctx, person_id)
+        if person is None:
+            return _not_found("Person")
+
+        data = request.data or {}
+        reason = (data.get("reason") or "").strip()
+        if not reason:
+            return Response({"detail": "reason is required."}, status=status.HTTP_400_BAD_REQUEST)
+
+        confirm_destructive = bool(data.get("confirm_destructive"))
+        plan = plan_discard_person(person=person, confirm_destructive=confirm_destructive)
+        if not plan.ok:
+            payload = _build_delete_response(person=person, plan=plan)
+            return Response(payload, status=status.HTTP_409_CONFLICT)
+
+        before = _person_snapshot(person)
+        actor = ctx.membership or request.user
+        deleted_id = person.pk
+
+        try:
+            with transaction.atomic():
+                audit_module.override_edit(
+                    actor,
+                    person,
+                    before,
+                    {"deleted": True},
+                    reason=reason,
+                    content_type="person_delete",
+                    metadata={
+                        "person_id": deleted_id,
+                        "impact_counts": dict(plan.impact_counts),
+                        "plan": serialize_discard_plan(plan),
+                    },
+                )
+                discard_person(person=person, confirm_destructive=confirm_destructive)
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_409_CONFLICT)
+
+        return Response({"ok": True, "person_id": deleted_id, "deleted": True})

--- a/backend/bunk_logs/api/admin_flow/urls.py
+++ b/backend/bunk_logs/api/admin_flow/urls.py
@@ -24,6 +24,8 @@ from .people import AdminPersonInviteView
 from .people import AdminPersonMembershipsView
 from .people_dedupe import AdminPeopleDedupeApplyView
 from .people_dedupe import AdminPeopleDedupePreviewView
+from .people_delete import AdminPersonDeleteApplyView
+from .people_delete import AdminPersonDeletePreviewView
 from .programs import AdminProgramDetailView
 from .programs import AdminProgramEndView
 from .programs import AdminProgramsListCreateView
@@ -72,6 +74,16 @@ urlpatterns = [
         "people/dedupe/",
         AdminPeopleDedupeApplyView.as_view(),
         name="admin-people-dedupe",
+    ),
+    path(
+        "people/<int:person_id>/delete/preview/",
+        AdminPersonDeletePreviewView.as_view(),
+        name="admin-person-delete-preview",
+    ),
+    path(
+        "people/<int:person_id>/delete/",
+        AdminPersonDeleteApplyView.as_view(),
+        name="admin-person-delete",
     ),
     path(
         "memberships/<int:membership_id>/",

--- a/backend/bunk_logs/api/tests/test_admin_people_delete.py
+++ b/backend/bunk_logs/api/tests/test_admin_people_delete.py
@@ -1,0 +1,160 @@
+"""API tests for admin Person delete preview/apply."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from bunk_logs.core.context import organization_context
+from bunk_logs.core.models import AuditEvent
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Person
+from bunk_logs.core.models import Program
+from bunk_logs.core.models import Reflection
+from bunk_logs.core.models import ReflectionTemplate
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def _hdr(slug: str) -> dict:
+    return {"HTTP_X_ORGANIZATION_SLUG": slug}
+
+
+@pytest.fixture
+def api() -> APIClient:
+    return APIClient()
+
+
+@pytest.fixture
+def org():
+    return Organization.objects.create(name="Delete Org", slug="delete-org")
+
+
+@pytest.fixture
+def program(org):
+    from datetime import date as d
+
+    return Program.all_objects.create(
+        organization=org,
+        name="Delete Org Summer",
+        slug="delete-org-summer",
+        program_type="summer_camp",
+        start_date=d(2026, 6, 1),
+        end_date=d(2026, 8, 31),
+    )
+
+
+@pytest.fixture
+def admin_user(org, program):
+    u = User.objects.create_user(email="admin-delete@example.com", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="Ad", last_name="Min", user=u,
+    )
+    Membership.all_objects.create(
+        program=program, person=person, role="admin", is_active=True,
+    )
+    return u
+
+
+class TestAdminPersonDelete:
+    def test_non_admin_blocked(self, api, org, program):
+        u = User.objects.create_user(email="other-delete@example.com", password="pw")
+        person = Person.all_objects.create(
+            organization=org, first_name="Co", last_name="Un", user=u,
+        )
+        Membership.all_objects.create(
+            program=program, person=person, role="counselor", is_active=True,
+        )
+        target = Person.all_objects.create(
+            organization=org, first_name="Tar", last_name="Get",
+        )
+        api.force_authenticate(user=u)
+        with organization_context(org):
+            r = api.post(
+                f"/api/v1/admin/people/{target.id}/delete/preview/",
+                {},
+                format="json",
+                **_hdr(org.slug),
+            )
+        assert r.status_code == 403
+
+    def test_delete_person(self, api, org, program, admin_user):
+        target = Person.all_objects.create(
+            organization=org, first_name="Dup", last_name="Licate", email="dup@example.com",
+        )
+        Membership.all_objects.create(
+            program=program, person=target, role="counselor", is_active=True,
+        )
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            preview = api.post(
+                f"/api/v1/admin/people/{target.id}/delete/preview/",
+                {},
+                format="json",
+                **_hdr(org.slug),
+            )
+        assert preview.status_code == 200, preview.content
+        assert preview.json()["ok"] is True
+
+        with organization_context(org):
+            applied = api.post(
+                f"/api/v1/admin/people/{target.id}/delete/",
+                {"reason": "Duplicate import row"},
+                format="json",
+                **_hdr(org.slug),
+            )
+        assert applied.status_code == 200, applied.content
+        assert not Person.all_objects.filter(pk=target.id).exists()
+        assert AuditEvent.all_objects.filter(content_type="person_delete").exists()
+
+    def test_delete_blocked_without_confirm_destructive(
+        self, api, org, program, admin_user,
+    ):
+        target = Person.all_objects.create(
+            organization=org, first_name="Cam", last_name="Per",
+        )
+        author = Person.all_objects.create(
+            organization=org, first_name="Auth", last_name="Or",
+        )
+        template = ReflectionTemplate.all_objects.create(
+            organization=org,
+            name="Delete Org Daily",
+            slug="daily",
+            cadence="daily",
+            schema={"fields": []},
+        )
+        Reflection.all_objects.create(
+            organization=org,
+            program=program,
+            subject=target,
+            author=author,
+            template=template,
+            period_start=date(2026, 7, 1),
+            period_end=date(2026, 7, 7),
+            answers={},
+        )
+
+        api.force_authenticate(user=admin_user)
+        with organization_context(org):
+            blocked = api.post(
+                f"/api/v1/admin/people/{target.id}/delete/",
+                {"reason": "Remove duplicate camper row"},
+                format="json",
+                **_hdr(org.slug),
+            )
+        assert blocked.status_code == 409
+
+        with organization_context(org):
+            applied = api.post(
+                f"/api/v1/admin/people/{target.id}/delete/",
+                {"reason": "Remove duplicate camper row", "confirm_destructive": True},
+                format="json",
+                **_hdr(org.slug),
+            )
+        assert applied.status_code == 200, applied.content
+        assert not Person.all_objects.filter(pk=target.id).exists()

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -101,6 +101,16 @@ export async function commitAdminPeopleDedupe(payload) {
   return resp?.data ?? null;
 }
 
+export async function previewAdminPersonDelete(personId, payload = {}) {
+  const resp = await api.post(`${ADMIN_BASE}/people/${personId}/delete/preview/`, payload);
+  return resp?.data ?? null;
+}
+
+export async function commitAdminPersonDelete(personId, payload) {
+  const resp = await api.post(`${ADMIN_BASE}/people/${personId}/delete/`, payload);
+  return resp?.data ?? null;
+}
+
 // ---------------------------------------------------------------------------
 // Assignments (Story 56)
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/admin/DedupePeopleModal.jsx
+++ b/frontend/src/components/admin/DedupePeopleModal.jsx
@@ -12,6 +12,22 @@ function campminderId(person) {
   return person?.external_ids?.campminder_id || '';
 }
 
+function hasUserConflictBlocker(plans) {
+  return (plans || []).some(
+    (plan) => plan.blockers?.some((blocker) => blocker.includes('different Users')),
+  );
+}
+
+function repointLosersWithUsers(people, winnerId, loserStrategies) {
+  const winner = people.find((person) => person.id === winnerId);
+  if (!winner?.has_user) return false;
+  return people.some(
+    (person) => person.id !== winnerId
+      && person.has_user
+      && (loserStrategies[person.id] || 'repoint') === 'repoint',
+  );
+}
+
 /**
  * Modal for merging duplicate Person records selected on the Admin People page.
  */
@@ -78,14 +94,24 @@ export default function DedupePeopleModal({
       });
       setPreview(data);
       if (!data.ok) {
-        setPreviewError('Resolve the blockers below before deduping.');
+        setPreviewError(
+          hasUserConflictBlocker(data.plans)
+            ? 'Both records have separate logins. Enable "Keep winner\'s login" and preview again.'
+            : 'Resolve the blockers below before deduping.',
+        );
       }
     } catch (err) {
       const data = err?.response?.data;
       if (data?.plans) {
         setPreview(data);
+        setPreviewError(
+          hasUserConflictBlocker(data.plans)
+            ? 'Both records have separate logins. Enable "Keep winner\'s login" and preview again.'
+            : 'Resolve the blockers below before deduping.',
+        );
+      } else {
+        setPreviewError(data?.detail || 'Preview failed.');
       }
-      setPreviewError(data?.detail || 'Preview failed.');
     } finally {
       setPreviewLoading(false);
     }
@@ -112,9 +138,9 @@ export default function DedupePeopleModal({
     }
   };
 
-  const needsForceUser = preview?.plans?.some(
-    (plan) => plan.blockers?.some((blocker) => blocker.includes('different Users')),
-  );
+  const needsForceUser = hasUserConflictBlocker(preview?.plans);
+  const showForceUserOption = repointLosersWithUsers(people, winnerId, loserStrategies)
+    || needsForceUser;
   const needsDestructiveConfirm = preview?.plans?.some(
     (plan) => plan.blockers?.some((blocker) => blocker.includes('confirm_destructive')),
   );
@@ -159,7 +185,7 @@ export default function DedupePeopleModal({
                   <p className="font-medium text-sm">{person.full_name}</p>
                   <p className="text-xs text-gray-500">{person.email || 'no email'}</p>
                   <p className="text-xs text-gray-500">
-                    User: {person.has_user ? 'linked' : 'none'}
+                    Login: {person.has_user ? `User #${person.user_id}` : 'none'}
                     {campminderId(person) ? ` · Campminder ${campminderId(person)}` : ''}
                   </p>
                   <p className="text-xs text-gray-500">
@@ -205,17 +231,28 @@ export default function DedupePeopleModal({
           </section>
         )}
 
-        <div className="flex flex-wrap items-center gap-4">
-          {needsForceUser && (
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={forceUser}
-                onChange={(e) => setForceUser(e.target.checked)}
-                data-testid="dedupe-force-user"
-              />
-              Keep winner&apos;s login (unlink duplicate users)
-            </label>
+        <div className="flex flex-col gap-3">
+          {showForceUserOption && (
+            <div
+              data-testid="dedupe-force-user-panel"
+              className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-100"
+            >
+              <p className="font-medium">Separate login accounts detected</p>
+              <p className="text-xs mt-1">
+                The winner and duplicate each have a User record. To roll the duplicate into the
+                winner, keep one login and unlink the loser&apos;s User before deleting Person #
+                {losers.map((person) => person.id).join(', ')}.
+              </p>
+              <label className="mt-2 flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={forceUser}
+                  onChange={(e) => setForceUser(e.target.checked)}
+                  data-testid="dedupe-force-user"
+                />
+                Keep winner&apos;s login (unlink duplicate users)
+              </label>
+            </div>
           )}
           {needsDestructiveConfirm && (
             <label className="flex items-center gap-2 text-sm text-amber-800">

--- a/frontend/src/components/admin/DeletePersonModal.jsx
+++ b/frontend/src/components/admin/DeletePersonModal.jsx
@@ -1,0 +1,170 @@
+import { useState } from 'react';
+import {
+  previewAdminPersonDelete,
+  commitAdminPersonDelete,
+} from '../../api/admin';
+
+/**
+ * Modal for permanently deleting a Person from the admin People page.
+ */
+export default function DeletePersonModal({ person, onClose, onCompleted }) {
+  const [confirmDestructive, setConfirmDestructive] = useState(false);
+  const [reason, setReason] = useState('');
+  const [preview, setPreview] = useState(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState('');
+
+  const needsDestructiveConfirm = preview?.blockers?.some(
+    (blocker) => blocker.includes('confirm_destructive'),
+  );
+
+  const handlePreview = async () => {
+    setPreviewLoading(true);
+    setPreviewError('');
+    setPreview(null);
+    try {
+      const data = await previewAdminPersonDelete(person.id, {
+        confirm_destructive: confirmDestructive,
+      });
+      setPreview(data);
+      if (!data.ok) {
+        setPreviewError('Resolve the blockers below before deleting.');
+      }
+    } catch (err) {
+      const data = err?.response?.data;
+      if (data?.person_id) {
+        setPreview(data);
+      }
+      setPreviewError(data?.detail || 'Preview failed.');
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!reason.trim()) {
+      setSubmitError('A reason is required.');
+      return;
+    }
+    setSubmitting(true);
+    setSubmitError('');
+    try {
+      const result = await commitAdminPersonDelete(person.id, {
+        reason: reason.trim(),
+        confirm_destructive: confirmDestructive,
+      });
+      onCompleted(result);
+    } catch (err) {
+      const data = err?.response?.data;
+      if (data?.person_id) {
+        setPreview(data);
+      }
+      setSubmitError(data?.detail || 'Delete failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      data-testid="delete-person-modal"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => { if (e.target === e.currentTarget && !submitting) onClose(); }}
+    >
+      <div className="w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-xl bg-white p-5 shadow-lg dark:bg-gray-900 space-y-4">
+        <header>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Delete person</h2>
+          <p className="text-sm text-gray-500 mt-1">
+            Permanently remove <strong>{person.full_name}</strong> (Person #{person.id}).
+            Active memberships are deactivated first; linked content may be removed.
+          </p>
+        </header>
+
+        {needsDestructiveConfirm && (
+          <label
+            className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-100"
+          >
+            <input
+              type="checkbox"
+              checked={confirmDestructive}
+              onChange={(e) => setConfirmDestructive(e.target.checked)}
+              data-testid="delete-confirm-destructive"
+              className="mt-0.5"
+            />
+            <span>
+              This person is the subject of reflections. Confirm destructive delete of that data.
+            </span>
+          </label>
+        )}
+
+        <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+          Reason (required)
+          <input
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            data-testid="delete-person-reason"
+            className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 p-2 text-sm"
+            placeholder="Why is this record being deleted?"
+          />
+        </label>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            data-testid="delete-person-preview"
+            disabled={previewLoading}
+            onClick={handlePreview}
+            className="px-3 py-1.5 rounded-md text-sm border border-indigo-300 text-indigo-700 hover:bg-indigo-50 disabled:opacity-50"
+          >
+            {previewLoading ? 'Previewing…' : 'Preview delete'}
+          </button>
+        </div>
+
+        {previewError && <p className="text-sm text-red-700">{previewError}</p>}
+        {submitError && <p className="text-sm text-red-700">{submitError}</p>}
+
+        {preview && (
+          <section
+            data-testid="delete-person-preview-results"
+            className="rounded-md border border-gray-200 dark:border-gray-700 p-3 space-y-2 text-sm"
+          >
+            <p className="font-medium">
+              Preview {preview.ok ? 'ready' : 'blocked'}
+            </p>
+            {(preview.blockers || []).map((blocker) => (
+              <p key={blocker} className="text-xs text-red-700">{blocker}</p>
+            ))}
+            {(preview.actions || []).map((action) => (
+              <p key={`${action.model}-${action.description}`} className="text-xs text-gray-600">
+                [{action.model}] {action.description}
+              </p>
+            ))}
+          </section>
+        )}
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="text-sm text-gray-600 hover:underline disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            data-testid="delete-person-confirm"
+            disabled={submitting || !preview?.ok || !reason.trim()}
+            onClick={handleDelete}
+            className="px-3 py-1.5 rounded-md text-sm bg-red-600 text-white disabled:opacity-50"
+          >
+            {submitting ? 'Deleting…' : 'Delete person'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/People.jsx
+++ b/frontend/src/pages/admin/People.jsx
@@ -14,6 +14,7 @@ import {
 } from '../../api/admin';
 import BulkImportModal from '../../components/admin/BulkImportModal';
 import DedupePeopleModal from '../../components/admin/DedupePeopleModal';
+import DeletePersonModal from '../../components/admin/DeletePersonModal';
 import { profileLink } from '../../utils/dashboardLinks';
 
 /**
@@ -527,6 +528,7 @@ function PersonProfilePanel({
   programs,
   invitedStatus,
   onInvite,
+  onDelete,
   onPersonChanged,
   onDismiss,
 }) {
@@ -548,6 +550,14 @@ function PersonProfilePanel({
           <p className="text-xs text-gray-500">{person.email || 'no email'}</p>
         </div>
         <div className="flex items-center gap-2 shrink-0">
+          <button
+            type="button"
+            data-testid={`delete-person-${person.id}`}
+            onClick={() => onDelete(person)}
+            className="text-xs px-2 py-1 rounded-md border border-red-300 text-red-700 hover:bg-red-50"
+          >
+            Delete
+          </button>
           <button
             type="button"
             data-testid={`invite-person-${person.id}`}
@@ -596,6 +606,7 @@ export default function AdminPeople() {
   const [adding, setAdding] = useState(false);
   const [importing, setImporting] = useState(false);
   const [deduping, setDeduping] = useState(false);
+  const [deletingPerson, setDeletingPerson] = useState(null);
   const [invitedStatus, setInvitedStatus] = useState({});
   const [reloadToken, setReloadToken] = useState(0);
   const reloadPeople = () => setReloadToken((token) => token + 1);
@@ -878,6 +889,7 @@ export default function AdminPeople() {
                   programs={programs}
                   invitedStatus={invitedStatus}
                   onInvite={handleInvite}
+                  onDelete={setDeletingPerson}
                   onPersonChanged={() => refreshPerson(person.id)}
                   onDismiss={multiSelected ? (personId) => togglePersonSelection(personId) : null}
                 />
@@ -908,6 +920,28 @@ export default function AdminPeople() {
               setSelectedIds(new Set([result.winner_id]));
             } else {
               clearSelection();
+            }
+          }}
+        />
+      )}
+      {deletingPerson && (
+        <DeletePersonModal
+          person={deletingPerson}
+          onClose={() => setDeletingPerson(null)}
+          onCompleted={(result) => {
+            setDeletingPerson(null);
+            reloadPeople();
+            if (result?.person_id) {
+              setSelectedIds((prev) => {
+                const next = new Set(prev);
+                next.delete(result.person_id);
+                return next;
+              });
+              setSelectedPeople((prev) => {
+                const next = new Map(prev);
+                next.delete(result.person_id);
+                return next;
+              });
             }
           }}
         />

--- a/frontend/src/pages/admin/__tests__/People.test.jsx
+++ b/frontend/src/pages/admin/__tests__/People.test.jsx
@@ -35,6 +35,22 @@ vi.mock('../../../components/admin/DedupePeopleModal', () => ({
   ),
 }));
 
+vi.mock('../../../components/admin/DeletePersonModal', () => ({
+  default: ({ person, onClose, onCompleted }) => (
+    <div data-testid="delete-person-modal">
+      <span>{person.full_name}</span>
+      <button type="button" data-testid="delete-modal-close" onClick={onClose}>Close</button>
+      <button
+        type="button"
+        data-testid="delete-modal-complete"
+        onClick={() => onCompleted({ person_id: person.id })}
+      >
+        Complete
+      </button>
+    </div>
+  ),
+}));
+
 import {
   listAdminPeople,
   getAdminPerson,
@@ -160,6 +176,16 @@ describe('AdminPeople (7_13 PR2)', () => {
     fireEvent.click(screen.getByTestId('add-person-save'));
 
     expect(await screen.findByTestId('add-person-conflict')).toBeInTheDocument();
+  });
+
+  it('opens the delete modal from the profile panel', async () => {
+    renderPeople();
+    await screen.findByTestId('person-row-1');
+    fireEvent.click(screen.getByTestId('person-row-1'));
+    await screen.findByTestId('person-profile-panel-1');
+
+    fireEvent.click(screen.getByTestId('delete-person-1'));
+    expect(await screen.findByTestId('delete-person-modal')).toBeInTheDocument();
   });
 
   it('paginates the people list and passes filter params to the API', async () => {


### PR DESCRIPTION
## Summary
- Add admin Person delete flow with preview/apply endpoints, audited `person_delete` events, and a Delete modal on the People profile drawer.
- Improve dedupe UX when both records have logins: show User IDs, an amber callout with the force-login checkbox, and clearer blocked-preview messaging.

## Test plan
- [ ] Admin People: select a person, Delete → preview → confirm with reason; person removed from list
- [ ] Admin People: dedupe two records with different Users → enable "Keep winner's login" → preview succeeds → apply
- [ ] Person who is a reflection subject requires destructive confirm before delete
- [ ] `make test-backend` — `test_admin_people_delete.py` passes
- [ ] `make test-frontend` — `People.test.jsx` passes


Made with [Cursor](https://cursor.com)