### PR TITLE
Fix group creation slug and enable group-scoped roster import

### DIFF
--- a/backend/bunk_logs/api/assignment_groups.py
+++ b/backend/bunk_logs/api/assignment_groups.py
@@ -344,6 +344,16 @@ class AssignmentGroupViewSet(viewsets.ModelViewSet):
             )
 
         reconcile = request.data.get("reconcile", "false").lower() in ("1", "true", "yes")
+        bulk_role_in_group = (
+            request.data.get("default_role_in_group")
+            or request.data.get("bulk_role_in_group")
+            or "subject"
+        ).strip().lower()
+        if bulk_role_in_group not in {"subject", "author"}:
+            return Response(
+                {"default_role_in_group": "Must be 'subject' or 'author'."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         csv_content = csv_file.read().decode("utf-8")
 
         log = RosterImportLog.all_objects.create(
@@ -356,16 +366,36 @@ class AssignmentGroupViewSet(viewsets.ModelViewSet):
         )
 
         from bunk_logs.core.tasks import import_roster_task
-        import_roster_task.delay(
-            log_id=log.pk,
-            csv_content=csv_content,
-            importer_type=importer_type,
-            options={"reconcile": reconcile},
-        )
 
+        # No Celery worker is deployed yet; run inline so admin imports complete.
+        try:
+            import_roster_task.apply(
+                kwargs={
+                    "log_id": log.pk,
+                    "csv_content": csv_content,
+                    "importer_type": importer_type,
+                    "options": {
+                        "reconcile": reconcile,
+                        "target_group_id": group.pk,
+                        "bulk_role_in_group": bulk_role_in_group,
+                    },
+                },
+            ).get()
+        except Exception as exc:
+            log.refresh_from_db()
+            if log.status != "failed":
+                log.status = "failed"
+                log.summary = {**(log.summary or {}), "error": str(exc)}
+                log.save(update_fields=["status", "summary"])
+            return Response(
+                RosterImportLogSerializer(log).data,
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        log.refresh_from_db()
         return Response(
-            {"task_id": log.pk, "log_id": log.pk, "status": log.status},
-            status=status.HTTP_202_ACCEPTED,
+            RosterImportLogSerializer(log).data,
+            status=status.HTTP_200_OK,
         )
 
     @action(detail=False, methods=["get"], url_path=r"import-logs/(?P<log_id>\d+)")

--- a/backend/bunk_logs/api/assignment_groups.py
+++ b/backend/bunk_logs/api/assignment_groups.py
@@ -99,6 +99,7 @@ class AssignmentGroupListSerializer(serializers.ModelSerializer):
 
 
 class AssignmentGroupWriteSerializer(serializers.ModelSerializer):
+    slug = serializers.SlugField(required=False, allow_blank=True)
     parent = serializers.PrimaryKeyRelatedField(
         queryset=AssignmentGroup.all_objects.all(),
         required=False,

--- a/backend/bunk_logs/api/tests/test_assignment_groups_write_api.py
+++ b/backend/bunk_logs/api/tests/test_assignment_groups_write_api.py
@@ -121,6 +121,18 @@ class TestCreateGroup:
         assert r.status_code == 201
         assert AssignmentGroup.all_objects.filter(slug="bunk-bravo-write").exists()
 
+    def test_admin_can_create_without_slug(self, client, org, program, admin_user):
+        user, _ = admin_user
+        client.force_authenticate(user=user)
+        r = client.post(
+            "/api/v1/assignment-groups/",
+            {"name": "Bunk Delta", "group_type": "bunk", "program": program.pk},
+            **_hdr(org.slug),
+        )
+        assert r.status_code == 201, r.content
+        created = AssignmentGroup.all_objects.get(program=program, name="Bunk Delta")
+        assert created.slug == "bunk-delta"
+
     def test_admin_can_create_team_group(self, client, org, program, admin_user):
         user, _ = admin_user
         client.force_authenticate(user=user)

--- a/backend/bunk_logs/core/assignment_resolution.py
+++ b/backend/bunk_logs/core/assignment_resolution.py
@@ -63,6 +63,33 @@ _ACTIVE_STATUSES = (
 
 
 # ---------------------------------------------------------------------------
+# Assignment-group audience helpers
+# ---------------------------------------------------------------------------
+
+
+def _effective_author_roles(template: ReflectionTemplate) -> list[str]:
+    """Membership roles that qualify to fill an assignment-group form."""
+    roles = [r for r in (template.author_role_filter or []) if r]
+    if roles:
+        return roles
+    if template.role:
+        return [template.role]
+    return []
+
+
+def _assignment_group_membership_roles(template: ReflectionTemplate) -> tuple[str, ...]:
+    """Which ``AssignmentGroupMembership.role_in_group`` values count.
+
+    Self-reflection templates are filled by the team member themselves,
+    so both ``author`` and ``subject`` roster rows qualify. Roster-style
+    templates still require active ``author`` rows only.
+    """
+    if template.subject_mode == "self":
+        return ("author", "subject")
+    return ("author",)
+
+
+# ---------------------------------------------------------------------------
 # Membership resolution (moved from api/leadership_team/assignments.py)
 # ---------------------------------------------------------------------------
 
@@ -78,8 +105,10 @@ def resolve_members(assignment: TemplateAssignment, as_of: date):
     * ``tag_group``: dynamic — Memberships whose ``tags`` JSON contains
       the given tag.
     * ``assignment_group``: dynamic — Memberships whose role is in
-      ``template.author_role_filter`` AND who are active authors in the
-      group.
+      ``template.author_role_filter`` (or ``template.role`` when that
+      filter is empty) AND who hold an active roster row in the group.
+      Self-reflection templates accept either ``author`` or ``subject``
+      roster rows; roster templates require ``author``.
     """
     payload = assignment.target_payload or {}
     base = Membership.all_objects.filter(
@@ -103,16 +132,18 @@ def resolve_members(assignment: TemplateAssignment, as_of: date):
         group_id = assignment.assignment_group_id
         if not group_id:
             return base.none()
-        author_roles = assignment.template.author_role_filter or []
+        tpl = assignment.template
+        author_roles = _effective_author_roles(tpl)
         if not author_roles:
             return base.none()
-        author_person_ids = AssignmentGroupMembership.all_objects.filter(
+        roster_roles = _assignment_group_membership_roles(tpl)
+        member_person_ids = AssignmentGroupMembership.all_objects.filter(
             group_id=group_id,
-            role_in_group="author",
+            role_in_group__in=roster_roles,
             is_active=True,
         ).values_list("person_id", flat=True)
         return base.filter(
-            person_id__in=author_person_ids, role__in=author_roles,
+            person_id__in=member_person_ids, role__in=author_roles,
         )
     return base.none()
 
@@ -204,13 +235,15 @@ def _viewer_in_audience(
         group_id = assignment.assignment_group_id
         if not group_id:
             return False
-        author_roles = assignment.template.author_role_filter or []
+        tpl = assignment.template
+        author_roles = _effective_author_roles(tpl)
         if not author_roles:
             return False
+        roster_roles = _assignment_group_membership_roles(tpl)
         return AssignmentGroupMembership.all_objects.filter(
             group_id=group_id,
             person=viewer,
-            role_in_group="author",
+            role_in_group__in=roster_roles,
             is_active=True,
         ).filter(
             Q(person__memberships__role__in=author_roles)
@@ -241,8 +274,9 @@ def active_assignments_for(
         * target_type='role' and target_payload['role'] matches, OR
         * target_type='individuals' and the viewer's Membership is in
           target_payload['membership_ids'], OR
-        * target_type='assignment_group' and the viewer is an author in
-          that group whose role is in template.author_role_filter, OR
+        * target_type='assignment_group' and the viewer is in that
+          group's roster with a role in template.author_role_filter
+          (or template.role when the filter is empty), OR
         * target_type='tag_group' and the viewer's Membership tags
           include the tag.
     - When ``require_required`` is True (default), drops is_required=False

--- a/backend/bunk_logs/core/campminder_csv.py
+++ b/backend/bunk_logs/core/campminder_csv.py
@@ -90,6 +90,7 @@ _HEADER_ALIASES: dict[str, tuple[str, ...]] = {
     "tags": ("tags",),
     "start_date": ("start date", "start_date", "start"),
     "end_date": ("end date", "end_date", "end"),
+    "role_in_group": ("role in group", "role_in_group", "group role"),
 }
 
 
@@ -261,6 +262,7 @@ def normalize_campminder_row(row: dict) -> dict:
         "tags": _field_value(indexed, "tags"),
         "start_date": _field_value(indexed, "start_date"),
         "end_date": _field_value(indexed, "end_date"),
+        "role_in_group": _field_value(indexed, "role_in_group"),
     }
 
 

--- a/backend/bunk_logs/core/group_roster_import.py
+++ b/backend/bunk_logs/core/group_roster_import.py
@@ -1,0 +1,46 @@
+"""Helpers for group-scoped roster CSV imports."""
+
+from __future__ import annotations
+
+from django.core.management.base import CommandError
+
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Program
+
+
+def load_target_group(
+    *,
+    target_group_id: int | None,
+    org: Organization,
+    program: Program,
+) -> AssignmentGroup | None:
+    if target_group_id is None:
+        return None
+    try:
+        group = AssignmentGroup.all_objects.get(pk=target_group_id)
+    except AssignmentGroup.DoesNotExist:
+        msg = f"AssignmentGroup not found: {target_group_id}"
+        raise CommandError(msg)
+    if group.organization_id != org.pk or group.program_id != program.pk:
+        msg = "Target group must belong to the import organization and program."
+        raise CommandError(msg)
+    return group
+
+
+def infer_role_in_group_from_program_role(program_role: str) -> str:
+    return "subject" if program_role == "camper" else "author"
+
+
+def resolve_role_in_group(
+    row: dict,
+    program_role: str,
+    *,
+    bulk_role_in_group: str | None = None,
+) -> str:
+    explicit = (row.get("role_in_group") or "").strip().lower()
+    if explicit in {"subject", "author"}:
+        return explicit
+    if bulk_role_in_group in {"subject", "author"}:
+        return bulk_role_in_group
+    return infer_role_in_group_from_program_role(program_role)

--- a/backend/bunk_logs/core/management/commands/import_campminder_roster.py
+++ b/backend/bunk_logs/core/management/commands/import_campminder_roster.py
@@ -31,6 +31,8 @@ from bunk_logs.core.campminder_person_match import match_campminder_person
 from bunk_logs.core.campminder_person_match import strategy_is_duplicate
 from bunk_logs.core.campminder_user_link import UserLinkAction
 from bunk_logs.core.campminder_user_link import ensure_user_for_imported_person
+from bunk_logs.core.group_roster_import import load_target_group
+from bunk_logs.core.group_roster_import import resolve_role_in_group
 from bunk_logs.core.models import AssignmentGroup
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
@@ -242,6 +244,61 @@ class Command(BaseCommand):
                 "for (group, role_in_group) pairs that appear in the DB but not in the CSV."
             ),
         )
+        parser.add_argument(
+            "--log-id",
+            type=int,
+            default=None,
+            help="Existing RosterImportLog PK to update (API import path).",
+        )
+        parser.add_argument(
+            "--target-group-id",
+            type=int,
+            default=None,
+            help="Add each imported row to this AssignmentGroup (group detail import path).",
+        )
+        parser.add_argument(
+            "--bulk-role-in-group",
+            default="",
+            help="Default role_in_group for target-group imports (subject or author).",
+        )
+
+    def _resolve_import_log(
+        self,
+        *,
+        org: Organization,
+        program: Program,
+        csv_path: Path,
+        log_id: int | None,
+        dry_run: bool,
+    ) -> RosterImportLog | None:
+        if dry_run:
+            return None
+        if log_id is not None:
+            try:
+                log = RosterImportLog.all_objects.get(pk=log_id)
+            except RosterImportLog.DoesNotExist:
+                msg = f"RosterImportLog not found: {log_id}"
+                raise CommandError(msg)
+            if log.organization_id != org.pk or log.program_id != program.pk:
+                msg = "RosterImportLog organization/program does not match import target."
+                raise CommandError(msg)
+            updates: list[str] = []
+            if log.csv_filename != csv_path.name:
+                log.csv_filename = csv_path.name
+                updates.append("csv_filename")
+            if log.status != "running":
+                log.status = "running"
+                updates.append("status")
+            if updates:
+                log.save(update_fields=updates)
+            return log
+        return RosterImportLog.all_objects.create(
+            organization=org,
+            program=program,
+            importer_type="campminder",
+            status="running",
+            csv_filename=csv_path.name,
+        )
 
     def handle(self, *args, **options) -> None:
         csv_path = Path(options["csv_path"])
@@ -265,18 +322,25 @@ class Command(BaseCommand):
 
         dry_run: bool = options["dry_run"]
         reconcile: bool = options["reconcile"]
+        target_group = load_target_group(
+            target_group_id=options.get("target_group_id"),
+            org=org,
+            program=program,
+        )
+        bulk_role_in_group = (options.get("bulk_role_in_group") or "").strip().lower()
+        if bulk_role_in_group and bulk_role_in_group not in {"subject", "author"}:
+            msg = f"Invalid bulk_role_in_group: {bulk_role_in_group!r}"
+            raise CommandError(msg)
 
         rows = read_campminder_csv_rows(csv_path)
 
-        log: RosterImportLog | None = None
-        if not dry_run:
-            log = RosterImportLog.all_objects.create(
-                organization=org,
-                program=program,
-                importer_type="campminder",
-                status="running",
-                csv_filename=csv_path.name,
-            )
+        log = self._resolve_import_log(
+            org=org,
+            program=program,
+            csv_path=csv_path,
+            log_id=options.get("log_id"),
+            dry_run=dry_run,
+        )
 
         persons_created = persons_updated = persons_skipped = persons_merged = 0
         users_created = users_linked = users_already_linked = 0
@@ -434,7 +498,24 @@ class Command(BaseCommand):
                         "message": user_link.message,
                     })
 
-                if bunk_name:
+                if target_group is not None:
+                    role_in_group = resolve_role_in_group(
+                        row,
+                        role,
+                        bulk_role_in_group=bulk_role_in_group or None,
+                    )
+                    _, group_mem_created = _ensure_membership(
+                        target_group,
+                        person,
+                        role_in_group,
+                        start_date=start_date,
+                        end_date=end_date,
+                    )
+                    key = (target_group.pk, role_in_group)
+                    seen_group_members.setdefault(key, set()).add(person.pk)
+                    if group_mem_created:
+                        memberships_created += 1
+                elif bunk_name:
                     division_group: AssignmentGroup | None = None
                     unit_group: AssignmentGroup | None = None
 

--- a/backend/bunk_logs/core/management/commands/import_tbe_roster.py
+++ b/backend/bunk_logs/core/management/commands/import_tbe_roster.py
@@ -17,6 +17,7 @@ from django.core.management.base import CommandError
 from django.db import transaction
 from django.utils.text import slugify
 
+from bunk_logs.core.group_roster_import import load_target_group
 from bunk_logs.core.models import AssignmentGroup
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Membership
@@ -112,6 +113,61 @@ class Command(BaseCommand):
             action="store_true",
             help="Validate and report without writing to the database.",
         )
+        parser.add_argument(
+            "--log-id",
+            type=int,
+            default=None,
+            help="Existing RosterImportLog PK to update (API import path).",
+        )
+        parser.add_argument(
+            "--target-group-id",
+            type=int,
+            default=None,
+            help="Add each imported row to this AssignmentGroup (group detail import path).",
+        )
+        parser.add_argument(
+            "--bulk-role-in-group",
+            default="",
+            help="Default role_in_group for target-group imports (subject or author).",
+        )
+
+    def _resolve_import_log(
+        self,
+        *,
+        org: Organization,
+        program: Program,
+        csv_path: Path,
+        log_id: int | None,
+        dry_run: bool,
+    ) -> RosterImportLog | None:
+        if dry_run:
+            return None
+        if log_id is not None:
+            try:
+                log = RosterImportLog.all_objects.get(pk=log_id)
+            except RosterImportLog.DoesNotExist:
+                msg = f"RosterImportLog not found: {log_id}"
+                raise CommandError(msg)
+            if log.organization_id != org.pk or log.program_id != program.pk:
+                msg = "RosterImportLog organization/program does not match import target."
+                raise CommandError(msg)
+            updates: list[str] = []
+            if log.csv_filename != csv_path.name:
+                log.csv_filename = csv_path.name
+                updates.append("csv_filename")
+            if log.status != "running":
+                log.status = "running"
+                updates.append("status")
+            if updates:
+                log.save(update_fields=updates)
+            return log
+        return RosterImportLog.all_objects.create(
+            organization=org,
+            program=program,
+            importer_type="tbe_shulcloud",
+            status="running",
+            csv_filename=csv_path.name,
+        )
 
     def handle(self, *args, **options) -> None:
         csv_path = Path(options["csv_path"])
@@ -134,19 +190,26 @@ class Command(BaseCommand):
             )
 
         dry_run: bool = options["dry_run"]
+        target_group = load_target_group(
+            target_group_id=options.get("target_group_id"),
+            org=org,
+            program=program,
+        )
+        bulk_role_in_group = (options.get("bulk_role_in_group") or "").strip().lower()
+        if bulk_role_in_group and bulk_role_in_group not in {"subject", "author"}:
+            msg = f"Invalid bulk_role_in_group: {bulk_role_in_group!r}"
+            raise CommandError(msg)
 
         with csv_path.open(newline="", encoding="utf-8") as f:
             rows = list(csv.DictReader(f))
 
-        log: RosterImportLog | None = None
-        if not dry_run:
-            log = RosterImportLog.all_objects.create(
-                organization=org,
-                program=program,
-                importer_type="tbe_shulcloud",
-                status="running",
-                csv_filename=csv_path.name,
-            )
+        log = self._resolve_import_log(
+            org=org,
+            program=program,
+            csv_path=csv_path,
+            log_id=options.get("log_id"),
+            dry_run=dry_run,
+        )
 
         persons_created = persons_updated = persons_skipped = 0
         memberships_created = 0
@@ -169,7 +232,7 @@ class Command(BaseCommand):
             if role not in VALID_ROLES:
                 warnings.append(f"Row {i} ({first_name} {last_name}): unknown role {role!r} — skipped")
                 continue
-            if not classroom_name:
+            if not classroom_name and target_group is None:
                 warnings.append(f"Row {i} ({first_name} {last_name}): missing classroom_name — skipped")
                 continue
 
@@ -206,9 +269,18 @@ class Command(BaseCommand):
                     membership.grade_level = grade_level
                     membership.save(update_fields=["grade_level"])
 
-                classroom = _get_or_create_classroom(program, classroom_name)
+                classroom = target_group if target_group is not None else _get_or_create_classroom(program, classroom_name)
 
-                if role == "madrich":
+                if bulk_role_in_group in {"subject", "author"}:
+                    _, created_flag = AssignmentGroupMembership.all_objects.get_or_create(
+                        group=classroom,
+                        person=person,
+                        role_in_group=bulk_role_in_group,
+                        defaults={"is_active": True},
+                    )
+                    if created_flag:
+                        memberships_created += 1
+                elif role == "madrich":
                     # Madrichim: subject in the classroom (faculty observes them)
                     _, sub_created = AssignmentGroupMembership.all_objects.get_or_create(
                         group=classroom,

--- a/backend/bunk_logs/core/tasks.py
+++ b/backend/bunk_logs/core/tasks.py
@@ -347,6 +347,9 @@ def import_roster_task(
                 program_slug=log.program.slug,
                 dry_run=False,
                 reconcile=opts.get("reconcile", False),
+                log_id=log_id,
+                target_group_id=opts.get("target_group_id"),
+                bulk_role_in_group=opts.get("bulk_role_in_group"),
             )
         elif importer_type == "tbe_shulcloud":
             from bunk_logs.core.management.commands.import_tbe_roster import Command as TBECmd
@@ -357,6 +360,9 @@ def import_roster_task(
                 org_slug=log.organization.slug,
                 program_slug=log.program.slug,
                 dry_run=False,
+                log_id=log_id,
+                target_group_id=opts.get("target_group_id"),
+                bulk_role_in_group=opts.get("bulk_role_in_group"),
             )
         else:
             msg = f"Unknown importer_type: {importer_type!r}"

--- a/backend/bunk_logs/core/test_assignment_resolution.py
+++ b/backend/bunk_logs/core/test_assignment_resolution.py
@@ -400,3 +400,71 @@ class TestActiveAssignmentsFor:
             viewer=viewer, organization=org, program=program, as_of=TODAY,
         )
         assert len(out) == 1
+
+
+class TestAssignmentGroupSelfAudience:
+    def test_self_team_subject_counts_with_template_role_fallback(
+        self, org, program, lt_membership,
+    ):
+        """Team self-reflection: subjects qualify; role falls back to template.role."""
+        user = User.objects.create_user(email="kitchen@test.com", password="pw")
+        person = Person.all_objects.create(
+            organization=org, first_name="Kitchen", last_name="Staff", user=user,
+        )
+        Membership.all_objects.create(
+            program=program, person=person, role="kitchen_staff", is_active=True,
+        )
+        team = AssignmentGroup.objects.create(
+            organization=org, program=program, name="Kitchen Staff",
+            slug="kitchen-staff-team", group_type="team", is_active=True,
+        )
+        AssignmentGroupMembership.objects.create(
+            group=team, person=person, role_in_group="subject", is_active=True,
+        )
+        template = ReflectionTemplate.all_objects.create(
+            organization=org, name="Kitchen Daily", slug="kitchen-daily-team",
+            cadence="daily", subject_mode="self", schema=SCHEMA, languages=["en"],
+            is_active=True, role="kitchen_staff", author_role_filter=[],
+        )
+        TemplateAssignment.all_objects.create(
+            organization=org, program=program, template=template,
+            target_type=TemplateAssignment.TargetType.ASSIGNMENT_GROUP,
+            assignment_group=team,
+            start_date=TODAY - timedelta(days=1),
+            status=TemplateAssignment.Status.ACTIVE,
+            created_by=lt_membership, is_required=True,
+        )
+        out = active_assignments_for(
+            viewer=person, organization=org, program=program, as_of=TODAY,
+        )
+        assert len(out) == 1
+
+    def test_roster_template_still_requires_author(
+        self, org, program, viewer, lt_membership,
+    ):
+        template = ReflectionTemplate.all_objects.create(
+            organization=org, name="Bunk Reflection", slug="bunk-reflection-subject",
+            cadence="daily", subject_mode="single_subject",
+            assignment_group_types=["bunk"],
+            schema=SCHEMA, languages=["en"], is_active=True,
+            author_role_filter=["counselor"],
+        )
+        bunk = AssignmentGroup.objects.create(
+            organization=org, program=program, name="Bunk Pine", slug="bunk-pine-subject",
+            group_type="bunk", is_active=True,
+        )
+        AssignmentGroupMembership.objects.create(
+            group=bunk, person=viewer, role_in_group="subject", is_active=True,
+        )
+        TemplateAssignment.all_objects.create(
+            organization=org, program=program, template=template,
+            target_type=TemplateAssignment.TargetType.ASSIGNMENT_GROUP,
+            target_payload={}, assignment_group=bunk,
+            start_date=TODAY - timedelta(days=1),
+            status=TemplateAssignment.Status.ACTIVE,
+            created_by=lt_membership,
+        )
+        out = active_assignments_for(
+            viewer=viewer, organization=org, program=program, as_of=TODAY,
+        )
+        assert out == []

--- a/backend/bunk_logs/core/test_my_tasks_api.py
+++ b/backend/bunk_logs/core/test_my_tasks_api.py
@@ -355,6 +355,46 @@ def test_my_tasks_leadership_assignment_appears(org, program, lt_membership):
 
 
 @pytest.mark.django_db
+def test_my_tasks_team_self_reflection_subject_in_group(org, program, lt_membership):
+    """Kitchen-style team assignment surfaces for subjects, not only authors."""
+    user = User.objects.create_user(email="kitchen_tasks@test.com", password="pw")
+    person = Person.all_objects.create(
+        organization=org, first_name="Kitchen", last_name="Staff", user=user,
+    )
+    Membership.all_objects.create(
+        program=program, person=person, role="kitchen_staff", is_active=True,
+    )
+    team = AssignmentGroup.all_objects.create(
+        organization=org, program=program, name="Kitchen Staff",
+        slug="kitchen-team-tasks", group_type="team", is_active=True,
+    )
+    AssignmentGroupMembership.all_objects.create(
+        group=team, person=person, role_in_group="subject", is_active=True,
+    )
+    template = ReflectionTemplate.all_objects.create(
+        organization=org, name="Kitchen Daily", slug="kitchen-daily-tasks",
+        cadence="daily", subject_mode="self", schema=SIMPLE_SCHEMA,
+        languages=["en"], is_active=True, role="kitchen_staff",
+        author_role_filter=[],
+    )
+    TemplateAssignment.all_objects.create(
+        organization=org, program=program, template=template,
+        target_type=TemplateAssignment.TargetType.ASSIGNMENT_GROUP,
+        assignment_group=team,
+        start_date=date.today() - timedelta(days=1),
+        status=TemplateAssignment.Status.ACTIVE,
+        created_by=lt_membership, is_required=True,
+    )
+    with organization_context(org):
+        client = _authed_client(user, org)
+        resp = client.get("/api/v1/reflections/my-tasks/")
+
+    assert resp.status_code == 200
+    slugs = {t["template"]["slug"] for t in resp.data["tasks"]}
+    assert "kitchen-daily-tasks" in slugs
+
+
+@pytest.mark.django_db
 def test_my_tasks_ignores_unassigned_templates(
     org, program, counselor_user, counselor_membership, self_template,
 ):

--- a/backend/bunk_logs/core/test_roster_import.py
+++ b/backend/bunk_logs/core/test_roster_import.py
@@ -416,6 +416,69 @@ class TestCampminderRosterImportLog:
         assert log.status == "completed"
         assert log.summary["persons_created"] == 3
 
+    def test_reuses_existing_log_id(self, tmp_path, program):
+        existing = RosterImportLog.all_objects.create(
+            organization=program.organization,
+            program=program,
+            importer_type="campminder",
+            status="pending",
+            csv_filename="roster.csv",
+        )
+        _run_campminder(tmp_path, CAMPMINDER_BUNK_CSV, log_id=existing.pk)
+        existing.refresh_from_db()
+        assert existing.status == "completed"
+        assert existing.summary["persons_created"] == 3
+        assert RosterImportLog.all_objects.filter(program=program).count() == 1
+
+    def test_target_group_bulk_import_as_subjects(self, tmp_path, program):
+        team = AssignmentGroup.all_objects.create(
+            organization=program.organization,
+            program=program,
+            name="Camper Bunk",
+            slug="camper-bunk-import",
+            group_type="bunk",
+        )
+        _run_campminder(
+            tmp_path,
+            CAMPMINDER_STAFF_ONLY_CSV,
+            target_group_id=team.pk,
+            bulk_role_in_group="subject",
+        )
+        dave = Person.all_objects.get(
+            organization=program.organization,
+            external_ids__campminder_id="CM010",
+        )
+        assert AssignmentGroupMembership.all_objects.filter(
+            group=team,
+            person=dave,
+            role_in_group="subject",
+            is_active=True,
+        ).exists()
+
+    def test_target_group_adds_staff_without_bunk_column(self, tmp_path, program):
+        team = AssignmentGroup.all_objects.create(
+            organization=program.organization,
+            program=program,
+            name="Kitchen Staff",
+            slug="kitchen-staff-import",
+            group_type="team",
+        )
+        _run_campminder(
+            tmp_path,
+            CAMPMINDER_STAFF_ONLY_CSV,
+            target_group_id=team.pk,
+        )
+        dave = Person.all_objects.get(
+            organization=program.organization,
+            external_ids__campminder_id="CM010",
+        )
+        assert AssignmentGroupMembership.all_objects.filter(
+            group=team,
+            person=dave,
+            role_in_group="author",
+            is_active=True,
+        ).exists()
+
 
 @pytest.mark.django_db
 class TestCampminderDryRun:

--- a/frontend/src/dashboards/performance/ScorePieChart.jsx
+++ b/frontend/src/dashboards/performance/ScorePieChart.jsx
@@ -5,10 +5,10 @@ import { ratingColor } from '../colors';
  */
 export default function ScorePieChart({ distribution = {}, scaleMax = 5, size = 72 }) {
   const entries = Object.entries(distribution)
-    .filter(([, count]) => count > 0)
+    .filter(([, count]) => Number(count) > 0)
     .sort((a, b) => Number(a[0]) - Number(b[0]));
 
-  const total = entries.reduce((sum, [, count]) => sum + count, 0);
+  const total = entries.reduce((sum, [, count]) => sum + Number(count), 0);
   if (total === 0) {
     return (
       <div
@@ -24,6 +24,25 @@ export default function ScorePieChart({ distribution = {}, scaleMax = 5, size = 
   const cx = size / 2;
   const cy = size / 2;
   const r = size / 2 - 2;
+
+  // A single bucket holding 100% of ratings must render as a circle.
+  // SVG arc paths degenerate when start and end points coincide.
+  if (entries.length === 1 && Number(entries[0][1]) === total) {
+    const [value] = entries[0];
+    const fill = ratingColor(Number(value), scaleMax) || '#9ca3af';
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        role="img"
+        aria-label={`Score distribution: ${value}: ${total}`}
+      >
+        <circle cx={cx} cy={cy} r={r} fill={fill} stroke="white" strokeWidth="1" />
+      </svg>
+    );
+  }
+
   let startAngle = -Math.PI / 2;
   const slices = entries.map(([value, count]) => {
     const angle = (count / total) * Math.PI * 2;

--- a/frontend/src/dashboards/performance/__tests__/ScorePieChart.test.jsx
+++ b/frontend/src/dashboards/performance/__tests__/ScorePieChart.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import ScorePieChart from '../ScorePieChart';
+
+describe('ScorePieChart', () => {
+  it('renders a filled circle for a single-score distribution', () => {
+    const { container } = render(
+      <ScorePieChart distribution={{ 1: 1, 2: 0, 3: 0, 4: 0 }} scaleMax={4} size={96} />,
+    );
+    expect(container.querySelector('circle')).toBeTruthy();
+    expect(screen.getByRole('img', { name: 'Score distribution: 1: 1' })).toBeInTheDocument();
+  });
+
+  it('renders arc slices for multi-bucket distributions', () => {
+    const { container } = render(
+      <ScorePieChart distribution={{ 2: 1, 4: 1 }} scaleMax={5} size={96} />,
+    );
+    expect(container.querySelectorAll('path').length).toBe(2);
+    expect(container.querySelector('circle')).toBeFalsy();
+  });
+});

--- a/frontend/src/pages/admin/groups/GroupDetailPage.jsx
+++ b/frontend/src/pages/admin/groups/GroupDetailPage.jsx
@@ -2,30 +2,52 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { Link, useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { ArrowLeft, BarChart3, UserPlus, Trash2, Upload, RotateCcw, CheckCircle, XCircle } from 'lucide-react';
 import api from '../../../api';
+import { listAdminPeople } from '../../../api/admin';
 import Button from '../../../components/ui/Button';
 import ErrorPanel from '../../../components/ui/ErrorPanel';
 import LoadingState from '../../../components/ui/LoadingState';
 import Toast, { useToast } from '../../../components/ui/Toast';
 import { canHaveParent, parentTypesFor } from '../../../lib/groupHierarchy';
 
-function PersonSearchInput({ orgContext, onSelect }) {
+function formatApiError(data, fallback = 'Request failed.') {
+  if (!data) return fallback;
+  if (typeof data.detail === 'string') return data.detail;
+  if (Array.isArray(data.non_field_errors) && data.non_field_errors.length) {
+    return data.non_field_errors.join(' ');
+  }
+  const fieldMsgs = Object.entries(data)
+    .filter(([, v]) => Array.isArray(v) && v.length)
+    .map(([k, v]) => `${k}: ${v.join(', ')}`);
+  if (fieldMsgs.length) return fieldMsgs.join('; ');
+  return fallback;
+}
+
+function PersonSearchInput({ programId, onSelect }) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState([]);
   const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState('');
 
   const search = useCallback(async (q) => {
-    if (!q.trim() || q.length < 2) { setResults([]); return; }
-    setSearching(true);
-    try {
-      const { data } = await api.get('/api/v1/memberships/', { params: { search: q, page_size: 20 } });
-      const list = Array.isArray(data?.results) ? data.results : Array.isArray(data) ? data : [];
-      setResults(list.map((m) => m.person).filter(Boolean));
-    } catch {
+    if (!q.trim() || q.length < 2) {
       setResults([]);
+      setSearchError('');
+      return;
+    }
+    setSearching(true);
+    setSearchError('');
+    try {
+      const params = { search: q, page_size: 20 };
+      if (programId) params.program = programId;
+      const data = await listAdminPeople(params);
+      setResults(Array.isArray(data?.results) ? data.results : []);
+    } catch (err) {
+      setResults([]);
+      setSearchError(formatApiError(err.response?.data, 'Person search failed.'));
     } finally {
       setSearching(false);
     }
-  }, []);
+  }, [programId]);
 
   useEffect(() => {
     const t = setTimeout(() => search(query), 300);
@@ -41,6 +63,12 @@ function PersonSearchInput({ orgContext, onSelect }) {
         placeholder="Search by name…"
         className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
       />
+      {searchError && (
+        <p className="text-xs text-red-600 dark:text-red-400 mt-1">{searchError}</p>
+      )}
+      {searching && (
+        <p className="text-xs text-gray-400 mt-1">Searching…</p>
+      )}
       {results.length > 0 && (
         <div className="absolute z-10 mt-1 w-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg max-h-48 overflow-y-auto">
           {results.map((p) => (
@@ -62,42 +90,74 @@ function PersonSearchInput({ orgContext, onSelect }) {
   );
 }
 
-function MemberList({ title, members, onRemove, removing }) {
-  if (!members.length) {
+function MemberRoster({
+  members,
+  selectedIds,
+  onToggle,
+  onToggleAll,
+  onRemove,
+  removing,
+  bulkBusy,
+}) {
+  const activeMembers = members.filter((m) => m.is_active);
+  const allSelected = activeMembers.length > 0
+    && activeMembers.every((m) => selectedIds.has(m.id));
+
+  if (!activeMembers.length) {
     return (
-      <div>
-        <h3 className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">
-          {title} <span className="font-normal">(0)</span>
-        </h3>
-        <p className="text-sm text-gray-400 dark:text-gray-600 italic">None yet.</p>
-      </div>
+      <p className="text-sm text-gray-400 dark:text-gray-600 italic">No members yet.</p>
     );
   }
+
   return (
-    <div>
-      <h3 className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">
-        {title} <span className="font-normal">({members.length})</span>
-      </h3>
+    <div className="space-y-2" data-testid="group-member-roster">
+      <div className="flex items-center gap-2 px-1">
+        <input
+          type="checkbox"
+          checked={allSelected}
+          onChange={(e) => onToggleAll(e.target.checked)}
+          disabled={bulkBusy}
+          className="rounded border-gray-300 dark:border-gray-600"
+          aria-label="Select all members"
+          data-testid="group-member-select-all"
+        />
+        <span className="text-xs text-gray-500 dark:text-gray-400">Select all</span>
+      </div>
       <ul className="space-y-1">
-        {members.map((m) => (
+        {activeMembers.map((m) => (
           <li
             key={m.id}
-            className="flex items-center justify-between bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2"
+            className="flex items-center gap-2 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2"
           >
-            <span className="text-sm text-gray-900 dark:text-white">
+            <input
+              type="checkbox"
+              checked={selectedIds.has(m.id)}
+              onChange={() => onToggle(m.id)}
+              disabled={bulkBusy}
+              className="rounded border-gray-300 dark:border-gray-600 shrink-0"
+              aria-label={`Select ${m.person.first_name} ${m.person.last_name}`}
+              data-testid={`group-member-select-${m.id}`}
+            />
+            <span className="flex-1 text-sm text-gray-900 dark:text-white min-w-0">
               {m.person.first_name} {m.person.last_name}
               {m.person.preferred_name && m.person.preferred_name !== m.person.first_name && (
                 <span className="text-gray-400 ml-1 text-xs">({m.person.preferred_name})</span>
               )}
-              {!m.is_active && (
-                <span className="ml-2 text-xs text-gray-400 italic">inactive</span>
-              )}
+            </span>
+            <span
+              className={`text-xs px-2 py-0.5 rounded-full shrink-0 ${
+                m.role_in_group === 'subject'
+                  ? 'bg-blue-50 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300'
+                  : 'bg-purple-50 text-purple-700 dark:bg-purple-950/40 dark:text-purple-300'
+              }`}
+            >
+              {m.role_in_group === 'subject' ? 'Subject' : 'Author'}
             </span>
             <button
               type="button"
               onClick={() => onRemove(m.id)}
-              disabled={removing === m.id}
-              className="text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors disabled:opacity-40"
+              disabled={removing === m.id || bulkBusy}
+              className="text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors disabled:opacity-40 shrink-0"
               aria-label="Remove member"
             >
               <Trash2 size={14} />
@@ -128,10 +188,13 @@ function ImportStatus({ log }) {
           </p>
         )}
         {log.summary?.memberships_created !== undefined && (
-          <p className="text-xs">Memberships created: {log.summary.memberships_created}</p>
+          <p className="text-xs">Group memberships created: {log.summary.memberships_created}</p>
         )}
         {log.summary?.warnings?.length > 0 && (
-          <p className="text-xs mt-1 font-medium">{log.summary.warnings.length} warning(s)</p>
+          <p className="text-xs mt-1">
+            {log.summary.warnings.length} warning(s)
+            {log.summary.warnings[0] ? `: ${log.summary.warnings[0]}` : ''}
+          </p>
         )}
         {log.summary?.error && (
           <p className="text-xs mt-1 font-medium">Error: {log.summary.error}</p>
@@ -157,10 +220,13 @@ export default function GroupDetailPage() {
 
   // Remove member state
   const [removing, setRemoving] = useState(null);
+  const [selectedMembershipIds, setSelectedMembershipIds] = useState(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
 
   // Import roster state
   const fileRef = useRef(null);
   const [importerType, setImporterType] = useState('campminder');
+  const [importRole, setImportRole] = useState('subject');
   const [reconcile, setReconcile] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [lastLog, setLastLog] = useState(null);
@@ -241,7 +307,7 @@ export default function GroupDetailPage() {
       showToast(`Added ${selectedPerson.first_name} ${selectedPerson.last_name} as ${addRole}`);
       load();
     } catch (err) {
-      showToast(err.response?.data?.detail || 'Failed to add member.');
+      showToast(formatApiError(err.response?.data, 'Failed to add member.'));
     } finally {
       setAddingMember(false);
     }
@@ -251,12 +317,93 @@ export default function GroupDetailPage() {
     setRemoving(membershipId);
     try {
       await api.delete(`/api/v1/assignment-groups/${id}/memberships/${membershipId}/`);
+      setSelectedMembershipIds((prev) => {
+        const next = new Set(prev);
+        next.delete(membershipId);
+        return next;
+      });
       showToast('Member removed.');
       load();
     } catch (err) {
       showToast(err.response?.data?.detail || 'Failed to remove member.');
     } finally {
       setRemoving(null);
+    }
+  };
+
+  const toggleMemberSelection = (membershipId) => {
+    setSelectedMembershipIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(membershipId)) next.delete(membershipId);
+      else next.add(membershipId);
+      return next;
+    });
+  };
+
+  const toggleAllMembers = (checked) => {
+    if (!checked) {
+      setSelectedMembershipIds(new Set());
+      return;
+    }
+    const activeIds = (group?.memberships || [])
+      .filter((m) => m.is_active)
+      .map((m) => m.id);
+    setSelectedMembershipIds(new Set(activeIds));
+  };
+
+  const handleBulkRemove = async () => {
+    if (selectedMembershipIds.size === 0) return;
+    if (!window.confirm(`Remove ${selectedMembershipIds.size} selected member(s) from this group?`)) return;
+    setBulkBusy(true);
+    const errors = [];
+    for (const membershipId of selectedMembershipIds) {
+      try {
+        await api.delete(`/api/v1/assignment-groups/${id}/memberships/${membershipId}/`);
+      } catch (err) {
+        errors.push(formatApiError(err.response?.data, `Membership ${membershipId}`));
+      }
+    }
+    setSelectedMembershipIds(new Set());
+    setBulkBusy(false);
+    await load();
+    if (errors.length) {
+      showToast(errors.join('; '));
+    } else {
+      showToast('Selected members removed.');
+    }
+  };
+
+  const handleBulkSetRole = async (role) => {
+    if (selectedMembershipIds.size === 0) return;
+    const activeMembers = (group?.memberships || []).filter((m) => m.is_active);
+    const selected = activeMembers.filter((m) => selectedMembershipIds.has(m.id));
+    const personIds = [...new Set(selected.map((m) => m.person.id))];
+    const opposite = role === 'subject' ? 'author' : 'subject';
+    setBulkBusy(true);
+    const errors = [];
+    for (const personId of personIds) {
+      try {
+        await api.post(`/api/v1/assignment-groups/${id}/memberships/`, {
+          person_id: personId,
+          role_in_group: role,
+        });
+        const oppositeMem = activeMembers.find(
+          (m) => m.person.id === personId && m.role_in_group === opposite,
+        );
+        if (oppositeMem) {
+          await api.delete(`/api/v1/assignment-groups/${id}/memberships/${oppositeMem.id}/`);
+        }
+      } catch (err) {
+        errors.push(formatApiError(err.response?.data, `Person ${personId}`));
+      }
+    }
+    setSelectedMembershipIds(new Set());
+    setBulkBusy(false);
+    await load();
+    if (errors.length) {
+      showToast(errors.join('; '));
+    } else {
+      showToast(`Updated ${personIds.length} member(s) as ${role === 'subject' ? 'subjects' : 'authors'}.`);
     }
   };
 
@@ -295,7 +442,14 @@ export default function GroupDetailPage() {
   };
 
   const pollLog = useCallback((logId) => {
+    const startedAt = Date.now();
     const interval = setInterval(async () => {
+      if (Date.now() - startedAt > 5 * 60 * 1000) {
+        clearInterval(interval);
+        setPollInterval(null);
+        showToast('Import is taking longer than expected. Refresh the page to check status.');
+        return;
+      }
       try {
         const { data } = await api.get(`/api/v1/assignment-groups/import-logs/${logId}/`);
         setLastLog(data);
@@ -304,15 +458,37 @@ export default function GroupDetailPage() {
           setPollInterval(null);
           if (data.status === 'completed') {
             load();
+            showToast('Import completed.');
+          } else {
+            showToast(data.summary?.error || 'Import failed.');
           }
         }
-      } catch {
+      } catch (err) {
         clearInterval(interval);
         setPollInterval(null);
+        showToast(formatApiError(err.response?.data, 'Failed to check import status.'));
       }
     }, 2000);
     setPollInterval(interval);
-  }, [load]);
+  }, [load, showToast]);
+
+  const handleImportResponse = useCallback((data) => {
+    setLastLog(data);
+    if (data.status === 'completed') {
+      load();
+      showToast('Import completed.');
+      return;
+    }
+    if (data.status === 'failed') {
+      showToast(data.summary?.error || 'Import failed.');
+      return;
+    }
+    const pollId = data.log_id ?? data.id;
+    if (pollId && (data.status === 'pending' || data.status === 'running')) {
+      pollLog(pollId);
+      showToast('Import started. Polling for status…');
+    }
+  }, [load, pollLog, showToast]);
 
   const handleImport = async () => {
     const file = fileRef.current?.files?.[0];
@@ -323,16 +499,17 @@ export default function GroupDetailPage() {
       const form = new FormData();
       form.append('file', file);
       form.append('importer_type', importerType);
+      form.append('default_role_in_group', importRole);
       form.append('reconcile', reconcile ? 'true' : 'false');
-      const { data } = await api.post(`/api/v1/assignment-groups/${id}/import-roster/`, form, {
+      const response = await api.post(`/api/v1/assignment-groups/${id}/import-roster/`, form, {
         headers: { 'Content-Type': 'multipart/form-data' },
       });
-      setLastLog({ ...data, status: 'pending', csv_filename: file.name });
-      pollLog(data.log_id);
-      showToast('Import started. Polling for status…');
+      handleImportResponse({ ...response.data, csv_filename: file.name });
       if (fileRef.current) fileRef.current.value = '';
     } catch (err) {
-      showToast(err.response?.data?.detail || 'Import failed.');
+      const data = err.response?.data;
+      if (data?.status) setLastLog(data);
+      showToast(formatApiError(data, 'Import failed.'));
     } finally {
       setUploading(false);
     }
@@ -356,6 +533,17 @@ export default function GroupDetailPage() {
 
   const subjects = (group.memberships || []).filter((m) => m.role_in_group === 'subject');
   const authors = (group.memberships || []).filter((m) => m.role_in_group === 'author');
+  const rosterMembers = [...(group.memberships || [])]
+    .filter((m) => m.is_active)
+    .sort((a, b) => {
+      const last = (a.person.last_name || '').localeCompare(b.person.last_name || '');
+      if (last !== 0) return last;
+      const first = (a.person.first_name || '').localeCompare(b.person.first_name || '');
+      if (first !== 0) return first;
+      return a.role_in_group.localeCompare(b.role_in_group);
+    });
+  const subjectCount = subjects.filter((m) => m.is_active).length;
+  const authorCount = authors.filter((m) => m.is_active).length;
 
   return (
     <main className="grow px-4 sm:px-6 lg:px-8 py-6 w-full max-w-screen-2xl mx-auto" data-testid="admin-group-detail">
@@ -490,7 +678,7 @@ export default function GroupDetailPage() {
           <div className="flex flex-wrap gap-3 items-end">
             <div className="flex-1 min-w-48">
               <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Search person</label>
-              <PersonSearchInput onSelect={setSelectedPerson} />
+              <PersonSearchInput programId={group.program} onSelect={setSelectedPerson} />
               {selectedPerson && (
                 <p className="text-xs text-blue-600 dark:text-blue-400 mt-1">
                   Selected: {selectedPerson.first_name} {selectedPerson.last_name}
@@ -518,10 +706,62 @@ export default function GroupDetailPage() {
           </div>
         </div>
 
-        {/* Roster columns */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
-          <MemberList title="Subjects (observed)" members={subjects} onRemove={handleRemoveMember} removing={removing} />
-          <MemberList title="Authors (observers)" members={authors} onRemove={handleRemoveMember} removing={removing} />
+        {/* Roster */}
+        <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-5 mb-6">
+          <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+            <div>
+              <h2 className="text-sm font-semibold text-gray-900 dark:text-white">Members</h2>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                {subjectCount} subject{subjectCount === 1 ? '' : 's'} · {authorCount} author{authorCount === 1 ? '' : 's'}
+              </p>
+            </div>
+            {selectedMembershipIds.size > 0 && (
+              <div
+                className="flex flex-wrap items-center gap-2"
+                data-testid="group-member-bulk-actions"
+              >
+                <span className="text-xs text-gray-500 dark:text-gray-400">
+                  {selectedMembershipIds.size} selected
+                </span>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => handleBulkSetRole('subject')}
+                  disabled={bulkBusy}
+                  data-testid="group-bulk-make-subjects"
+                >
+                  Make subjects
+                </Button>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => handleBulkSetRole('author')}
+                  disabled={bulkBusy}
+                  data-testid="group-bulk-make-authors"
+                >
+                  Make authors
+                </Button>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={handleBulkRemove}
+                  disabled={bulkBusy}
+                  data-testid="group-bulk-remove"
+                >
+                  Remove from group
+                </Button>
+              </div>
+            )}
+          </div>
+          <MemberRoster
+            members={rosterMembers}
+            selectedIds={selectedMembershipIds}
+            onToggle={toggleMemberSelection}
+            onToggleAll={toggleAllMembers}
+            onRemove={handleRemoveMember}
+            removing={removing}
+            bulkBusy={bulkBusy}
+          />
         </div>
 
         {/* CSV import */}
@@ -529,6 +769,11 @@ export default function GroupDetailPage() {
           <h2 className="text-sm font-semibold text-gray-900 dark:text-white mb-3 flex items-center gap-2">
             <Upload size={15} /> Import roster from CSV
           </h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+            Rows are added to <span className="font-medium text-gray-700 dark:text-gray-300">{group.name}</span>{' '}
+            using the import role below. Per-row CSV column{' '}
+            <code className="text-xs">role_in_group</code> overrides when present.
+          </p>
           <div className="flex flex-wrap gap-3 items-end mb-3">
             <div>
               <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Importer</label>
@@ -539,6 +784,21 @@ export default function GroupDetailPage() {
               >
                 <option value="campminder">Campminder</option>
                 <option value="tbe_shulcloud">TBE ShulCloud</option>
+              </select>
+            </div>
+            <div>
+              <label htmlFor="import-role-in-group" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                Import as
+              </label>
+              <select
+                id="import-role-in-group"
+                value={importRole}
+                onChange={(e) => setImportRole(e.target.value)}
+                className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                data-testid="import-role-in-group"
+              >
+                <option value="subject">Subject (observed)</option>
+                <option value="author">Author (observer)</option>
               </select>
             </div>
             <div className="flex items-center gap-2 pb-1">


### PR DESCRIPTION
## Summary
- Auto-generate assignment group slugs on create when the client omits `slug`, so admin group creation no longer fails validation before the serializer can derive one.
- Enable group-detail roster CSV import: imports run inline (no Celery worker yet), support a target group with bulk/default `role_in_group`, and reuse an existing `RosterImportLog` from the API path.
- Fix assignment resolution for team self-reflection templates so roster `subject` rows qualify (with `template.role` fallback when `author_role_filter` is empty); roster-style templates still require `author`.
- Polish group detail UX (program-scoped person search, unified member roster with bulk select/remove, clearer import feedback) and fix `ScorePieChart` when 100% of ratings share a single score.

## Test plan
- [ ] Create a group from admin UI without supplying a slug — should succeed with an auto-derived slug.
- [ ] Import a CampMinder CSV into a group from group detail — members appear with expected subject/author roles.
- [ ] Kitchen/team self-reflection assignment surfaces on My Tasks for subjects imported into the group.
- [ ] Group performance dashboard pie chart renders correctly when all responses share one rating.
- [ ] Backend pytest and frontend vitest/build pass in CI.


Made with [Cursor](https://cursor.com)