### PR TITLE
Enable Datadog RUM, browser logs, and APM log correlation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,7 +72,11 @@ ACCOUNT_LOGOUT_REDIRECT_URL=http://localhost:5173/signin
 # ==============================================================================
 # DATADOG APM (production only — leave blank locally)
 # ==============================================================================
+# DD_LOGS_INJECTION=true injects dd.trace_id/dd.span_id into Django logs when
+# running under ddtrace-run (see config/datadog_logging.py). Requires
+# DD_TRACE_ENABLED=true and a reachable agent for correlated traces.
 DD_LOGS_INJECTION=
+DD_TRACE_ENABLED=
 DD_SERVERLESS_LOG_PATH=
 
 # ==============================================================================

--- a/backend/config/datadog_logging.py
+++ b/backend/config/datadog_logging.py
@@ -1,0 +1,49 @@
+"""Datadog log-trace correlation for Django LOGGING.
+
+When ``DD_LOGS_INJECTION=true`` and the app runs under ``ddtrace-run``, ddtrace
+patches ``logging`` and adds ``dd.trace_id``, ``dd.span_id``, etc. to each
+LogRecord. The formatter must emit those fields so Render's log drain (or any
+collector) can correlate logs with APM traces.
+
+See: https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/python/
+"""
+
+DATADOG_LOG_FORMAT = (
+    "%(levelname)s %(asctime)s %(name)s "
+    "[dd.service=%(dd.service)s dd.env=%(dd.env)s dd.version=%(dd.version)s "
+    "dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] "
+    "%(message)s"
+)
+
+
+def apply_log_injection(logging_config: dict) -> None:
+    """Augment a Django LOGGING dict in place for Datadog trace correlation."""
+    formatters = logging_config.setdefault("formatters", {})
+    formatters["datadog"] = {"format": DATADOG_LOG_FORMAT}
+
+    handlers = logging_config.setdefault("handlers", {})
+    console = handlers.setdefault(
+        "console",
+        {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+        },
+    )
+    console["formatter"] = "datadog"
+
+    loggers = logging_config.setdefault("loggers", {})
+    loggers.setdefault(
+        "ddtrace",
+        {
+            "handlers": ["console"],
+            "level": "WARNING",
+        },
+    )
+    loggers.setdefault(
+        "bunk_logs",
+        {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": True,
+        },
+    )

--- a/backend/config/settings/production.py
+++ b/backend/config/settings/production.py
@@ -242,41 +242,12 @@ SPECTACULAR_SETTINGS["SERVERS"] = [
 # Set DD_TRACE_ENABLED=false in the Render dashboard to disable without redeploy.
 DD_TRACE_ENABLED = env.bool("DD_TRACE_ENABLED", default=True)
 DD_LOGS_INJECTION = env.bool("DD_LOGS_INJECTION", default=True)
-DD_ENV = env("DD_ENV", default="production")
+DD_ENV = env("DD_ENV", default="prod")
 
 if DD_LOGS_INJECTION:
-    LOGGING = {
-        "version": 1,
-        "disable_existing_loggers": False,
-        "formatters": {
-            "verbose": {
-                "format": "[{levelname}] {asctime} {name} {message}",
-                "style": "{",
-            },
-        },
-        "handlers": {
-            "console": {
-                "level": "INFO",
-                "class": "logging.StreamHandler",
-                "formatter": "verbose",
-            },
-        },
-        "loggers": {
-            "django": {
-                "handlers": ["console"],
-                "level": "INFO",
-                "propagate": True,
-            },
-            "ddtrace": {
-                "handlers": ["console"],
-                "level": "WARNING",
-            },
-        },
-        "root": {
-            "handlers": ["console"],
-            "level": "INFO",
-        },
-    }
+    from config.datadog_logging import apply_log_injection
+
+    apply_log_injection(LOGGING)
 
 # Frontend URLs - Production overrides
 # ------------------------------------------------------------------------------

--- a/backend/config/settings/render.py
+++ b/backend/config/settings/render.py
@@ -275,47 +275,10 @@ if os.getenv("DD_TRACE_ENABLED", "false").lower() == "true":
     # Ensure ddtrace patches Django components
     INSTALLED_APPS += ["ddtrace.contrib.django"]
 
-    # Enhanced logging for Datadog
-    LOGGING = {
-        "version": 1,
-        "disable_existing_loggers": False,
-        "formatters": {
-            "verbose": {
-                "format": "{levelname} {asctime} {module} {process:d} {thread:d} {message}",
-                "style": "{",
-            },
-            "datadog": {
-                "format": "[dd.service=%(dd.service)s dd.env=%(dd.env)s dd.version=%(dd.version)s dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] %(levelname)s %(asctime)s %(module)s %(message)s",  # noqa: E501
-            },
-        },
-        "handlers": {
-            "console": {
-                "level": "INFO",
-                "class": "logging.StreamHandler",
-                "formatter": "datadog" if os.getenv("DD_LOGS_INJECTION") == "true" else "verbose",
-            },
-        },
-        "loggers": {
-            "django": {
-                "handlers": ["console"],
-                "level": "INFO",
-                "propagate": True,
-            },
-            "ddtrace": {
-                "handlers": ["console"],
-                "level": "WARNING",
-            },
-            "bunk_logs": {  # Your app-specific logging
-                "handlers": ["console"],
-                "level": "INFO",
-                "propagate": True,
-            },
-        },
-        "root": {
-            "handlers": ["console"],
-            "level": "INFO",
-        },
-    }
+    if os.getenv("DD_LOGS_INJECTION", "false").lower() == "true":
+        from config.datadog_logging import apply_log_injection
+
+        apply_log_injection(LOGGING)
 
 # Database instrumentation settings
 DATABASES["default"]["OPTIONS"] = DATABASES["default"].get("OPTIONS", {})

--- a/backend/config/tests/test_datadog_logging.py
+++ b/backend/config/tests/test_datadog_logging.py
@@ -1,0 +1,29 @@
+from config.datadog_logging import DATADOG_LOG_FORMAT
+from config.datadog_logging import apply_log_injection
+
+
+def test_datadog_log_format_includes_correlation_fields():
+    for field in ("dd.trace_id", "dd.span_id", "dd.service", "dd.env", "dd.version"):
+        assert field in DATADOG_LOG_FORMAT
+
+
+def test_apply_log_injection_sets_console_formatter():
+    logging_config = {
+        "version": 1,
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "verbose",
+            },
+        },
+        "formatters": {
+            "verbose": {"format": "%(message)s"},
+        },
+    }
+
+    apply_log_injection(logging_config)
+
+    assert "datadog" in logging_config["formatters"]
+    assert logging_config["handlers"]["console"]["formatter"] == "datadog"
+    assert "bunk_logs" in logging_config["loggers"]
+    assert "ddtrace" in logging_config["loggers"]

--- a/docs/observability-setup.md
+++ b/docs/observability-setup.md
@@ -1,121 +1,171 @@
 # Observability Setup
 
-BunkLogs uses Datadog for APM tracing, log management, and custom metrics.
+BunkLogs uses Datadog for browser RUM, browser logs, APM tracing, and log management.
 
-## Architecture
+## End-to-end correlation on Render (multi-service)
+
+BunkLogs production on Render splits across separate services. Correlation works across
+them when each hop uses matching tags and trace propagation — not because they share a
+process or agent.
 
 ```
-Render (Django) ──ddtrace-run──► Datadog Agent (if present)
-                                       │
-                                       ├── Traces  → Datadog APM
-                                       ├── Metrics → Datadog Metrics
-                                       └── Logs    → Datadog Log Management
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  Browser (clc.bunklogs.net)                                                 │
+│  Static frontend — no Node/dd-trace at runtime                              │
+│                                                                             │
+│  @datadog/browser-rum  ──► RUM views, resources, errors, session replay     │
+│  @datadog/browser-logs ──► warn/error console + structured logs             │
+│         │                                                                   │
+│         │  traceContextInjection: 'all' + allowedTracingUrls                │
+│         │  injects x-datadog-* / traceparent headers on API calls           │
+└─────────┼───────────────────────────────────────────────────────────────────┘
+          │ HTTPS  (admin.bunklogs.net)
+          ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  bunklogs-backend (Render web service)                                      │
+│  ddtrace-run gunicorn                                                       │
+│                                                                             │
+│  • Continues distributed trace from browser headers                         │
+│  • Emits APM spans (Django, DRF, psycopg, Redis) ──► DD_AGENT_HOST:8126     │
+│  • DD_LOGS_INJECTION=true adds dd.trace_id to stdout log lines              │
+└─────────┼───────────────────────────────────────────────────────────────────┘
+          │ private network
+          ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  datadog-agent-fbsh (Render private service)                                │
+│  Forwards traces + DogStatsD metrics to Datadog intake                      │
+└─────────────────────────────────────────────────────────────────────────────┘
 
-Render logs ──► Render Log Drain ──► Datadog Log Management (always on)
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  bunklogs-db (Render Postgres)                                              │
+│  Appears as child spans inside backend traces (psycopg instrumentation).    │
+│  Not a separate log/trace source.                                           │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+Log paths (two separate pipelines, linked by trace_id / session_id):
+
+  Browser logs  ──► browser-intake-datadoghq.com  (direct from SDK, no agent)
+  Backend logs  ──► Render stdout ──► Render Log Stream ──► Datadog Logs
 ```
+
+### Correlation matrix
+
+| Link | Mechanism | Required config |
+|------|-----------|-----------------|
+| **RUM ↔ Browser Logs** | Same `clientToken`, `site`, `env`, `service`, `version` on both SDKs; shared `session_id` | `initDatadogRum()` initializes Logs immediately after RUM |
+| **RUM ↔ Backend APM** | RUM injects trace headers on XHR/fetch to `VITE_API_URL`; ddtrace continues the trace | `allowedTracingUrls`, `traceContextInjection: 'all'`, backend `DD_TRACE_ENABLED=true`, CORS allows `traceparent` + `x-datadog-*` (in `base.py`) |
+| **APM ↔ Backend Logs** | `DD_LOGS_INJECTION=true` + log formatter emits `dd.trace_id` / `dd.span_id` | `ddtrace-run`, `config/datadog_logging.py`, Render log stream to Datadog |
+| **RUM ↔ Backend Logs** | **Indirect** — pivot through the shared trace in APM, or match `session_id` on browser logs | No direct link; use Traces tab in RUM Explorer |
+
+Datadog documents this explicitly: there is no direct RUM-view ↔ server-log link; you
+navigate through traces. See
+[Ease troubleshooting with cross-product correlation](https://docs.datadoghq.com/logs/guide/ease-troubleshooting-with-cross-product-correlation/).
+
+### Tag alignment checklist (must match across services)
+
+| Tag | Frontend (`VITE_*`) | Backend (`DD_*` in render.yaml) |
+|-----|---------------------|----------------------------------|
+| env | `VITE_DATADOG_ENV=prod` | `DD_ENV=prod` |
+| service | `bunklogs-frontend` | `bunklogs-backend` |
+| version | `VITE_DATADOG_VERSION` | `DD_VERSION` |
+
+Different `service` names are correct (frontend vs backend). **`env` must match** or
+traces won't group in the same environment facet.
+
+### Render prerequisites
+
+1. **Backend APM**: `DD_AGENT_HOST=datadog-agent-fbsh` (private network hostname) +
+   agent service running with valid `DD_API_KEY`.
+2. **Backend logs in Datadog**: Render dashboard → bunklogs-backend → **Log Streams** →
+   add Datadog drain with `DD_API_KEY`. Without this, `DD_LOGS_INJECTION` enriches
+   stdout but logs never reach Datadog Log Management.
+3. **Frontend**: `VITE_DATADOG_*` vars baked in at static-site build time (Render
+   env vars on the frontend service, or `.env.production` in CI).
+4. **Postgres**: no extra setup; query spans appear under Django request traces.
+
+### Validate after deploy
+
+1. **RUM → APM**: In Datadog RUM Explorer, open a session → Resources tab → click an
+   API call to `admin.bunklogs.net` → should show linked backend trace.
+2. **RUM → Browser Logs**: Same session → Logs tab → warn/error console output appears
+   with matching `session_id`.
+3. **APM → Backend Logs**: APM Trace Explorer → open a trace → Logs tab → Django
+   stdout lines with the same `dd.trace_id`.
+4. **Network sanity**: Browser DevTools → API request headers include `traceparent`
+   and/or `x-datadog-trace-id`.
 
 ## Components
 
-### ddtrace (APM tracing)
+### Browser RUM + Logs (frontend)
 
-`ddtrace==4.7.1` is installed in all environments (base.txt). The Django process
-starts via `ddtrace-run gunicorn ...` which auto-instruments Django, DRF, psycopg,
-and Redis without code changes.
+Packages: `@datadog/browser-rum`, `@datadog/browser-rum-react`, `@datadog/browser-logs`.
 
-- **Traces**: sent to `DD_AGENT_HOST:8126` (TCP). Dropped silently if no agent.
-- **Log injection**: when `DD_LOGS_INJECTION=true`, trace/span IDs are injected
-  into every log line so logs and traces correlate in the Datadog UI.
+Initialized in `frontend/src/lib/datadog.js`:
+
+- **RUM**: views (via `createBrowserRouter`), errors, session replay, API resource timing.
+- **Logs**: `forwardErrorsToLogs`, `forwardConsoleLogs: ['error', 'warn']`, plus
+  `logToDatadog()` for structured messages.
+- **Trace propagation**: headers injected on requests to `VITE_API_URL`.
+
+Browser telemetry goes **directly** to Datadog intake — it does not route through the
+Render Datadog Agent.
+
+### ddtrace (backend APM)
+
+`ddtrace==4.7.1` in base.txt. Django starts via `ddtrace-run gunicorn` (see `render.yaml`).
+
+- Traces sent to `DD_AGENT_HOST:8126`.
+- Log injection via `DD_LOGS_INJECTION=true` and `config/datadog_logging.py`.
 
 ### Log forwarding (Render → Datadog)
 
-Render streams all stdout/stderr to its log drain. To forward to Datadog:
+Render streams stdout/stderr. Forward to Datadog:
 
-1. Render dashboard → **Environment** → **Log Streams** → **Add Log Stream**
-2. Select **Datadog**
-3. Paste your **DD_API_KEY** and choose the correct Datadog site (e.g. `datadoghq.com`)
-4. Save — logs start flowing within minutes
-
-No code changes are required for log forwarding.
+1. Render dashboard → **Log Streams** → **Add Log Stream** → Datadog
+2. Paste `DD_API_KEY`, select site `datadoghq.com`
 
 ### Custom metrics (DogStatsD)
 
-Custom metrics are sent via UDP to the Datadog Agent on port 8125.
-
-| Metric | Type | Tags | Source |
-|--------|------|------|--------|
-| `bunklogs.reflections.submitted` | counter | `tenant`, `env`, `service` | Reflection model signal (Phase 2) |
-| `bunklogs.users.logged_in` | counter | `method`, `env`, `service` | `user_logged_in` signal |
-
-Metrics silently no-op when `DD_AGENT_HOST` is unreachable (e.g. local dev without agent).
-
-To add a new metric, call `_send()` from `bunk_logs/utils/metrics.py` or add a
-typed helper alongside the existing ones.
+UDP to agent port 8125. See `bunk_logs/utils/metrics.py`.
 
 ## Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `DD_API_KEY` | — | **Required in production.** Set in Render dashboard, never commit. |
-| `DD_ENV` | `development` / `production` | Separates dev/prod in Datadog |
-| `DD_SERVICE` | `bunklogs` | Service name shown in APM |
-| `DD_VERSION` | `""` | App version tag (set to git SHA in CI for deployment tracking) |
-| `DD_AGENT_HOST` | `localhost` | Hostname of the Datadog Agent. Leave unset on Render unless running an agent service. |
-| `DD_DOGSTATSD_PORT` | `8125` | DogStatsD UDP port |
-| `DD_TRACE_ENABLED` | `false` (dev) / `true` (prod) | Master switch for APM traces |
-| `DD_LOGS_INJECTION` | `false` (dev) / `true` (prod) | Injects trace IDs into Django log records |
-
-## Enabling in Production (Render)
-
-All DD env vars are declared in `render.yaml`. Only `DD_API_KEY` requires manual
-entry in the Render dashboard (it is marked `sync: false` to avoid accidental
-commits).
-
-Steps:
-1. Render dashboard → `bunklogs-backend` → **Environment**
-2. Add `DD_API_KEY` with your Datadog API key
-3. Optionally set `DD_VERSION` to the current release SHA
-4. Redeploy — `ddtrace-run` will pick up the vars at startup
-
-## Running a Datadog Agent on Render (optional, for full APM)
-
-Render does not support sidecars. To get APM traces (not just logs) in production:
-
-**Option A – Render Background Worker as Agent** (not recommended; agent is heavyweight)
-
-**Option B – Datadog Agentless Tracing** (ddtrace 2.x+ supports sending traces
-directly to the Datadog intake without an agent):
-```
-DD_TRACE_AGENT_URL=https://trace.agent.datadoghq.com
-DD_API_KEY=<your key>
-```
-Set `DD_TRACE_AGENT_URL` in the Render dashboard alongside `DD_API_KEY`.
-
-**Option C – Logs only** (current default): rely on Render log drain + log injection
-for correlated traces via logs. This is zero-infrastructure-cost and sufficient for
-most debugging needs.
+| Variable | Frontend | Backend | Description |
+|----------|----------|---------|-------------|
+| `DD_ENV` / `VITE_DATADOG_ENV` | `prod` | `prod` | **Must match** for cross-product correlation |
+| `DD_SERVICE` / `VITE_DATADOG_SERVICE` | `bunklogs-frontend` | `bunklogs-backend` | Different per tier (expected) |
+| `DD_VERSION` / `VITE_DATADOG_VERSION` | `1.0.0` | `1.0` | Release tag |
+| `DD_LOGS_INJECTION` | — | `true` | Injects trace IDs into Django log records |
+| `DD_TRACE_ENABLED` | — | `true` | Master switch for APM |
+| `DD_AGENT_HOST` | — | `datadog-agent-fbsh` | Private Render agent hostname |
+| `VITE_DATADOG_CLIENT_TOKEN` | required | — | Shared by RUM + Logs SDKs |
+| `VITE_DATADOG_APPLICATION_ID` | required | — | RUM application ID |
 
 ## Local Development
 
-ddtrace is installed locally but tracing is disabled by default (`DD_TRACE_ENABLED=false`).
-The app starts normally without any Datadog agent running.
+Tracing disabled by default (`DD_TRACE_ENABLED=false`). To test full correlation locally:
 
-To test metrics locally:
 ```bash
-# Start a local Datadog Agent (requires a Datadog account)
+# Terminal 1: local Datadog Agent (optional)
 docker run -d --name dd-agent \
-  -e DD_API_KEY=<your-key> \
-  -e DD_SITE=datadoghq.com \
-  -p 8125:8125/udp \
-  -p 8126:8126/tcp \
+  -e DD_API_KEY=<key> -e DD_SITE=datadoghq.com \
+  -p 8125:8125/udp -p 8126:8126/tcp \
   gcr.io/datadoghq/agent:7
 
-# Then in .envs/.local/.django add:
+# .envs/.local/.django
 DD_TRACE_ENABLED=true
 DD_LOGS_INJECTION=true
+DD_ENV=development
 DD_AGENT_HOST=localhost
+
+# frontend/.env
+VITE_DATADOG_FORCE_ENABLE=true
+VITE_DATADOG_ENV=development
+# + application ID and client token
 ```
+
+`ddtrace` "failed to send traces to localhost:8126" without an agent is harmless.
 
 ## Synthetic Checks
 
-Synthetic monitor definitions are in `docs/synthetics.yml`. Import them via the
-Datadog API or Terraform provider (`datadog_synthetics_test` resource).
+Definitions in `docs/synthetics.yml`.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,12 +4,13 @@ VITE_GOOGLE_CLIENT_ID=your-google-oauth-client-id.apps.googleusercontent.com
 # Set to 'true' to enable the dev-login user picker on the Signin page
 # VITE_DEV_BYPASS=true
 
-# Datadog RUM + APM trace correlation (production by default)
+# Datadog RUM + Browser Logs + APM trace correlation (production by default)
+# RUM and Logs SDKs must share clientToken/site/env/service/version for correlation.
 # VITE_DATADOG_APPLICATION_ID=
 # VITE_DATADOG_CLIENT_TOKEN=
 # VITE_DATADOG_SITE=datadoghq.com
-# VITE_DATADOG_ENV=development  # use "prod" in production to match backend APM
+# VITE_DATADOG_ENV=prod  # must match backend DD_ENV
 # VITE_DATADOG_SERVICE=bunklogs-frontend
 # VITE_DATADOG_VERSION=1.0.0
-# Set to 'true' to enable RUM locally (requires credentials above)
+# Set to 'true' to enable RUM + Logs locally (requires credentials above)
 # VITE_DATADOG_FORCE_ENABLE=true

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mosaic-react",
       "version": "0.1.0",
       "dependencies": {
+        "@datadog/browser-logs": "^6.33.0",
         "@datadog/browser-rum": "^6.12.3",
         "@datadog/browser-rum-react": "^6.12.3",
         "@dnd-kit/core": "^6.3.1",
@@ -22,7 +23,6 @@
         "chartjs-adapter-moment": "^1.0.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.4.0",
-        "dd-trace": "^5.104.0",
         "i18next": "^24.2.3",
         "i18next-browser-languagedetector": "^8.2.1",
         "jwt-decode": "^4.0.0",
@@ -513,17 +513,40 @@
       "integrity": "sha512-PXtLAszdaEMnGcIF2KT3cuLZJ32vmxfsRujvTaibOFPuTDO/1uItozDR9D1XbfknDGV3KaU2WY7fDExv4PABHQ==",
       "license": "Apache-2.0"
     },
-    "node_modules/@datadog/browser-rum": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-6.12.3.tgz",
-      "integrity": "sha512-cr0ddLvXXobY/dR63oYlTgA9MKFw7fQwYWe1IRa51jw1u4jULLVibW1TtiWVCt5sM+VYoYbs28tLB5ySrCUOUg==",
+    "node_modules/@datadog/browser-logs": {
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-logs/-/browser-logs-6.33.0.tgz",
+      "integrity": "sha512-WZ1XEIIYK2sijR0hUG3hTPu2kQs8hE/PpoJcMDE7p0/NPXX3TR3dGVrwag+gvIVyBaszRkITiBsHQfnRvxV1DA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@datadog/browser-core": "6.12.3",
-        "@datadog/browser-rum-core": "6.12.3"
+        "@datadog/browser-core": "6.33.0"
       },
       "peerDependencies": {
-        "@datadog/browser-logs": "6.12.3"
+        "@datadog/browser-rum": "6.33.0"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-rum": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@datadog/browser-logs/node_modules/@datadog/browser-core": {
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-6.33.0.tgz",
+      "integrity": "sha512-h/xuBuY4Xi32CbBHkChMMWlOQ4al/mFF08x3o0hqrderfJvX7VO5tD3OVNwF+pfMXOGlDtBCIhwazr9sn24h3g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@datadog/browser-rum": {
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-6.33.0.tgz",
+      "integrity": "sha512-zdxs1PyKt1RQ/fdxsmaCJUeBhB+leCIaPJBcum7uDi/DL8nuu9A9NUc5qGVPlY9zc12v7t2NI8bLpOrMjv+jTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/browser-core": "6.33.0",
+        "@datadog/browser-rum-core": "6.33.0"
+      },
+      "peerDependencies": {
+        "@datadog/browser-logs": "6.33.0"
       },
       "peerDependenciesMeta": {
         "@datadog/browser-logs": {
@@ -568,131 +591,19 @@
         }
       }
     },
-    "node_modules/@datadog/flagging-core": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@datadog/flagging-core/-/flagging-core-0.3.3.tgz",
-      "integrity": "sha512-LnkTXMVxaCDGCOF2I+CCACndpbi4E8CP8NIsb1IbMmmATzkQHmYiL1ntFcS4mt5kNGAWXNrKquM02jhoiVc+dA==",
+    "node_modules/@datadog/browser-rum/node_modules/@datadog/browser-core": {
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-6.33.0.tgz",
+      "integrity": "sha512-h/xuBuY4Xi32CbBHkChMMWlOQ4al/mFF08x3o0hqrderfJvX7VO5tD3OVNwF+pfMXOGlDtBCIhwazr9sn24h3g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@datadog/browser-rum/node_modules/@datadog/browser-rum-core": {
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-6.33.0.tgz",
+      "integrity": "sha512-Ais4x7zQBrBI6JyILYwFAmjUsqy0iQp2C7JcEEfzU4YYYcVO3DGpyVuYYrqHT27jY1QToHY8EnQUr3Yaj6saDA==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
-        "spark-md5": "^3.0.2"
-      }
-    },
-    "node_modules/@datadog/libdatadog": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.9.3.tgz",
-      "integrity": "sha512-L+scIlcRRRF0qjeSU3VQLQlqezfQHkDdnOdbmx/gLjPqewKSyqVGp7XRdKXYo2vZTzmG8dH6rPKXwgI68UQufw==",
-      "license": "Apache-2.0",
-      "optional": true
-    },
-    "node_modules/@datadog/native-appsec": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-11.0.1.tgz",
-      "integrity": "sha512-Y/XfknUmmJcw4hhQVhqzgdQvfjy+EGmXuUBgtVkI1r+/qS00egYu+wD/x7pOvjdbZNqN96znVszAnXvDQAzMDQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build": "^3.9.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@datadog/native-iast-taint-tracking": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-4.1.0.tgz",
-      "integrity": "sha512-g9K9Ddx1YQfrQIC2hgtfnYUGuzAFvSvhvt2lPZOAWBPo+bkYoW5KEkMHoY5XykCigTfXBYcQicRV0xB22AMkHw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build": "^3.9.0"
-      }
-    },
-    "node_modules/@datadog/native-metrics": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-3.1.2.tgz",
-      "integrity": "sha512-7AEWt0ZLr/ogR/9if1DmFBDTg3y67xM+gdhXUXKs+UQMxK0lnjrOHgN7fkpEmUG1uL+EkX2BDE3ENDlQ23J7OQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "node-addon-api": "^6.1.0",
-        "node-gyp-build": "^3.9.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@datadog/openfeature-node-server": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-1.1.2.tgz",
-      "integrity": "sha512-fr+zCaKoCSdizX22H7eA9Z3QaZrOMu5qU0yK0M2aWtUxokSAKPlLz3+9HdmqwBWU/ikqI+lbiAK0oNdvmUKeQA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@datadog/flagging-core": "0.3.3"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@openfeature/server-sdk": ">=1.15.1"
-      }
-    },
-    "node_modules/@datadog/pprof": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.14.1.tgz",
-      "integrity": "sha512-MlODCE9Gltmx7WChOg1BkIm7W2iE4CDW7K72BMwgzCvxFkG9rFWVsuA7/NEZL1nDvJ0qDe2du7DZZdZHTjcVPw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build": "<4.0",
-        "pprof-format": "^2.2.1",
-        "source-map": "^0.7.4"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@datadog/wasm-js-rewriter": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-5.0.1.tgz",
-      "integrity": "sha512-EzbV3Lrdt3udQEsbDOVC5gB1y7yxfpBbrSIk4jaEsGjyj0Dbv2HGj7tZjs+qXzIzNonHc8h5El2bYZOGfC2wwg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "js-yaml": "^4.1.0",
-        "lru-cache": "^7.14.0",
-        "module-details-from-path": "^1.0.3",
-        "node-gyp-build": "^4.5.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@datadog/wasm-js-rewriter/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@datadog/wasm-js-rewriter/node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
+        "@datadog/browser-core": "6.33.0"
       }
     },
     "node_modules/@date-fns/tz": {
@@ -752,37 +663,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emotion/cache": {
@@ -1823,401 +1703,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
       "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "license": "MIT"
-    },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@openfeature/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-C3ynxtPYhe5qVJgQIqCNxZXeRXo4t1Eo86uiROr8+sD6F2OjEJGIp6VOGxz+r6jkad2s8Br9BnUJOvskhai/3A==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@openfeature/server-sdk": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.21.0.tgz",
-      "integrity": "sha512-ZBVAiyMeN+dxurcXGJlvuOpYg9X7V923MVCI5dq/kE/5o8ys7MCOPhW44e4PS+XABHzSRTw44hcgWez93xwifw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@openfeature/core": "^1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
-      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-android-arm-eabi": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.129.0.tgz",
-      "integrity": "sha512-sG37CfXLlYXdDrggAFO/mKcO4w36piwf862xAZXIuf3nzKhWK1FvW4dqie+06++z+mDto2QeOQSvhyzBeK5jsQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-android-arm64": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.129.0.tgz",
-      "integrity": "sha512-DVyLFN2+S0VOhT6lm5++tFqlu3x2Njiby6y5DhTzjV5uRsZWpifsBn6+yjtwAxl105peEjs5BHE3ToBJuQjLTg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.129.0.tgz",
-      "integrity": "sha512-QeqThtB8qax4IL+NFBWgshudyKkj5c076L8vyd8PCEx7U1wHyIbH49MEQ5J5iURFhUW5jiFmdnLKEwyOo0GAJA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.129.0.tgz",
-      "integrity": "sha512-zn5+7nv4DlK4uFgblmhKm6xRV0QUHXOHyIDkjmhxJ53xSA9ahkb3pHNiHesNPXn/nK/VWU+C+Z6JYHdatZBh7g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.129.0.tgz",
-      "integrity": "sha512-SPTcDBiHWlgRpWFC1jnoi0sBWqCw4DFR+4b8+dV+NAhUu2ONERWyIVIOCfcE9a8BlvZsDCuXf3l/x7wQUs1Rsw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.129.0.tgz",
-      "integrity": "sha512-Rgc9+WNKLbc+chyDTXyyJ7gbgLo+ve27CrRnmIwGgucGflrBZbutge5jdPPegcgf46RrR4dkBbMCp0/x16mdig==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.129.0.tgz",
-      "integrity": "sha512-YtSsJ51VysXqlO8Cs2mWTyXvxBRemTHj4WDQjXwKl0SAxh+CVrEdXrdH+RnjxLj3JCUMFeYuHs5c+/DImfbKkg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.129.0.tgz",
-      "integrity": "sha512-9oK8iQr9KtgI5JhaJ+5IwiQsXEo6NuasFgovtJGrdK/RxbA0bO4YKRvVY7M+8lozUCVz1U7XrFFODv3emIOPRA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.129.0.tgz",
-      "integrity": "sha512-GghE/bf9ZqgqZFxLacgP0ImVD6UiLKQOpvpgUoIsqjopu2ms/+p1L0d0Dv2Sck+8p0FbKS2WE3IjqmIlLbxJgA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.129.0.tgz",
-      "integrity": "sha512-A2PW0UbERzKGV6fKX1zoe2Tkc1zVcEJSSPW9IUSKbZAPuPe+M5/5hTA+6fQbWmevabe2B3IDky66a1lFGjpBKA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.129.0.tgz",
-      "integrity": "sha512-omwxd9H+jrl1T72RI666k4ho7Eli2iHdELzf+dL0D+uXThNZXYJCbKjm5rK2hrHmDy4O+NWv7+khBrEkorLsgw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.129.0.tgz",
-      "integrity": "sha512-v2hi8id+M8C0uY8uuG2t2a5vr8H9XyHXiHL12yMdMNtgn04nnM/8hlOGuoJuxVc07PhClNiaoSaY2eXehSRa7w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.129.0.tgz",
-      "integrity": "sha512-UXrdDyLh1Obgj5X+IVVXWoo5/FJbFsU8/uLQ/M9lkVUwBUKpRFxNEhzwBNv21qqdKgAh+pr2CCVD8J1JfRPsIQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.129.0.tgz",
-      "integrity": "sha512-hsL/3/kdX9FGLqOj8DR3Eki4Y6zO1i3+ZHhiPwX0hDt4n+18abkfUzePCv3h8SShprwCmwdxPnlrebZ5+MZ+cw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.129.0.tgz",
-      "integrity": "sha512-kdXvJ4crOeRld3vWl0J0VU4nmnT4pZ3lKGA5tZ1y0UPWsBtElDYd+jsz4lE36tpAbCiWm0M0PG0laUNBSE+Wlw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-openharmony-arm64": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.129.0.tgz",
-      "integrity": "sha512-DusJfcK7EGwf9TEakB+z6SXCLdHGvDZ8U8882bzWb4oVrORHpbkFl9npS7cN3YC2axcVKoktbxZevS1nxVCKFw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-wasm32-wasi": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.129.0.tgz",
-      "integrity": "sha512-Iie9CcII+ELSinKFnxTR15xhI9qriVivEhbFh3driRNbzms/5ioDAU0fwe8Mf1FEaz3n2FtiUVX0h0nwKLYk0A==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.129.0.tgz",
-      "integrity": "sha512-99kH1udLyrts+wGm+u0VhPbogkb2wxc/6J1XMKOpS6Kx5DjBWGRZZfBjfCGI3xKSInpYbZn4TLWLX1Q1GURYwg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.129.0.tgz",
-      "integrity": "sha512-tmSBR1A4yH697qV291xKyDe4OAWFchJ+cXf2wuipx/vK3n5d5Ej9MVLRtXlIcZ38n8qAjsF0/AnskaYgxM151A==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.129.0.tgz",
-      "integrity": "sha512-Z1PbJvkPeLASIUxa3AnrQ5H+vv1K9zC0IGnQqoKfM0ZvsvCSe0d3u5m7d9iuy+HB7GrcElHuwKb0d0qFdtG0iA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-project/types": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
-      "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
     },
     "node_modules/@playwright/test": {
       "version": "1.60.0",
@@ -3485,16 +2970,6 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -3749,21 +3224,13 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -3830,7 +3297,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
@@ -4139,12 +3606,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/cjs-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-      "license": "MIT"
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -4301,42 +3762,6 @@
       "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
       "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
       "license": "MIT"
-    },
-    "node_modules/dc-polyfill": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/dc-polyfill/-/dc-polyfill-0.1.11.tgz",
-      "integrity": "sha512-TyyeGcjx0YeThAI9fTFtgsvj5qd4R+aGfVmXiUhevbgzWFDr7IK4tv4YjE6jaGzLHQTchk4h7DHdr5q4WGgaZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
-    "node_modules/dd-trace": {
-      "version": "5.104.0",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.104.0.tgz",
-      "integrity": "sha512-uQ5V6YB53A6PALe0ItslHbtjp6hD9VURVG6XB6GnMQgwvTs9OLuL4b+IoUzShUCKuciyfdxmS/L7vjU+sCvnGQ==",
-      "hasInstallScript": true,
-      "license": "(Apache-2.0 OR BSD-3-Clause)",
-      "dependencies": {
-        "dc-polyfill": "^0.1.11",
-        "import-in-the-middle": "^3.0.1",
-        "opentracing": ">=0.14.7"
-      },
-      "engines": {
-        "node": ">=18 <26"
-      },
-      "optionalDependencies": {
-        "@datadog/libdatadog": "0.9.3",
-        "@datadog/native-appsec": "11.0.1",
-        "@datadog/native-iast-taint-tracking": "4.1.0",
-        "@datadog/native-metrics": "3.1.2",
-        "@datadog/openfeature-node-server": "1.1.2",
-        "@datadog/pprof": "5.14.1",
-        "@datadog/wasm-js-rewriter": "5.0.1",
-        "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/api-logs": "<1.0.0",
-        "oxc-parser": "^0.129.0"
-      }
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -5310,21 +4735,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/import-in-the-middle": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
-      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-import-attributes": "^1.9.5",
-        "cjs-module-lexer": "^2.2.0",
-        "module-details-from-path": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -5464,7 +4874,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6890,12 +6300,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/module-details-from-path": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
-      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
-      "license": "MIT"
-    },
     "node_modules/moment": {
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -6937,25 +6341,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-addon-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/node-gyp-build": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
-      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -6979,15 +6364,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/opentracing": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
-      "integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7004,44 +6380,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/oxc-parser": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.129.0.tgz",
-      "integrity": "sha512-S6eFI+VLkpyA+/Lf8z6qURjDV6Mgo74SLNznNopHTlQW3hedv2MB/z31kBRuBCCTqZN9HHdva0ojljEhPnBKFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@oxc-project/types": "^0.129.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      },
-      "optionalDependencies": {
-        "@oxc-parser/binding-android-arm-eabi": "0.129.0",
-        "@oxc-parser/binding-android-arm64": "0.129.0",
-        "@oxc-parser/binding-darwin-arm64": "0.129.0",
-        "@oxc-parser/binding-darwin-x64": "0.129.0",
-        "@oxc-parser/binding-freebsd-x64": "0.129.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.129.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.129.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.129.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.129.0",
-        "@oxc-parser/binding-linux-ppc64-gnu": "0.129.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.129.0",
-        "@oxc-parser/binding-linux-riscv64-musl": "0.129.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.129.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.129.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.129.0",
-        "@oxc-parser/binding-openharmony-arm64": "0.129.0",
-        "@oxc-parser/binding-wasm32-wasi": "0.129.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.129.0",
-        "@oxc-parser/binding-win32-ia32-msvc": "0.129.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.129.0"
       }
     },
     "node_modules/p-limit": {
@@ -7265,13 +6603,6 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
-    },
-    "node_modules/pprof-format": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.1.tgz",
-      "integrity": "sha512-p4tVN7iK19ccDqQv8heyobzUmbHyds4N2FI6aBMcXz6y99MglTWDxIyhFkNaLeEXs6IFUEzT0zya0icbSLLY0g==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -7842,16 +7173,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/source-map": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7871,13 +7192,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/spark-md5": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
-      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
-      "license": "(WTFPL OR MIT)",
-      "optional": true
     },
     "node_modules/stackback": {
       "version": "0.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "lint:i18n": "node scripts/check-i18n-key-parity.mjs && eslint --no-error-on-unmatched-pattern 'src/components/LanguagePicker.jsx' 'src/components/TranslationDisplay.jsx' 'src/components/AudienceDisclosure.jsx'"
   },
   "dependencies": {
+    "@datadog/browser-logs": "^6.33.0",
     "@datadog/browser-rum": "^6.12.3",
     "@datadog/browser-rum-react": "^6.12.3",
     "@dnd-kit/core": "^6.3.1",

--- a/frontend/src/lib/__tests__/datadog.test.js
+++ b/frontend/src/lib/__tests__/datadog.test.js
@@ -1,18 +1,35 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const initMock = vi.fn();
+const initRumMock = vi.fn();
+const initLogsMock = vi.fn();
 const setUserMock = vi.fn();
 const clearUserMock = vi.fn();
 const addActionMock = vi.fn();
+const startViewMock = vi.fn();
+const getInternalContextMock = vi.fn(() => ({ session_id: 'sess-1' }));
+const logsLoggerMock = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
 
 vi.mock('@datadog/browser-rum', () => ({
   datadogRum: {
-    init: initMock,
+    init: initRumMock,
     setUser: setUserMock,
     clearUser: clearUserMock,
     addAction: addActionMock,
+    startView: startViewMock,
+    getInternalContext: getInternalContextMock,
     setGlobalContextProperty: vi.fn(),
     removeGlobalContextProperty: vi.fn(),
+  },
+}));
+
+vi.mock('@datadog/browser-logs', () => ({
+  datadogLogs: {
+    init: initLogsMock,
+    logger: logsLoggerMock,
   },
 }));
 
@@ -23,17 +40,52 @@ vi.mock('@datadog/browser-rum-react', () => ({
 describe('datadog helpers', () => {
   beforeEach(() => {
     vi.resetModules();
-    initMock.mockClear();
+    vi.unstubAllEnvs();
+    initRumMock.mockClear();
+    initLogsMock.mockClear();
     setUserMock.mockClear();
     clearUserMock.mockClear();
     addActionMock.mockClear();
+    startViewMock.mockClear();
+    logsLoggerMock.info.mockClear();
   });
 
   it('does not initialize without credentials', async () => {
-    const { initDatadogRum, isDatadogRumEnabled } = await import('../datadog');
+    vi.stubEnv('VITE_DATADOG_APPLICATION_ID', '');
+    vi.stubEnv('VITE_DATADOG_CLIENT_TOKEN', '');
+    vi.stubEnv('VITE_DATADOG_FORCE_ENABLE', 'false');
+
+    const { initDatadogRum, isDatadogRumEnabled, isDatadogLogsEnabled } = await import('../datadog');
     initDatadogRum();
-    expect(initMock).not.toHaveBeenCalled();
+    expect(initRumMock).not.toHaveBeenCalled();
+    expect(initLogsMock).not.toHaveBeenCalled();
     expect(isDatadogRumEnabled()).toBe(false);
+    expect(isDatadogLogsEnabled()).toBe(false);
+  });
+
+  it('initializes RUM and Logs with matching config when enabled', async () => {
+    vi.stubEnv('VITE_DATADOG_APPLICATION_ID', 'app-id');
+    vi.stubEnv('VITE_DATADOG_CLIENT_TOKEN', 'client-token');
+    vi.stubEnv('VITE_DATADOG_FORCE_ENABLE', 'true');
+    vi.stubEnv('VITE_DATADOG_ENV', 'prod');
+    vi.stubEnv('VITE_DATADOG_SERVICE', 'bunklogs-frontend');
+    vi.stubEnv('VITE_DATADOG_VERSION', '1.2.3');
+    vi.stubEnv('PROD', '');
+
+    const { initDatadogRum, isDatadogRumEnabled, isDatadogLogsEnabled } = await import('../datadog');
+    initDatadogRum();
+
+    expect(initRumMock).toHaveBeenCalledTimes(1);
+    expect(initLogsMock).toHaveBeenCalledTimes(1);
+    expect(isDatadogRumEnabled()).toBe(true);
+    expect(isDatadogLogsEnabled()).toBe(true);
+
+    const logsConfig = initLogsMock.mock.calls[0][0];
+    expect(logsConfig.env).toBe('prod');
+    expect(logsConfig.service).toBe('bunklogs-frontend');
+    expect(logsConfig.version).toBe('1.2.3');
+    expect(logsConfig.forwardErrorsToLogs).toBe(true);
+    expect(logsConfig.forwardConsoleLogs).toEqual(['error', 'warn']);
   });
 
   it('sets user context when RUM is enabled', async () => {
@@ -51,7 +103,6 @@ describe('datadog helpers', () => {
       role: 'Counselor',
     });
 
-    expect(initMock).toHaveBeenCalledTimes(1);
     expect(setUserMock).toHaveBeenCalledWith({
       id: '42',
       email: 'counselor@example.com',
@@ -80,5 +131,18 @@ describe('datadog helpers', () => {
       templateId: 3,
       programSlug: 'summer-2026',
     });
+  });
+
+  it('writes structured logs when Logs SDK is initialized', async () => {
+    vi.stubEnv('VITE_DATADOG_APPLICATION_ID', 'app-id');
+    vi.stubEnv('VITE_DATADOG_CLIENT_TOKEN', 'client-token');
+    vi.stubEnv('VITE_DATADOG_FORCE_ENABLE', 'true');
+    vi.stubEnv('PROD', '');
+
+    const { initDatadogRum, logToDatadog } = await import('../datadog');
+    initDatadogRum();
+    logToDatadog('info', 'reflection saved', { reflectionId: 1 });
+
+    expect(logsLoggerMock.info).toHaveBeenCalledWith('reflection saved', { reflectionId: 1 });
   });
 });

--- a/frontend/src/lib/datadog.js
+++ b/frontend/src/lib/datadog.js
@@ -1,8 +1,10 @@
 import { datadogRum } from '@datadog/browser-rum';
+import { datadogLogs } from '@datadog/browser-logs';
 import { reactPlugin } from '@datadog/browser-rum-react';
 import { resolveOrganizationSlug } from '../utils/orgSlug';
 
-let initialized = false;
+let rumInitialized = false;
+let logsInitialized = false;
 
 function normalizeApiUrl(url) {
   if (!url) return null;
@@ -23,8 +25,27 @@ function shouldEnableDatadog() {
   return import.meta.env.PROD || import.meta.env.VITE_DATADOG_FORCE_ENABLE === 'true';
 }
 
+function getDatadogConfig() {
+  const environment =
+    import.meta.env.VITE_DATADOG_ENV ||
+    (import.meta.env.PROD ? 'prod' : 'development');
+
+  return {
+    applicationId: import.meta.env.VITE_DATADOG_APPLICATION_ID,
+    clientToken: import.meta.env.VITE_DATADOG_CLIENT_TOKEN,
+    site: import.meta.env.VITE_DATADOG_SITE || 'datadoghq.com',
+    service: import.meta.env.VITE_DATADOG_SERVICE || 'bunklogs-frontend',
+    env: environment,
+    version: import.meta.env.VITE_DATADOG_VERSION || '1.0.0',
+  };
+}
+
 export function isDatadogRumEnabled() {
-  return initialized;
+  return rumInitialized;
+}
+
+export function isDatadogLogsEnabled() {
+  return logsInitialized;
 }
 
 /**
@@ -33,7 +54,7 @@ export function isDatadogRumEnabled() {
  * auth) run before React mounts Routes — start the current path immediately.
  */
 export function startInitialDatadogView() {
-  if (!initialized) return;
+  if (!rumInitialized) return;
 
   const path = window.location.pathname || '/';
   datadogRum.startView({ name: path });
@@ -52,22 +73,20 @@ export async function waitForDatadogSession(timeoutMs = 5000) {
 }
 
 export function initDatadogRum() {
-  if (initialized || !shouldEnableDatadog()) {
+  if (rumInitialized || !shouldEnableDatadog()) {
     return;
   }
 
-  const environment =
-    import.meta.env.VITE_DATADOG_ENV ||
-    (import.meta.env.PROD ? 'prod' : 'development');
+  const config = getDatadogConfig();
 
   try {
     datadogRum.init({
-      applicationId: import.meta.env.VITE_DATADOG_APPLICATION_ID,
-      clientToken: import.meta.env.VITE_DATADOG_CLIENT_TOKEN,
-      site: import.meta.env.VITE_DATADOG_SITE || 'datadoghq.com',
-      service: import.meta.env.VITE_DATADOG_SERVICE || 'bunklogs-frontend',
-      env: environment,
-      version: import.meta.env.VITE_DATADOG_VERSION || '1.0.0',
+      applicationId: config.applicationId,
+      clientToken: config.clientToken,
+      site: config.site,
+      service: config.service,
+      env: config.env,
+      version: config.version,
       sessionSampleRate: 100,
       sessionReplaySampleRate: 20,
       traceSampleRate: 100,
@@ -92,13 +111,28 @@ export function initDatadogRum() {
       plugins: [reactPlugin({ router: true })],
     });
 
-    initialized = true;
+    rumInitialized = true;
     startInitialDatadogView();
 
+    // Logs SDK must share env/service/version/site/clientToken with RUM for correlation.
+    // See https://docs.datadoghq.com/real_user_monitoring/correlate_with_other_telemetry/logs/
+    datadogLogs.init({
+      clientToken: config.clientToken,
+      site: config.site,
+      service: config.service,
+      env: config.env,
+      version: config.version,
+      forwardErrorsToLogs: true,
+      // Avoid forwarding hundreds of dev console.log calls; capture warn/error only.
+      forwardConsoleLogs: ['error', 'warn'],
+      sessionSampleRate: 100,
+    });
+    logsInitialized = true;
+
     if (import.meta.env.DEV) {
-      console.info('Datadog RUM initialized', {
-        env: environment,
-        service: import.meta.env.VITE_DATADOG_SERVICE || 'bunklogs-frontend',
+      console.info('Datadog RUM + Logs initialized', {
+        env: config.env,
+        service: config.service,
         tracing: true,
       });
     }
@@ -108,7 +142,7 @@ export function initDatadogRum() {
 }
 
 export function setDatadogUser(user) {
-  if (!initialized || !user) return;
+  if (!rumInitialized || !user) return;
 
   const displayName =
     user.name ||
@@ -137,7 +171,7 @@ export function setDatadogUser(user) {
 }
 
 export function clearDatadogUser() {
-  if (!initialized) return;
+  if (!rumInitialized) return;
 
   datadogRum.clearUser();
   datadogRum.removeGlobalContextProperty('user.role');
@@ -146,8 +180,17 @@ export function clearDatadogUser() {
 }
 
 export function addDatadogAction(name, context = {}) {
-  if (!initialized) return;
+  if (!rumInitialized) return;
   datadogRum.addAction(name, context);
+}
+
+/** Structured browser log correlated with the active RUM session/trace. */
+export function logToDatadog(level, message, context = {}) {
+  if (!logsInitialized) return;
+  const logger = datadogLogs.logger;
+  if (typeof logger[level] === 'function') {
+    logger[level](message, context);
+  }
 }
 
 function detectLoginMethod(tokens) {
@@ -166,7 +209,7 @@ export function trackUserLogout() {
 }
 
 export function trackApiSuccess(config, response) {
-  if (!initialized || !config?.url) return;
+  if (!rumInitialized || !config?.url) return;
 
   const method = (config.method || 'get').toLowerCase();
   const url = config.url;
@@ -215,4 +258,4 @@ export function trackApiSuccess(config, response) {
   }
 }
 
-export { datadogRum };
+export { datadogRum, datadogLogs };

--- a/render.yaml
+++ b/render.yaml
@@ -58,7 +58,7 @@ services:
     runtime: python3
     buildCommand: "./build.sh"
     schedule: "0 8 * * *"  # Daily at 8 AM
-    startCommand: "python manage.py send_daily_reports"
+    startCommand: "ddtrace-run python manage.py send_daily_reports"
     envVars:
       - key: PYTHON_VERSION
         value: "3.11.4"


### PR DESCRIPTION
## Summary
- Add `@datadog/browser-logs` alongside RUM so browser warn/error logs correlate with RUM sessions via shared `clientToken`/`env`/`service`/`version`.
- Fix backend log injection: Django formatter now emits `dd.trace_id` / `dd.span_id` when `DD_LOGS_INJECTION=true` (`config/datadog_logging.py`).
- Align `DD_ENV` default to `prod` (matches Render + frontend `VITE_DATADOG_ENV`).
- Run daily-reports cron under `ddtrace-run` for trace/log correlation on batch jobs.
- Document the full Render multi-service correlation path (browser → backend → agent → logs) in `docs/observability-setup.md`.

## Correlation path (Render)
- **RUM → APM**: trace headers on API calls → `ddtrace-run gunicorn` → Datadog Agent
- **RUM → Browser Logs**: shared SDK config + `session_id`
- **APM → Backend Logs**: `DD_LOGS_INJECTION` + Render log stream to Datadog

## Test plan
- [x] `npm run test -- src/lib/__tests__/datadog.test.js`
- [x] `backend/config/tests/test_datadog_logging.py` (runs in CI)
- [ ] After deploy: RUM session → linked backend trace on API resource
- [ ] After deploy: APM trace → Logs tab shows Django lines with matching `dd.trace_id`
- [ ] Confirm Render log stream to Datadog is configured on `bunklogs-backend`


Made with [Cursor](https://cursor.com)