### PR TITLE
fix: start Datadog RUM so trace headers inject on production API calls

### DIFF
--- a/frontend/src/lib/datadog.js
+++ b/frontend/src/lib/datadog.js
@@ -72,7 +72,9 @@ export function initDatadogRum() {
           propagatorTypes: ['datadog', 'tracecontext'],
         },
       ],
-      plugins: [reactPlugin({ router: true })],
+      // Automatic view tracking — router:true sets trackViewsManually but requires
+      // startView() on every route change, which we do not wire up yet.
+      plugins: [reactPlugin()],
     });
 
     initialized = true;


### PR DESCRIPTION
## Summary
- Remove `reactPlugin({ router: true })` so RUM uses automatic view tracking instead of `trackViewsManually`.
- `router: true` required `startView()` on every route change, but no router integration was wired up — RUM initialized but never started a session, so `x-datadog-*` trace headers were never injected on `admin.bunklogs.net` requests.

## Test plan
- [ ] Merge and let Render redeploy the frontend static site
- [ ] Hard-refresh `https://clc.bunklogs.net` and confirm bundle hash changed
- [ ] DevTools → Network → API calls to `admin.bunklogs.net` show `x-datadog-trace-id`, `x-datadog-origin: rum`, and `traceparent`
- [ ] DevTools → Network → filter `browser-intake` — RUM beacons should appear
- [ ] Datadog RUM Explorer shows new sessions; APM spans correlate with RUM resources


Made with [Cursor](https://cursor.com)