### PR TITLE
fix: inject Datadog trace headers in axios interceptor

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { getCSRFToken } from './django';
-import { trackApiSuccess } from './lib/datadog';
+import { applyTraceHeaders, trackApiSuccess } from './lib/datadog';
 import isSuperAdmin from './utils/auth/isSuperAdmin';
 import { resolveOrganizationSlug } from './utils/orgSlug';
 
@@ -35,9 +35,20 @@ const getServerCSRFToken = async () => {
   }
 };
 
+function resolveAxiosRequestUrl(config) {
+  const url = config.url || '';
+  if (/^https?:\/\//.test(url)) {
+    return url;
+  }
+  const base = (config.baseURL || apiUrl).replace(/\/$/, '');
+  return `${base}${url.startsWith('/') ? url : `/${url}`}`;
+}
+
 // Add request interceptor to attach token and CSRF token
 api.interceptors.request.use(
   async (config) => {
+    applyTraceHeaders(config.headers, resolveAxiosRequestUrl(config));
+
     const token = localStorage.getItem('access_token');
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;

--- a/frontend/src/lib/datadog.js
+++ b/frontend/src/lib/datadog.js
@@ -1,8 +1,32 @@
 import { datadogRum } from '@datadog/browser-rum';
-import { reactPlugin } from '@datadog/browser-rum-react';
 import { resolveOrganizationSlug } from '../utils/orgSlug';
 
 let initialized = false;
+
+function createTraceIdentifier(bits = 64) {
+  const buffer = crypto.getRandomValues(new Uint32Array(2));
+  if (bits === 63) {
+    buffer[buffer.length - 1] >>>= 1;
+  }
+  return {
+    toString(radix = 10) {
+      let high = buffer[1];
+      let low = buffer[0];
+      let str = '';
+      do {
+        const mod = (high % radix) * 4294967296 + low;
+        high = Math.floor(high / radix);
+        low = Math.floor(mod / radix);
+        str = (mod % radix).toString(radix) + str;
+      } while (high || low);
+      return str;
+    },
+  };
+}
+
+function toPaddedHexadecimalString(id) {
+  return id.toString(16).padStart(16, '0');
+}
 
 function normalizeApiUrl(url) {
   if (!url) return null;
@@ -39,6 +63,55 @@ export function isDatadogRumEnabled() {
   return initialized;
 }
 
+function resolveRequestUrl(baseURL, url) {
+  if (!url) return null;
+  if (/^https?:\/\//.test(url)) return url;
+  const base = (baseURL || '').replace(/\/$/, '');
+  return `${base}${url.startsWith('/') ? url : `/${url}`}`;
+}
+
+/**
+ * Inject Datadog + W3C trace headers on API requests.
+ * RUM's passive XHR hook is unreliable with axios; set headers explicitly here.
+ */
+export function applyTraceHeaders(headers, requestUrl) {
+  if (!initialized || !requestUrl || !isApiTracingUrl(requestUrl)) {
+    return;
+  }
+
+  const traceId = createTraceIdentifier(64);
+  const spanId = createTraceIdentifier(63);
+  const traceIdHex = toPaddedHexadecimalString(traceId);
+  const spanIdHex = toPaddedHexadecimalString(spanId);
+
+  const setHeader = (name, value) => {
+    if (headers?.set) {
+      headers.set(name, value);
+    } else {
+      headers[name] = value;
+    }
+  };
+
+  setHeader('x-datadog-origin', 'rum');
+  setHeader('x-datadog-trace-id', traceId.toString());
+  setHeader('x-datadog-parent-id', spanId.toString());
+  setHeader('x-datadog-sampling-priority', '1');
+  setHeader('traceparent', `00-0000000000000000${traceIdHex}-${spanIdHex}-01`);
+  setHeader('tracestate', 'dd=s:1;o:rum');
+}
+
+export async function waitForDatadogSession(timeoutMs = 3000) {
+  if (!shouldEnableDatadog()) return;
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (datadogRum.getInternalContext?.()?.session_id) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
 export function initDatadogRum() {
   if (initialized || !shouldEnableDatadog()) {
     return;
@@ -59,6 +132,7 @@ export function initDatadogRum() {
       sessionSampleRate: 100,
       sessionReplaySampleRate: 20,
       traceSampleRate: 100,
+      traceContextInjection: 'all',
       defaultPrivacyLevel: 'mask-user-input',
       trackUserInteractions: true,
       trackResources: true,
@@ -68,13 +142,14 @@ export function initDatadogRum() {
       silentMultipleInit: true,
       allowedTracingUrls: [
         {
-          match: isApiTracingUrl,
+          match: normalizeApiUrl(import.meta.env.VITE_API_URL) || 'https://admin.bunklogs.net',
+          propagatorTypes: ['datadog', 'tracecontext'],
+        },
+        {
+          match: 'http://localhost:8000',
           propagatorTypes: ['datadog', 'tracecontext'],
         },
       ],
-      // Automatic view tracking — router:true sets trackViewsManually but requires
-      // startView() on every route change, which we do not wire up yet.
-      plugins: [reactPlugin()],
     });
 
     initialized = true;

--- a/frontend/src/lib/datadog.js
+++ b/frontend/src/lib/datadog.js
@@ -72,7 +72,9 @@ export function initDatadogRum() {
           propagatorTypes: ['datadog', 'tracecontext'],
         },
       ],
-      plugins: [reactPlugin({ router: true })],
+      // Automatic view tracking — router:true sets trackViewsManually but requires
+      // startView() on every route change, which we do not wire up yet.
+      plugins: [reactPlugin()],
     });
 
     initialized = true;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,25 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { initDatadogRum } from './lib/datadog';
+import { initDatadogRum, waitForDatadogSession } from './lib/datadog';
 import ThemeProvider from './utils/ThemeContext';
 import App from './App';
 
 import { init } from './init';
-
-initDatadogRum();
-
-// Initialize the application asynchronously
-async function initializeApp() {
-  try {
-    await init();
-    console.log('App initialization completed');
-  } catch (error) {
-    console.error('App initialization failed:', error);
-  }
-}
-
-// Start initialization
-initializeApp();
 
 // Create a function to safely render the app after DOM is ready
 function renderApp() {
@@ -43,9 +28,22 @@ function renderApp() {
   }
 }
 
-// Render only after DOM is ready
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', renderApp);
-} else {
-  renderApp();
+async function bootstrap() {
+  initDatadogRum();
+  await waitForDatadogSession();
+
+  try {
+    await init();
+    console.log('App initialization completed');
+  } catch (error) {
+    console.error('App initialization failed:', error);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', renderApp, { once: true });
+  } else {
+    renderApp();
+  }
 }
+
+bootstrap();


### PR DESCRIPTION
## Summary
- Add `applyTraceHeaders()` in `datadog.js` and call it from the axios request interceptor so every `/api` call to `admin.bunklogs.net` gets `x-datadog-*` and `traceparent` headers directly.
- Wait for a RUM session before app bootstrap so tracing is ready before the first API call.
- Drop the react RUM plugin and use string `allowedTracingUrls` plus `traceContextInjection: 'all'`.

## Why
RUM init was working, but the SDK's passive XHR hook was not reliably attaching trace headers to axios requests — which is why DevTools showed no `x-datadog-*` on production API calls.

## Test plan
- [ ] Merge and redeploy frontend on Render
- [ ] Hard-refresh `https://clc.bunklogs.net` (Cmd+Shift+R)
- [ ] DevTools → Network → filter `admin.bunklogs` → open any `/api/` request → Request Headers must include `x-datadog-trace-id`, `x-datadog-origin: rum`, `traceparent`
- [ ] Confirm Datadog RUM resources to `admin.bunklogs.net` show `@resource.trace_id`


Made with [Cursor](https://cursor.com)