### PR TITLE
Start Datadog RUM view before bootstrap network calls

### DIFF
--- a/frontend/src/lib/datadog.js
+++ b/frontend/src/lib/datadog.js
@@ -27,7 +27,19 @@ export function isDatadogRumEnabled() {
   return initialized;
 }
 
-export async function waitForDatadogSession(timeoutMs = 3000) {
+/**
+ * reactPlugin({ router: true }) enables trackViewsManually, so RUM does not
+ * trace API calls until a view exists. Bootstrap network calls (CSRF prefetch,
+ * auth) run before React mounts Routes — start the current path immediately.
+ */
+export function startInitialDatadogView() {
+  if (!initialized) return;
+
+  const path = window.location.pathname || '/';
+  datadogRum.startView({ name: path });
+}
+
+export async function waitForDatadogSession(timeoutMs = 5000) {
   if (!shouldEnableDatadog()) return;
 
   const deadline = Date.now() + timeoutMs;
@@ -81,6 +93,7 @@ export function initDatadogRum() {
     });
 
     initialized = true;
+    startInitialDatadogView();
 
     if (import.meta.env.DEV) {
       console.info('Datadog RUM initialized', {

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -32,17 +32,19 @@ async function bootstrap() {
   initDatadogRum();
   await waitForDatadogSession();
 
+  if (document.readyState === 'loading') {
+    await new Promise((resolve) => {
+      document.addEventListener('DOMContentLoaded', resolve, { once: true });
+    });
+  }
+
+  renderApp();
+
   try {
     await init();
     console.log('App initialization completed');
   } catch (error) {
     console.error('App initialization failed:', error);
-  }
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', renderApp, { once: true });
-  } else {
-    renderApp();
   }
 }
 


### PR DESCRIPTION
## Summary
- Call `startInitialDatadogView()` immediately after RUM init so `trackViewsManually` (from `reactPlugin({ router: true })`) does not block trace header injection on early requests.
- Reorder bootstrap: render React before `init()` so Routes can track views before CSRF prefetch and auth calls.
- Increase session wait timeout from 3s to 5s.

## Context
Production RUM was sending sessions to app `c61d7723-...` with `env:prod`, but bootstrap API calls ran before any view existed, so trace headers were missing on the first requests. Datadog dashboard filters must use **`env:prod`** (not `production`) and application **BunkLogs** (`c61d7723-...`).

## Test plan
- [ ] `npm run build` in `frontend/` succeeds
- [ ] After deploy, hard-refresh `clc.bunklogs.net` and confirm API requests include `x-datadog-*` / `traceparent` on first load (CSRF prefetch)
- [ ] In Datadog RUM → Sessions: filter `env:prod` on app `c61d7723-dc16-4455-ade0-5ad22fadb898`


Made with [Cursor](https://cursor.com)