### PR TITLE
Improve LT responses aggregate analytics and reorganize admin nav

### DIFF
--- a/backend/bunk_logs/api/leadership_team/responses.py
+++ b/backend/bunk_logs/api/leadership_team/responses.py
@@ -5,10 +5,10 @@
 * ``tab=individual`` — paginated reflections under a template (across
   versions), with filters: date range, respondent multi-select,
   language_of_authorship, ``rating_le``, ``has_free_text``.
-* ``tab=aggregate`` — completion rate over time, avg rating per
-  dimension (annotated with version-boundary markers when a dimension
-  only exists in some versions), language distribution, response volume
-  per period.
+* ``tab=aggregate`` — per-dimension rating distributions and averages
+  for the filtered date window, plus ``avg_rating_over_time`` (composite
+  daily average across all scored fields, computed from the full visible
+  reflection set so day filtering does not hide the trend line).
 
 ``combine_assignments=true`` includes responses from all assignments of
 the same template slug rather than only the matching version chain.
@@ -36,6 +36,7 @@ from bunk_logs.core.models import Reflection
 from bunk_logs.core.models import ReflectionTemplate
 from bunk_logs.core.reflection_scores import _as_float
 from bunk_logs.core.reflection_scores import iter_scored_fields
+from bunk_logs.core.reflection_scores import scale_max
 
 from .common import viewer_or_403
 
@@ -107,6 +108,7 @@ class LeadershipTeamTemplateResponsesView(APIView):
         date_to = _parse_filter_date(
             request.query_params.get("date_to"), field="date_to",
         )
+        reflections_for_trend = reflections
         if date_from:
             reflections = reflections.filter(period_end__gte=date_from)
         if date_to:
@@ -114,7 +116,13 @@ class LeadershipTeamTemplateResponsesView(APIView):
 
         tab = (request.query_params.get("tab") or "individual").lower()
         if tab == "aggregate":
-            return Response(self._aggregate(reflections, list(templates_qs)))
+            return Response(
+                self._aggregate(
+                    reflections,
+                    list(templates_qs),
+                    reflections_for_trend,
+                ),
+            )
         return Response(self._individual(request, reflections, template))
 
     # ------------------------------------------------------------------
@@ -245,8 +253,15 @@ class LeadershipTeamTemplateResponsesView(APIView):
     # Aggregate tab
     # ------------------------------------------------------------------
 
-    def _aggregate(self, reflections, templates) -> dict[str, Any]:
-        rows = list(reflections.values("pk", "language", "period_start", "answers", "template_id"))
+    def _aggregate(
+        self,
+        reflections,
+        templates,
+        reflections_for_trend,
+    ) -> dict[str, Any]:
+        row_fields = ("pk", "language", "period_start", "answers", "template_id")
+        rows = list(reflections.values(*row_fields))
+        trend_rows = list(reflections_for_trend.values(*row_fields))
 
         per_period: dict[date, int] = defaultdict(int)
         per_language: dict[str, int] = defaultdict(int)
@@ -254,42 +269,7 @@ class LeadershipTeamTemplateResponsesView(APIView):
             per_period[r["period_start"]] += 1
             per_language[r["language"] or "en"] += 1
 
-        ratings_by_key: dict[str, list[float]] = defaultdict(list)
-        valid_versions_by_key: dict[str, set[int]] = defaultdict(set)
-        templates_by_id = {t.pk: t for t in templates}
-        for r in rows:
-            tpl = templates_by_id.get(r["template_id"])
-            if tpl is None:
-                continue
-            for field, label, _ in iter_scored_fields(tpl):
-                valid_versions_by_key[label].add(tpl.version)
-                key = field.get("key")
-                ftype = field.get("type")
-                answers = r["answers"] or {}
-                if ftype == "single_rating":
-                    val = _as_float(answers.get(key))
-                    if val is not None:
-                        ratings_by_key[label].append(val)
-                else:
-                    block = answers.get(key) or {}
-                    if isinstance(block, dict):
-                        for cat in field.get("categories") or []:
-                            ck = cat.get("key") if isinstance(cat, dict) else None
-                            if ck is None:
-                                continue
-                            v = _as_float(block.get(ck))
-                            if v is not None:
-                                ratings_by_key[f"{key}__{ck}"].append(v)
-
-        avg_per_dimension = [
-            {
-                "key": label,
-                "avg": (sum(values) / len(values)) if values else None,
-                "count": len(values),
-                "versions": sorted(valid_versions_by_key.get(label, set())),
-            }
-            for label, values in sorted(ratings_by_key.items())
-        ]
+        avg_per_dimension = _avg_rating_per_dimension(rows, templates)
 
         return {
             "tab": "aggregate",
@@ -303,8 +283,119 @@ class LeadershipTeamTemplateResponsesView(APIView):
                 for k, v in sorted(per_language.items())
             ],
             "avg_rating_per_dimension": avg_per_dimension,
+            "avg_rating_over_time": _avg_rating_over_time(trend_rows, templates),
             "completion_rate_over_time": _completion_rate_over_time(reflections),
         }
+
+
+def _extract_scored_values(
+    answers: dict,
+    field: dict,
+    label: str,
+) -> float | None:
+    """Return the numeric rating for ``label`` on this answers blob."""
+    key = field.get("key")
+    ftype = field.get("type")
+    if ftype == "single_rating":
+        return _as_float(answers.get(key))
+    if ftype != "rating_group":
+        return None
+    block = answers.get(key) or {}
+    if not isinstance(block, dict):
+        return None
+    suffix = f"{key}__"
+    if not label.startswith(suffix):
+        return None
+    cat_key = label[len(suffix):]
+    return _as_float(block.get(cat_key))
+
+
+def _distribution_for_field(field: dict) -> dict[str, int]:
+    scale = field.get("scale") or [1, 5]
+    scale_min, scale_max_val = int(scale[0]), int(scale[-1])
+    return {str(i): 0 for i in range(scale_min, scale_max_val + 1)}
+
+
+def _avg_rating_per_dimension(
+    rows: list[dict[str, Any]],
+    templates: list,
+) -> list[dict[str, Any]]:
+    ratings_by_key: dict[str, list[float]] = defaultdict(list)
+    dists_by_key: dict[str, dict[str, int]] = {}
+    scale_by_key: dict[str, int] = {}
+    field_by_label: dict[str, dict] = {}
+    valid_versions_by_key: dict[str, set[int]] = defaultdict(set)
+    templates_by_id = {t.pk: t for t in templates}
+
+    for tpl in templates:
+        for field, label, sm in iter_scored_fields(tpl):
+            scale_by_key[label] = sm
+            field_by_label.setdefault(label, field)
+            valid_versions_by_key[label].add(tpl.version)
+            if label not in dists_by_key:
+                dists_by_key[label] = _distribution_for_field(field)
+
+    for r in rows:
+        tpl = templates_by_id.get(r["template_id"])
+        if tpl is None:
+            continue
+        answers = r["answers"] or {}
+        for field, label, _sm in iter_scored_fields(tpl):
+            val = _extract_scored_values(answers, field, label)
+            if val is None:
+                continue
+            ratings_by_key[label].append(val)
+            scale = field.get("scale") or [1, 5]
+            scale_min, scale_max_val = int(scale[0]), int(scale[-1])
+            bucket = str(max(scale_min, min(scale_max_val, int(round(val)))))
+            if bucket in dists_by_key[label]:
+                dists_by_key[label][bucket] += 1
+
+    out: list[dict[str, Any]] = []
+    for label in sorted(field_by_label.keys()):
+        values = ratings_by_key.get(label, [])
+        out.append(
+            {
+                "key": label,
+                "avg": (sum(values) / len(values)) if values else None,
+                "count": len(values),
+                "scale_max": scale_by_key.get(label, scale_max(field_by_label[label])),
+                "distribution": dists_by_key.get(label, {}),
+                "versions": sorted(valid_versions_by_key.get(label, set())),
+            },
+        )
+    return out
+
+
+def _avg_rating_over_time(
+    rows: list[dict[str, Any]],
+    templates: list,
+) -> list[dict[str, Any]]:
+    """Composite average of every scored value submitted on each day."""
+    by_date: dict[date, list[float]] = defaultdict(list)
+    templates_by_id = {t.pk: t for t in templates}
+
+    for r in rows:
+        tpl = templates_by_id.get(r["template_id"])
+        if tpl is None:
+            continue
+        day = r["period_start"]
+        if day is None:
+            continue
+        answers = r["answers"] or {}
+        for field, label, _sm in iter_scored_fields(tpl):
+            val = _extract_scored_values(answers, field, label)
+            if val is not None:
+                by_date[day].append(val)
+
+    return [
+        {
+            "date": day.isoformat(),
+            "avg": (sum(values) / len(values)) if values else None,
+            "count": len(values),
+        }
+        for day, values in sorted(by_date.items())
+    ]
 
 
 def _completion_rate_over_time(reflections) -> list[dict[str, Any]]:

--- a/backend/bunk_logs/api/tests/test_leadership_team_templates.py
+++ b/backend/bunk_logs/api/tests/test_leadership_team_templates.py
@@ -455,6 +455,12 @@ def test_responses_aggregate_tab(
     assert dim is not None
     assert dim["count"] == 3
     assert dim["avg"] == pytest.approx(4.0)
+    assert dim["scale_max"] == 5
+    assert dim["distribution"]["3"] == 1
+    assert dim["distribution"]["4"] == 1
+    assert dim["distribution"]["5"] == 1
+    assert body["avg_rating_over_time"]
+    assert body["avg_rating_over_time"][0]["avg"] == pytest.approx(4.0)
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
         document.querySelector('html').style.colorScheme = 'light';
       }        
     </script>      
-    <script type="module" crossorigin src="/assets/index-C_D-sg7j.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-CT8X2pNL.css">
+    <script type="module" crossorigin src="/assets/index-DlXtugWF.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-AxLzxKqA.css">
   </head>
   <body class="font-inter antialiased bg-gray-100 dark:bg-gray-900 text-gray-600 dark:text-gray-400">
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/pages/leadership-team/Responses.jsx
+++ b/frontend/src/pages/leadership-team/Responses.jsx
@@ -17,7 +17,7 @@
  * already supports range filters so no backend change required. Date
  * range remains available through the Filters drawer for power users.
  *
- * Aggregate tab is unchanged.
+ * Aggregate tab: pie charts per scored dimension, daily trend line, date picker.
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -47,7 +47,10 @@ import {
   getInitials,
   pickLabel,
   ratingTierClass,
+  seriesDisplayLabel,
 } from '../../dashboards/subject/responseTable/schema';
+import ScorePieChart from '../../dashboards/performance/ScorePieChart';
+import { ratingColor } from '../../dashboards/colors';
 import {
   DescriptionCell,
   FlagChip,
@@ -303,84 +306,369 @@ function IndividualTab({
   );
 }
 
-function AggregateTab({ payload }) {
-  if (!payload) return null;
-  // Backend serializers (LT responses endpoint) emit:
-  //   avg_rating_per_dimension: [{key, avg, count, versions}]
-  //   language_distribution:    [{language, count}]  -- list, not dict
-  //   response_volume_per_period: [{period_start, count}]
-  const dims = payload.avg_rating_per_dimension ?? payload.avg_per_dimension ?? [];
-  const langDistRaw = payload.language_distribution ?? [];
-  const langDist = Array.isArray(langDistRaw)
-    ? langDistRaw
-    : Object.entries(langDistRaw).map(([language, count]) => ({ language, count }));
-  const volume = payload.response_volume_per_period ?? [];
+function orderRatingDims(dims, ratingCols) {
+  const orderIndex = (key) => {
+    const col = ratingCols.find((c) =>
+      (c.subKey ? `${c.key}__${c.subKey}` : c.key) === key,
+    );
+    const sortKey = col?.subKey ?? col?.key ?? key;
+    return RATING_COLUMN_ORDER[sortKey] ?? 99;
+  };
+  return [...dims].sort((a, b) => {
+    const ra = orderIndex(a.key);
+    const rb = orderIndex(b.key);
+    if (ra !== rb) return ra - rb;
+    return a.key.localeCompare(b.key);
+  });
+}
+
+function emptyDistribution(scaleMax = 5) {
+  const dist = {};
+  for (let i = 1; i <= scaleMax; i += 1) dist[String(i)] = 0;
+  return dist;
+}
+
+/** Merge API aggregate dimensions with schema rating columns so every scored field gets a card. */
+function buildAggregateDims(apiDims, ratingCols) {
+  const byKey = Object.fromEntries((apiDims ?? []).map((d) => [d.key, d]));
+  const orderedCols = orderRatingCols(ratingCols);
+  const fromSchema = orderedCols.map((col) => {
+    const key = col.subKey ? `${col.key}__${col.subKey}` : col.key;
+    const scaleMax = col.scaleMax ?? 5;
+    const fromApi = byKey[key];
+    if (fromApi) {
+      return {
+        ...fromApi,
+        scale_max: fromApi.scale_max ?? scaleMax,
+        distribution: fromApi.distribution ?? emptyDistribution(fromApi.scale_max ?? scaleMax),
+      };
+    }
+    return {
+      key,
+      avg: null,
+      count: 0,
+      scale_max: scaleMax,
+      distribution: emptyDistribution(scaleMax),
+      versions: [],
+    };
+  });
+  const schemaKeys = new Set(fromSchema.map((d) => d.key));
+  const extras = orderRatingDims(
+    (apiDims ?? []).filter((d) => !schemaKeys.has(d.key)),
+    ratingCols,
+  );
+  return [...fromSchema, ...extras];
+}
+
+function distributionLegend(distribution) {
+  return Object.entries(distribution)
+    .filter(([, count]) => Number(count) > 0)
+    .sort(([a], [b]) => Number(a) - Number(b))
+    .map(([value, count]) => `${value}: ${count}`)
+    .join(' · ');
+}
+
+function DateStepperBar({ dateStr, setSingleDate, stepDate, embedded = false }) {
+  const controls = (
+    <div className="flex flex-wrap items-center gap-3 shrink-0">
+      <div className="flex items-center space-x-3">
+        <button
+          type="button"
+          onClick={() => stepDate(-1)}
+          className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700"
+          aria-label="Previous day"
+          data-testid="lt-responses-prev-day"
+        >
+          <ChevronLeft className="w-4 h-4" />
+        </button>
+        <div className="flex items-center space-x-2">
+          <Calendar className="w-5 h-5 text-gray-400" />
+          <SingleDatePicker
+            date={dateFromISO(dateStr)}
+            setDate={(d) => d && setSingleDate(isoFromDate(d))}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => stepDate(1)}
+          className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700"
+          aria-label="Next day"
+          data-testid="lt-responses-next-day"
+        >
+          <ChevronRight className="w-4 h-4" />
+        </button>
+      </div>
+      <div
+        className="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap"
+        data-testid="lt-responses-long-date"
+      >
+        {formatLongDate(dateStr)}
+      </div>
+    </div>
+  );
+
+  if (embedded) return controls;
+
   return (
-    <div className="space-y-4">
+    <div className="bg-white dark:bg-gray-800 shadow-sm rounded-xl p-5 mb-6">
+      {controls}
+    </div>
+  );
+}
+
+function AggregateTrendChart({ series, selectedDate, scaleMax = 5, onSelectDate }) {
+  const containerRef = useRef(null);
+  const [chartWidth, setChartWidth] = useState(0);
+  const [hoveredDate, setHoveredDate] = useState(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return undefined;
+    const update = () => setChartWidth(el.clientWidth);
+    update();
+    if (typeof ResizeObserver === 'undefined') return undefined;
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const selectDate = (date) => {
+    if (!onSelectDate || !date || date === selectedDate) return;
+    onSelectDate(date);
+  };
+
+  const points = (series ?? []).filter((p) => p.avg != null);
+  if (points.length === 0) {
+    return (
+      <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+        No rating history yet.
+      </p>
+    );
+  }
+  const w = chartWidth || 640;
+  const h = 160;
+  const padX = 36;
+  const padY = 20;
+  const sorted = [...points].sort((a, b) => a.date.localeCompare(b.date));
+  const xs = sorted.length;
+  const xStep = xs > 1 ? (w - 2 * padX) / (xs - 1) : 0;
+  const yScale = (v) => {
+    const clamped = Math.max(1, Math.min(scaleMax, v));
+    return h - padY - ((clamped - 1) / (scaleMax - 1)) * (h - 2 * padY);
+  };
+  const path = sorted
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${padX + i * xStep},${yScale(p.avg)}`)
+    .join(' ');
+
+  return (
+    <div ref={containerRef} className="w-full">
+      <svg
+        width="100%"
+        height={h}
+        viewBox={`0 0 ${w} ${h}`}
+        aria-label="Average score over time. Click a point to view that day."
+        className="block w-full"
+        data-testid="lt-responses-trend-chart"
+      >
+        {[1, Math.ceil(scaleMax / 2), scaleMax].map((v) => (
+          <g key={v}>
+            <line
+              x1={padX}
+              x2={w - padX}
+              y1={yScale(v)}
+              y2={yScale(v)}
+              stroke="#e5e7eb"
+              strokeWidth="0.5"
+            />
+            <text x={4} y={yScale(v) + 4} className="fill-gray-400 text-[10px]">{v}</text>
+          </g>
+        ))}
+        <path d={path} stroke="#4f46e5" strokeWidth="2" fill="none" />
+        {sorted.map((p, i) => {
+          const selected = p.date === selectedDate;
+          const hovered = p.date === hoveredDate;
+          const cx = padX + i * xStep;
+          const cy = yScale(p.avg);
+          const dotR = selected ? 5 : hovered ? 5 : 3.5;
+          return (
+            <g
+              key={p.date}
+              className="cursor-pointer"
+              data-testid={`lt-responses-trend-point-${p.date}`}
+              onMouseEnter={() => setHoveredDate(p.date)}
+              onMouseLeave={() => setHoveredDate((cur) => (cur === p.date ? null : cur))}
+              onClick={() => selectDate(p.date)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  selectDate(p.date);
+                }
+              }}
+              role="button"
+              tabIndex={0}
+              aria-label={`View ${formatLongDate(p.date)}, average ${p.avg.toFixed(2)}`}
+              aria-current={selected ? 'date' : undefined}
+            >
+              <title>{`${formatLongDate(p.date)} · avg ${p.avg.toFixed(2)} · click to view`}</title>
+              <circle
+                cx={cx}
+                cy={cy}
+                r={14}
+                fill="transparent"
+              />
+              {hovered && (
+                <g pointerEvents="none" data-testid={`lt-responses-trend-tooltip-${p.date}`}>
+                  <rect
+                    x={cx - 72}
+                    y={cy - 30}
+                    width={144}
+                    height={20}
+                    rx={4}
+                    className="fill-gray-900 dark:fill-gray-700"
+                    opacity={0.92}
+                  />
+                  <text
+                    x={cx}
+                    y={cy - 16}
+                    textAnchor="middle"
+                    className="fill-white text-[10px]"
+                  >
+                    {formatLongDate(p.date)}
+                  </text>
+                </g>
+              )}
+              <circle
+                cx={cx}
+                cy={cy}
+                r={dotR}
+                fill={selected || hovered ? '#4f46e5' : (ratingColor(p.avg, scaleMax) ?? '#6b7280')}
+                stroke="#fff"
+                strokeWidth="1.5"
+                pointerEvents="none"
+              />
+              <text
+                x={cx}
+                y={h - 4}
+                textAnchor="middle"
+                pointerEvents="none"
+                className={`text-[9px] ${
+                  selected || hovered
+                    ? 'fill-indigo-600 font-semibold'
+                    : 'fill-gray-500'
+                }`}
+              >
+                {formatShortDate(p.date)}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+function AggregateRatingCard({ dim, ratingCols }) {
+  const displayLabel = seriesDisplayLabel(dim.key, ratingCols) || dim.key;
+  const scaleMax = dim.scale_max ?? 5;
+  const distribution = dim.distribution ?? emptyDistribution(scaleMax);
+  const total = Object.values(distribution).reduce((sum, count) => sum + Number(count), 0);
+
+  return (
+    <div
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 flex flex-col items-center text-center"
+      data-testid={`lt-responses-dim-${dim.key}`}
+    >
+      <h4 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
+        {displayLabel}
+      </h4>
+      {total === 0 ? (
+        <p className="text-xs text-gray-400 italic py-8">No ratings for this day.</p>
+      ) : (
+        <div className="flex flex-col items-center gap-2" aria-label={`${displayLabel} score distribution`}>
+          <ScorePieChart distribution={distribution} scaleMax={scaleMax} size={96} />
+          <p className="text-[10px] text-gray-500 dark:text-gray-400 text-center">
+            {distributionLegend(distribution)}
+          </p>
+        </div>
+      )}
+      <p className="mt-3 text-2xl font-semibold tabular-nums text-gray-900 dark:text-white">
+        {dim.avg == null ? '—' : dim.avg.toFixed(2)}
+      </p>
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        average · {dim.count ?? 0} rating{(dim.count ?? 0) === 1 ? '' : 's'}
+      </p>
+    </div>
+  );
+}
+
+function AggregateTab({ payload, dateStr, ratingCols, onSelectDate, loading = false }) {
+  if (!payload) return null;
+  const ratingColsOrdered = orderRatingCols(ratingCols);
+  const dims = buildAggregateDims(
+    payload.avg_rating_per_dimension ?? payload.avg_per_dimension ?? [],
+    ratingColsOrdered,
+  );
+  const trend = payload.avg_rating_over_time ?? [];
+  const trendScaleMax = dims.reduce(
+    (max, d) => Math.max(max, d.scale_max ?? 5),
+    5,
+  );
+
+  return (
+    <div className="space-y-6">
+      {loading && (
+        <p className="text-xs text-gray-500 dark:text-gray-400" data-testid="lt-responses-aggregate-loading">
+          Updating…
+        </p>
+      )}
       <div
         className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
         data-testid="lt-responses-summary"
       >
         <p className="text-sm text-gray-700 dark:text-gray-300">
-          <span className="font-semibold text-gray-900 dark:text-white">{payload.total_responses}</span> responses
+          <span className="font-semibold text-gray-900 dark:text-white">
+            {payload.total_responses}
+          </span>
+          {' '}
+          response{payload.total_responses === 1 ? '' : 's'} on {formatLongDate(dateStr)}
         </p>
       </div>
 
-      <div
-        className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
-        data-testid="lt-responses-avg"
-      >
-        <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-2">
-          Average per dimension
-        </h3>
-        {dims.length === 0 ? (
-          <p className="text-sm text-gray-500 dark:text-gray-400">No scored fields.</p>
-        ) : (
-          <ul className="space-y-1 text-sm">
-            {dims.map((d) => (
-              <li key={d.key} className="flex justify-between" data-testid={`lt-responses-dim-${d.key}`}>
-                <span className="text-gray-700 dark:text-gray-300">
-                  {d.key}
-                  <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">
-                    versions: {(d.versions ?? []).join(', ') || '—'}
-                  </span>
-                </span>
-                <span className="text-gray-900 dark:text-white font-medium">
-                  {d.avg == null ? '—' : d.avg.toFixed(2)}
-                  <span className="text-xs text-gray-500 dark:text-gray-400 ml-1">({d.count})</span>
-                </span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
+      {dims.length === 0 ? (
+        <div
+          className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6"
+          data-testid="lt-responses-avg"
+        >
+          <p className="text-sm text-gray-500 dark:text-gray-400">No scored fields on this template.</p>
+        </div>
+      ) : (
+        <div
+          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
+          data-testid="lt-responses-avg"
+        >
+          {dims.map((d) => (
+            <AggregateRatingCard
+              key={d.key}
+              dim={d}
+              ratingCols={ratingColsOrdered}
+            />
+          ))}
+        </div>
+      )}
 
       <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
-        <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-2">
-          Language distribution
+        <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-1">
+          Average score over time
         </h3>
-        <ul className="text-sm space-y-1">
-          {langDist.map(({ language, count }) => (
-            <li key={language} className="flex justify-between text-gray-700 dark:text-gray-300">
-              <span>{language}</span>
-              <span>{count}</span>
-            </li>
-          ))}
-        </ul>
-      </div>
-
-      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
-        <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-2">
-          Volume per period
-        </h3>
-        <ul className="text-xs space-y-0.5">
-          {volume.map((v) => (
-            <li key={v.period_start} className="flex justify-between text-gray-700 dark:text-gray-300">
-              <span>{v.period_start}</span>
-              <span>{v.count}</span>
-            </li>
-          ))}
-        </ul>
+        <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
+          Composite average across all rating fields for each day. Hover to preview a date; click to view that day.
+        </p>
+        <AggregateTrendChart
+          series={trend}
+          selectedDate={dateStr}
+          scaleMax={trendScaleMax}
+          onSelectDate={onSelectDate}
+        />
       </div>
     </div>
   );
@@ -397,7 +685,7 @@ function AggregateTab({ payload }) {
  * any stale range in the URL. The Filters drawer clears ``?date=`` when
  * the user picks a range, so the two never conflict in practice.
  */
-function buildApiParams(urlParams) {
+function buildApiParams(urlParams, activeTab) {
   const out = {};
   for (const [k, v] of urlParams.entries()) {
     if (k === 'q' || k === 'date') continue;
@@ -408,6 +696,7 @@ function buildApiParams(urlParams) {
     out.date_from = single;
     out.date_to = single;
   }
+  out.tab = activeTab;
   return out;
 }
 
@@ -424,6 +713,7 @@ export default function LeadershipTeamResponses() {
   const [showFilters, setShowFilters] = useState(false);
   const [template, setTemplate] = useState(null);
   const [payload, setPayload] = useState(null);
+  const lastAggregatePayloadRef = useRef(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
@@ -444,9 +734,9 @@ export default function LeadershipTeamResponses() {
   }, []);
 
   const apiParamsKey = useMemo(() => {
-    const built = buildApiParams(params);
+    const built = buildApiParams(params, tab);
     return JSON.stringify(built);
-  }, [params]);
+  }, [params, tab]);
 
   useEffect(() => {
     let cancelled = false;
@@ -461,6 +751,7 @@ export default function LeadershipTeamResponses() {
         if (cancelled) return;
         setTemplate(tpl);
         setPayload(data);
+        if (data?.tab === 'aggregate') lastAggregatePayloadRef.current = data;
       } catch (err) {
         if (cancelled) return;
         if (err?.response?.status === 403) setError('You cannot view these responses.');
@@ -543,7 +834,11 @@ export default function LeadershipTeamResponses() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filteredRows, sections.flagFields, params]);
 
-  const exportHref = exportResponsesUrl(id, buildApiParams(params));
+  const exportHref = exportResponsesUrl(id, buildApiParams(params, tab));
+
+  const aggregatePayload = payload?.tab === 'aggregate'
+    ? payload
+    : lastAggregatePayloadRef.current;
 
   const { href: backHref, label: backLabel } = responsesBackLink({
     dashboard: params.get('dashboard'),
@@ -640,41 +935,12 @@ export default function LeadershipTeamResponses() {
                         </button>
                       )}
                     </div>
-                    <div className="flex flex-wrap items-center gap-3 shrink-0">
-                      <div className="flex items-center space-x-3">
-                        <button
-                          type="button"
-                          onClick={() => stepDate(-1)}
-                          className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700"
-                          aria-label="Previous day"
-                          data-testid="lt-responses-prev-day"
-                        >
-                          <ChevronLeft className="w-4 h-4" />
-                        </button>
-                        <div className="flex items-center space-x-2">
-                          <Calendar className="w-5 h-5 text-gray-400" />
-                          <SingleDatePicker
-                            date={dateFromISO(dateStr)}
-                            setDate={(d) => d && setSingleDate(isoFromDate(d))}
-                          />
-                        </div>
-                        <button
-                          type="button"
-                          onClick={() => stepDate(1)}
-                          className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700"
-                          aria-label="Next day"
-                          data-testid="lt-responses-next-day"
-                        >
-                          <ChevronRight className="w-4 h-4" />
-                        </button>
-                      </div>
-                      <div
-                        className="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap"
-                        data-testid="lt-responses-long-date"
-                      >
-                        {formatLongDate(dateStr)}
-                      </div>
-                    </div>
+                    <DateStepperBar
+                      dateStr={dateStr}
+                      setSingleDate={setSingleDate}
+                      stepDate={stepDate}
+                      embedded
+                    />
                   </div>
                 </div>
 
@@ -811,7 +1077,15 @@ export default function LeadershipTeamResponses() {
               </>
             )}
 
-            {loading && (
+            {tab === 'aggregate' && (
+              <DateStepperBar
+                dateStr={dateStr}
+                setSingleDate={setSingleDate}
+                stepDate={stepDate}
+              />
+            )}
+
+            {loading && tab !== 'aggregate' && (
               <p className="text-sm text-gray-500 dark:text-gray-400" data-testid="lt-responses-loading">
                 Loading…
               </p>
@@ -832,7 +1106,15 @@ export default function LeadershipTeamResponses() {
                 dateStr={dateStr}
               />
             )}
-            {!loading && !error && tab === 'aggregate' && <AggregateTab payload={payload} />}
+            {!error && tab === 'aggregate' && aggregatePayload && (
+              <AggregateTab
+                payload={aggregatePayload}
+                dateStr={dateStr}
+                ratingCols={sections.ratingCols}
+                onSelectDate={setSingleDate}
+                loading={loading}
+              />
+            )}
     </div>
   );
 }

--- a/frontend/src/pages/leadership-team/__tests__/Responses.test.jsx
+++ b/frontend/src/pages/leadership-team/__tests__/Responses.test.jsx
@@ -125,10 +125,21 @@ const individualPayload = {
 const aggregatePayload = {
   tab: 'aggregate',
   total_responses: 2,
-  response_volume_per_period: [{ period_start: '2026-07-06', count: 2 }],
+  response_volume_per_period: [{ period_start: '2026-07-12', count: 2 }],
   language_distribution: [{ language: 'en', count: 2 }],
   avg_rating_per_dimension: [
-    { key: 'behavior', avg: 3.0, count: 2, versions: [1] },
+    {
+      key: 'camper_scores__behavior',
+      avg: 3.0,
+      count: 2,
+      scale_max: 5,
+      distribution: { 1: 0, 2: 1, 3: 0, 4: 1, 5: 0 },
+      versions: [1],
+    },
+  ],
+  avg_rating_over_time: [
+    { date: '2026-07-11', avg: 3.2, count: 3 },
+    { date: '2026-07-12', avg: 3.5, count: 4 },
   ],
 };
 
@@ -251,16 +262,44 @@ describe('LeadershipTeamResponses', () => {
     expect(back).toHaveTextContent('← Bunk Logs');
   });
 
-  it('switches to the aggregate tab and shows per-dimension averages', async () => {
+  it('switches to the aggregate tab and shows rating pie charts with averages', async () => {
     getMock.mockImplementation((url, { params } = {}) => {
       if (!url.includes('/responses/')) return Promise.resolve({ data: templatePayload });
       if (params?.tab === 'aggregate') return Promise.resolve({ data: aggregatePayload });
       return Promise.resolve({ data: individualPayload });
     });
-    renderAt('/admin/templates/7/responses');
+    renderAt('/admin/templates/7/responses?date=2026-07-12');
     await screen.findByTestId('lt-responses-row-401');
     fireEvent.click(screen.getByTestId('lt-responses-tab-aggregate'));
-    await waitFor(() => expect(screen.getByTestId('lt-responses-dim-behavior')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId('lt-responses-dim-camper_scores__behavior')).toBeInTheDocument(),
+    );
     expect(screen.getByText('3.00')).toBeInTheDocument();
+    expect(screen.getByTestId('lt-responses-trend-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('lt-responses-prev-day')).toBeInTheDocument();
+  });
+
+  it('navigates to a trend chart date when clicking a point', async () => {
+    getMock.mockImplementation((url, { params } = {}) => {
+      if (!url.includes('/responses/')) return Promise.resolve({ data: templatePayload });
+      if (params?.tab === 'aggregate') return Promise.resolve({ data: aggregatePayload });
+      return Promise.resolve({ data: individualPayload });
+    });
+    renderAt('/admin/templates/7/responses?date=2026-07-12&tab=aggregate');
+    await waitFor(() =>
+      expect(screen.getByTestId('lt-responses-trend-point-2026-07-11')).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByTestId('lt-responses-trend-point-2026-07-11'));
+
+    await waitFor(() => {
+      const responseCalls = getMock.mock.calls.filter(
+        ([url, config]) =>
+          url.includes('/responses/')
+          && config?.params?.tab === 'aggregate'
+          && config?.params?.date_from === '2026-07-11',
+      );
+      expect(responseCalls.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/frontend/src/partials/Sidebar.jsx
+++ b/frontend/src/partials/Sidebar.jsx
@@ -71,12 +71,11 @@ const PROGRAM_LEAD_PLUS = ['program_lead'];
  *     Author attribution /dashboards/authors
  *
  *   ADMIN (collapsible, below Supervise)
- *     Admin dashboard     /admin/dashboard
- *     Templates           /admin/templates
  *     People              /admin/people
- *     Assignments         /admin/assignments
  *     Memberships         /admin/memberships
- *     Assignment groups   /admin/groups
+ *     Groups              /admin/groups
+ *     Assignments         /admin/assignments
+ *     Templates           /admin/templates
  *     Field keys          /admin/field-keys
  *     Settings            /admin/settings
  *
@@ -300,13 +299,12 @@ function Sidebar({
           >
             {canAdmin && (
               <>
-                <SubItem to="/admin/dashboard" label="Admin Dashboard" />
-                <SubItem to="/admin/templates" label="Templates" />
                 <SubItem to="/admin/people" label="People" />
-                <SubItem to="/admin/assignments" label="Assignments" />
                 <SubItem to="/admin/memberships" label="Memberships" />
-                <SubItem to="/admin/groups" label="Assignment groups" />
-                <SubItem to="/admin/field-keys" label="Field keys" />
+                <SubItem to="/admin/groups" label="Groups" />
+                <SubItem to="/admin/assignments" label="Assignments" />
+                <SubItem to="/admin/templates" label="Templates" />
+                <SubItem to="/admin/field-keys" label="Field Keys" />
                 <SubItem to="/admin/settings" label="Settings" />
               </>
             )}

--- a/frontend/src/partials/__tests__/Sidebar.test.jsx
+++ b/frontend/src/partials/__tests__/Sidebar.test.jsx
@@ -181,7 +181,7 @@ describe('Sidebar — section gating (3.32)', () => {
     const links = hrefs();
     expect(links).toContain('/admin/home');
     expect(links).toContain('/help');
-    expect(links).toContain('/admin/dashboard');
+    expect(links).not.toContain('/admin/dashboard');
     expect(links).toContain('/dashboards/logs');
     expect(links).toContain('/dashboards/reflections');
     expect(links).toContain('/admin/templates');
@@ -238,7 +238,7 @@ describe('Sidebar — maintenance-only nav', () => {
     renderWith({ role: 'Admin', membership_roles: ['maintenance', 'admin'] });
     const links = hrefs();
     expect(links).toContain('/admin/home');
-    expect(links).toContain('/admin/dashboard');
+    expect(links).not.toContain('/admin/dashboard');
     expect(screen.getAllByText('Admin').length).toBeGreaterThan(0);
   });
 });
@@ -275,18 +275,19 @@ describe('Sidebar — Admin submenu items (3.32)', () => {
     expect(hrefs()).toContain('/admin/field-keys');
   });
 
-  it('still includes Memberships / Templates / Groups and top-level Home', () => {
+  it('still includes People / Memberships / Groups / Templates and top-level Home', () => {
     renderWith({ role: 'Admin' }, { path: '/admin/home' });
     const links = hrefs();
     expect(links).toEqual(
       expect.arrayContaining([
         '/admin/home',
-        '/admin/dashboard',
+        '/admin/people',
         '/admin/memberships',
-        '/admin/templates',
         '/admin/groups',
+        '/admin/templates',
       ]),
     );
+    expect(links).not.toContain('/admin/dashboard');
   });
 
   it('renders Admin submenu after Supervise with no legacy links', () => {
@@ -297,16 +298,25 @@ describe('Sidebar — Admin submenu items (3.32)', () => {
     const logsIdx = links.indexOf('/dashboards/logs');
     const reflectionsIdx = links.indexOf('/dashboards/reflections');
     const authorsIdx = links.indexOf('/dashboards/authors');
-    const adminDashboardIdx = links.indexOf('/admin/dashboard');
-    const templatesIdx = links.indexOf('/admin/templates');
     const peopleIdx = links.indexOf('/admin/people');
+    const membershipsIdx = links.indexOf('/admin/memberships');
+    const groupsIdx = links.indexOf('/admin/groups');
+    const assignmentsIdx = links.indexOf('/admin/assignments');
+    const templatesIdx = links.indexOf('/admin/templates');
+    const fieldKeysIdx = links.indexOf('/admin/field-keys');
+    const settingsIdx = links.indexOf('/admin/settings');
     expect(homeIdx).toBeGreaterThanOrEqual(0);
     expect(performanceIdx).toBeGreaterThan(homeIdx);
     expect(logsIdx).toBeGreaterThan(performanceIdx);
     expect(reflectionsIdx).toBeGreaterThan(logsIdx);
-    expect(authorsIdx).toBeLessThan(adminDashboardIdx);
-    expect(templatesIdx).toBeGreaterThan(adminDashboardIdx);
-    expect(peopleIdx).toBeGreaterThan(templatesIdx);
+    expect(authorsIdx).toBeLessThan(peopleIdx);
+    expect(membershipsIdx).toBeGreaterThan(peopleIdx);
+    expect(groupsIdx).toBeGreaterThan(membershipsIdx);
+    expect(assignmentsIdx).toBeGreaterThan(groupsIdx);
+    expect(templatesIdx).toBeGreaterThan(assignmentsIdx);
+    expect(fieldKeysIdx).toBeGreaterThan(templatesIdx);
+    expect(settingsIdx).toBeGreaterThan(fieldKeysIdx);
+    expect(links).not.toContain('/admin/dashboard');
     expect(links).not.toContain('/admin-bunk-logs');
     expect(links).not.toContain('/admin-dashboard');
     expect(screen.queryByText('Crane Lake legacy')).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Add per-dimension rating distributions and a composite daily trend line to the Leadership Team template responses aggregate tab (backend + frontend).
- Reorganize the admin sidebar: hide the unfinished Admin Dashboard link, rename Assignment groups to Groups, and order links People → Memberships → Groups → Assignments → Templates → Field Keys → Settings.

## Test plan
- [ ] Open LT template responses → Aggregate tab; confirm pie charts per scored dimension, trend line, and date stepper work.
- [ ] Filter by date and confirm dimension stats respect the window while the trend line shows full history.
- [ ] As admin, expand Admin nav and confirm link order/labels and that Admin Dashboard is hidden.
- [ ] `make test-frontend` — Sidebar and Responses tests pass.


Made with [Cursor](https://cursor.com)