### PR TITLE
Clone assignment groups across programs and fix reflection rich text

### DIFF
--- a/backend/bunk_logs/api/assignment_groups.py
+++ b/backend/bunk_logs/api/assignment_groups.py
@@ -10,6 +10,9 @@ from rest_framework.parsers import FormParser
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
 
+from bunk_logs.core.group_clone import GroupCloneError
+from bunk_logs.core.group_clone import clone_assignment_group
+from bunk_logs.core.group_clone import unique_group_slug
 from bunk_logs.core.models import AssignmentGroup
 from bunk_logs.core.models import AssignmentGroupMembership
 from bunk_logs.core.models import Person
@@ -17,20 +20,6 @@ from bunk_logs.core.models import Program
 from bunk_logs.core.models import Reflection
 from bunk_logs.core.models import RosterImportLog
 from bunk_logs.core.permissions import IsOrgAdminOrSuperuser
-
-
-def _unique_group_slug(program: Program, base_slug: str) -> str:
-    """Return a slug unique within the program, suffixing -2, -3, … on collision."""
-    slug = (base_slug or "group").strip("-")[:100] or "group"
-    if not AssignmentGroup.all_objects.filter(program=program, slug=slug).exists():
-        return slug
-    stem = slug[:95] if len(slug) > 95 else slug
-    for n in range(2, 1000):
-        candidate = f"{stem}-{n}"
-        if not AssignmentGroup.all_objects.filter(program=program, slug=candidate).exists():
-            return candidate
-    msg = "Could not generate a unique slug for this program."
-    raise serializers.ValidationError({"slug": msg})
 
 
 class PersonSummarySerializer(serializers.ModelSerializer):
@@ -119,7 +108,10 @@ class AssignmentGroupWriteSerializer(serializers.ModelSerializer):
             program = attrs.get("program")
             if program:
                 base_slug = attrs.get("slug") or slugify(attrs.get("name", ""))[:100]
-                attrs["slug"] = _unique_group_slug(program, base_slug)
+                try:
+                    attrs["slug"] = unique_group_slug(program, base_slug)
+                except GroupCloneError as exc:
+                    raise serializers.ValidationError({"slug": exc.message}) from exc
         super().run_validators(attrs)
 
     def validate(self, attrs):
@@ -178,6 +170,28 @@ class RosterImportLogSerializer(serializers.ModelSerializer):
         ]
 
 
+class GroupCloneSerializer(serializers.Serializer):
+    target_program = serializers.PrimaryKeyRelatedField(queryset=Program.all_objects.all())
+
+    def validate_target_program(self, value: Program) -> Program:
+        request = self.context.get("request")
+        org = getattr(request, "organization", None)
+        if org and value.organization_id != org.pk:
+            msg = "Target program must belong to your organization."
+            raise serializers.ValidationError(msg)
+        return value
+
+
+class AssignmentGroupCloneResponseSerializer(AssignmentGroupSerializer):
+    clone_summary = serializers.SerializerMethodField()
+
+    class Meta(AssignmentGroupSerializer.Meta):
+        fields = [*AssignmentGroupSerializer.Meta.fields, "clone_summary"]
+
+    def get_clone_summary(self, obj):
+        return self.context.get("clone_summary", {})
+
+
 class AssignmentGroupPermission(permissions.BasePermission):
     message = "Organization context required."
 
@@ -193,13 +207,15 @@ class AssignmentGroupViewSet(viewsets.ModelViewSet):
     permission_classes = [AssignmentGroupPermission]
 
     def get_permissions(self):
-        if self.action in ("create", "update", "partial_update", "destroy", "add_membership", "remove_membership", "import_roster"):
+        if self.action in ("create", "update", "partial_update", "destroy", "add_membership", "remove_membership", "import_roster", "clone"):
             return [AssignmentGroupPermission(), IsOrgAdminOrSuperuser()]
         return [AssignmentGroupPermission()]
 
     def get_serializer_class(self):
         if self.action == "retrieve":
             return AssignmentGroupSerializer
+        if self.action == "clone":
+            return AssignmentGroupCloneResponseSerializer
         if self.action in ("create", "update", "partial_update"):
             return AssignmentGroupWriteSerializer
         return AssignmentGroupListSerializer
@@ -397,6 +413,38 @@ class AssignmentGroupViewSet(viewsets.ModelViewSet):
             RosterImportLogSerializer(log).data,
             status=status.HTTP_200_OK,
         )
+
+    @action(detail=True, methods=["post"], url_path="clone")
+    def clone(self, request, pk=None):
+        source = self.get_object()
+        serializer = GroupCloneSerializer(data=request.data, context={"request": request})
+        serializer.is_valid(raise_exception=True)
+        target_program = serializer.validated_data["target_program"]
+
+        try:
+            result = clone_assignment_group(
+                source=source,
+                target_program=target_program,
+                organization=request.organization,
+            )
+        except GroupCloneError as exc:
+            field = exc.field_name or "detail"
+            return Response({field: exc.message}, status=status.HTTP_400_BAD_REQUEST)
+
+        cloned = AssignmentGroup.all_objects.prefetch_related(
+            "memberships__person",
+        ).select_related("parent", "program", "organization").get(pk=result.group.pk)
+
+        clone_summary = {
+            "memberships_copied": result.memberships_copied,
+            "program_memberships_copied": result.program_memberships_copied,
+            "warnings": result.warnings,
+        }
+        out = AssignmentGroupCloneResponseSerializer(
+            cloned,
+            context={"request": request, "clone_summary": clone_summary},
+        )
+        return Response(out.data, status=status.HTTP_201_CREATED)
 
     @action(detail=False, methods=["get"], url_path=r"import-logs/(?P<log_id>\d+)")
     def import_log_status(self, request, log_id=None):

--- a/backend/bunk_logs/api/tests/test_assignment_groups_write_api.py
+++ b/backend/bunk_logs/api/tests/test_assignment_groups_write_api.py
@@ -398,3 +398,108 @@ class TestRemoveMembership:
         row = rows2[0]
         assert row["name"] == "Bunk Maple"
         assert row["program_name"] == "Write API Org Session 2"
+
+
+# ---------------------------------------------------------------------------
+# CLONE group
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestCloneGroup:
+    def test_admin_clones_team_with_roster_and_program_memberships(
+        self, client, org, program, admin_user,
+    ):
+        program2 = Program.all_objects.create(
+            organization=org,
+            name="Write API Org Session 2",
+            slug="write-api-session-2-clone",
+            program_type="summer_camp",
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 8, 31),
+        )
+        team = AssignmentGroup.all_objects.create(
+            organization=org,
+            program=program,
+            name="Kitchen Staff",
+            slug="kitchen-staff-clone",
+            group_type="team",
+        )
+        person1 = Person.all_objects.create(organization=org, first_name="Kit", last_name="Chen")
+        person2 = Person.all_objects.create(organization=org, first_name="Sam", last_name="Lee")
+        Membership.all_objects.create(
+            program=program, person=person1, role="kitchen_staff", is_active=True,
+        )
+        Membership.all_objects.create(
+            program=program, person=person2, role="kitchen_staff", is_active=True,
+        )
+        AssignmentGroupMembership.all_objects.create(
+            group=team, person=person1, role_in_group="author", is_active=True,
+        )
+        AssignmentGroupMembership.all_objects.create(
+            group=team, person=person2, role_in_group="author", is_active=True,
+        )
+
+        user, _ = admin_user
+        client.force_authenticate(user=user)
+        r = client.post(
+            f"/api/v1/assignment-groups/{team.pk}/clone/",
+            {"target_program": program2.pk},
+            **_hdr(org.slug),
+        )
+        assert r.status_code == 201, r.content
+        data = r.json()
+        assert data["name"] == "Kitchen Staff"
+        assert data["program"] == program2.pk
+        assert data["clone_summary"]["memberships_copied"] == 2
+        assert data["clone_summary"]["program_memberships_copied"] == 2
+        assert len(data["memberships"]) == 2
+
+        cloned = AssignmentGroup.all_objects.get(pk=data["id"])
+        assert cloned.program_id == program2.pk
+        assert cloned.slug == "kitchen-staff-clone"
+        assert AssignmentGroupMembership.all_objects.filter(
+            group=cloned, is_active=True,
+        ).count() == 2
+        assert Membership.all_objects.filter(
+            program=program2, role="kitchen_staff", is_active=True,
+        ).count() == 2
+
+    def test_regular_user_denied(self, client, org, program, group, regular_user):
+        program2 = Program.all_objects.create(
+            organization=org,
+            name="Write API Org Session 2",
+            slug="session-2-clone-denied",
+            program_type="summer_camp",
+            start_date=date(2026, 6, 1),
+            end_date=date(2026, 8, 31),
+        )
+        user, _ = regular_user
+        client.force_authenticate(user=user)
+        r = client.post(
+            f"/api/v1/assignment-groups/{group.pk}/clone/",
+            {"target_program": program2.pk},
+            **_hdr(org.slug),
+        )
+        assert r.status_code == 403
+
+    def test_same_program_and_cross_org_rejected(
+        self, client, org, org_b, program, program_b, group, admin_user,
+    ):
+        user, _ = admin_user
+        client.force_authenticate(user=user)
+
+        r_same = client.post(
+            f"/api/v1/assignment-groups/{group.pk}/clone/",
+            {"target_program": program.pk},
+            **_hdr(org.slug),
+        )
+        assert r_same.status_code == 400
+        assert "target_program" in r_same.json()
+
+        r_cross = client.post(
+            f"/api/v1/assignment-groups/{group.pk}/clone/",
+            {"target_program": program_b.pk},
+            **_hdr(org.slug),
+        )
+        assert r_cross.status_code == 400
+        assert "target_program" in r_cross.json()

--- a/backend/bunk_logs/core/group_clone.py
+++ b/backend/bunk_logs/core/group_clone.py
@@ -1,0 +1,187 @@
+"""Clone an assignment group (structure + roster) to another program."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+
+from django.utils.text import slugify
+
+from bunk_logs.core.models import AssignmentGroup
+from bunk_logs.core.models import AssignmentGroupMembership
+from bunk_logs.core.models import Membership
+from bunk_logs.core.models import Organization
+from bunk_logs.core.models import Program
+
+
+class GroupCloneError(Exception):
+    """Raised when clone preconditions fail."""
+
+    def __init__(self, message: str, *, field_name: str | None = None):
+        super().__init__(message)
+        self.field_name = field_name
+        self.message = message
+
+
+def unique_group_slug(program: Program, base_slug: str) -> str:
+    """Return a slug unique within the program, suffixing -2, -3, … on collision."""
+    slug = (base_slug or "group").strip("-")[:100] or "group"
+    if not AssignmentGroup.all_objects.filter(program=program, slug=slug).exists():
+        return slug
+    stem = slug[:95] if len(slug) > 95 else slug
+    for n in range(2, 1000):
+        candidate = f"{stem}-{n}"
+        if not AssignmentGroup.all_objects.filter(program=program, slug=candidate).exists():
+            return candidate
+    msg = "Could not generate a unique slug for this program."
+    raise GroupCloneError(msg, field_name="slug")
+
+
+@dataclass
+class CloneResult:
+    group: AssignmentGroup
+    memberships_copied: int = 0
+    program_memberships_copied: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+
+def clone_assignment_group(
+    *,
+    source: AssignmentGroup,
+    target_program: Program,
+    organization: Organization,
+) -> CloneResult:
+    """Copy group structure and active roster to another program in the same org."""
+    if target_program.organization_id != organization.pk:
+        msg = "Target program must belong to your organization."
+        raise GroupCloneError(msg, field_name="target_program")
+    if source.organization_id != organization.pk:
+        msg = "Source group must belong to your organization."
+        raise GroupCloneError(msg, field_name="source")
+    if source.program_id == target_program.pk:
+        msg = "Target program must differ from the source group's program."
+        raise GroupCloneError(msg, field_name="target_program")
+
+    warnings: list[str] = []
+
+    if AssignmentGroup.all_objects.filter(
+        program=target_program,
+        name=source.name,
+        is_active=True,
+    ).exists():
+        warnings.append(
+            f"Target program already has an active group named '{source.name}'.",
+        )
+
+    parent = None
+    if source.parent_id:
+        parent_match = AssignmentGroup.all_objects.filter(
+            program=target_program,
+            slug=source.parent.slug,
+            is_active=True,
+        ).first()
+        if parent_match:
+            parent = parent_match
+        else:
+            warnings.append(
+                f"Parent group '{source.parent.name}' was not found in the target program; "
+                "cloned group has no parent.",
+            )
+
+    metadata = {**(source.metadata or {})}
+    metadata["cloned_from"] = {
+        "group_id": source.pk,
+        "program_id": source.program_id,
+    }
+
+    base_slug = source.slug or slugify(source.name)[:100]
+    slug = unique_group_slug(target_program, base_slug)
+
+    cloned_group = AssignmentGroup.all_objects.create(
+        organization=organization,
+        program=target_program,
+        name=source.name,
+        slug=slug,
+        group_type=source.group_type,
+        parent=parent,
+        metadata=metadata,
+        is_active=True,
+    )
+
+    source_memberships = AssignmentGroupMembership.all_objects.filter(
+        group=source,
+        is_active=True,
+    ).select_related("person")
+
+    roster_person_ids: set[int] = set()
+    memberships_copied = 0
+
+    for src_mem in source_memberships:
+        roster_person_ids.add(src_mem.person_id)
+        membership, created = AssignmentGroupMembership.all_objects.get_or_create(
+            group=cloned_group,
+            person=src_mem.person,
+            role_in_group=src_mem.role_in_group,
+            defaults={
+                "is_active": True,
+                "start_date": src_mem.start_date,
+                "end_date": src_mem.end_date,
+                "metadata": dict(src_mem.metadata or {}),
+            },
+        )
+        if not created:
+            membership.is_active = True
+            membership.start_date = src_mem.start_date
+            membership.end_date = src_mem.end_date
+            membership.metadata = dict(src_mem.metadata or {})
+            membership.save(
+                update_fields=["is_active", "start_date", "end_date", "metadata"],
+            )
+        memberships_copied += 1
+
+    program_memberships_copied = 0
+    if roster_person_ids:
+        source_program_memberships = Membership.all_objects.filter(
+            program=source.program,
+            person_id__in=roster_person_ids,
+            is_active=True,
+        )
+        for src_prog_mem in source_program_memberships:
+            prog_mem, created = Membership.all_objects.get_or_create(
+                program=target_program,
+                person=src_prog_mem.person,
+                role=src_prog_mem.role,
+                defaults={
+                    "is_active": True,
+                    "start_date": src_prog_mem.start_date,
+                    "end_date": src_prog_mem.end_date,
+                    "tags": list(src_prog_mem.tags or []),
+                    "metadata": dict(src_prog_mem.metadata or {}),
+                    "grade_level": src_prog_mem.grade_level,
+                },
+            )
+            if not created:
+                prog_mem.is_active = True
+                prog_mem.start_date = src_prog_mem.start_date
+                prog_mem.end_date = src_prog_mem.end_date
+                prog_mem.tags = list(src_prog_mem.tags or [])
+                prog_mem.metadata = dict(src_prog_mem.metadata or {})
+                prog_mem.grade_level = src_prog_mem.grade_level
+                prog_mem.save(
+                    update_fields=[
+                        "is_active",
+                        "start_date",
+                        "end_date",
+                        "tags",
+                        "metadata",
+                        "grade_level",
+                    ],
+                )
+            program_memberships_copied += 1
+
+    return CloneResult(
+        group=cloned_group,
+        memberships_copied=memberships_copied,
+        program_memberships_copied=program_memberships_copied,
+        warnings=warnings,
+    )

--- a/frontend/src/pages/ReflectionDetailPage.jsx
+++ b/frontend/src/pages/ReflectionDetailPage.jsx
@@ -5,6 +5,9 @@ import api from '../api';
 import Header from '../partials/Header';
 import Sidebar from '../partials/Sidebar';
 import PrivacyChip from '../components/reflection/PrivacyChip';
+import RichText from '../components/ui/RichText';
+
+const RICH_TEXT_FIELD_TYPES = new Set(['textarea', 'long_text', 'rich_text', 'text', 'short_text']);
 
 function promptText(field) {
   if (!field?.prompts || typeof field.prompts !== 'object') return '';
@@ -32,6 +35,29 @@ function formatAnswer(field, value) {
   if (Array.isArray(value)) return value.join(', ') || '—';
   if (typeof value === 'object') return JSON.stringify(value);
   return String(value);
+}
+
+function AnswerDisplay({ field, value }) {
+  if (value === undefined || value === null || value === '') {
+    return (
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">—</p>
+    );
+  }
+
+  if (RICH_TEXT_FIELD_TYPES.has(field.type)) {
+    return (
+      <RichText
+        html={String(value)}
+        className="mt-1 text-sm text-gray-600 dark:text-gray-400 prose prose-sm dark:prose-invert max-w-none"
+      />
+    );
+  }
+
+  return (
+    <p className="mt-1 text-sm text-gray-600 dark:text-gray-400 whitespace-pre-wrap">
+      {formatAnswer(field, value)}
+    </p>
+  );
 }
 
 function formatDate(iso) {
@@ -214,9 +240,7 @@ export default function ReflectionDetailPage() {
                           ? 'Ratings'
                           : promptText(field) || field.key}
                       </p>
-                      <p className="mt-1 text-sm text-gray-600 dark:text-gray-400 whitespace-pre-wrap">
-                        {formatAnswer(field, reflection.answers?.[field.key])}
-                      </p>
+                      <AnswerDisplay field={field} value={reflection.answers?.[field.key]} />
                     </li>
                   ))}
                 </ul>

--- a/frontend/src/pages/ReflectionDetailPage.test.jsx
+++ b/frontend/src/pages/ReflectionDetailPage.test.jsx
@@ -108,4 +108,31 @@ describe('ReflectionDetailPage', () => {
 
     expect(screen.queryByTestId('privacy-chip')).toBeNull();
   });
+
+  it('renders textarea answers as formatted HTML, not raw tags', async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        ...FULL_REFLECTION,
+        localized_schema: {
+          fields: [
+            {
+              key: 'notes',
+              type: 'textarea',
+              prompts: { en: 'Notes' },
+            },
+          ],
+        },
+        answers: { notes: '<p>Great <strong>day</strong></p>' },
+      },
+    });
+    renderAt('/reflections/91');
+
+    await waitFor(() => expect(screen.getByText('Notes')).toBeInTheDocument());
+
+    expect(screen.queryByText('<p>Great')).not.toBeInTheDocument();
+    expect(screen.getByText('day')).toBeInTheDocument();
+    const strong = document.querySelector('strong');
+    expect(strong).not.toBeNull();
+    expect(strong.textContent).toBe('day');
+  });
 });

--- a/frontend/src/pages/admin/groups/GroupDetailPage.jsx
+++ b/frontend/src/pages/admin/groups/GroupDetailPage.jsx
@@ -1,8 +1,8 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { Link, useParams, useNavigate, useSearchParams } from 'react-router-dom';
-import { ArrowLeft, BarChart3, UserPlus, Trash2, Upload, RotateCcw, CheckCircle, XCircle } from 'lucide-react';
+import { ArrowLeft, BarChart3, Copy, UserPlus, Trash2, Upload, RotateCcw, CheckCircle, XCircle } from 'lucide-react';
 import api from '../../../api';
-import { listAdminPeople } from '../../../api/admin';
+import { listAdminPeople, listAdminPrograms } from '../../../api/admin';
 import Button from '../../../components/ui/Button';
 import ErrorPanel from '../../../components/ui/ErrorPanel';
 import LoadingState from '../../../components/ui/LoadingState';
@@ -239,6 +239,12 @@ export default function GroupDetailPage() {
   const [parentOptions, setParentOptions] = useState([]);
   const [editingParent, setEditingParent] = useState(false);
 
+  // Clone state
+  const [showClonePanel, setShowClonePanel] = useState(false);
+  const [clonePrograms, setClonePrograms] = useState([]);
+  const [cloneTargetProgram, setCloneTargetProgram] = useState('');
+  const [cloning, setCloning] = useState(false);
+
   const load = useCallback(async () => {
     setLoading(true);
     try {
@@ -294,6 +300,56 @@ export default function GroupDetailPage() {
       .catch(() => { if (!cancelled) setParentOptions([]); });
     return () => { cancelled = true; };
   }, [group?.id, group?.program, group?.group_type]);
+
+  useEffect(() => {
+    if (!showClonePanel) return;
+    let cancelled = false;
+    listAdminPrograms()
+      .then((data) => {
+        if (cancelled) return;
+        const list = (data.results || []).filter(
+          (p) => String(p.id) !== String(group?.program),
+        );
+        setClonePrograms(list);
+        setCloneTargetProgram(list.length ? String(list[0].id) : '');
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setClonePrograms([]);
+          setCloneTargetProgram('');
+        }
+      });
+    return () => { cancelled = true; };
+  }, [showClonePanel, group?.program]);
+
+  const handleClone = async () => {
+    if (!cloneTargetProgram) {
+      showToast('Select a target program.');
+      return;
+    }
+    setCloning(true);
+    try {
+      const { data } = await api.post(`/api/v1/assignment-groups/${id}/clone/`, {
+        target_program: Number(cloneTargetProgram),
+      });
+      const summary = data.clone_summary || {};
+      const parts = [
+        `Cloned with ${summary.memberships_copied ?? 0} roster member(s)`,
+      ];
+      if (summary.program_memberships_copied) {
+        parts.push(`${summary.program_memberships_copied} program membership(s) created`);
+      }
+      showToast(parts.join('; '));
+      if (summary.warnings?.length) {
+        setTimeout(() => showToast(summary.warnings.join(' ')), 500);
+      }
+      navigate(`/admin/groups/${data.id}`);
+    } catch (err) {
+      showToast(formatApiError(err.response?.data, 'Clone failed.'));
+    } finally {
+      setCloning(false);
+    }
+  };
 
   const handleAddMember = async () => {
     if (!selectedPerson) return;
@@ -661,6 +717,15 @@ export default function GroupDetailPage() {
             </Link>
             <button
               type="button"
+              onClick={() => setShowClonePanel((v) => !v)}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+              data-testid="group-clone-toggle"
+            >
+              <Copy size={14} aria-hidden="true" />
+              Clone to program
+            </button>
+            <button
+              type="button"
               onClick={handleDeactivate}
               disabled={!group.is_active}
               className="text-xs text-gray-400 hover:text-red-500 dark:hover:text-red-400 underline disabled:opacity-40 disabled:cursor-not-allowed"
@@ -669,6 +734,59 @@ export default function GroupDetailPage() {
             </button>
           </div>
         </div>
+
+        {showClonePanel && (
+          <div
+            className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-5 mb-6"
+            data-testid="group-clone-panel"
+          >
+            <h2 className="text-sm font-semibold text-gray-900 dark:text-white mb-3 flex items-center gap-2">
+              <Copy size={15} /> Clone to another program
+            </h2>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+              Creates a copy of <span className="font-medium text-gray-700 dark:text-gray-300">{group.name}</span>{' '}
+              in the selected program, including active roster members and their program memberships.
+            </p>
+            <div className="flex flex-wrap gap-3 items-end">
+              <div>
+                <label htmlFor="clone-target-program" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                  Target program
+                </label>
+                <select
+                  id="clone-target-program"
+                  value={cloneTargetProgram}
+                  onChange={(e) => setCloneTargetProgram(e.target.value)}
+                  className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-white min-w-48"
+                  data-testid="clone-target-program"
+                >
+                  {clonePrograms.length === 0 && (
+                    <option value="">No other programs available</option>
+                  )}
+                  {clonePrograms.map((p) => (
+                    <option key={p.id} value={String(p.id)}>
+                      {p.name}{p.is_active ? '' : ' (Ended)'}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <Button
+                size="sm"
+                onClick={handleClone}
+                disabled={cloning || !cloneTargetProgram}
+                data-testid="group-clone-confirm"
+              >
+                {cloning ? 'Cloning…' : 'Clone group'}
+              </Button>
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => setShowClonePanel(false)}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
 
         {/* Add member */}
         <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-5 mb-6">


### PR DESCRIPTION
## Summary
- Add single-group clone API and admin UI to copy a group (structure, roster, and program memberships) from one program to another.
- Fix reflection detail page to render textarea/HTML answers with the shared `RichText` component instead of showing raw tags.

## Test plan
- [x] Backend: `TestCloneGroup` (3 tests) — happy path, auth, validation
- [x] Frontend: `ReflectionDetailPage.test.jsx` — HTML rendering test
- [ ] Manual: clone Kitchen Team from Session 1 → Session 2 via group detail page
- [ ] Manual: open `/reflections/:id` and confirm formatted text responses


Made with [Cursor](https://cursor.com)