### PR TITLE
Fix admin group creation slug validation

### DIFF
--- a/backend/bunk_logs/api/assignment_groups.py
+++ b/backend/bunk_logs/api/assignment_groups.py
@@ -99,6 +99,7 @@ class AssignmentGroupListSerializer(serializers.ModelSerializer):
 
 
 class AssignmentGroupWriteSerializer(serializers.ModelSerializer):
+    slug = serializers.SlugField(required=False, allow_blank=True)
     parent = serializers.PrimaryKeyRelatedField(
         queryset=AssignmentGroup.all_objects.all(),
         required=False,

--- a/backend/bunk_logs/api/tests/test_assignment_groups_write_api.py
+++ b/backend/bunk_logs/api/tests/test_assignment_groups_write_api.py
@@ -121,6 +121,18 @@ class TestCreateGroup:
         assert r.status_code == 201
         assert AssignmentGroup.all_objects.filter(slug="bunk-bravo-write").exists()
 
+    def test_admin_can_create_without_slug(self, client, org, program, admin_user):
+        user, _ = admin_user
+        client.force_authenticate(user=user)
+        r = client.post(
+            "/api/v1/assignment-groups/",
+            {"name": "Bunk Delta", "group_type": "bunk", "program": program.pk},
+            **_hdr(org.slug),
+        )
+        assert r.status_code == 201, r.content
+        created = AssignmentGroup.all_objects.get(program=program, name="Bunk Delta")
+        assert created.slug == "bunk-delta"
+
     def test_admin_can_create_team_group(self, client, org, program, admin_user):
         user, _ = admin_user
         client.force_authenticate(user=user)


### PR DESCRIPTION
## Summary
- Make `slug` optional on `AssignmentGroupWriteSerializer` so create requests without a slug pass validation
- Existing `run_validators` logic still auto-generates a unique slug from the group name
- Add API test covering create-without-slug behavior

## Test plan
- [x] `pytest bunk_logs/api/tests/test_assignment_groups_write_api.py::TestCreateGroup::test_admin_can_create_without_slug`
- [ ] Create a group at `/admin/groups?program=1` without providing a slug and confirm it succeeds


Made with [Cursor](https://cursor.com)